### PR TITLE
feat(kernel): expose tx script root via public kernel procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [BREAKING] Added cycle counts to notes returned by `NoteConsumptionInfo` and removed public fields from related types ([#2772](https://github.com/0xMiden/miden-base/issues/2772)).
 - [BREAKING] Removed unused `payback_attachment` from `SwapNoteStorage` and `attachment` from `MintNoteStorage` ([#2789](https://github.com/0xMiden/protocol/pull/2789)).
 - Automatically enable `concurrent` feature in `miden-tx` for `std` context ([#2791](https://github.com/0xMiden/protocol/pull/2791)).
-- Added `tx::get_tx_script_root` kernel procedure returning the root of the executed transaction script (zero word if no script was executed) ([#2816](https://github.com/0xMiden/protocol/pull/2816)).
+- Added `tx::get_tx_script_root` kernel procedure returning the root of the executed transaction script (empty word if no script was executed) ([#2816](https://github.com/0xMiden/protocol/pull/2816)).
 - Added `TransactionScript::from_package()` method to create `TransactionScript` from `miden-mast-package::Package` ([#2779](https://github.com/0xMiden/protocol/pull/2779)).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [BREAKING] Added cycle counts to notes returned by `NoteConsumptionInfo` and removed public fields from related types ([#2772](https://github.com/0xMiden/miden-base/issues/2772)).
 - [BREAKING] Removed unused `payback_attachment` from `SwapNoteStorage` and `attachment` from `MintNoteStorage` ([#2789](https://github.com/0xMiden/protocol/pull/2789)).
 - Automatically enable `concurrent` feature in `miden-tx` for `std` context ([#2791](https://github.com/0xMiden/protocol/pull/2791)).
-- Added `tx::get_script_root` kernel procedure returning the root of the executed transaction script (zero word if no script was executed) ([#2816](https://github.com/0xMiden/protocol/pull/2816)).
+- Added `tx::get_tx_script_root` kernel procedure returning the root of the executed transaction script (zero word if no script was executed) ([#2816](https://github.com/0xMiden/protocol/pull/2816)).
 - Added `TransactionScript::from_package()` method to create `TransactionScript` from `miden-mast-package::Package` ([#2779](https://github.com/0xMiden/protocol/pull/2779)).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [BREAKING] Added cycle counts to notes returned by `NoteConsumptionInfo` and removed public fields from related types ([#2772](https://github.com/0xMiden/miden-base/issues/2772)).
 - [BREAKING] Removed unused `payback_attachment` from `SwapNoteStorage` and `attachment` from `MintNoteStorage` ([#2789](https://github.com/0xMiden/protocol/pull/2789)).
 - Automatically enable `concurrent` feature in `miden-tx` for `std` context ([#2791](https://github.com/0xMiden/protocol/pull/2791)).
+- Added `tx::get_script_root` kernel procedure returning the root of the executed transaction script (zero word if no script was executed) ([#2816](https://github.com/0xMiden/protocol/pull/2816)).
 
 ### Fixes
 

--- a/crates/miden-protocol/asm/kernels/transaction/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/api.masm
@@ -1336,7 +1336,7 @@ end
 #! Outputs: [TX_SCRIPT_ROOT, pad(12)]
 #!
 #! Where:
-#! - TX_SCRIPT_ROOT is the transaction script root, or the zero word if no transaction script was
+#! - TX_SCRIPT_ROOT is the transaction script root, or the empty word if no transaction script was
 #!   executed.
 #!
 #! Invocation: dynexec

--- a/crates/miden-protocol/asm/kernels/transaction/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/api.masm
@@ -1323,6 +1323,26 @@ pub proc tx_get_num_input_notes
     # => [num_input_notes, pad(15)]
 end
 
+#! Returns the transaction script root.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [TX_SCRIPT_ROOT, pad(12)]
+#!
+#! Where:
+#! - TX_SCRIPT_ROOT is the transaction script root, or the zero word if no transaction script was
+#!   executed.
+#!
+#! Invocation: dynexec
+pub proc tx_get_script_root
+    # get the tx script root
+    exec.tx::get_script_root
+    # => [TX_SCRIPT_ROOT, pad(16)]
+
+    # truncate the stack
+    swapw dropw
+    # => [TX_SCRIPT_ROOT, pad(12)]
+end
+
 #! Returns the current number of output notes created in this transaction.
 #!
 #! Inputs:  [pad(16)]

--- a/crates/miden-protocol/asm/kernels/transaction/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/api.masm
@@ -1333,9 +1333,9 @@ end
 #!   executed.
 #!
 #! Invocation: dynexec
-pub proc tx_get_script_root
+pub proc tx_get_tx_script_root
     # get the tx script root
-    exec.tx::get_script_root
+    exec.tx::get_tx_script_root
     # => [TX_SCRIPT_ROOT, pad(16)]
 
     # truncate the stack

--- a/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
@@ -666,7 +666,7 @@ end
 #! Outputs: [TX_SCRIPT_ROOT]
 #!
 #! Where:
-#! - TX_SCRIPT_ROOT is the transaction script root, or the zero word if no transaction script was
+#! - TX_SCRIPT_ROOT is the transaction script root, or the empty word if no transaction script was
 #!   executed.
 pub proc get_tx_script_root
     padw mem_loadw_le.TX_SCRIPT_ROOT_PTR

--- a/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
@@ -660,6 +660,18 @@ pub proc set_tx_script_root
     mem_storew_le.TX_SCRIPT_ROOT_PTR
 end
 
+#! Returns the transaction script root.
+#!
+#! Inputs:  []
+#! Outputs: [TX_SCRIPT_ROOT]
+#!
+#! Where:
+#! - TX_SCRIPT_ROOT is the transaction script root, or the zero word if no transaction script was
+#!   executed.
+pub proc get_tx_script_root
+    padw mem_loadw_le.TX_SCRIPT_ROOT_PTR
+end
+
 #! Returns the transaction script arguments.
 #!
 #! Inputs:  []

--- a/crates/miden-protocol/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/tx.masm
@@ -91,7 +91,7 @@ pub use memory::get_num_output_notes
 #! Outputs: [TX_SCRIPT_ROOT]
 #!
 #! Where:
-#! - TX_SCRIPT_ROOT is the transaction script root, or the zero word if no transaction script was
+#! - TX_SCRIPT_ROOT is the transaction script root, or the empty word if no transaction script was
 #!   executed.
 pub use memory::get_tx_script_root
 

--- a/crates/miden-protocol/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/tx.masm
@@ -85,6 +85,16 @@ pub use memory::get_num_input_notes
 #! - num_output_notes is the number of output notes created in this transaction so far.
 pub use memory::get_num_output_notes
 
+#! Returns the transaction script root.
+#!
+#! Inputs:  []
+#! Outputs: [TX_SCRIPT_ROOT]
+#!
+#! Where:
+#! - TX_SCRIPT_ROOT is the transaction script root, or the zero word if no transaction script was
+#!   executed.
+pub use memory::get_tx_script_root->get_script_root
+
 #! Updates the transaction expiration block delta.
 #!
 #! The input block_height_delta is added to the block reference number in order to output an upper

--- a/crates/miden-protocol/asm/kernels/transaction/lib/tx.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/tx.masm
@@ -93,7 +93,7 @@ pub use memory::get_num_output_notes
 #! Where:
 #! - TX_SCRIPT_ROOT is the transaction script root, or the zero word if no transaction script was
 #!   executed.
-pub use memory::get_tx_script_root->get_script_root
+pub use memory::get_tx_script_root
 
 #! Updates the transaction expiration block delta.
 #!

--- a/crates/miden-protocol/asm/protocol/kernel_proc_offsets.masm
+++ b/crates/miden-protocol/asm/protocol/kernel_proc_offsets.masm
@@ -91,4 +91,4 @@ pub const TX_GET_EXPIRATION_DELTA_OFFSET=49               # accessor
 pub const TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET=50      # mutator
 
 # tx script
-pub const TX_GET_SCRIPT_ROOT_OFFSET=51
+pub const TX_GET_TX_SCRIPT_ROOT_OFFSET=51

--- a/crates/miden-protocol/asm/protocol/kernel_proc_offsets.masm
+++ b/crates/miden-protocol/asm/protocol/kernel_proc_offsets.masm
@@ -89,3 +89,6 @@ pub const TX_EXEC_FOREIGN_PROC_OFFSET = 48
 # expiration data
 pub const TX_GET_EXPIRATION_DELTA_OFFSET=49               # accessor
 pub const TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET=50      # mutator
+
+# tx script
+pub const TX_GET_SCRIPT_ROOT_OFFSET=51

--- a/crates/miden-protocol/asm/protocol/tx.masm
+++ b/crates/miden-protocol/asm/protocol/tx.masm
@@ -9,6 +9,7 @@ use miden::protocol::kernel_proc_offsets::TX_PREPARE_FPI_OFFSET
 use miden::protocol::kernel_proc_offsets::TX_EXEC_FOREIGN_PROC_OFFSET
 use miden::protocol::kernel_proc_offsets::TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET
 use miden::protocol::kernel_proc_offsets::TX_GET_EXPIRATION_DELTA_OFFSET
+use miden::protocol::kernel_proc_offsets::TX_GET_SCRIPT_ROOT_OFFSET
 
 #! Returns the block number of the transaction reference block.
 #!
@@ -318,4 +319,30 @@ pub proc get_expiration_block_delta
     # clear the stack
     swapdw dropw dropw swapw dropw movdn.3 drop drop drop
     # => [expiration_delta]
+end
+
+#! Returns the transaction script root, or the zero word if no transaction script was executed.
+#!
+#! Inputs:  []
+#! Outputs: [TX_SCRIPT_ROOT]
+#!
+#! Where:
+#! - TX_SCRIPT_ROOT is the root of the transaction script executed in this transaction, or the zero
+#!   word if no transaction script was executed.
+#!
+#! Invocation: exec
+pub proc get_script_root
+    # pad the stack
+    padw padw padw push.0.0.0
+    # => [pad(15)]
+
+    push.TX_GET_SCRIPT_ROOT_OFFSET
+    # => [offset, pad(15)]
+
+    syscall.exec_kernel_proc
+    # => [TX_SCRIPT_ROOT, pad(12)]
+
+    # clean the stack
+    swapdw dropw dropw swapw dropw
+    # => [TX_SCRIPT_ROOT]
 end

--- a/crates/miden-protocol/asm/protocol/tx.masm
+++ b/crates/miden-protocol/asm/protocol/tx.masm
@@ -321,14 +321,14 @@ pub proc get_expiration_block_delta
     # => [expiration_delta]
 end
 
-#! Returns the transaction script root, or the zero word if no transaction script was executed.
+#! Returns the transaction script root, or the empty word if no transaction script was executed.
 #!
 #! Inputs:  []
 #! Outputs: [TX_SCRIPT_ROOT]
 #!
 #! Where:
-#! - TX_SCRIPT_ROOT is the root of the transaction script executed in this transaction, or the zero
-#!   word if no transaction script was executed.
+#! - TX_SCRIPT_ROOT is the root of the transaction script executed in this transaction, or the
+#!   empty word if no transaction script was executed.
 #!
 #! Invocation: exec
 pub proc get_tx_script_root

--- a/crates/miden-protocol/asm/protocol/tx.masm
+++ b/crates/miden-protocol/asm/protocol/tx.masm
@@ -9,7 +9,7 @@ use miden::protocol::kernel_proc_offsets::TX_PREPARE_FPI_OFFSET
 use miden::protocol::kernel_proc_offsets::TX_EXEC_FOREIGN_PROC_OFFSET
 use miden::protocol::kernel_proc_offsets::TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET
 use miden::protocol::kernel_proc_offsets::TX_GET_EXPIRATION_DELTA_OFFSET
-use miden::protocol::kernel_proc_offsets::TX_GET_SCRIPT_ROOT_OFFSET
+use miden::protocol::kernel_proc_offsets::TX_GET_TX_SCRIPT_ROOT_OFFSET
 
 #! Returns the block number of the transaction reference block.
 #!
@@ -331,12 +331,12 @@ end
 #!   word if no transaction script was executed.
 #!
 #! Invocation: exec
-pub proc get_script_root
+pub proc get_tx_script_root
     # pad the stack
     padw padw padw push.0.0.0
     # => [pad(15)]
 
-    push.TX_GET_SCRIPT_ROOT_OFFSET
+    push.TX_GET_TX_SCRIPT_ROOT_OFFSET
     # => [offset, pad(15)]
 
     syscall.exec_kernel_proc

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -752,6 +752,61 @@ async fn test_tx_script_args() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that `tx::get_script_root` returns the root of the executed transaction script.
+#[tokio::test]
+async fn test_get_script_root_with_script() -> anyhow::Result<()> {
+    let tx_script = CodeBuilder::default().compile_tx_script("begin nop end")?;
+    let expected_root = tx_script.root();
+
+    let code = format!(
+        r#"
+        use miden::protocol::tx
+        use $kernel::prologue
+
+        begin
+            exec.prologue::prepare_transaction
+
+            exec.tx::get_script_root
+            # => [TX_SCRIPT_ROOT]
+
+            push.{expected_root} assert_eqw.err="tx script root mismatch"
+        end
+        "#
+    );
+
+    let tx_context = TransactionContextBuilder::with_existing_mock_account()
+        .tx_script(tx_script)
+        .build()?;
+
+    tx_context.execute_code(&code).await?;
+
+    Ok(())
+}
+
+/// Tests that `tx::get_script_root` returns the zero word when no transaction script is executed.
+#[tokio::test]
+async fn test_get_script_root_without_script() -> anyhow::Result<()> {
+    let code = r#"
+        use miden::protocol::tx
+        use $kernel::prologue
+
+        begin
+            exec.prologue::prepare_transaction
+
+            exec.tx::get_script_root
+            # => [TX_SCRIPT_ROOT]
+
+            padw assert_eqw.err="tx script root must be zero when no script is executed"
+        end
+        "#;
+
+    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
+
+    tx_context.execute_code(code).await?;
+
+    Ok(())
+}
+
 // Tests that advice map from the account code and transaction script gets correctly passed as
 // part of the transaction advice inputs
 #[tokio::test]

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -752,7 +752,7 @@ async fn test_tx_script_args() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Tests that `tx::get_script_root` returns the root of the executed transaction script.
+/// Tests that `tx::get_tx_script_root` returns the root of the executed transaction script.
 #[tokio::test]
 async fn test_get_script_root_with_script() -> anyhow::Result<()> {
     let tx_script = CodeBuilder::default().compile_tx_script("begin nop end")?;
@@ -766,7 +766,7 @@ async fn test_get_script_root_with_script() -> anyhow::Result<()> {
         begin
             exec.prologue::prepare_transaction
 
-            exec.tx::get_script_root
+            exec.tx::get_tx_script_root
             # => [TX_SCRIPT_ROOT]
 
             push.{expected_root} assert_eqw.err="tx script root mismatch"
@@ -783,7 +783,7 @@ async fn test_get_script_root_with_script() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Tests that `tx::get_script_root` returns the zero word when no transaction script is executed.
+/// Tests that `tx::get_tx_script_root` returns the zero word when no transaction script is executed.
 #[tokio::test]
 async fn test_get_script_root_without_script() -> anyhow::Result<()> {
     let code = r#"
@@ -793,7 +793,7 @@ async fn test_get_script_root_without_script() -> anyhow::Result<()> {
         begin
             exec.prologue::prepare_transaction
 
-            exec.tx::get_script_root
+            exec.tx::get_tx_script_root
             # => [TX_SCRIPT_ROOT]
 
             padw assert_eqw.err="tx script root must be zero when no script is executed"

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -783,7 +783,8 @@ async fn test_get_script_root_with_script() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Tests that `tx::get_tx_script_root` returns the zero word when no transaction script is executed.
+/// Tests that `tx::get_tx_script_root` returns the zero word when no transaction script is
+/// executed.
 #[tokio::test]
 async fn test_get_script_root_without_script() -> anyhow::Result<()> {
     let code = r#"

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -783,7 +783,7 @@ async fn test_get_script_root_with_script() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Tests that `tx::get_tx_script_root` returns the zero word when no transaction script is
+/// Tests that `tx::get_tx_script_root` returns the empty word when no transaction script is
 /// executed.
 #[tokio::test]
 async fn test_get_script_root_without_script() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- Adds `tx_get_script_root` to the transaction kernel API so MASM auth code can read the executed tx script root (zero word if no script ran).
- Required by the upcoming `NetworkAccount` auth component (#2814), which rejects transactions that executed a tx script as part of the #2797 fix.
- No existing behavior changes: adds a new kernel procedure, a new offset, and a user-facing `tx::get_script_root` wrapper.

## Changes
- `lib/memory.masm`: new `get_tx_script_root` word getter (mirrors `get_tx_script_args`).
- `lib/tx.masm`: re-export as `tx::get_script_root`.
- `api.masm`: new `tx_get_script_root` public kernel procedure.
- `kernel_proc_offsets.masm`: new `TX_GET_SCRIPT_ROOT_OFFSET=51`.
- `protocol/tx.masm`: new user-facing `tx::get_script_root` wrapper.
- Tests in `miden-testing`: script set returns expected root, no script returns zero word.

Closes #2813. Part of the #2797 fix chain (this unblocks #2814, which unblocks #2815).