### PR TITLE
feat(agglayer): add emergency pause mechanism to bridge

### DIFF
--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -12,6 +12,7 @@ const ERR_FAUCET_NOT_REGISTERED = "faucet is not registered in the bridge's fauc
 const ERR_TOKEN_NOT_REGISTERED = "token address is not registered in the bridge's token registry"
 const ERR_SENDER_NOT_BRIDGE_ADMIN = "note sender is not the bridge admin"
 const ERR_SENDER_NOT_GER_MANAGER = "note sender is not the global exit root manager"
+const ERR_BRIDGE_IS_PAUSED = "bridge is currently paused"
 
 # CONSTANTS
 # =================================================================================================
@@ -22,6 +23,7 @@ const GER_MANAGER_SLOT = word("agglayer::bridge::ger_manager_account_id")
 const GER_MAP_STORAGE_SLOT = word("agglayer::bridge::ger_map")
 const FAUCET_REGISTRY_MAP_SLOT = word("agglayer::bridge::faucet_registry_map")
 const TOKEN_REGISTRY_MAP_SLOT = word("agglayer::bridge::token_registry_map")
+const PAUSED_SLOT = word("agglayer::bridge::paused")
 
 # Flags
 const GER_KNOWN_FLAG = 1
@@ -46,6 +48,10 @@ const TOKEN_ADDR_HASH_PTR = 0
 #!
 #! Invocation: call
 pub proc update_ger
+    # assert the bridge is not paused.
+    exec.assert_not_paused
+    # => [GER_LOWER[4], GER_UPPER[4], pad(8)]
+
     # assert the note sender is the global exit root manager.
     exec.assert_sender_is_ger_manager
     # => [GER_LOWER[4], GER_UPPER[4], pad(8)]
@@ -117,6 +123,10 @@ end
 #!
 #! Invocation: call
 pub proc register_faucet
+    # assert the bridge is not paused.
+    exec.assert_not_paused
+    # => [origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
+
     # assert the note sender is the bridge admin.
     exec.assert_sender_is_bridge_admin
     # => [origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)]
@@ -164,6 +174,37 @@ pub proc register_faucet
 
     push.TOKEN_REGISTRY_MAP_SLOT[0..2]
     exec.native_account::set_map_item
+    # => [OLD_VALUE, pad(12)]
+
+    dropw
+    # => [pad(16)]
+end
+
+#! Sets or clears the emergency paused flag in the bridge account storage.
+#!
+#! The caller must be the bridge admin. This procedure is NOT guarded by the pause check,
+#! so the admin can unpause the bridge even when it is paused.
+#!
+#! Inputs:  [paused_flag, pad(15)]
+#! Outputs: [pad(16)]
+#!
+#! Where:
+#! - paused_flag is 1 to pause, 0 to unpause.
+#!
+#! Panics if:
+#! - the note sender is not the bridge admin.
+#!
+#! Invocation: call
+pub proc set_emergency_paused
+    # assert the note sender is the bridge admin.
+    exec.assert_sender_is_bridge_admin
+    # => [paused_flag, 0, 0, 0, pad(12)]
+
+    # The top 4 elements already form the value word [paused_flag, 0, 0, 0].
+    push.PAUSED_SLOT[0..2]
+    # => [slot_id_prefix, slot_id_suffix, paused_flag, 0, 0, 0, pad(12)]
+
+    exec.native_account::set_item
     # => [OLD_VALUE, pad(12)]
 
     dropw
@@ -230,6 +271,27 @@ end
 
 # HELPER PROCEDURES
 # =================================================================================================
+
+#! Asserts that the bridge is not paused.
+#!
+#! Reads the paused flag from the PAUSED_SLOT and asserts it is zero.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [pad(16)]
+#!
+#! Panics if:
+#! - the bridge is currently paused.
+#!
+#! Invocation: exec
+proc assert_not_paused
+    push.PAUSED_SLOT[0..2]
+    exec.active_account::get_item
+    # => [paused_flag, 0, 0, 0, pad(16)]
+
+    assertz.err=ERR_BRIDGE_IS_PAUSED
+    drop drop drop
+    # => [pad(16)]
+end
 
 #! Hashes a 5-felt origin token address using Poseidon2.
 #!

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -199,6 +199,10 @@ const CLAIM_DEST_ID_SUFFIX_LOCAL = 1
 #! Invocation: call
 @locals(2) # 0: dest_prefix, 1: dest_suffix
 pub proc claim
+    # assert the bridge is not paused.
+    exec.bridge_config::assert_not_paused
+    # => [PROOF_DATA_KEY, LEAF_DATA_KEY, faucet_amount, pad(7)]
+
     # Write output note faucet amount to memory
     movup.8 mem_store.CLAIM_OUTPUT_NOTE_FAUCET_AMOUNT
     # => [PROOF_DATA_KEY, LEAF_DATA_KEY, pad(8)]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -105,6 +105,10 @@ const BURN_NOTE_NUM_STORAGE_ITEMS=0
 pub proc bridge_out
     # => [ASSET_KEY, ASSET_VALUE, dest_network_id, dest_address(5), pad(2)]
 
+    # assert the bridge is not paused.
+    exec.bridge_config::assert_not_paused
+    # => [ASSET_KEY, ASSET_VALUE, dest_network_id, dest_address(5), pad(2)]
+
     # Save ASSET to local memory for later BURN note creation
     locaddr.BRIDGE_OUT_BURN_ASSET_LOC
     exec.asset::store

--- a/crates/miden-agglayer/asm/components/bridge.masm
+++ b/crates/miden-agglayer/asm/components/bridge.masm
@@ -5,10 +5,12 @@
 # The bridge exposes:
 # - `register_faucet` from the bridge_config module
 # - `update_ger` from the bridge_config module
+# - `set_emergency_paused` from the bridge_config module
 # - `claim` for bridge-in
 # - `bridge_out` for bridge-out
 
 pub use ::agglayer::bridge::bridge_config::register_faucet
 pub use ::agglayer::bridge::bridge_config::update_ger
+pub use ::agglayer::bridge::bridge_config::set_emergency_paused
 pub use ::agglayer::bridge::bridge_in::claim
 pub use ::agglayer::bridge::bridge_out::bridge_out

--- a/crates/miden-agglayer/asm/note_scripts/emergency_pause.masm
+++ b/crates/miden-agglayer/asm/note_scripts/emergency_pause.masm
@@ -1,0 +1,62 @@
+use agglayer::bridge::bridge_config
+use miden::protocol::active_note
+use miden::standards::attachments::network_account_target
+
+# CONSTANTS
+# =================================================================================================
+
+const EMERGENCY_PAUSE_NUM_STORAGE_ITEMS = 1
+const STORAGE_PTR_PAUSED_FLAG = 0
+
+# ERRORS
+# =================================================================================================
+
+const ERR_EMERGENCY_PAUSE_UNEXPECTED_STORAGE_ITEMS = "EMERGENCY_PAUSE script expects exactly 1 note storage item"
+const ERR_EMERGENCY_PAUSE_TARGET_ACCOUNT_MISMATCH = "EMERGENCY_PAUSE note attachment target account does not match consuming account"
+
+# NOTE SCRIPT
+# =================================================================================================
+
+#! Agglayer Bridge EMERGENCY_PAUSE script: sets or clears the emergency paused flag by calling
+#! bridge_config::set_emergency_paused.
+#!
+#! This note can only be consumed by the specific agglayer bridge account whose ID is provided
+#! in the note attachment (target_account_id), and only if the note was sent by the bridge admin.
+#!
+#! Requires that the account exposes:
+#! - agglayer::bridge_config::set_emergency_paused procedure.
+#!
+#! Inputs:  [ARGS, pad(12)]
+#! Outputs: [pad(16)]
+#!
+#! NoteStorage layout (1 felt total):
+#! - paused_flag [0] : 1 felt (1 = pause, 0 = unpause)
+#!
+#! Panics if:
+#! - account does not expose set_emergency_paused procedure.
+#! - target account ID does not match the consuming account ID.
+#! - number of note storage items is not exactly 1.
+begin
+    dropw
+    # => [pad(16)]
+
+    # Ensure note attachment targets the consuming bridge account.
+    exec.network_account_target::active_account_matches_target_account
+    assert.err=ERR_EMERGENCY_PAUSE_TARGET_ACCOUNT_MISMATCH
+    # => [pad(16)]
+
+    # Load note storage to memory
+    push.STORAGE_PTR_PAUSED_FLAG exec.active_note::get_storage
+    # => [num_storage_items, dest_ptr, pad(16)]
+
+    # Validate the number of storage items
+    push.EMERGENCY_PAUSE_NUM_STORAGE_ITEMS assert_eq.err=ERR_EMERGENCY_PAUSE_UNEXPECTED_STORAGE_ITEMS drop
+    # => [pad(16)]
+
+    # Load the paused flag word from memory (replaces top 4 stack elements, keeping depth at 16).
+    mem_loadw_le.STORAGE_PTR_PAUSED_FLAG
+    # => [paused_flag, 0, 0, 0, pad(12)]
+
+    call.bridge_config::set_emergency_paused
+    # => [pad(16)]
+end

--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -70,6 +70,10 @@ static TOKEN_REGISTRY_MAP_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|
     StorageSlotName::new("agglayer::bridge::token_registry_map")
         .expect("token registry map storage slot name should be valid")
 });
+static PAUSED_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
+    StorageSlotName::new("agglayer::bridge::paused")
+        .expect("paused storage slot name should be valid")
+});
 
 // bridge in
 // ------------------------------------------------------------------------------------------------
@@ -133,6 +137,7 @@ static LET_NUM_LEAVES_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// - [`Self::let_root_lo_slot_name`]: Stores the lower 32 bits of the LET root.
 /// - [`Self::let_root_hi_slot_name`]: Stores the upper 32 bits of the LET root.
 /// - [`Self::let_num_leaves_slot_name`]: Stores the number of leaves in the LET frontier.
+/// - [`Self::paused_slot_name`]: Stores the emergency paused flag (0 = active, 1 = paused).
 ///
 /// The bridge starts with an empty faucet registry; faucets are registered at runtime via
 /// CONFIG_AGG_BRIDGE notes.
@@ -184,6 +189,11 @@ impl AggLayerBridge {
     /// Storage slot name for the token registry map.
     pub fn token_registry_map_slot_name() -> &'static StorageSlotName {
         &TOKEN_REGISTRY_MAP_SLOT_NAME
+    }
+
+    /// Storage slot name for the emergency paused flag.
+    pub fn paused_slot_name() -> &'static StorageSlotName {
+        &PAUSED_SLOT_NAME
     }
 
     // --- bridge in --------
@@ -256,6 +266,23 @@ impl AggLayerBridge {
         } else {
             Ok(false)
         }
+    }
+
+    /// Returns whether the bridge is currently paused.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - the provided account is not an [`AggLayerBridge`] account.
+    pub fn is_paused(bridge_account: &Account) -> Result<bool, AgglayerBridgeError> {
+        Self::assert_bridge_account(bridge_account)?;
+
+        let paused_value = bridge_account
+            .storage()
+            .get_item(AggLayerBridge::paused_slot_name())
+            .expect("provided account should have AggLayer Bridge specific storage slots");
+
+        Ok(paused_value[0] != ZERO)
     }
 
     /// Reads the Local Exit Root (double-word) from the bridge account's storage.
@@ -417,6 +444,7 @@ impl AggLayerBridge {
             &*CGI_CHAIN_HASH_LO_SLOT_NAME,
             &*CGI_CHAIN_HASH_HI_SLOT_NAME,
             &*CLAIM_NULLIFIERS_SLOT_NAME,
+            &*PAUSED_SLOT_NAME,
         ]
     }
 }
@@ -439,6 +467,7 @@ impl From<AggLayerBridge> for AccountComponent {
             StorageSlot::with_value(CGI_CHAIN_HASH_LO_SLOT_NAME.clone(), Word::empty()),
             StorageSlot::with_value(CGI_CHAIN_HASH_HI_SLOT_NAME.clone(), Word::empty()),
             StorageSlot::with_empty_map(CLAIM_NULLIFIERS_SLOT_NAME.clone()),
+            StorageSlot::with_value(PAUSED_SLOT_NAME.clone(), Word::empty()),
         ];
         bridge_component(bridge_storage_slots)
     }

--- a/crates/miden-agglayer/src/emergency_pause_note.rs
+++ b/crates/miden-agglayer/src/emergency_pause_note.rs
@@ -1,0 +1,106 @@
+//! EMERGENCY_PAUSE note creation utilities.
+//!
+//! This module provides helpers for creating EMERGENCY_PAUSE notes,
+//! which are used to set or clear the emergency paused flag on the bridge account.
+
+extern crate alloc;
+
+use alloc::string::ToString;
+use alloc::vec;
+
+use miden_assembly::serde::Deserializable;
+use miden_core::{Felt, Word};
+use miden_protocol::account::AccountId;
+use miden_protocol::crypto::rand::FeltRng;
+use miden_protocol::errors::NoteError;
+use miden_protocol::note::{
+    Note,
+    NoteAssets,
+    NoteAttachment,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScript,
+    NoteStorage,
+    NoteType,
+};
+use miden_protocol::vm::Program;
+use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint};
+use miden_utils_sync::LazyLock;
+
+// NOTE SCRIPT
+// ================================================================================================
+
+static EMERGENCY_PAUSE_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
+    let bytes =
+        include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/emergency_pause.masb"));
+    let program =
+        Program::read_from_bytes(bytes).expect("shipped EMERGENCY_PAUSE script is well-formed");
+    NoteScript::new(program)
+});
+
+// EMERGENCY_PAUSE NOTE
+// ================================================================================================
+
+/// EMERGENCY_PAUSE note.
+///
+/// This note is used to set or clear the emergency paused flag on the bridge account.
+/// It carries a single felt (1 = pause, 0 = unpause) and is always public.
+pub struct EmergencyPauseNote;
+
+impl EmergencyPauseNote {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// Expected number of storage items for an EMERGENCY_PAUSE note.
+    pub const NUM_STORAGE_ITEMS: usize = 1;
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the EMERGENCY_PAUSE note script.
+    pub fn script() -> NoteScript {
+        EMERGENCY_PAUSE_SCRIPT.clone()
+    }
+
+    /// Returns the EMERGENCY_PAUSE note script root.
+    pub fn script_root() -> Word {
+        EMERGENCY_PAUSE_SCRIPT.root()
+    }
+
+    // BUILDERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates an EMERGENCY_PAUSE note with the given paused flag.
+    ///
+    /// # Parameters
+    /// - `paused`: true to pause, false to unpause
+    /// - `sender_account_id`: The account ID of the note creator (must be bridge admin)
+    /// - `target_account_id`: The bridge account ID that will consume this note
+    /// - `rng`: Random number generator for creating the note serial number
+    ///
+    /// # Errors
+    /// Returns an error if note creation fails.
+    pub fn create<R: FeltRng>(
+        paused: bool,
+        sender_account_id: AccountId,
+        target_account_id: AccountId,
+        rng: &mut R,
+    ) -> Result<Note, NoteError> {
+        let paused_felt = if paused { Felt::ONE } else { Felt::ZERO };
+        let note_storage = NoteStorage::new(vec![paused_felt])?;
+
+        let serial_num = rng.draw_word();
+        let recipient = NoteRecipient::new(serial_num, Self::script(), note_storage);
+
+        let attachment = NoteAttachment::from(
+            NetworkAccountTarget::new(target_account_id, NoteExecutionHint::Always)
+                .map_err(|e| NoteError::other(e.to_string()))?,
+        );
+        let metadata =
+            NoteMetadata::new(sender_account_id, NoteType::Public).with_attachment(attachment);
+
+        let assets = NoteAssets::new(vec![])?;
+
+        Ok(Note::new(assets, metadata, recipient))
+    }
+}

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -25,6 +25,7 @@ pub mod b2agg_note;
 pub mod bridge;
 pub mod claim_note;
 pub mod config_note;
+pub mod emergency_pause_note;
 pub mod errors;
 pub mod eth_types;
 pub mod faucet;
@@ -44,6 +45,7 @@ pub use claim_note::{
     create_claim_note,
 };
 pub use config_note::ConfigAggBridgeNote;
+pub use emergency_pause_note::EmergencyPauseNote;
 #[cfg(any(test, feature = "testing"))]
 pub use eth_types::GlobalIndexExt;
 pub use eth_types::{

--- a/crates/miden-testing/tests/agglayer/emergency_pause.rs
+++ b/crates/miden-testing/tests/agglayer/emergency_pause.rs
@@ -1,0 +1,196 @@
+extern crate alloc;
+
+use miden_agglayer::errors::{ERR_BRIDGE_IS_PAUSED, ERR_SENDER_NOT_BRIDGE_ADMIN};
+use miden_agglayer::{
+    AggLayerBridge,
+    EmergencyPauseNote,
+    ExitRoot,
+    UpdateGerNote,
+    create_existing_bridge_account,
+};
+use miden_protocol::account::auth::AuthScheme;
+use miden_protocol::crypto::rand::FeltRng;
+use miden_protocol::transaction::RawOutputNote;
+use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
+
+/// Tests that pausing the bridge blocks update_ger operations.
+///
+/// Flow:
+/// 1. Create bridge admin, GER manager, and bridge account
+/// 2. Pause the bridge via an EMERGENCY_PAUSE note
+/// 3. Verify that an UPDATE_GER note fails with ERR_BRIDGE_IS_PAUSED
+#[tokio::test]
+async fn test_pause_blocks_update_ger() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let bridge_account = create_existing_bridge_account(
+        builder.rng_mut().draw_word(),
+        bridge_admin.id(),
+        ger_manager.id(),
+    );
+    builder.add_account(bridge_account.clone())?;
+
+    // Verify bridge starts unpaused
+    assert!(!AggLayerBridge::is_paused(&bridge_account)?);
+
+    // Create both notes upfront
+    let pause_note = EmergencyPauseNote::create(
+        true,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+    builder.add_output_note(RawOutputNote::Full(pause_note.clone()));
+
+    let ger = ExitRoot::from([0x42u8; 32]);
+    let update_ger_note =
+        UpdateGerNote::create(ger, ger_manager.id(), bridge_account.id(), builder.rng_mut())?;
+    builder.add_output_note(RawOutputNote::Full(update_ger_note.clone()));
+
+    let mut mock_chain = builder.build()?;
+
+    // TX0: Pause the bridge
+    let pause_tx = mock_chain
+        .build_tx_context(bridge_account.id(), &[pause_note.id()], &[])?
+        .build()?;
+    let pause_executed = pause_tx.execute().await?;
+    mock_chain.add_pending_executed_transaction(&pause_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // TX1: Attempt update_ger while paused - should fail
+    let update_ger_tx = mock_chain
+        .build_tx_context(bridge_account.id(), &[update_ger_note.id()], &[])?
+        .build()?;
+    let result = update_ger_tx.execute().await;
+
+    assert_transaction_executor_error!(result, ERR_BRIDGE_IS_PAUSED);
+
+    Ok(())
+}
+
+/// Tests that unpausing the bridge restores operations.
+///
+/// Flow:
+/// 1. Pause the bridge
+/// 2. Unpause the bridge via another EMERGENCY_PAUSE note (paused=false)
+/// 3. Verify that update_ger succeeds
+#[tokio::test]
+async fn test_unpause_restores_operations() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let bridge_account = create_existing_bridge_account(
+        builder.rng_mut().draw_word(),
+        bridge_admin.id(),
+        ger_manager.id(),
+    );
+    builder.add_account(bridge_account.clone())?;
+
+    // Create all three notes upfront
+    let pause_note = EmergencyPauseNote::create(
+        true,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+    builder.add_output_note(RawOutputNote::Full(pause_note.clone()));
+
+    let unpause_note = EmergencyPauseNote::create(
+        false,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+    builder.add_output_note(RawOutputNote::Full(unpause_note.clone()));
+
+    let ger = ExitRoot::from([0x42u8; 32]);
+    let update_ger_note =
+        UpdateGerNote::create(ger, ger_manager.id(), bridge_account.id(), builder.rng_mut())?;
+    builder.add_output_note(RawOutputNote::Full(update_ger_note.clone()));
+
+    let mut mock_chain = builder.build()?;
+
+    // TX0: Pause
+    let pause_tx = mock_chain
+        .build_tx_context(bridge_account.id(), &[pause_note.id()], &[])?
+        .build()?;
+    let pause_executed = pause_tx.execute().await?;
+    mock_chain.add_pending_executed_transaction(&pause_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // TX1: Unpause
+    let unpause_tx = mock_chain
+        .build_tx_context(bridge_account.id(), &[unpause_note.id()], &[])?
+        .build()?;
+    let unpause_executed = unpause_tx.execute().await?;
+    mock_chain.add_pending_executed_transaction(&unpause_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // TX2: update_ger should succeed now
+    let update_ger_tx = mock_chain
+        .build_tx_context(bridge_account.id(), &[update_ger_note.id()], &[])?
+        .build()?;
+    update_ger_tx.execute().await?;
+
+    Ok(())
+}
+
+/// Tests that a non-admin account cannot pause the bridge.
+///
+/// Flow:
+/// 1. Create a non-admin account
+/// 2. Send an EMERGENCY_PAUSE note from the non-admin
+/// 3. Verify the transaction fails with ERR_SENDER_NOT_BRIDGE_ADMIN
+#[tokio::test]
+async fn test_non_admin_cannot_pause() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let non_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let bridge_account = create_existing_bridge_account(
+        builder.rng_mut().draw_word(),
+        bridge_admin.id(),
+        ger_manager.id(),
+    );
+    builder.add_account(bridge_account.clone())?;
+
+    // Send pause note from non-admin
+    let pause_note =
+        EmergencyPauseNote::create(true, non_admin.id(), bridge_account.id(), builder.rng_mut())?;
+    builder.add_output_note(RawOutputNote::Full(pause_note.clone()));
+    let mock_chain = builder.build()?;
+
+    let tx_context = mock_chain
+        .build_tx_context(bridge_account.id(), &[pause_note.id()], &[])?
+        .build()?;
+    let result = tx_context.execute().await;
+
+    assert_transaction_executor_error!(result, ERR_SENDER_NOT_BRIDGE_ADMIN);
+
+    Ok(())
+}

--- a/crates/miden-testing/tests/agglayer/mod.rs
+++ b/crates/miden-testing/tests/agglayer/mod.rs
@@ -2,6 +2,7 @@ pub mod asset_conversion;
 mod bridge_in;
 mod bridge_out;
 mod config_bridge;
+mod emergency_pause;
 mod faucet_helpers;
 mod global_index;
 mod leaf_utils;


### PR DESCRIPTION
## Summary

- Add `emergency_paused` storage flag to the AggLayer bridge that, when set, blocks all 4 public entry points (`bridge_out`, `claim`, `register_faucet`, `update_ger`)
- Add `set_emergency_paused` procedure (admin-gated, deliberately NOT pause-guarded so admin can always unpause)
- Add `assert_not_paused` guard called at the top of each entry point
- Add `EMERGENCY_PAUSE` note type and Rust builder (`EmergencyPauseNote`) for toggling the flag
- Add `is_paused()` helper on `AggLayerBridge` for off-chain tooling

## Test plan

- [x] `test_pause_blocks_update_ger` - pause bridge, verify `UpdateGerNote` fails with `ERR_BRIDGE_IS_PAUSED`
- [x] `test_unpause_restores_operations` - pause then unpause, verify `UpdateGerNote` succeeds after
- [x] `test_non_admin_cannot_pause` - non-admin sends pause note, verify it fails with `ERR_SENDER_NOT_BRIDGE_ADMIN`
- [x] All 49 existing agglayer tests pass (bridge code commitment auto-regenerated)

Closes #2696

🤖 Generated with [Claude Code](https://claude.com/claude-code)