### PR TITLE
fix(rewrite): CycleInterval::len to safe pattern and correct bounds

### DIFF
--- a/crates/miden-tx/src/host/tx_progress.rs
+++ b/crates/miden-tx/src/host/tx_progress.rs
@@ -201,13 +201,10 @@ impl CycleInterval {
 
     /// Calculate the length of the interval
     pub fn len(&self) -> usize {
-        if let Some(start) = self.start
-            && let Some(end) = self.end
-            && end >= start
-        {
-            return end - start;
+        // Safe, straightforward computation without relying on unstable syntax
+        match (self.start, self.end) {
+            (Some(start), Some(end)) if end >= start => end - start,
+            _ => 0,
         }
-
-        0
     }
 }


### PR DESCRIPTION
## Problem
The CycleInterval::len() method used invalid Rust syntax to conditionally extract start and end, potentially causing compilation issues and incorrect interval length computation.

## Fix
Refactor CycleInterval::len() to a simple, idiomatic match over (start, end) and compute length only when both bounds exist and end >= start.

## Why this is safe
- Minimal change confined to a single method with no API changes.
- Preserves existing behavior for valid intervals and gracefully returns 0 when bounds are missing or inverted.
- Avoids unstable or illegal syntax, ensuring compatibility with stable Rust compilers.