### PR TITLE
feat: introduce AssetAmount wrapper type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Introduced `AssetAmount` wrapper type for fungible asset amounts with validated construction and a maximum value of `2^63 - 2^31` ([#2658](https://github.com/0xMiden/protocol/pull/2658)).
 - Made `NoteMetadataHeader` and `NoteMetadata::to_header()` public, added `NoteMetadata::from_header()` constructor, and exported `NoteMetadataHeader` from the `note` module ([#2561](https://github.com/0xMiden/protocol/pull/2561)).
 - Introduce NOTE_MAX_SIZE (256 KiB) and enforce it on individual output notes ([#2205](https://github.com/0xMiden/miden-base/pull/2205), [#2651](https://github.com/0xMiden/miden-base/pull/2651))
 - Added AggLayer faucet registry to bridge account with conversion metadata, `CONFIG_AGG_BRIDGE` note for faucet registration, and FPI-based asset conversion in `bridge_out` ([#2426](https://github.com/0xMiden/miden-base/pull/2426)).

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -216,7 +216,7 @@ impl FungibleAssetDelta {
     /// # Errors
     /// Returns an error if the delta would overflow.
     pub fn add(&mut self, asset: FungibleAsset) -> Result<(), AccountDeltaError> {
-        let amount: i64 = asset.amount().try_into().expect("Amount it too high");
+        let amount: i64 = asset.amount().inner().try_into().expect("Amount it too high");
         self.add_delta(asset.vault_key(), amount)
     }
 
@@ -225,7 +225,7 @@ impl FungibleAssetDelta {
     /// # Errors
     /// Returns an error if the delta would overflow.
     pub fn remove(&mut self, asset: FungibleAsset) -> Result<(), AccountDeltaError> {
-        let amount: i64 = asset.amount().try_into().expect("Amount it too high");
+        let amount: i64 = asset.amount().inner().try_into().expect("Amount it too high");
         self.add_delta(asset.vault_key(), -amount)
     }
 

--- a/crates/miden-protocol/src/asset/asset_amount.rs
+++ b/crates/miden-protocol/src/asset/asset_amount.rs
@@ -1,0 +1,200 @@
+use alloc::string::ToString;
+use core::fmt;
+
+use super::AssetError;
+use crate::utils::serde::{
+    ByteReader,
+    ByteWriter,
+    Deserializable,
+    DeserializationError,
+    Serializable,
+};
+
+// ASSET AMOUNT
+// ================================================================================================
+
+/// A validated amount for a [`super::FungibleAsset`].
+///
+/// The inner value is guaranteed to be at most [`AssetAmount::MAX`].
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AssetAmount(u64);
+
+impl AssetAmount {
+    /// The maximum amount a fungible asset can represent.
+    ///
+    /// This number was chosen so that it can be represented as a positive and negative number in a
+    /// field element. See `account_delta.masm` for more details on how this number was chosen.
+    pub const MAX: Self = Self(2u64.pow(63) - 2u64.pow(31));
+
+    /// An amount of zero.
+    pub const ZERO: Self = Self(0);
+
+    /// Creates a new [`AssetAmount`] after validating that `amount` does not exceed
+    /// [`Self::MAX`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AssetError::FungibleAssetAmountTooBig`] if `amount` exceeds [`Self::MAX`].
+    pub fn new(amount: u64) -> Result<Self, AssetError> {
+        if amount > Self::MAX.0 {
+            return Err(AssetError::FungibleAssetAmountTooBig(amount));
+        }
+        Ok(Self(amount))
+    }
+
+    /// Returns the inner `u64` value.
+    pub const fn inner(&self) -> u64 {
+        self.0
+    }
+
+    /// Creates a new [`AssetAmount`] without validating bounds.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `amount <= AssetAmount::MAX`.
+    pub(crate) const fn new_unchecked(amount: u64) -> Self {
+        Self(amount)
+    }
+}
+
+// TRAIT IMPLEMENTATIONS
+// ================================================================================================
+
+impl From<u8> for AssetAmount {
+    fn from(amount: u8) -> Self {
+        Self(amount as u64)
+    }
+}
+
+impl From<u16> for AssetAmount {
+    fn from(amount: u16) -> Self {
+        Self(amount as u64)
+    }
+}
+
+impl From<u32> for AssetAmount {
+    fn from(amount: u32) -> Self {
+        Self(amount as u64)
+    }
+}
+
+impl TryFrom<u64> for AssetAmount {
+    type Error = AssetError;
+
+    fn try_from(amount: u64) -> Result<Self, Self::Error> {
+        Self::new(amount)
+    }
+}
+
+impl From<AssetAmount> for u64 {
+    fn from(amount: AssetAmount) -> Self {
+        amount.0
+    }
+}
+
+impl fmt::Display for AssetAmount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// SERIALIZATION
+// ================================================================================================
+
+impl Serializable for AssetAmount {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.0);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
+    }
+}
+
+impl Deserializable for AssetAmount {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let amount: u64 = source.read()?;
+        Self::new(amount).map_err(|err| DeserializationError::InvalidValue(err.to_string()))
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_amount_max_value() {
+        let max = AssetAmount::MAX;
+        assert_eq!(max.inner(), 2u64.pow(63) - 2u64.pow(31));
+    }
+
+    #[test]
+    fn asset_amount_new_valid() {
+        assert!(AssetAmount::new(0).is_ok());
+        assert!(AssetAmount::new(100).is_ok());
+        assert!(AssetAmount::new(AssetAmount::MAX.inner()).is_ok());
+    }
+
+    #[test]
+    fn asset_amount_new_exceeds_max() {
+        assert!(AssetAmount::new(AssetAmount::MAX.inner() + 1).is_err());
+        assert!(AssetAmount::new(u64::MAX).is_err());
+    }
+
+    #[test]
+    fn asset_amount_from_small_types() {
+        let a: AssetAmount = 42u8.into();
+        assert_eq!(a.inner(), 42);
+
+        let b: AssetAmount = 1000u16.into();
+        assert_eq!(b.inner(), 1000);
+
+        let c: AssetAmount = 1_000_000u32.into();
+        assert_eq!(c.inner(), 1_000_000);
+    }
+
+    #[test]
+    fn asset_amount_try_from_u64() {
+        assert!(AssetAmount::try_from(100u64).is_ok());
+        assert!(AssetAmount::try_from(AssetAmount::MAX.inner() + 1).is_err());
+    }
+
+    #[test]
+    fn asset_amount_into_u64() {
+        let amount = AssetAmount::new(42).unwrap();
+        let val: u64 = amount.into();
+        assert_eq!(val, 42);
+    }
+
+    #[test]
+    fn asset_amount_display() {
+        let amount = AssetAmount::new(12345).unwrap();
+        assert_eq!(format!("{amount}"), "12345");
+    }
+
+    #[test]
+    fn asset_amount_ordering() {
+        let a = AssetAmount::new(10).unwrap();
+        let b = AssetAmount::new(20).unwrap();
+        assert!(a < b);
+        assert!(b > a);
+        assert_eq!(a, AssetAmount::new(10).unwrap());
+    }
+
+    #[test]
+    fn asset_amount_default_is_zero() {
+        assert_eq!(AssetAmount::default(), AssetAmount::ZERO);
+        assert_eq!(AssetAmount::default().inner(), 0);
+    }
+
+    #[test]
+    fn asset_amount_serde_roundtrip() {
+        let amount = AssetAmount::new(999).unwrap();
+        let bytes = amount.to_bytes();
+        let restored = AssetAmount::read_from_bytes(&bytes).unwrap();
+        assert_eq!(amount, restored);
+    }
+}

--- a/crates/miden-protocol/src/asset/fungible.rs
+++ b/crates/miden-protocol/src/asset/fungible.rs
@@ -2,7 +2,7 @@ use alloc::string::ToString;
 use core::fmt;
 
 use super::vault::AssetVaultKey;
-use super::{AccountType, Asset, AssetCallbackFlag, AssetError, Word};
+use super::{AccountType, Asset, AssetAmount, AssetCallbackFlag, AssetError, Word};
 use crate::Felt;
 use crate::account::AccountId;
 use crate::asset::AssetId;
@@ -26,7 +26,7 @@ use crate::utils::serde::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct FungibleAsset {
     faucet_id: AccountId,
-    amount: u64,
+    amount: AssetAmount,
     callbacks: AssetCallbackFlag,
 }
 
@@ -35,15 +35,14 @@ impl FungibleAsset {
     // --------------------------------------------------------------------------------------------
     /// Specifies the maximum amount a fungible asset can represent.
     ///
-    /// This number was chosen so that it can be represented as a positive and negative number in a
-    /// field element. See `account_delta.masm` for more details on how this number was chosen.
-    pub const MAX_AMOUNT: u64 = 2u64.pow(63) - 2u64.pow(31);
+    /// Use [`AssetAmount::MAX`] instead for the validated wrapper type.
+    pub const MAX_AMOUNT: u64 = AssetAmount::MAX.inner();
 
     /// The serialized size of a [`FungibleAsset`] in bytes.
     ///
     /// An account ID (15 bytes) plus an amount (u64) plus a callbacks flag (u8).
     pub const SERIALIZED_SIZE: usize = AccountId::SERIALIZED_SIZE
-        + core::mem::size_of::<u64>()
+        + core::mem::size_of::<AssetAmount>()
         + AssetCallbackFlag::SERIALIZED_SIZE;
 
     // CONSTRUCTOR
@@ -55,15 +54,13 @@ impl FungibleAsset {
     ///
     /// Returns an error if:
     /// - The faucet ID is not a valid fungible faucet ID.
-    /// - The provided amount is greater than [`FungibleAsset::MAX_AMOUNT`].
+    /// - The provided amount is greater than [`AssetAmount::MAX`].
     pub fn new(faucet_id: AccountId, amount: u64) -> Result<Self, AssetError> {
         if !matches!(faucet_id.account_type(), AccountType::FungibleFaucet) {
             return Err(AssetError::FungibleFaucetIdTypeMismatch(faucet_id));
         }
 
-        if amount > Self::MAX_AMOUNT {
-            return Err(AssetError::FungibleAssetAmountTooBig(amount));
-        }
+        let amount = AssetAmount::new(amount)?;
 
         Ok(Self {
             faucet_id,
@@ -126,7 +123,7 @@ impl FungibleAsset {
     }
 
     /// Returns the amount of this asset.
-    pub fn amount(&self) -> u64 {
+    pub fn amount(&self) -> AssetAmount {
         self.amount
     }
 
@@ -154,7 +151,7 @@ impl FungibleAsset {
     /// Returns the asset's value encoded to a [`Word`].
     pub fn to_value_word(&self) -> Word {
         Word::new([
-            Felt::try_from(self.amount)
+            Felt::try_from(self.amount.inner())
                 .expect("fungible asset should only allow amounts that fit into a felt"),
             Felt::ZERO,
             Felt::ZERO,
@@ -180,13 +177,12 @@ impl FungibleAsset {
             });
         }
 
-        let amount = self
+        let raw_amount = self
             .amount
-            .checked_add(other.amount)
+            .inner()
+            .checked_add(other.amount.inner())
             .expect("even MAX_AMOUNT + MAX_AMOUNT should not overflow u64");
-        if amount > Self::MAX_AMOUNT {
-            return Err(AssetError::FungibleAssetAmountTooBig(amount));
-        }
+        let amount = AssetAmount::new(raw_amount)?;
 
         Ok(Self {
             faucet_id: self.faucet_id,
@@ -210,12 +206,14 @@ impl FungibleAsset {
             });
         }
 
-        let amount = self.amount.checked_sub(other.amount).ok_or(
+        let raw_amount = self.amount.inner().checked_sub(other.amount.inner()).ok_or(
             AssetError::FungibleAssetAmountNotSufficient {
-                minuend: self.amount,
-                subtrahend: other.amount,
+                minuend: self.amount.inner(),
+                subtrahend: other.amount.inner(),
             },
         )?;
+        // SAFETY: subtraction of two valid amounts always produces a valid amount.
+        let amount = AssetAmount::new_unchecked(raw_amount);
 
         Ok(FungibleAsset {
             faucet_id: self.faucet_id,

--- a/crates/miden-protocol/src/asset/mod.rs
+++ b/crates/miden-protocol/src/asset/mod.rs
@@ -10,6 +10,9 @@ use super::utils::serde::{
 use super::{Felt, Word};
 use crate::account::AccountId;
 
+mod asset_amount;
+pub use asset_amount::AssetAmount;
+
 mod fungible;
 
 pub use fungible::FungibleAsset;

--- a/crates/miden-protocol/src/asset/vault/mod.rs
+++ b/crates/miden-protocol/src/asset/vault/mod.rs
@@ -6,6 +6,7 @@ use miden_crypto::merkle::InnerNodeInfo;
 use super::{
     AccountType,
     Asset,
+    AssetAmount,
     ByteReader,
     ByteWriter,
     Deserializable,
@@ -118,7 +119,7 @@ impl AssetVault {
         let asset = FungibleAsset::from_key_value(vault_key, asset_value)
             .expect("asset vault should only store valid assets");
 
-        Ok(asset.amount())
+        Ok(asset.amount().inner())
     }
 
     /// Returns an iterator over the assets stored in the vault.
@@ -312,7 +313,7 @@ impl AssetVault {
                 .expect("asset vault should store valid assets");
 
         // If the asset's amount is 0, we consider it absent from the vault.
-        if current_asset.amount() == 0 {
+        if current_asset.amount() == AssetAmount::ZERO {
             return Err(AssetVaultError::FungibleAssetNotFound(other_asset));
         }
 
@@ -325,7 +326,7 @@ impl AssetVault {
         // leaf.
         #[cfg(debug_assertions)]
         {
-            if new_asset.amount() == 0 {
+            if new_asset.amount() == AssetAmount::ZERO {
                 assert!(new_asset.to_value_word().is_empty())
             }
         }

--- a/crates/miden-protocol/src/transaction/kernel/mod.rs
+++ b/crates/miden-protocol/src/transaction/kernel/mod.rs
@@ -224,7 +224,7 @@ impl TransactionKernel {
         outputs.extend(account_update_commitment);
         outputs.push(fee.faucet_id().suffix());
         outputs.push(fee.faucet_id().prefix().as_felt());
-        outputs.push(Felt::try_from(fee.amount()).expect("amount should fit into felt"));
+        outputs.push(Felt::try_from(fee.amount().inner()).expect("amount should fit into felt"));
         outputs.push(Felt::from(expiration_block_num));
 
         StackOutputs::new(&outputs).expect("number of stack inputs should be <= 16")

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -1123,7 +1123,7 @@ async fn test_get_init_balance_addition() -> anyhow::Result<()> {
         suffix = faucet_existing_asset.suffix(),
         prefix = faucet_existing_asset.prefix().as_felt(),
         final_balance =
-            initial_balance + fungible_asset_for_note_existing.unwrap_fungible().amount(),
+            initial_balance + fungible_asset_for_note_existing.unwrap_fungible().amount().inner(),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(add_existing_source)?;
@@ -1176,7 +1176,8 @@ async fn test_get_init_balance_addition() -> anyhow::Result<()> {
     "#,
         suffix = faucet_new_asset.suffix(),
         prefix = faucet_new_asset.prefix().as_felt(),
-        final_balance = initial_balance + fungible_asset_for_note_new.unwrap_fungible().amount(),
+        final_balance =
+            initial_balance + fungible_asset_for_note_new.unwrap_fungible().amount().inner(),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(add_new_source)?;
@@ -1271,7 +1272,7 @@ async fn test_get_init_balance_subtraction() -> anyhow::Result<()> {
         suffix = faucet_existing_asset.suffix(),
         prefix = faucet_existing_asset.prefix().as_felt(),
         final_balance =
-            initial_balance - fungible_asset_for_note_existing.unwrap_fungible().amount(),
+            initial_balance - fungible_asset_for_note_existing.unwrap_fungible().amount().inner(),
     );
 
     let tx_script = CodeBuilder::with_mock_libraries().compile_tx_script(remove_existing_source)?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -472,13 +472,17 @@ async fn fungible_asset_delta() -> anyhow::Result<()> {
         .account_delta()
         .vault()
         .added_assets()
-        .map(|asset| (asset.unwrap_fungible().faucet_id(), asset.unwrap_fungible().amount()))
+        .map(|asset| {
+            (asset.unwrap_fungible().faucet_id(), asset.unwrap_fungible().amount().inner())
+        })
         .collect::<BTreeMap<_, _>>();
     let mut removed_assets = executed_tx
         .account_delta()
         .vault()
         .removed_assets()
-        .map(|asset| (asset.unwrap_fungible().faucet_id(), asset.unwrap_fungible().amount()))
+        .map(|asset| {
+            (asset.unwrap_fungible().faucet_id(), asset.unwrap_fungible().amount().inner())
+        })
         .collect::<BTreeMap<_, _>>();
 
     assert_eq!(added_assets.len(), 2);
@@ -486,17 +490,20 @@ async fn fungible_asset_delta() -> anyhow::Result<()> {
 
     assert_eq!(
         added_assets.remove(&original_asset2.faucet_id()).unwrap(),
-        added_asset2.amount() - removed_asset2.amount()
+        added_asset2.amount().inner() - removed_asset2.amount().inner()
     );
-    assert_eq!(added_assets.remove(&added_asset4.faucet_id()).unwrap(), added_asset4.amount());
+    assert_eq!(
+        added_assets.remove(&added_asset4.faucet_id()).unwrap(),
+        added_asset4.amount().inner()
+    );
 
     assert_eq!(
         removed_assets.remove(&original_asset0.faucet_id()).unwrap(),
-        removed_asset0.amount() - added_asset0.amount()
+        removed_asset0.amount().inner() - added_asset0.amount().inner()
     );
     assert_eq!(
         removed_assets.remove(&original_asset3.faucet_id()).unwrap(),
-        removed_asset3.amount()
+        removed_asset3.amount().inner()
     );
 
     Ok(())

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -140,7 +140,7 @@ async fn test_transaction_epilogue() -> anyhow::Result<()> {
         exec_output
             .get_stack_element(TransactionOutputs::FEE_AMOUNT_ELEMENT_IDX)
             .as_canonical_u64(),
-        fee_asset.amount()
+        fee_asset.amount().inner()
     );
     assert_eq!(
         exec_output

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -33,7 +33,7 @@ async fn create_account_with_fees() -> anyhow::Result<()> {
         .context("failed to execute account-creating transaction")?;
 
     let expected_fee = tx.compute_fee();
-    assert_eq!(expected_fee, tx.fee().amount());
+    assert_eq!(expected_fee, tx.fee().amount().inner());
 
     // We expect that the new account contains the note_amount minus the paid fee.
     let added_asset = FungibleAsset::new(chain.native_asset_id(), note_amount)?.sub(tx.fee())?;

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -120,7 +120,7 @@ use crate::{MockChainBuilder, TransactionContextBuilder};
 ///         .committed_account(receiver.id())?
 ///         .vault()
 ///         .get_balance(fungible_asset.faucet_id())?,
-///     fungible_asset.amount()
+///     fungible_asset.amount().inner()
 /// );
 /// # Ok(())
 /// # }

--- a/crates/miden-testing/tests/agglayer/bridge_in.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_in.rs
@@ -340,7 +340,7 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
 
     // Verify minted amount matches expected scaled value
     assert_eq!(
-        Felt::new(p2id_asset.amount()),
+        Felt::new(p2id_asset.amount().inner()),
         miden_claim_amount,
         "asset amount does not match"
     );

--- a/crates/miden-testing/tests/auth/hybrid_multisig.rs
+++ b/crates/miden-testing/tests/auth/hybrid_multisig.rs
@@ -194,7 +194,7 @@ async fn test_multisig_2_of_2_with_note_creation() -> anyhow::Result<()> {
         multisig_account
             .vault()
             .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?,
-        multisig_starting_balance - output_note_asset.unwrap_fungible().amount()
+        multisig_starting_balance - output_note_asset.unwrap_fungible().amount().inner()
     );
 
     Ok(())

--- a/crates/miden-testing/tests/auth/multisig.rs
+++ b/crates/miden-testing/tests/auth/multisig.rs
@@ -202,7 +202,7 @@ async fn test_multisig_2_of_2_with_note_creation(
         multisig_account
             .vault()
             .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?,
-        multisig_starting_balance - output_note_asset.unwrap_fungible().amount()
+        multisig_starting_balance - output_note_asset.unwrap_fungible().amount().inner()
     );
 
     Ok(())

--- a/crates/miden-testing/tests/auth/multisig_psm.rs
+++ b/crates/miden-testing/tests/auth/multisig_psm.rs
@@ -205,7 +205,7 @@ async fn test_multisig_psm_signature_required(
         multisig_account
             .vault()
             .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?,
-        10 - output_note_asset.unwrap_fungible().amount()
+        10 - output_note_asset.unwrap_fungible().amount().inner()
     );
 
     Ok(())

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -674,7 +674,7 @@ async fn network_faucet_mint() -> anyhow::Result<()> {
 
     // Verify the account's vault now contains the expected fungible asset
     let balance = target_account.vault().get_balance(faucet.id())?;
-    assert_eq!(balance, expected_asset.amount(),);
+    assert_eq!(balance, expected_asset.amount().inner(),);
 
     Ok(())
 }
@@ -1415,7 +1415,7 @@ async fn test_mint_note_output_note_types(#[case] note_type: NoteType) -> anyhow
 
     let expected_asset = FungibleAsset::new(faucet.id(), amount.as_canonical_u64())?;
     let balance = target_account_mut.vault().get_balance(faucet.id())?;
-    assert_eq!(balance, expected_asset.amount());
+    assert_eq!(balance, expected_asset.amount().inner());
 
     Ok(())
 }

--- a/crates/miden-testing/tests/scripts/fee.rs
+++ b/crates/miden-testing/tests/scripts/fee.rs
@@ -30,7 +30,7 @@ async fn prove_account_creation_with_fees() -> anyhow::Result<()> {
         .context("failed to execute account-creating transaction")?;
 
     let expected_fee = tx.compute_fee();
-    assert_eq!(expected_fee, tx.fee().amount());
+    assert_eq!(expected_fee, tx.fee().amount().inner());
 
     // We expect that the new account contains the amount minus the paid fee.
     let added_asset = FungibleAsset::new(chain.native_asset_id(), amount)?.sub(tx.fee())?;

--- a/crates/miden-testing/tests/scripts/p2id.rs
+++ b/crates/miden-testing/tests/scripts/p2id.rs
@@ -178,7 +178,7 @@ async fn prove_consume_multiple_notes() -> anyhow::Result<()> {
     account.apply_delta(executed_transaction.account_delta())?;
     let resulting_asset = account.vault().assets().next().unwrap();
     if let Asset::Fungible(asset) = resulting_asset {
-        assert_eq!(asset.amount(), 123u64);
+        assert_eq!(asset.amount().inner(), 123u64);
     } else {
         panic!("Resulting asset should be fungible");
     }

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -263,8 +263,8 @@ where
         // Return an error if the balance in the account does not cover the fee.
         if current_fee_asset.amount() < fee_asset.amount() {
             return Err(TransactionKernelError::InsufficientFee {
-                account_balance: current_fee_asset.amount(),
-                tx_fee: fee_asset.amount(),
+                account_balance: current_fee_asset.amount().inner(),
+                tx_fee: fee_asset.amount().inner(),
             });
         }
 

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -371,7 +371,7 @@ where
                 .read_vault_asset(vault_root, fee_asset_vault_key)
                 .map_err(TransactionExecutorError::FeeAssetRetrievalFailed)?;
             match fee_asset {
-                Some(Asset::Fungible(fee_asset)) => fee_asset.amount(),
+                Some(Asset::Fungible(fee_asset)) => fee_asset.amount().inner(),
                 Some(Asset::NonFungible(_)) => {
                     return Err(TransactionExecutorError::FeeAssetMustBeFungible);
                 },


### PR DESCRIPTION
## Summary

Introduces a new `AssetAmount` newtype wrapper over `u64` that enforces the `MAX = 2^63 - 2^31` invariant at construction time, as described in #2532.

## Motivation

Currently, `FungibleAsset` stores its amount as a raw `u64` and validates the range only during construction. This means any internal code that manipulates the amount directly could accidentally create invalid values. By introducing `AssetAmount` as a validated wrapper type, the type system enforces correctness at all construction points.

## Changes

### New type: `AssetAmount` (`crates/miden-protocol/src/asset/asset_amount.rs`)

- Newtype `AssetAmount(u64)` with `MAX` and `ZERO` constants
- Validated constructor `new(u64) -> Result<Self, AssetError>`
- `inner() -> u64` accessor for when the raw value is needed
- `new_unchecked(u64)` (crate-visible) for cases where validity is already guaranteed (e.g., subtraction of two valid amounts)
- `From<u8>`, `From<u16>`, `From<u32>` (infallible, always in range)
- `TryFrom<u64>` and `From<AssetAmount> for u64`
- `Display`, `Serializable`, `Deserializable`
- Derives: `Debug`, `Default`, `Copy`, `Clone`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash`
- Comprehensive test suite (9 unit tests)

### Integration into `FungibleAsset`

- **Field**: `amount: u64` -> `amount: AssetAmount`
- **`amount()`**: now returns `AssetAmount` instead of `u64`
- **`new()`**: still accepts `u64` for ergonomic construction, validates internally via `AssetAmount::new()`
- **`MAX_AMOUNT`**: retained as `pub const MAX_AMOUNT: u64` for backward compatibility, delegates to `AssetAmount::MAX.inner()`
- **`add()`/`sub()`**: operate on inner values, construct validated `AssetAmount` for results

### Updated callers

All call sites across 3 crates updated to use `.inner()` where a raw `u64` is needed:

- **miden-protocol**: `delta/vault.rs`, `vault/mod.rs`, `kernel/mod.rs`
- **miden-tx**: `exec_host.rs`, `mod.rs`
- **miden-testing**: test files across `test_account.rs`, `test_account_delta.rs`, `test_epilogue.rs`, `test_fee.rs`, `bridge_in.rs`, `multisig.rs`, `multisig_psm.rs`, `hybrid_multisig.rs`, `faucet.rs`, `fee.rs`, `p2id.rs`

## Design Decisions

1. **Name**: `AssetAmount` per @bobbinth's suggestion in #2532 (concise, since it's only used for fungible assets)
2. **`FungibleAsset::new()` signature unchanged**: Keeps `u64` parameter to avoid breaking all callers  validates internally
3. **`MAX_AMOUNT` retained**: Backward-compatible `u64` constant for existing comparisons
4. **`new_unchecked` is `pub(crate)`**: Needed internally (e.g., subtraction results are guaranteed valid) but not exposed publicly

Closes #2532