### PR TITLE
feat:  add `Package` support in `TransactionScript`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 ### Fixes
 
 - Made deserialization of `AccountCode` more robust ([#2788](https://github.com/0xMiden/protocol/pull/2788)).
+- Added `TransactionScript::from_package()` method to create `TransactionScript` from `miden-mast-package::Package` ([#2779](https://github.com/0xMiden/protocol/pull/2779)).
+
 
 ## 0.14.3 (2026-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@
 - [BREAKING] Added cycle counts to notes returned by `NoteConsumptionInfo` and removed public fields from related types ([#2772](https://github.com/0xMiden/miden-base/issues/2772)).
 - [BREAKING] Removed unused `payback_attachment` from `SwapNoteStorage` and `attachment` from `MintNoteStorage` ([#2789](https://github.com/0xMiden/protocol/pull/2789)).
 - Automatically enable `concurrent` feature in `miden-tx` for `std` context ([#2791](https://github.com/0xMiden/protocol/pull/2791)).
+- Added `TransactionScript::from_package()` method to create `TransactionScript` from `miden-mast-package::Package` ([#2779](https://github.com/0xMiden/protocol/pull/2779)).
 
 ### Fixes
 
 - Made deserialization of `AccountCode` more robust ([#2788](https://github.com/0xMiden/protocol/pull/2788)).
-- Added `TransactionScript::from_package()` method to create `TransactionScript` from `miden-mast-package::Package` ([#2779](https://github.com/0xMiden/protocol/pull/2779)).
 
 
 ## 0.14.3 (2026-04-07)

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -763,7 +763,7 @@ pub enum TransactionScriptError {
     #[error("failed to assemble transaction script:\n{}", PrintDiagnostic::new(.0))]
     AssemblyError(Report),
     #[error("failed to convert package to transaction script:\n{}", PrintDiagnostic::new(.0))]
-    TransactionScriptNotProgram(Report),
+    PackageNotProgram(Report),
 }
 
 // TRANSACTION INPUT ERROR

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -764,8 +764,6 @@ pub enum TransactionScriptError {
     AssemblyError(Report),
     #[error("failed to convert package to transaction script:\n{}", PrintDiagnostic::new(.0))]
     PackageNotProgram(Report),
-    #[error("failed to convert package to transaction script:\n{}", PrintDiagnostic::new(.0))]
-    PackageNotTransactionScript(Report),
 }
 
 // TRANSACTION INPUT ERROR

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -762,6 +762,8 @@ impl PartialBlockchainError {
 pub enum TransactionScriptError {
     #[error("failed to assemble transaction script:\n{}", PrintDiagnostic::new(.0))]
     AssemblyError(Report),
+    #[error("failed to convert package to transaction script:\n{}", PrintDiagnostic::new(.0))]
+    TransactionScriptNotProgram(Report),
 }
 
 // TRANSACTION INPUT ERROR

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -764,6 +764,8 @@ pub enum TransactionScriptError {
     AssemblyError(Report),
     #[error("failed to convert package to transaction script:\n{}", PrintDiagnostic::new(.0))]
     PackageNotProgram(Report),
+    #[error("failed to convert package to transaction script:\n{}", PrintDiagnostic::new(.0))]
+    PackageNotTransactionScript(Report),
 }
 
 // TRANSACTION INPUT ERROR

--- a/crates/miden-protocol/src/transaction/tx_args.rs
+++ b/crates/miden-protocol/src/transaction/tx_args.rs
@@ -320,7 +320,7 @@ impl TransactionScript {
     pub fn from_package(package: &Package) -> Result<Self, TransactionScriptError> {
         let program = package
             .try_into_program()
-            .map_err(TransactionScriptError::TransactionScriptNotProgram)?;
+            .map_err(TransactionScriptError::PackageNotProgram)?;
 
         Ok(TransactionScript::new(program))
     }

--- a/crates/miden-protocol/src/transaction/tx_args.rs
+++ b/crates/miden-protocol/src/transaction/tx_args.rs
@@ -2,9 +2,10 @@ use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+use miden_assembly::Report;
 use miden_core::mast::MastNodeExt;
 use miden_crypto::merkle::InnerNodeInfo;
-use miden_mast_package::Package;
+use miden_mast_package::{Package, TargetType};
 
 use super::{Felt, Hasher, Word};
 use crate::account::auth::{PublicKeyCommitment, Signature};
@@ -313,14 +314,22 @@ impl TransactionScript {
     /// Creates a [TransactionScript] from a [`Package`].
     ///
     /// The package must be an executable (i.e., its target type must be
-    /// [`TargetType::Executable`](miden_mast_package::TargetType::Executable)).
+    /// [`TargetType::TransactionScript`](miden_mast_package::TargetType::TransactionScript)).
     ///
     /// # Errors
     /// Returns an error if the package cannot be converted to an executable program.
     pub fn from_package(package: &Package) -> Result<Self, TransactionScriptError> {
-        let program = package
-            .try_into_program()
-            .map_err(TransactionScriptError::PackageNotProgram)?;
+        let package_kind = package.kind;
+        if !matches!(package_kind, TargetType::TransactionScript) {
+            let err_report = Report::msg(format!(
+                "package's kind is {}, expected TransactionScript",
+                package_kind
+            ));
+            return Err(TransactionScriptError::PackageNotTransactionScript(err_report));
+        };
+
+        let program =
+            package.try_into_program().map_err(TransactionScriptError::PackageNotProgram)?;
 
         Ok(TransactionScript::new(program))
     }

--- a/crates/miden-protocol/src/transaction/tx_args.rs
+++ b/crates/miden-protocol/src/transaction/tx_args.rs
@@ -4,9 +4,11 @@ use alloc::vec::Vec;
 
 use miden_core::mast::MastNodeExt;
 use miden_crypto::merkle::InnerNodeInfo;
+use miden_mast_package::Package;
 
 use super::{Felt, Hasher, Word};
 use crate::account::auth::{PublicKeyCommitment, Signature};
+use crate::errors::TransactionScriptError;
 use crate::note::{NoteId, NoteRecipient};
 use crate::utils::serde::{
     ByteReader,
@@ -306,6 +308,21 @@ impl TransactionScript {
         assert!(mast.get_node_by_id(entrypoint).is_some());
 
         Self { mast, entrypoint }
+    }
+
+    /// Creates a [TransactionScript] from a [`Package`].
+    ///
+    /// The package must be an executable (i.e., its target type must be
+    /// [`TargetType::Executable`](miden_mast_package::TargetType::Executable)).
+    ///
+    /// # Errors
+    /// Returns an error if the package cannot be converted to an executable program.
+    pub fn from_package(package: &Package) -> Result<Self, TransactionScriptError> {
+        let program = package
+            .try_into_program()
+            .map_err(TransactionScriptError::TransactionScriptNotProgram)?;
+
+        Ok(TransactionScript::new(program))
     }
 
     // PUBLIC ACCESSORS

--- a/crates/miden-protocol/src/transaction/tx_args.rs
+++ b/crates/miden-protocol/src/transaction/tx_args.rs
@@ -2,10 +2,9 @@ use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-use miden_assembly::Report;
 use miden_core::mast::MastNodeExt;
 use miden_crypto::merkle::InnerNodeInfo;
-use miden_mast_package::{Package, TargetType};
+use miden_mast_package::Package;
 
 use super::{Felt, Hasher, Word};
 use crate::account::auth::{PublicKeyCommitment, Signature};
@@ -314,22 +313,14 @@ impl TransactionScript {
     /// Creates a [TransactionScript] from a [`Package`].
     ///
     /// The package must be an executable (i.e., its target type must be
-    /// [`TargetType::TransactionScript`](miden_mast_package::TargetType::TransactionScript)).
+    /// [`TargetType::Executable`](miden_mast_package::TargetType::Executable)).
     ///
     /// # Errors
     /// Returns an error if the package cannot be converted to an executable program.
     pub fn from_package(package: &Package) -> Result<Self, TransactionScriptError> {
-        let package_kind = package.kind;
-        if !matches!(package_kind, TargetType::TransactionScript) {
-            let err_report = Report::msg(format!(
-                "package's kind is {}, expected TransactionScript",
-                package_kind
-            ));
-            return Err(TransactionScriptError::PackageNotTransactionScript(err_report));
-        };
-
-        let program =
-            package.try_into_program().map_err(TransactionScriptError::PackageNotProgram)?;
+        let program = package
+            .try_into_program()
+            .map_err(TransactionScriptError::PackageNotProgram)?;
 
         Ok(TransactionScript::new(program))
     }

--- a/crates/miden-protocol/src/transaction/tx_args.rs
+++ b/crates/miden-protocol/src/transaction/tx_args.rs
@@ -318,9 +318,8 @@ impl TransactionScript {
     /// # Errors
     /// Returns an error if the package cannot be converted to an executable program.
     pub fn from_package(package: &Package) -> Result<Self, TransactionScriptError> {
-        let program = package
-            .try_into_program()
-            .map_err(TransactionScriptError::PackageNotProgram)?;
+        let program =
+            package.try_into_program().map_err(TransactionScriptError::PackageNotProgram)?;
 
         Ok(TransactionScript::new(program))
     }


### PR DESCRIPTION
Closes https://github.com/0xMiden/protocol/issues/2111

This PR adds a `TransactionScript::from_package` method, analogous to the `AccountComponent::from_package` and `NoteScript::from_package`. This came up while we were working on: https://github.com/0xMiden/faucet/pull/204


This is a follow up of https://github.com/0xMiden/protocol/pull/2502 and also https://github.com/0xMiden/protocol/pull/1802

