### PR TITLE
feat(agglayer): add emergency pause mechanism to bridge

### DIFF
--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -12,6 +12,8 @@ const ERR_FAUCET_NOT_REGISTERED = "faucet is not registered in the bridge's fauc
 const ERR_TOKEN_NOT_REGISTERED = "token address is not registered in the bridge's token registry"
 const ERR_SENDER_NOT_BRIDGE_ADMIN = "note sender is not the bridge admin"
 const ERR_SENDER_NOT_GER_MANAGER = "note sender is not the global exit root manager"
+const ERR_BRIDGE_IS_PAUSED = "bridge is paused"
+const ERR_INVALID_PAUSE_FLAG = "pause flag must be 0 or 1"
 
 # CONSTANTS
 # =================================================================================================
@@ -22,6 +24,7 @@ const GER_MANAGER_SLOT = word("agglayer::bridge::ger_manager_account_id")
 const GER_MAP_STORAGE_SLOT = word("agglayer::bridge::ger_map")
 const FAUCET_REGISTRY_MAP_SLOT = word("agglayer::bridge::faucet_registry_map")
 const TOKEN_REGISTRY_MAP_SLOT = word("agglayer::bridge::token_registry_map")
+const PAUSED_SLOT = word("agglayer::bridge::paused")
 
 # Flags
 const GER_KNOWN_FLAG = 1
@@ -33,6 +36,39 @@ const TOKEN_ADDR_HASH_PTR = 0
 # PUBLIC INTERFACE
 # =================================================================================================
 
+#! Sets or clears the emergency pause flag on the bridge.
+#!
+#! When paused, all bridge entry points (bridge_out, claim, register_faucet, update_ger) will panic.
+#! This procedure itself is NOT guarded by the pause check so it can always be used to unpause.
+#!
+#! Inputs:  [paused_flag, pad(15)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - paused_flag is 0 (unpause) or 1 (pause).
+#!
+#! Panics if:
+#! - the note sender is not the bridge admin.
+#! - the paused_flag is not 0 or 1.
+#!
+#! Invocation: call
+pub proc set_emergency_paused
+    exec.assert_sender_is_bridge_admin
+    # => [paused_flag, pad(15)] -- 16
+
+    dup push.1 u32lte assert.err=ERR_INVALID_PAUSE_FLAG
+    # => [paused_flag, pad(15)] -- 16
+
+    # VALUE = [paused_flag, 0, 0, 0] is the top 4 elements (pad is zero).
+    push.PAUSED_SLOT[0..2]
+    # => [slot_id(2), paused_flag, 0, 0, 0, pad(12)] -- 18
+
+    exec.native_account::set_item
+    # Consumes [slot_id(2), VALUE(4)] = 6 from top, returns [OLD_VALUE(4)].
+    # 18 - 6 + 4 = 16
+    # => [OLD_VALUE(4), pad(12)] -- 16
+end
+
 #! Updates the Global Exit Root (GER) in the bridge account storage.
 #!
 #! Computes hash(GER) = poseidon2::merge(GER_LOWER, GER_UPPER) and stores it in a map with value
@@ -42,10 +78,14 @@ const TOKEN_ADDR_HASH_PTR = 0
 #! Outputs: [pad(16)]
 #!
 #! Panics if:
+#! - the bridge is paused.
 #! - the note sender is not the global exit root manager.
 #!
 #! Invocation: call
 pub proc update_ger
+    # assert the bridge is not paused.
+    exec.assert_not_paused
+
     # assert the note sender is the global exit root manager.
     exec.assert_sender_is_ger_manager
     # => [GER_LOWER[4], GER_UPPER[4], pad(8)]
@@ -113,10 +153,14 @@ end
 #! Outputs: [pad(16)]
 #!
 #! Panics if:
+#! - the bridge is paused.
 #! - the note sender is not the bridge admin.
 #!
 #! Invocation: call
 pub proc register_faucet
+    # assert the bridge is not paused.
+    exec.assert_not_paused
+
     # assert the note sender is the bridge admin.
     exec.assert_sender_is_bridge_admin
     # => [origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
@@ -230,6 +274,25 @@ end
 
 # HELPER PROCEDURES
 # =================================================================================================
+
+#! Asserts that the bridge is not in emergency pause state.
+#!
+#! Reads the PAUSED_SLOT from account storage and panics if the flag is set (non-zero).
+#! This procedure is stack-neutral: it does not consume or produce any stack elements.
+#!
+#! Panics if:
+#! - the bridge is paused.
+#!
+#! Invocation: exec
+proc assert_not_paused
+    push.PAUSED_SLOT[0..2]
+    exec.active_account::get_item
+    # => [paused_flag, 0, 0, 0, ...]
+
+    assertz.err=ERR_BRIDGE_IS_PAUSED
+    drop drop drop
+    # => [...]
+end
 
 #! Hashes a 5-felt origin token address using Poseidon2.
 #!

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -192,6 +192,7 @@ const CLAIM_DEST_ID_SUFFIX_LOCAL = 1
 #! }
 #!
 #! Panics if:
+#! - the bridge is paused.
 #! - the leaf type is not 0 (not an asset claim).
 #! - the Merkle proof validation fails.
 #! - the origin token address is not registered in the bridge's token registry.
@@ -199,6 +200,10 @@ const CLAIM_DEST_ID_SUFFIX_LOCAL = 1
 #! Invocation: call
 @locals(2) # 0: dest_prefix, 1: dest_suffix
 pub proc claim
+    # assert the bridge is not paused.
+    exec.bridge_config::assert_not_paused
+    # => [PROOF_DATA_KEY, LEAF_DATA_KEY, faucet_mint_amount, pad(7)]
+
     # Write output note faucet amount to memory
     movup.8 mem_store.CLAIM_OUTPUT_NOTE_FAUCET_AMOUNT
     # => [PROOF_DATA_KEY, LEAF_DATA_KEY, pad(8)]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -100,9 +100,16 @@ const BURN_NOTE_NUM_STORAGE_ITEMS=0
 #! - dest_network_id is the u32 destination network/chain ID.
 #! - dest_address(5) are 5 u32 values representing a 20-byte Ethereum address.
 #!
+#! Panics if:
+#! - the bridge is paused.
+#!
 #! Invocation: call
 @locals(14)
 pub proc bridge_out
+    # => [ASSET_KEY, ASSET_VALUE, dest_network_id, dest_address(5), pad(2)]
+
+    # assert the bridge is not paused.
+    exec.bridge_config::assert_not_paused
     # => [ASSET_KEY, ASSET_VALUE, dest_network_id, dest_address(5), pad(2)]
 
     # Save ASSET to local memory for later BURN note creation

--- a/crates/miden-agglayer/asm/components/bridge.masm
+++ b/crates/miden-agglayer/asm/components/bridge.masm
@@ -4,11 +4,13 @@
 #
 # The bridge exposes:
 # - `register_faucet` from the bridge_config module
+# - `set_emergency_paused` from the bridge_config module
 # - `update_ger` from the bridge_config module
 # - `claim` for bridge-in
 # - `bridge_out` for bridge-out
 
 pub use ::agglayer::bridge::bridge_config::register_faucet
+pub use ::agglayer::bridge::bridge_config::set_emergency_paused
 pub use ::agglayer::bridge::bridge_config::update_ger
 pub use ::agglayer::bridge::bridge_in::claim
 pub use ::agglayer::bridge::bridge_out::bridge_out

--- a/crates/miden-agglayer/asm/note_scripts/emergency_pause_agg_bridge.masm
+++ b/crates/miden-agglayer/asm/note_scripts/emergency_pause_agg_bridge.masm
@@ -1,0 +1,65 @@
+use agglayer::bridge::bridge_config
+use miden::protocol::active_note
+use miden::standards::attachments::network_account_target
+
+# CONSTANTS
+# =================================================================================================
+
+const EMERGENCY_PAUSE_NUM_STORAGE_ITEMS = 1
+const STORAGE_START_PTR = 0
+
+# ERRORS
+# =================================================================================================
+
+const ERR_EMERGENCY_PAUSE_UNEXPECTED_STORAGE_ITEMS = "EMERGENCY_PAUSE expects exactly 1 note storage item"
+const ERR_EMERGENCY_PAUSE_TARGET_ACCOUNT_MISMATCH = "EMERGENCY_PAUSE note attachment target account does not match consuming account"
+
+# NOTE SCRIPT
+# =================================================================================================
+
+#! Agglayer Bridge EMERGENCY_PAUSE script: sets or clears the emergency pause flag on the bridge.
+#!
+#! This note can only be consumed by the agglayer bridge account targeted by the note attachment,
+#! and only if the note was sent by the bridge admin.
+#!
+#! Requires that the account exposes:
+#! - agglayer::bridge_config::set_emergency_paused procedure.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! NoteStorage layout (1 felt total):
+#! - paused_flag [0] : 1 felt (0 = unpause, 1 = pause)
+#!
+#! Panics if:
+#! - The note attachment target account does not match the consuming account.
+#! - The note does not contain exactly 1 storage item.
+#! - The account does not expose the set_emergency_paused procedure.
+#! - The note sender is not the bridge admin.
+begin
+    dropw
+    # => [pad(16)]
+
+    # Ensure note attachment targets the consuming bridge account.
+    exec.network_account_target::active_account_matches_target_account
+    assert.err=ERR_EMERGENCY_PAUSE_TARGET_ACCOUNT_MISMATCH
+    # => [pad(16)]
+
+    # Load note storage to memory
+    push.STORAGE_START_PTR exec.active_note::get_storage
+    # => [num_storage_items, dest_ptr, pad(16)]
+
+    # Validate the number of storage items
+    push.EMERGENCY_PAUSE_NUM_STORAGE_ITEMS assert_eq.err=ERR_EMERGENCY_PAUSE_UNEXPECTED_STORAGE_ITEMS drop
+    # => [pad(16)]
+
+    # Load paused_flag from note memory into the top word.
+    # mem_loadw_le replaces the top 4 elements (doesn't push), keeping stack at 16.
+    # Since only 1 storage item was written, remaining positions are zero.
+    mem_loadw_le.STORAGE_START_PTR
+    # => [paused_flag, 0, 0, 0, pad(12)]
+
+    # Call set_emergency_paused on the bridge
+    call.bridge_config::set_emergency_paused
+    # => [pad(16)]
+end

--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -70,6 +70,10 @@ static TOKEN_REGISTRY_MAP_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|
     StorageSlotName::new("agglayer::bridge::token_registry_map")
         .expect("token registry map storage slot name should be valid")
 });
+static PAUSED_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
+    StorageSlotName::new("agglayer::bridge::paused")
+        .expect("paused storage slot name should be valid")
+});
 
 // bridge in
 // ------------------------------------------------------------------------------------------------
@@ -113,6 +117,7 @@ static LET_NUM_LEAVES_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// component, the `agglayer` library must be available to the assembler.
 /// The procedures of this component are:
 /// - `register_faucet`, which registers a faucet in the bridge.
+/// - `set_emergency_paused`, which sets or clears the emergency pause flag.
 /// - `update_ger`, which injects a new GER into the storage map.
 /// - `bridge_out`, which bridges an asset out of Miden to the destination network.
 /// - `claim`, which validates a claim against the AggLayer bridge and creates a MINT note for the
@@ -133,6 +138,7 @@ static LET_NUM_LEAVES_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// - [`Self::let_root_lo_slot_name`]: Stores the lower 32 bits of the LET root.
 /// - [`Self::let_root_hi_slot_name`]: Stores the upper 32 bits of the LET root.
 /// - [`Self::let_num_leaves_slot_name`]: Stores the number of leaves in the LET frontier.
+/// - [`Self::paused_slot_name`]: Stores the emergency pause flag (0 = active, 1 = paused).
 ///
 /// The bridge starts with an empty faucet registry; faucets are registered at runtime via
 /// CONFIG_AGG_BRIDGE notes.
@@ -184,6 +190,11 @@ impl AggLayerBridge {
     /// Storage slot name for the token registry map.
     pub fn token_registry_map_slot_name() -> &'static StorageSlotName {
         &TOKEN_REGISTRY_MAP_SLOT_NAME
+    }
+
+    /// Storage slot name for the emergency pause flag.
+    pub fn paused_slot_name() -> &'static StorageSlotName {
+        &PAUSED_SLOT_NAME
     }
 
     // --- bridge in --------
@@ -304,6 +315,21 @@ impl AggLayerBridge {
         value.to_vec()[0].as_canonical_u64()
     }
 
+    /// Returns whether the bridge is currently paused.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - the provided account is not an [`AggLayerBridge`] account.
+    pub fn is_paused(bridge_account: &Account) -> Result<bool, AgglayerBridgeError> {
+        Self::assert_bridge_account(bridge_account)?;
+        let value = bridge_account
+            .storage()
+            .get_item(AggLayerBridge::paused_slot_name())
+            .expect("should be able to read paused slot");
+        Ok(value.to_vec()[0] != ZERO)
+    }
+
     /// Returns the claimed global index (CGI) chain hash from the corresponding storage slot.
     ///
     /// # Errors
@@ -417,6 +443,7 @@ impl AggLayerBridge {
             &*CGI_CHAIN_HASH_LO_SLOT_NAME,
             &*CGI_CHAIN_HASH_HI_SLOT_NAME,
             &*CLAIM_NULLIFIERS_SLOT_NAME,
+            &*PAUSED_SLOT_NAME,
         ]
     }
 }
@@ -439,6 +466,7 @@ impl From<AggLayerBridge> for AccountComponent {
             StorageSlot::with_value(CGI_CHAIN_HASH_LO_SLOT_NAME.clone(), Word::empty()),
             StorageSlot::with_value(CGI_CHAIN_HASH_HI_SLOT_NAME.clone(), Word::empty()),
             StorageSlot::with_empty_map(CLAIM_NULLIFIERS_SLOT_NAME.clone()),
+            StorageSlot::with_value(PAUSED_SLOT_NAME.clone(), Word::empty()),
         ];
         bridge_component(bridge_storage_slots)
     }

--- a/crates/miden-agglayer/src/emergency_pause_note.rs
+++ b/crates/miden-agglayer/src/emergency_pause_note.rs
@@ -1,0 +1,114 @@
+//! EMERGENCY_PAUSE note creation utilities.
+//!
+//! This module provides helpers for creating EMERGENCY_PAUSE notes,
+//! which are used to set or clear the emergency pause flag on the bridge.
+
+extern crate alloc;
+
+use alloc::string::ToString;
+use alloc::vec;
+
+use miden_assembly::serde::Deserializable;
+use miden_core::{Felt, Word};
+use miden_protocol::account::AccountId;
+use miden_protocol::crypto::rand::FeltRng;
+use miden_protocol::errors::NoteError;
+use miden_protocol::note::{
+    Note,
+    NoteAssets,
+    NoteAttachment,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScript,
+    NoteStorage,
+    NoteType,
+};
+use miden_protocol::vm::Program;
+use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint};
+use miden_utils_sync::LazyLock;
+
+// NOTE SCRIPT
+// ================================================================================================
+
+// Initialize the EMERGENCY_PAUSE note script only once
+static EMERGENCY_PAUSE_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
+    let bytes = include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/assets/note_scripts/emergency_pause_agg_bridge.masb"
+    ));
+    let program =
+        Program::read_from_bytes(bytes).expect("shipped EMERGENCY_PAUSE script is well-formed");
+    NoteScript::new(program)
+});
+
+// EMERGENCY_PAUSE NOTE
+// ================================================================================================
+
+/// EMERGENCY_PAUSE note.
+///
+/// This note is used to set or clear the emergency pause flag on the bridge.
+/// It carries a single felt (0 = unpause, 1 = pause) and is always public.
+pub struct EmergencyPauseNote;
+
+impl EmergencyPauseNote {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// Expected number of storage items for an EMERGENCY_PAUSE note.
+    /// Layout: [paused_flag]
+    pub const NUM_STORAGE_ITEMS: usize = 1;
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the EMERGENCY_PAUSE note script.
+    pub fn script() -> NoteScript {
+        EMERGENCY_PAUSE_SCRIPT.clone()
+    }
+
+    /// Returns the EMERGENCY_PAUSE note script root.
+    pub fn script_root() -> Word {
+        EMERGENCY_PAUSE_SCRIPT.root()
+    }
+
+    // BUILDERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates an EMERGENCY_PAUSE note to set or clear the bridge pause flag.
+    ///
+    /// The note storage contains 1 felt:
+    /// - `paused_flag`: 0 to unpause, 1 to pause
+    ///
+    /// # Parameters
+    /// - `paused`: `true` to pause the bridge, `false` to unpause
+    /// - `sender_account_id`: The bridge admin account ID
+    /// - `target_account_id`: The bridge account ID that will consume this note
+    /// - `rng`: Random number generator for creating the note serial number
+    ///
+    /// # Errors
+    /// Returns an error if note creation fails.
+    pub fn create<R: FeltRng>(
+        paused: bool,
+        sender_account_id: AccountId,
+        target_account_id: AccountId,
+        rng: &mut R,
+    ) -> Result<Note, NoteError> {
+        let paused_felt = if paused { Felt::ONE } else { Felt::ZERO };
+        let note_storage = NoteStorage::new(vec![paused_felt])?;
+
+        let serial_num = rng.draw_word();
+        let recipient = NoteRecipient::new(serial_num, Self::script(), note_storage);
+
+        let attachment = NoteAttachment::from(
+            NetworkAccountTarget::new(target_account_id, NoteExecutionHint::Always)
+                .map_err(|e| NoteError::other(e.to_string()))?,
+        );
+        let metadata =
+            NoteMetadata::new(sender_account_id, NoteType::Public).with_attachment(attachment);
+
+        // EMERGENCY_PAUSE notes don't carry assets
+        let assets = NoteAssets::new(vec![])?;
+
+        Ok(Note::new(assets, metadata, recipient))
+    }
+}

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -25,6 +25,7 @@ pub mod b2agg_note;
 pub mod bridge;
 pub mod claim_note;
 pub mod config_note;
+pub mod emergency_pause_note;
 pub mod errors;
 pub mod eth_types;
 pub mod faucet;
@@ -44,6 +45,7 @@ pub use claim_note::{
     create_claim_note,
 };
 pub use config_note::ConfigAggBridgeNote;
+pub use emergency_pause_note::EmergencyPauseNote;
 #[cfg(any(test, feature = "testing"))]
 pub use eth_types::GlobalIndexExt;
 pub use eth_types::{

--- a/crates/miden-testing/tests/agglayer/emergency_pause.rs
+++ b/crates/miden-testing/tests/agglayer/emergency_pause.rs
@@ -1,0 +1,289 @@
+extern crate alloc;
+
+use miden_agglayer::errors::{ERR_BRIDGE_IS_PAUSED, ERR_SENDER_NOT_BRIDGE_ADMIN};
+use miden_agglayer::{
+    AggLayerBridge,
+    ConfigAggBridgeNote,
+    EmergencyPauseNote,
+    EthAddress,
+    UpdateGerNote,
+    create_existing_bridge_account,
+};
+use miden_protocol::account::auth::AuthScheme;
+use miden_protocol::account::{AccountId, AccountIdVersion, AccountStorageMode, AccountType};
+use miden_protocol::crypto::rand::FeltRng;
+use miden_protocol::transaction::RawOutputNote;
+use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
+
+/// Tests that consuming an EMERGENCY_PAUSE note with paused=true sets the pause flag,
+/// and that consuming one with paused=false clears it.
+#[tokio::test]
+async fn test_emergency_pause_and_unpause() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let bridge_account = create_existing_bridge_account(
+        builder.rng_mut().draw_word(),
+        bridge_admin.id(),
+        ger_manager.id(),
+    );
+    builder.add_account(bridge_account.clone())?;
+
+    // Verify the bridge is NOT paused initially
+    assert!(
+        !AggLayerBridge::is_paused(&bridge_account)?,
+        "Bridge should not be paused initially"
+    );
+
+    // --- PAUSE the bridge ---
+    let pause_note = EmergencyPauseNote::create(
+        true,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+
+    builder.add_output_note(RawOutputNote::Full(pause_note.clone()));
+    let mock_chain = builder.build()?;
+
+    let tx_context = mock_chain
+        .build_tx_context(bridge_account.id(), &[pause_note.id()], &[])?
+        .build()?;
+    let executed_transaction = tx_context.execute().await?;
+
+    let mut updated_bridge = bridge_account.clone();
+    updated_bridge.apply_delta(executed_transaction.account_delta())?;
+
+    // Verify the bridge IS paused
+    assert!(
+        AggLayerBridge::is_paused(&updated_bridge)?,
+        "Bridge should be paused after consuming EMERGENCY_PAUSE note"
+    );
+
+    // --- UNPAUSE the bridge ---
+    let mut builder2 = MockChain::builder();
+
+    let _bridge_admin2 = builder2.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    // We need to re-add the updated bridge and create a new unpause note from the same admin
+    // For simplicity, create a fresh chain with the paused bridge
+    let unpause_note = EmergencyPauseNote::create(
+        false,
+        bridge_admin.id(),
+        updated_bridge.id(),
+        builder2.rng_mut(),
+    )?;
+
+    builder2.add_account(updated_bridge.clone())?;
+    builder2.add_output_note(RawOutputNote::Full(unpause_note.clone()));
+
+    // We need the bridge_admin account to be the sender, so we need it in the mock chain.
+    // Re-add the admin account from the first chain's state.
+    let mock_chain2 = builder2.build()?;
+
+    let tx_context2 = mock_chain2
+        .build_tx_context(updated_bridge.id(), &[unpause_note.id()], &[])?
+        .build()?;
+    let executed_transaction2 = tx_context2.execute().await?;
+
+    let mut unpaused_bridge = updated_bridge.clone();
+    unpaused_bridge.apply_delta(executed_transaction2.account_delta())?;
+
+    // Verify the bridge is NOT paused
+    assert!(
+        !AggLayerBridge::is_paused(&unpaused_bridge)?,
+        "Bridge should not be paused after unpause"
+    );
+
+    Ok(())
+}
+
+/// Tests that a non-admin sender cannot pause the bridge.
+#[tokio::test]
+async fn test_emergency_pause_rejects_non_admin() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+    // A non-admin account that will try to pause the bridge
+    let non_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let bridge_account = create_existing_bridge_account(
+        builder.rng_mut().draw_word(),
+        bridge_admin.id(),
+        ger_manager.id(),
+    );
+    builder.add_account(bridge_account.clone())?;
+
+    // Create an EMERGENCY_PAUSE note from the non-admin
+    let pause_note =
+        EmergencyPauseNote::create(true, non_admin.id(), bridge_account.id(), builder.rng_mut())?;
+
+    builder.add_output_note(RawOutputNote::Full(pause_note.clone()));
+    let mock_chain = builder.build()?;
+
+    let result = mock_chain
+        .build_tx_context(bridge_account.id(), &[pause_note.id()], &[])?
+        .build()?
+        .execute()
+        .await;
+
+    assert_transaction_executor_error!(result, ERR_SENDER_NOT_BRIDGE_ADMIN);
+
+    Ok(())
+}
+
+/// Tests that update_ger is blocked when the bridge is paused.
+#[tokio::test]
+async fn test_pause_blocks_update_ger() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let bridge_account = create_existing_bridge_account(
+        builder.rng_mut().draw_word(),
+        bridge_admin.id(),
+        ger_manager.id(),
+    );
+    builder.add_account(bridge_account.clone())?;
+
+    // First, pause the bridge
+    let pause_note = EmergencyPauseNote::create(
+        true,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+
+    builder.add_output_note(RawOutputNote::Full(pause_note.clone()));
+    let mock_chain = builder.build()?;
+
+    let tx_context = mock_chain
+        .build_tx_context(bridge_account.id(), &[pause_note.id()], &[])?
+        .build()?;
+    let executed_transaction = tx_context.execute().await?;
+
+    let mut paused_bridge = bridge_account.clone();
+    paused_bridge.apply_delta(executed_transaction.account_delta())?;
+
+    // Now try to send an UPDATE_GER note to the paused bridge
+    let mut builder2 = MockChain::builder();
+    builder2.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    builder2.add_account(paused_bridge.clone())?;
+
+    let ger_bytes: [u8; 32] = [0xab; 32];
+    let ger = miden_agglayer::ExitRoot::from(ger_bytes);
+    let update_ger_note =
+        UpdateGerNote::create(ger, ger_manager.id(), paused_bridge.id(), builder2.rng_mut())?;
+
+    builder2.add_output_note(RawOutputNote::Full(update_ger_note.clone()));
+    let mock_chain2 = builder2.build()?;
+
+    let result = mock_chain2
+        .build_tx_context(paused_bridge.id(), &[update_ger_note.id()], &[])?
+        .build()?
+        .execute()
+        .await;
+
+    assert_transaction_executor_error!(result, ERR_BRIDGE_IS_PAUSED);
+
+    Ok(())
+}
+
+/// Tests that register_faucet (CONFIG_AGG_BRIDGE) is blocked when the bridge is paused.
+#[tokio::test]
+async fn test_pause_blocks_register_faucet() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let bridge_account = create_existing_bridge_account(
+        builder.rng_mut().draw_word(),
+        bridge_admin.id(),
+        ger_manager.id(),
+    );
+    builder.add_account(bridge_account.clone())?;
+
+    // First, pause the bridge
+    let pause_note = EmergencyPauseNote::create(
+        true,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+
+    builder.add_output_note(RawOutputNote::Full(pause_note.clone()));
+    let mock_chain = builder.build()?;
+
+    let tx_context = mock_chain
+        .build_tx_context(bridge_account.id(), &[pause_note.id()], &[])?
+        .build()?;
+    let executed_transaction = tx_context.execute().await?;
+
+    let mut paused_bridge = bridge_account.clone();
+    paused_bridge.apply_delta(executed_transaction.account_delta())?;
+
+    // Now try to send a CONFIG_AGG_BRIDGE note to the paused bridge
+    let mut builder2 = MockChain::builder();
+    builder2.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    builder2.add_account(paused_bridge.clone())?;
+
+    let faucet_to_register = AccountId::dummy(
+        [42; 15],
+        AccountIdVersion::Version0,
+        AccountType::FungibleFaucet,
+        AccountStorageMode::Network,
+    );
+    let origin_token_address =
+        EthAddress::from_hex("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+    let config_note = ConfigAggBridgeNote::create(
+        faucet_to_register,
+        &origin_token_address,
+        bridge_admin.id(),
+        paused_bridge.id(),
+        builder2.rng_mut(),
+    )?;
+
+    builder2.add_output_note(RawOutputNote::Full(config_note.clone()));
+    let mock_chain2 = builder2.build()?;
+
+    let result = mock_chain2
+        .build_tx_context(paused_bridge.id(), &[config_note.id()], &[])?
+        .build()?
+        .execute()
+        .await;
+
+    assert_transaction_executor_error!(result, ERR_BRIDGE_IS_PAUSED);
+
+    Ok(())
+}

--- a/crates/miden-testing/tests/agglayer/mod.rs
+++ b/crates/miden-testing/tests/agglayer/mod.rs
@@ -2,6 +2,7 @@ pub mod asset_conversion;
 mod bridge_in;
 mod bridge_out;
 mod config_bridge;
+mod emergency_pause;
 mod faucet_helpers;
 mod global_index;
 mod leaf_utils;


### PR DESCRIPTION
## Summary

- Add an `emergency_paused` flag in bridge storage that, when set, blocks all four entry points (`bridge_out`, `claim`, `register_faucet`, `update_ger`) with `ERR_BRIDGE_IS_PAUSED`
- Add a bridge-admin-gated `set_emergency_paused` procedure to toggle the flag
- Add an `EMERGENCY_PAUSE` note type (following the CONFIG_AGG_BRIDGE pattern) to invoke the toggle

Closes #2696

## Test plan

- [x] `test_emergency_pause_and_unpause` - pause/unpause round-trip via EMERGENCY_PAUSE notes
- [x] `test_emergency_pause_rejects_non_admin` - non-admin sender is rejected
- [x] `test_pause_blocks_update_ger` - update_ger is blocked when paused
- [x] `test_pause_blocks_register_faucet` - register_faucet is blocked when paused
- [x] All 50 existing agglayer tests pass (no regressions)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)