### PR TITLE
fix(block-number): saturate BlockNumber::child to avoid overflow on MAX

### DIFF
--- a/crates/miden-protocol/src/block/block_number.rs
+++ b/crates/miden-protocol/src/block/block_number.rs
@@ -38,9 +38,10 @@ impl BlockNumber {
         self.checked_sub(1)
     }
 
-    /// Returns the next block number
+    /// Returns the next block number.
+    /// If the current number is the maximum representable value, we saturate at MAX to avoid overflow.
     pub fn child(self) -> BlockNumber {
-        self + 1
+        BlockNumber(self.0.saturating_add(1))
     }
 
     /// Creates the [`BlockNumber`] corresponding to the epoch block for the provided `epoch`.


### PR DESCRIPTION
## Error
Incrementing a BlockNumber at the maximum value (u32::MAX) can overflow, causing the next block number to wrap around (e.g., MAX + 1 -> 0). This breaks chain progression and can lead to subtle, hard-to-detect bugs.

# Fix
In protocol/crates/miden-protocol/src/block/block_number.rs, BlockNumber::child now uses saturating_add(1) instead of a plain + 1. This ensures the value caps at MAX instead of overflowing.

## How to verify locally
- Build and run tests as usual.
- Explicitly test the boundary:
  - let max = BlockNumber::MAX;
  - assert_eq!(max, max.child()); // should remain MAX
  - // also ensure that any typical block progression continues to increment normally