### PR TITLE
perf: reduce test build time by 4.4x via profile optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,12 @@ lto           = true
 
 [profile.test-dev]
 inherits  = "dev"
-opt-level = 1
+opt-level = 0
+
+# Optimize dependencies so that test execution (esp. crypto/ZK) is fast, while
+# keeping workspace crates at opt-level 0 for faster compilation.
+[profile.test-dev.package."*"]
+opt-level = 2
 
 [profile.bench]
 codegen-units = 1


### PR DESCRIPTION
## Summary

- Self-profiling revealed that **97% of `miden-testing`'s build time** was spent in LLVM codegen/optimization, not in Rust compilation phases
- The previous `opt-level = 1` for all crates in `test-dev` caused LLVM to optimize the large amount of monomorphized code from Plonky3-backed generics
- Split the optimization strategy: workspace crates compile at `opt-level = 0` (fast compilation, code is mostly test setup/glue) while external dependencies compile at `opt-level = 2` (crypto/ZK operations need optimization for acceptable test execution speed)

### Results (clean build, 60-core machine)

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total build time | 7m 39s | 1m 45s | **4.4x faster** |
| miden-testing lib (test) | 390.6s | 25.1s | **15.6x faster** |
| miden-testing test "lib" (test) | 269.4s | 17.2s | **15.7x faster** |
| Test execution (778 tests) | ~94s | ~94s | No regression |

### Profiling methodology

1. `cargo build --timings` for per-crate compilation times
2. `cargo llvm-lines` for monomorphization analysis
3. `RUSTFLAGS="-Zself-profile"` with `summarize` for detailed breakdown of compiler phases

The self-profile data showed that for `miden-testing lib (test)`:
- `finish_ongoing_codegen`: 268s (25.5%)
- `LLVM_module_codegen_emit_obj`: 187s (17.9%)
- `LLVM_module_optimize`: 154s (14.7%)
- `LLVM_thinlto`: 152s (14.5%)
- `LLVM_passes`: 125s (11.9%)
- `LLVM_lto_optimize`: 88s (8.4%)

All Rust-level compilation (typeck, monomorphization, MIR) was <5s total.

## Test plan

- [x] `make lint` passes
- [x] `make test-dev` passes (778 tests, no regressions)
- [x] No test execution speed regression (dependencies still optimized at opt-level 2)

Closes #2643

🤖 Generated with [Claude Code](https://claude.com/claude-code)