### PR TITLE
Fix note script compilation: use libraries instead of programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.5 (2026-04-23)
+
+- Fixed note script compilation: all note scripts are now compiled as libraries ([#2822](https://github.com/0xMiden/protocol/pull/2822)).
+
 ## 0.14.4 (2026-04-09)
 
 - Fixed AggLayer `write_mint_note_storage` stack padding before loading the mint serial number ([#2749](https://github.com/0xMiden/protocol/pull/2749)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "miden-protocol",
  "proc-macro2",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "miden-protocol",
  "miden-tx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.90"
-version      = "0.14.4"
+version      = "0.14.5"
 
 [profile.release]
 codegen-units = 1

--- a/bin/bench-note-checker/src/lib.rs
+++ b/bin/bench-note-checker/src/lib.rs
@@ -85,7 +85,7 @@ pub fn setup_mixed_notes_benchmark(config: MixedNotesConfig) -> anyhow::Result<M
         seed[0] = i as u8;
         let mut rng = RandomCoin::new([i as u32, 0, 0, 0].into());
         let failing_note = NoteBuilder::new(sender, &mut rng)
-            .code("begin push.0 div end") // Division by zero - will fail.
+            .code("@note_script pub proc main push.0 div end") // Division by zero - will fail.
             .build()?;
         failing_notes.push(failing_note);
     }

--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -402,7 +402,7 @@ Keccak preimage format directly — the felt value does **not** equal the numeri
 | Field | Value |
 |-------|-------|
 | `serial_num` | Random (`rng.draw_word()`) |
-| `script` | `B2AGG.masb` |
+| `script` | `B2AGG.masl` |
 | `storage` | 6 felts -- see layout below |
 
 **Storage layout (6 felts):**
@@ -461,7 +461,7 @@ token registry, and creates a MINT note targeting the faucet.
 | Field | Value |
 |-------|-------|
 | `serial_num` | Random (`rng.draw_word()`) |
-| `script` | `CLAIM.masb` |
+| `script` | `CLAIM.masl` |
 | `storage` | 569 felts -- see layout below |
 
 **Storage layout (569 felts):**
@@ -530,7 +530,7 @@ The storage is divided into three logical regions: proof data (felts 0-535), lea
 | Field | Value |
 |-------|-------|
 | `serial_num` | Random (`rng.draw_word()`) |
-| `script` | `CONFIG_AGG_BRIDGE.masb` |
+| `script` | `CONFIG_AGG_BRIDGE.masl` |
 | `storage` | 7 felts -- see layout below |
 
 **Storage layout (7 felts):**
@@ -577,7 +577,7 @@ CLAIM notes can be verified against it.
 | Field | Value |
 |-------|-------|
 | `serial_num` | Random (`rng.draw_word()`) |
-| `script` | `UPDATE_GER.masb` |
+| `script` | `UPDATE_GER.masl` |
 | `storage` | 8 felts -- see layout below |
 
 **Storage layout (8 felts):**

--- a/crates/miden-agglayer/asm/note_scripts/B2AGG.masm
+++ b/crates/miden-agglayer/asm/note_scripts/B2AGG.masm
@@ -50,7 +50,8 @@ const ERR_B2AGG_TARGET_ACCOUNT_MISMATCH="B2AGG note attachment target account do
 #! - The note does not contain exactly 6 storage items.
 #! - The note does not contain exactly 1 asset.
 #! - The note attachment does not target the consuming account.
-begin
+@note_script
+pub proc main
     dropw
     # => [pad(16)]
 

--- a/crates/miden-agglayer/asm/note_scripts/CLAIM.masm
+++ b/crates/miden-agglayer/asm/note_scripts/CLAIM.masm
@@ -75,7 +75,8 @@ const ERR_CLAIM_TARGET_ACCT_MISMATCH = "CLAIM note attachment target account doe
 #! Panics if:
 #! - account does not expose claim procedure.
 #! - note attachment target account does not match the consuming account.
-begin
+@note_script
+pub proc main
     dropw
     # => [pad(16)]
 

--- a/crates/miden-agglayer/asm/note_scripts/CONFIG_AGG_BRIDGE.masm
+++ b/crates/miden-agglayer/asm/note_scripts/CONFIG_AGG_BRIDGE.masm
@@ -47,7 +47,8 @@ const ERR_CONFIG_AGG_BRIDGE_TARGET_ACCOUNT_MISMATCH = "CONFIG_AGG_BRIDGE note at
 #! - The note attachment target account does not match the consuming bridge account.
 #! - The note does not contain exactly 7 storage items.
 #! - The account does not expose the register_faucet procedure.
-begin
+@note_script
+pub proc main
     dropw
     # => [pad(16)]
 

--- a/crates/miden-agglayer/asm/note_scripts/UPDATE_GER.masm
+++ b/crates/miden-agglayer/asm/note_scripts/UPDATE_GER.masm
@@ -39,7 +39,8 @@ const ERR_UPDATE_GER_TARGET_ACCOUNT_MISMATCH = "UPDATE_GER note attachment targe
 #! - account does not expose update_ger procedure.
 #! - target account ID does not match the consuming account ID.
 #! - number of note storage items is not exactly 8.
-begin
+@note_script
+pub proc main
     dropw
     # => [pad(16)]
 

--- a/crates/miden-agglayer/build.rs
+++ b/crates/miden-agglayer/build.rs
@@ -14,6 +14,7 @@ use miden_protocol::account::{
     AccountComponentMetadata,
     AccountType,
 };
+use miden_protocol::note::NoteScript;
 use miden_protocol::transaction::TransactionKernel;
 use miden_standards::account::auth::NoAuth;
 use miden_standards::account::mint_policies::OwnerControlled;
@@ -124,16 +125,15 @@ fn compile_agglayer_lib(
 // COMPILE EXECUTABLE MODULES
 // ================================================================================================
 
-/// Reads all MASM files from the "{source_dir}", complies each file individually into a MASB
-/// file, and stores the compiled files into the "{target_dir}".
-///
-/// The source files are expected to contain executable programs.
+/// Reads all MASM files from `{source_dir}`, compiles each file as a library with
+/// [`Assembler::assemble_library`], wraps it as a [`NoteScript`] via [`NoteScript::from_library`],
+/// and writes serialized bytes as `.masb`.
 fn compile_note_scripts(
     source_dir: &Path,
-    target_dir: &Path,
+    note_scripts_target_dir: &Path,
     mut assembler: Assembler,
 ) -> Result<()> {
-    fs::create_dir_all(target_dir)
+    fs::create_dir_all(note_scripts_target_dir)
         .into_diagnostic()
         .wrap_err("failed to create note_scripts directory")?;
 
@@ -141,22 +141,22 @@ fn compile_note_scripts(
     let standards_lib = miden_standards::StandardsLib::default();
     assembler.link_static_library(standards_lib)?;
 
-    for masm_file_path in shared::get_masm_files(source_dir).unwrap() {
+    for note_file_path in shared::get_masm_files(source_dir).unwrap() {
         // read the MASM file, parse it, and serialize the parsed AST to bytes
-        let code = assembler.clone().assemble_program(masm_file_path.clone())?;
+        let note_library = assembler.clone().assemble_library([note_file_path.clone()])?;
 
-        let bytes = code.to_bytes();
+        let note_script = NoteScript::from_library(&note_library).into_diagnostic()?;
 
-        let masm_file_name = masm_file_path
+        let note_file_name = note_file_path
             .file_name()
             .expect("file name should exist")
             .to_str()
             .ok_or_else(|| Report::msg("failed to convert file name to &str"))?;
-        let mut masb_file_path = target_dir.join(masm_file_name);
+        let mut masb_file_path = note_scripts_target_dir.join(note_file_name);
 
         // write the binary MASB to the output dir
         masb_file_path.set_extension("masb");
-        fs::write(masb_file_path, bytes).unwrap();
+        fs::write(masb_file_path, note_script.to_bytes()).unwrap();
     }
     Ok(())
 }

--- a/crates/miden-agglayer/build.rs
+++ b/crates/miden-agglayer/build.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use fs_err as fs;
 use miden_assembly::diagnostics::{IntoDiagnostic, NamedSource, Result, WrapErr};
-use miden_assembly::serde::Serializable;
 use miden_assembly::{Assembler, Library, Report};
 use miden_crypto::hash::keccak::{Keccak256, Keccak256Digest};
 use miden_protocol::account::{
@@ -14,7 +13,6 @@ use miden_protocol::account::{
     AccountComponentMetadata,
     AccountType,
 };
-use miden_protocol::note::NoteScript;
 use miden_protocol::transaction::TransactionKernel;
 use miden_standards::account::auth::NoAuth;
 use miden_standards::account::mint_policies::OwnerControlled;
@@ -44,7 +42,7 @@ const AGGLAYER_GLOBAL_CONSTANTS_FILE_NAME: &str = "agglayer_constants.rs";
 /// Read and parse the contents from `./asm`.
 /// - Compiles the contents of asm/agglayer directory into a single agglayer.masl library.
 /// - Compiles the contents of asm/components directory into individual per-component .masl files.
-/// - Compiles the contents of asm/note_scripts directory into individual .masb files.
+/// - Compiles the contents of asm/note_scripts directory into individual `.masl` libraries.
 fn main() -> Result<()> {
     // re-build when the MASM code changes
     println!("cargo::rerun-if-changed={ASM_DIR}/");
@@ -125,9 +123,9 @@ fn compile_agglayer_lib(
 // COMPILE EXECUTABLE MODULES
 // ================================================================================================
 
-/// Reads all MASM files from `{source_dir}`, compiles each file as a library with
-/// [`Assembler::assemble_library`], wraps it as a [`NoteScript`] via [`NoteScript::from_library`],
-/// and writes serialized bytes as `.masb`.
+/// Reads all MASM files from `{source_dir}`, compiles each file as a note script library with
+/// [`Assembler::assemble_library`], and writes the serialized library as `.masl` via
+/// [`Library::write_to_file`].
 fn compile_note_scripts(
     source_dir: &Path,
     note_scripts_target_dir: &Path,
@@ -142,21 +140,21 @@ fn compile_note_scripts(
     assembler.link_static_library(standards_lib)?;
 
     for note_file_path in shared::get_masm_files(source_dir).unwrap() {
-        // read the MASM file, parse it, and serialize the parsed AST to bytes
+        // compile the note script library from the provided MASM file
         let note_library = assembler.clone().assemble_library([note_file_path.clone()])?;
-
-        let note_script = NoteScript::from_library(&note_library).into_diagnostic()?;
 
         let note_file_name = note_file_path
             .file_name()
             .expect("file name should exist")
             .to_str()
             .ok_or_else(|| Report::msg("failed to convert file name to &str"))?;
-        let mut masb_file_path = note_scripts_target_dir.join(note_file_name);
+        let mut masl_file_path = note_scripts_target_dir.join(note_file_name);
+        masl_file_path.set_extension(Library::LIBRARY_EXTENSION);
 
-        // write the binary MASB to the output dir
-        masb_file_path.set_extension("masb");
-        fs::write(masb_file_path, note_script.to_bytes()).unwrap();
+        // write the note script library to the output dir
+        note_library
+            .write_to_file(&masl_file_path)
+            .map_err(|e| Report::msg(format!("{e:#}")))?;
     }
     Ok(())
 }

--- a/crates/miden-agglayer/src/b2agg_note.rs
+++ b/crates/miden-agglayer/src/b2agg_note.rs
@@ -6,6 +6,8 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
+use miden_assembly::Library;
+use miden_assembly::serde::Deserializable;
 use miden_core::{Felt, Word};
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
@@ -30,8 +32,10 @@ use crate::EthAddress;
 
 // Initialize the B2AGG note script only once
 static B2AGG_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
-    let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/B2AGG.masb"));
-    NoteScript::from_bytes(bytes).expect("shipped B2AGG script is well-formed")
+    let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/B2AGG.masl"));
+    let library =
+        Library::read_from_bytes(bytes).expect("shipped B2AGG script library is well-formed");
+    NoteScript::from_library(&library).expect("shipped B2AGG script is well-formed")
 });
 
 // B2AGG NOTE

--- a/crates/miden-agglayer/src/b2agg_note.rs
+++ b/crates/miden-agglayer/src/b2agg_note.rs
@@ -6,8 +6,6 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
-use miden_assembly::serde::Deserializable;
-use miden_core::program::Program;
 use miden_core::{Felt, Word};
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
@@ -33,8 +31,7 @@ use crate::EthAddress;
 // Initialize the B2AGG note script only once
 static B2AGG_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/B2AGG.masb"));
-    let program = Program::read_from_bytes(bytes).expect("shipped B2AGG script is well-formed");
-    NoteScript::new(program)
+    NoteScript::from_bytes(bytes).expect("shipped B2AGG script is well-formed")
 });
 
 // B2AGG NOTE

--- a/crates/miden-agglayer/src/config_note.rs
+++ b/crates/miden-agglayer/src/config_note.rs
@@ -9,6 +9,8 @@ use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
 
+use miden_assembly::Library;
+use miden_assembly::serde::Deserializable;
 use miden_core::{Felt, Word};
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
@@ -34,8 +36,10 @@ use crate::EthAddress;
 // Initialize the CONFIG_AGG_BRIDGE note script only once
 static CONFIG_AGG_BRIDGE_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes =
-        include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/CONFIG_AGG_BRIDGE.masb"));
-    NoteScript::from_bytes(bytes).expect("shipped CONFIG_AGG_BRIDGE script is well-formed")
+        include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/CONFIG_AGG_BRIDGE.masl"));
+    let library = Library::read_from_bytes(bytes)
+        .expect("shipped CONFIG_AGG_BRIDGE script library is well-formed");
+    NoteScript::from_library(&library).expect("shipped CONFIG_AGG_BRIDGE script is well-formed")
 });
 
 // CONFIG_AGG_BRIDGE NOTE

--- a/crates/miden-agglayer/src/config_note.rs
+++ b/crates/miden-agglayer/src/config_note.rs
@@ -9,7 +9,6 @@ use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use miden_assembly::serde::Deserializable;
 use miden_core::{Felt, Word};
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
@@ -24,7 +23,6 @@ use miden_protocol::note::{
     NoteStorage,
     NoteType,
 };
-use miden_protocol::vm::Program;
 use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint};
 use miden_utils_sync::LazyLock;
 
@@ -37,9 +35,7 @@ use crate::EthAddress;
 static CONFIG_AGG_BRIDGE_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes =
         include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/CONFIG_AGG_BRIDGE.masb"));
-    let program =
-        Program::read_from_bytes(bytes).expect("shipped CONFIG_AGG_BRIDGE script is well-formed");
-    NoteScript::new(program)
+    NoteScript::from_bytes(bytes).expect("shipped CONFIG_AGG_BRIDGE script is well-formed")
 });
 
 // CONFIG_AGG_BRIDGE NOTE

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -15,7 +15,6 @@ use miden_protocol::account::{
 };
 use miden_protocol::asset::TokenSymbol;
 use miden_protocol::note::NoteScript;
-use miden_protocol::vm::Program;
 use miden_standards::account::access::Ownable2Step;
 use miden_standards::account::auth::NoAuth;
 use miden_standards::account::mint_policies::OwnerControlled;
@@ -67,8 +66,7 @@ pub use utils::Keccak256Output;
 // Initialize the CLAIM note script only once
 static CLAIM_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/CLAIM.masb"));
-    let program = Program::read_from_bytes(bytes).expect("shipped CLAIM script is well-formed");
-    NoteScript::new(program)
+    NoteScript::from_bytes(bytes).expect("shipped CLAIM script is well-formed")
 });
 
 /// Returns the CLAIM (Bridge from AggLayer) note script.

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -65,8 +65,10 @@ pub use utils::Keccak256Output;
 
 // Initialize the CLAIM note script only once
 static CLAIM_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
-    let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/CLAIM.masb"));
-    NoteScript::from_bytes(bytes).expect("shipped CLAIM script is well-formed")
+    let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/CLAIM.masl"));
+    let library =
+        Library::read_from_bytes(bytes).expect("shipped CLAIM script library is well-formed");
+    NoteScript::from_library(&library).expect("shipped CLAIM script is well-formed")
 });
 
 /// Returns the CLAIM (Bridge from AggLayer) note script.

--- a/crates/miden-agglayer/src/update_ger_note.rs
+++ b/crates/miden-agglayer/src/update_ger_note.rs
@@ -8,9 +8,7 @@ extern crate alloc;
 use alloc::string::ToString;
 use alloc::vec;
 
-use miden_assembly::serde::Deserializable;
 use miden_core::Word;
-use miden_core::program::Program;
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::NoteError;
@@ -35,9 +33,7 @@ use crate::ExitRoot;
 // Initialize the UPDATE_GER note script only once
 static UPDATE_GER_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
     let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/UPDATE_GER.masb"));
-    let program =
-        Program::read_from_bytes(bytes).expect("shipped UPDATE_GER script is well-formed");
-    NoteScript::new(program)
+    NoteScript::from_bytes(bytes).expect("shipped UPDATE_GER script is well-formed")
 });
 
 // UPDATE_GER NOTE

--- a/crates/miden-agglayer/src/update_ger_note.rs
+++ b/crates/miden-agglayer/src/update_ger_note.rs
@@ -8,6 +8,8 @@ extern crate alloc;
 use alloc::string::ToString;
 use alloc::vec;
 
+use miden_assembly::Library;
+use miden_assembly::serde::Deserializable;
 use miden_core::Word;
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
@@ -32,8 +34,10 @@ use crate::ExitRoot;
 
 // Initialize the UPDATE_GER note script only once
 static UPDATE_GER_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
-    let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/UPDATE_GER.masb"));
-    NoteScript::from_bytes(bytes).expect("shipped UPDATE_GER script is well-formed")
+    let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/note_scripts/UPDATE_GER.masl"));
+    let library =
+        Library::read_from_bytes(bytes).expect("shipped UPDATE_GER script library is well-formed");
+    NoteScript::from_library(&library).expect("shipped UPDATE_GER script is well-formed")
 });
 
 // UPDATE_GER NOTE

--- a/crates/miden-protocol/src/note/script.rs
+++ b/crates/miden-protocol/src/note/script.rs
@@ -42,6 +42,10 @@ impl NoteScript {
     // --------------------------------------------------------------------------------------------
 
     /// Returns a new [NoteScript] instantiated from the provided program.
+    ///
+    /// TODO: since the note script now should be created from `Library`, not `Program`, this
+    /// constructor should be removed:
+    /// (https://github.com/0xMiden/protocol/pull/2822#discussion_r3132965577).
     pub fn new(code: Program) -> Self {
         Self {
             entrypoint: code.entrypoint(),

--- a/crates/miden-protocol/src/note/script.rs
+++ b/crates/miden-protocol/src/note/script.rs
@@ -359,14 +359,14 @@ fn create_external_node_forest(digest: Word) -> (MastForest, MastNodeId) {
 mod tests {
     use super::{Felt, NoteScript, Vec};
     use crate::assembly::Assembler;
-    use crate::testing::note::DEFAULT_NOTE_CODE;
+    use crate::testing::note::DEFAULT_NOTE_SCRIPT;
 
     #[test]
     fn test_note_script_to_from_felt() {
         let assembler = Assembler::default();
-        let script_src = DEFAULT_NOTE_CODE;
-        let program = assembler.assemble_program(script_src).unwrap();
-        let note_script = NoteScript::new(program);
+        let script_src = DEFAULT_NOTE_SCRIPT;
+        let library = assembler.assemble_library([script_src]).unwrap();
+        let note_script = NoteScript::from_library(&library).unwrap();
 
         let encoded: Vec<Felt> = (&note_script).into();
         let decoded: NoteScript = encoded.try_into().unwrap();
@@ -381,8 +381,8 @@ mod tests {
         use crate::Word;
 
         let assembler = Assembler::default();
-        let program = assembler.assemble_program("begin nop end").unwrap();
-        let script = NoteScript::new(program);
+        let library = assembler.assemble_library([DEFAULT_NOTE_SCRIPT]).unwrap();
+        let script = NoteScript::from_library(&library).unwrap();
 
         assert!(script.mast().advice_map().is_empty());
 

--- a/crates/miden-protocol/src/note/script.rs
+++ b/crates/miden-protocol/src/note/script.rs
@@ -45,7 +45,7 @@ impl NoteScript {
     ///
     /// TODO: since the note script now should be created from `Library`, not `Program`, this
     /// constructor should be removed:
-    /// (https://github.com/0xMiden/protocol/pull/2822#discussion_r3132965577).
+    /// (<https://github.com/0xMiden/protocol/pull/2822#discussion_r3132965577>).
     pub fn new(code: Program) -> Self {
         Self {
             entrypoint: code.entrypoint(),

--- a/crates/miden-protocol/src/testing/note.rs
+++ b/crates/miden-protocol/src/testing/note.rs
@@ -15,7 +15,11 @@ use crate::note::{
 };
 use crate::testing::account_id::ACCOUNT_ID_SENDER;
 
-pub const DEFAULT_NOTE_CODE: &str = "begin nop end";
+pub const DEFAULT_NOTE_SCRIPT: &str = "\
+@note_script
+pub proc main
+    nop
+end";
 
 impl Note {
     /// Returns a note with no-op code and one asset.
@@ -39,7 +43,7 @@ impl Note {
 impl NoteScript {
     pub fn mock() -> Self {
         let assembler = Assembler::default();
-        let code = assembler.assemble_program(DEFAULT_NOTE_CODE).unwrap();
-        Self::new(code)
+        let library = assembler.assemble_library([DEFAULT_NOTE_SCRIPT]).unwrap();
+        Self::from_library(&library).unwrap()
     }
 }

--- a/crates/miden-standards/src/account/interface/test.rs
+++ b/crates/miden-standards/src/account/interface/test.rs
@@ -260,7 +260,8 @@ fn test_basic_wallet_custom_notes() {
         use miden::standards::wallets::basic->wallet
         use miden::standards::faucets::basic_fungible->fungible_faucet
 
-        begin
+        @note_script
+        pub proc main
             push.1
             if.true
                 # supported procs
@@ -289,7 +290,8 @@ fn test_basic_wallet_custom_notes() {
         use miden::standards::wallets::basic->wallet
         use miden::standards::faucets::basic_fungible->fungible_faucet
 
-        begin
+        @note_script
+        pub proc main
             push.1
             if.true
                 # unsupported procs
@@ -342,7 +344,8 @@ fn test_basic_fungible_faucet_custom_notes() {
         use miden::standards::wallets::basic->wallet
         use miden::standards::faucets::basic_fungible->fungible_faucet
 
-        begin
+        @note_script
+        pub proc main
             push.1
             if.true
                 # supported procs
@@ -370,7 +373,8 @@ fn test_basic_fungible_faucet_custom_notes() {
         use miden::standards::wallets::basic->wallet
         use miden::standards::faucets::basic_fungible->fungible_faucet
 
-        begin
+        @note_script
+        pub proc main
             push.1
             if.true
                 # supported procs
@@ -445,7 +449,8 @@ fn test_custom_account_custom_notes() {
         use miden::standards::wallets::basic->wallet
         use test::account::component_1->test_account
 
-        begin
+        @note_script
+        pub proc main
             push.1
             if.true
                 # supported proc
@@ -476,7 +481,8 @@ fn test_custom_account_custom_notes() {
         use miden::standards::wallets::basic->wallet
         use test::account::component_1->test_account
 
-        begin
+        @note_script
+        pub proc main
             push.1
             if.true
                 call.wallet::receive_asset
@@ -550,7 +556,8 @@ fn test_custom_account_multiple_components_custom_notes() {
         use test::account::component_1->test_account
         use miden::standards::faucets::basic_fungible->fungible_faucet
 
-        begin
+        @note_script
+        pub proc main
             push.1
             if.true
                 # supported procs
@@ -587,7 +594,8 @@ fn test_custom_account_multiple_components_custom_notes() {
         use test::account::component_1->test_account
         use miden::standards::faucets::basic_fungible->fungible_faucet
 
-        begin
+        @note_script
+        pub proc main
             push.1
             if.true
                 # supported procs

--- a/crates/miden-standards/src/code_builder/mod.rs
+++ b/crates/miden-standards/src/code_builder/mod.rs
@@ -386,7 +386,8 @@ impl CodeBuilder {
     /// The parsed script will have access to all modules that have been added to this builder.
     ///
     /// # Arguments
-    /// * `source` - The note script source code
+    /// - `source` - the note script source code which is expected to have a single public procedure
+    ///   marked with the @note_script attribute.
     ///
     /// # Errors
     /// Returns an error if:
@@ -398,7 +399,7 @@ impl CodeBuilder {
             CodeBuilderError::build_error_with_report("failed to parse note script library", err)
         })?;
 
-        let note_script = NoteScript::from_library(&Self::apply_advice_map_to_library(
+        NoteScript::from_library(&Self::apply_advice_map_to_library(
             advice_map,
             Arc::unwrap_or_clone(note_script_lib),
         ))
@@ -407,9 +408,7 @@ impl CodeBuilder {
                 "failed to create note script from library",
                 err,
             )
-        })?;
-
-        Ok(note_script)
+        })
     }
 
     // ACCESSORS

--- a/crates/miden-standards/src/code_builder/mod.rs
+++ b/crates/miden-standards/src/code_builder/mod.rs
@@ -386,7 +386,7 @@ impl CodeBuilder {
     /// The parsed script will have access to all modules that have been added to this builder.
     ///
     /// # Arguments
-    /// * `program` - The note script source code
+    /// * `source` - The note script source code
     ///
     /// # Errors
     /// Returns an error if:
@@ -394,11 +394,22 @@ impl CodeBuilder {
     pub fn compile_note_script(self, source: impl Parse) -> Result<NoteScript, CodeBuilderError> {
         let CodeBuilder { assembler, advice_map, .. } = self;
 
-        let program = assembler.assemble_program(source).map_err(|err| {
-            CodeBuilderError::build_error_with_report("failed to parse note script", err)
+        let note_script_lib = assembler.assemble_library([source]).map_err(|err| {
+            CodeBuilderError::build_error_with_report("failed to parse note script library", err)
         })?;
 
-        Ok(NoteScript::new(Self::apply_advice_map(advice_map, program)))
+        let note_script = NoteScript::from_library(&Self::apply_advice_map_to_library(
+            advice_map,
+            Arc::unwrap_or_clone(note_script_lib),
+        ))
+        .map_err(|err| {
+            CodeBuilderError::build_error_with_source(
+                "failed to create note script from library",
+                err,
+            )
+        })?;
+
+        Ok(note_script)
     }
 
     // ACCESSORS
@@ -501,6 +512,7 @@ impl From<CodeBuilder> for Assembler {
 mod tests {
     use anyhow::Context;
     use miden_protocol::assembly::diagnostics::NamedSource;
+    use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 
     use super::*;
 
@@ -759,7 +771,7 @@ mod tests {
 
         let script = CodeBuilder::default()
             .with_advice_map_entry(key, value.clone())
-            .compile_note_script("begin nop end")
+            .compile_note_script(DEFAULT_NOTE_SCRIPT)
             .context("failed to compile note script with advice map")?;
 
         let mast = script.mast();

--- a/crates/miden-standards/src/testing/note.rs
+++ b/crates/miden-standards/src/testing/note.rs
@@ -18,7 +18,7 @@ use miden_protocol::note::{
     NoteTag,
     NoteType,
 };
-use miden_protocol::testing::note::DEFAULT_NOTE_CODE;
+use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::vm::Package;
 use miden_protocol::{Felt, Word};
 use rand::Rng;
@@ -67,7 +67,7 @@ impl NoteBuilder {
             serial_num,
             // The note tag is not under test, so we choose a value that is always valid.
             tag: NoteTag::with_account_target(sender),
-            code: DEFAULT_NOTE_CODE.to_string(),
+            code: DEFAULT_NOTE_SCRIPT.to_string(),
             attachment: NoteAttachment::default(),
             source_code: SourceCodeOrigin::Masm {
                 dyn_libraries: Vec::new(),

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -159,7 +159,7 @@ async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
         sender,
         ChaCha20Rng::from_seed(ChaCha20Rng::from_seed([0_u8; 32]).random()),
     )
-    .code("begin push.1 drop push.0 div end")
+    .code("@note_script pub proc main push.1 drop push.0 div end")
     .dynamically_linked_libraries([TransactionKernel::library()])
     .build()?;
 
@@ -167,7 +167,7 @@ async fn check_note_consumability_partial_success() -> anyhow::Result<()> {
         sender,
         ChaCha20Rng::from_seed(ChaCha20Rng::from_seed([0_u8; 32]).random()),
     )
-    .code("begin push.2 drop push.0 div end")
+    .code("@note_script pub proc main push.2 drop push.0 div end")
     .dynamically_linked_libraries([TransactionKernel::library()])
     .build()?;
 
@@ -337,14 +337,14 @@ async fn check_note_consumability_epilogue_failure_with_new_combination() -> any
         sender,
         ChaCha20Rng::from_seed(ChaCha20Rng::from_seed([0_u8; 32]).random()),
     )
-    .code("begin push.1 drop push.1 div end")
+    .code("@note_script pub proc main push.1 drop push.1 div end")
     .dynamically_linked_libraries([TransactionKernel::library()])
     .build()?;
     let failing_note_1 = NoteBuilder::new(
         sender,
         ChaCha20Rng::from_seed(ChaCha20Rng::from_seed([0_u8; 32]).random()),
     )
-    .code("begin push.1 drop push.0 div end")
+    .code("@note_script pub proc main push.1 drop push.0 div end")
     .dynamically_linked_libraries([TransactionKernel::library()])
     .build()?;
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -20,6 +20,7 @@ use miden_protocol::testing::account_id::{
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
     ACCOUNT_ID_SENDER,
 };
+use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::transaction::memory::{ASSET_SIZE, ASSET_VALUE_OFFSET};
 use miden_protocol::{EMPTY_WORD, Felt, ONE, WORD_SIZE, Word};
 use miden_standards::code_builder::CodeBuilder;
@@ -425,7 +426,7 @@ async fn test_active_note_get_exactly_8_inputs() -> anyhow::Result<()> {
     let metadata = NoteMetadata::new(sender_id, NoteType::Public).with_tag(tag);
     let vault = NoteAssets::new(vec![]).context("failed to create input note assets")?;
     let note_script = CodeBuilder::default()
-        .compile_note_script("begin nop end")
+        .compile_note_script(DEFAULT_NOTE_SCRIPT)
         .context("failed to parse note script")?;
 
     // create a recipient with note storage, which number divides by 8. For simplicity create 8

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -23,6 +23,7 @@ use miden_protocol::testing::account_id::{
     ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE,
     ACCOUNT_ID_SENDER,
 };
+use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::transaction::memory::ACTIVE_INPUT_NOTE_PTR;
 use miden_protocol::transaction::{RawOutputNote, TransactionArgs};
 use miden_protocol::{Felt, Word};
@@ -187,7 +188,7 @@ async fn test_build_recipient() -> anyhow::Result<()> {
     let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
 
     // Create test script and serial number
-    let note_script = CodeBuilder::default().compile_note_script("begin nop end")?;
+    let note_script = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_SCRIPT)?;
     let serial_num = Word::default();
 
     // Define test values as Words
@@ -417,7 +418,8 @@ pub async fn test_timelock() -> anyhow::Result<()> {
       use miden::protocol::active_note
       use miden::protocol::tx
 
-      begin
+      @note_script
+      pub proc main
           # store the note storage to memory starting at address 0
           push.0 exec.active_note::get_storage
           # => [num_storage_items, storage_ptr]
@@ -518,7 +520,7 @@ async fn test_public_key_as_note_input() -> anyhow::Result<()> {
     let tag = NoteTag::with_account_target(target_account.id());
     let metadata = NoteMetadata::new(sender_account.id(), NoteType::Public).with_tag(tag);
     let vault = NoteAssets::new(vec![])?;
-    let note_script = CodeBuilder::default().compile_note_script("begin nop end")?;
+    let note_script = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_SCRIPT)?;
     let recipient =
         NoteRecipient::new(serial_num, note_script, NoteStorage::new(public_key_value.to_vec())?);
     let note_with_pub_key = Note::new(vault.clone(), metadata, recipient);

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -43,7 +43,7 @@ use miden_protocol::testing::account_id::{
     ACCOUNT_ID_SENDER,
 };
 use miden_protocol::testing::constants::{FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA};
-use miden_protocol::testing::note::DEFAULT_NOTE_CODE;
+use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::transaction::{
     InputNotes,
     RawOutputNote,
@@ -235,7 +235,7 @@ async fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
     // Create the expected output note for Note 2 which is public
     let serial_num_2 = Word::from([1, 2, 3, 4u32]);
-    let note_script_2 = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_CODE)?;
+    let note_script_2 = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_SCRIPT)?;
     let inputs_2 = NoteStorage::new(vec![ONE])?;
     let metadata_2 = NoteMetadata::new(account_id, note_type2)
         .with_tag(tag2)
@@ -246,7 +246,7 @@ async fn executed_transaction_output_notes() -> anyhow::Result<()> {
 
     // Create the expected output note for Note 3 which is public
     let serial_num_3 = Word::from([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
-    let note_script_3 = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_CODE)?;
+    let note_script_3 = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_SCRIPT)?;
     let inputs_3 = NoteStorage::new(vec![ONE, Felt::new(2)])?;
     let metadata_3 = NoteMetadata::new(account_id, note_type3)
         .with_tag(tag3)

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -405,8 +405,7 @@ impl MastForestStore for TransactionContext {
 #[cfg(test)]
 mod tests {
     use miden_protocol::Felt;
-    use miden_protocol::assembly::Assembler;
-    use miden_protocol::note::NoteScript;
+    use miden_standards::code_builder::CodeBuilder;
 
     use super::*;
     use crate::TransactionContextBuilder;
@@ -414,20 +413,16 @@ mod tests {
     #[tokio::test]
     async fn test_get_note_scripts() {
         // Create two note scripts
-        let assembler1 = Assembler::default();
-        let script1_code = "begin push.1 end";
-        let program1 = assembler1
-            .assemble_program(script1_code)
+        let script1_code = "@note_script\npub proc main\n    push.1\nend";
+        let note_script1 = CodeBuilder::default()
+            .compile_note_script(script1_code)
             .expect("failed to assemble note script 1");
-        let note_script1 = NoteScript::new(program1);
         let script_root1 = note_script1.root();
 
-        let assembler2 = Assembler::default();
-        let script2_code = "begin push.2 push.3 add end";
-        let program2 = assembler2
-            .assemble_program(script2_code)
+        let script2_code = "@note_script\npub proc main\n    push.2 push.3 add\nend";
+        let note_script2 = CodeBuilder::default()
+            .compile_note_script(script2_code)
             .expect("failed to assemble note script 2");
-        let note_script2 = NoteScript::new(program2);
         let script_root2 = note_script2.root();
 
         // Build a transaction context with both note scripts

--- a/crates/miden-testing/src/utils.rs
+++ b/crates/miden-testing/src/utils.rs
@@ -135,7 +135,8 @@ pub fn create_p2any_note(
         use ::miden::protocol::asset::ASSET_SIZE
         use miden::standards::wallets::basic->wallet
 
-        begin
+        @note_script
+        pub proc main
             # fetch pointer & number of assets
             push.0 exec.active_note::get_assets     # [num_assets, dest_ptr]
 
@@ -201,7 +202,7 @@ fn note_script_that_creates_notes<'note>(
     sender_id: AccountId,
     output_notes: impl Iterator<Item = &'note Note>,
 ) -> anyhow::Result<String> {
-    let mut out = String::from("use miden::protocol::output_note\n\nbegin\n");
+    let mut out = String::from("use miden::protocol::output_note\n\n@note_script\npub proc main\n");
 
     for (idx, note) in output_notes.into_iter().enumerate() {
         anyhow::ensure!(

--- a/crates/miden-testing/tests/auth/multisig_psm.rs
+++ b/crates/miden-testing/tests/auth/multisig_psm.rs
@@ -12,6 +12,7 @@ use miden_protocol::testing::account_id::{
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
 };
+use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::{Felt, Word};
 use miden_standards::account::auth::{AuthMultisigPsm, AuthMultisigPsmConfig, PsmConfig};
@@ -461,7 +462,7 @@ async fn test_multisig_update_psm_public_key_must_be_called_alone(
 
     // Also reject rotation transactions that touch notes even when no other account procedure is
     // called.
-    let note_script = CodeBuilder::default().compile_note_script("begin nop end")?;
+    let note_script = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_SCRIPT)?;
     let note_serial_num = Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
     let note_recipient =
         NoteRecipient::new(note_serial_num, note_script.clone(), NoteStorage::default());

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -293,7 +293,8 @@ async fn prove_burning_fungible_asset_on_existing_faucet_succeeds() -> anyhow::R
     // need to create a note with the fungible asset to be burned
     let burn_note_script_code = "
         # burn the asset
-        begin
+        @note_script
+        pub proc main
             dropw
             # => []
 
@@ -356,7 +357,8 @@ async fn faucet_burn_fungible_asset_fails_amount_exceeds_token_supply() -> anyho
 
     let burn_note_script_code = "
         # burn the asset
-        begin
+        @note_script
+        pub proc main
             dropw
             # => []
 
@@ -407,7 +409,7 @@ async fn test_public_note_creation_with_script_from_datastore() -> anyhow::Resul
     let note_type = NoteType::Public;
 
     // Create a simple output note script
-    let output_note_script_code = "begin push.1 drop end";
+    let output_note_script_code = "@note_script pub proc main push.1 drop end";
     let source_manager = Arc::new(DefaultSourceManager::default());
     let output_note_script = CodeBuilder::with_source_manager(source_manager.clone())
         .compile_note_script(output_note_script_code)?;
@@ -441,7 +443,8 @@ async fn test_public_note_creation_with_script_from_datastore() -> anyhow::Resul
         "
             use miden::protocol::note
             
-            begin
+            @note_script
+            pub proc main
                 # Build recipient hash from SERIAL_NUM, SCRIPT_ROOT, and STORAGE_COMMITMENT
                 push.{script_root}
                 # => [SCRIPT_ROOT]
@@ -763,7 +766,8 @@ async fn test_network_faucet_set_policy_rejects_non_allowed_root() -> anyhow::Re
         r#"
         use miden::standards::mint_policies::policy_manager->policy_manager
 
-        begin
+        @note_script
+        pub proc main
             repeat.12 push.0 end
             push.{invalid_policy_root}
             call.policy_manager::set_mint_policy
@@ -944,7 +948,8 @@ async fn test_network_faucet_transfer_ownership() -> anyhow::Result<()> {
         r#"
         use miden::standards::access::ownable2step
 
-        begin
+        @note_script
+        pub proc main
             repeat.14 push.0 end
             push.{new_owner_prefix}
             push.{new_owner_suffix}
@@ -997,7 +1002,8 @@ async fn test_network_faucet_transfer_ownership() -> anyhow::Result<()> {
     let accept_note_script_code = r#"
         use miden::standards::access::ownable2step
 
-        begin
+        @note_script
+        pub proc main
             repeat.16 push.0 end
             call.ownable2step::accept_ownership
             dropw dropw dropw dropw
@@ -1072,7 +1078,8 @@ async fn test_network_faucet_only_owner_can_transfer() -> anyhow::Result<()> {
         r#"
         use miden::standards::access::ownable2step
 
-        begin
+        @note_script
+        pub proc main
             repeat.14 push.0 end
             push.{new_owner_prefix}
             push.{new_owner_suffix}
@@ -1142,7 +1149,8 @@ async fn test_network_faucet_renounce_ownership() -> anyhow::Result<()> {
     let renounce_note_script_code = r#"
         use miden::standards::access::ownable2step
 
-        begin
+        @note_script
+        pub proc main
             repeat.16 push.0 end
             call.ownable2step::renounce_ownership
             dropw dropw dropw dropw
@@ -1156,7 +1164,8 @@ async fn test_network_faucet_renounce_ownership() -> anyhow::Result<()> {
         r#"
         use miden::standards::access::ownable2step
 
-        begin
+        @note_script
+        pub proc main
             repeat.14 push.0 end
             push.{new_owner_prefix}
             push.{new_owner_suffix}

--- a/crates/miden-testing/tests/scripts/ownable2step.rs
+++ b/crates/miden-testing/tests/scripts/ownable2step.rs
@@ -80,7 +80,8 @@ fn create_transfer_note(
     let script = format!(
         r#"
         use miden::standards::access::ownable2step->test_account
-        begin
+        @note_script
+        pub proc main
             repeat.14 push.0 end
             push.{new_owner_prefix}
             push.{new_owner_suffix}
@@ -107,7 +108,8 @@ fn create_accept_note(
 ) -> anyhow::Result<Note> {
     let script = r#"
         use miden::standards::access::ownable2step->test_account
-        begin
+        @note_script
+        pub proc main
             repeat.16 push.0 end
             call.test_account::accept_ownership
             dropw dropw dropw dropw
@@ -129,7 +131,8 @@ fn create_renounce_note(
 ) -> anyhow::Result<Note> {
     let script = r#"
         use miden::standards::access::ownable2step->test_account
-        begin
+        @note_script
+        pub proc main
             repeat.16 push.0 end
             call.test_account::renounce_ownership
             dropw dropw dropw dropw
@@ -456,7 +459,8 @@ async fn test_transfer_ownership_fails_with_invalid_account_id() -> anyhow::Resu
     let script = format!(
         r#"
         use miden::standards::access::ownable2step->test_account
-        begin
+        @note_script
+        pub proc main
             repeat.14 push.0 end
             push.{invalid_suffix}
             push.{invalid_prefix}
@@ -464,6 +468,8 @@ async fn test_transfer_ownership_fails_with_invalid_account_id() -> anyhow::Resu
             dropw dropw dropw dropw
         end
     "#,
+        invalid_prefix = invalid_prefix,
+        invalid_suffix = invalid_suffix,
     );
 
     let source_manager: Arc<dyn SourceManagerSync> = Arc::new(DefaultSourceManager::default());

--- a/crates/miden-testing/tests/scripts/send_note.rs
+++ b/crates/miden-testing/tests/scripts/send_note.rs
@@ -16,6 +16,7 @@ use miden_protocol::note::{
     NoteType,
     PartialNote,
 };
+use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::{Felt, Word};
 use miden_standards::account::interface::{AccountInterface, AccountInterfaceExt};
@@ -67,7 +68,7 @@ async fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
         .with_tag(tag)
         .with_attachment(attachment.clone());
     let assets = NoteAssets::new(vec![sent_asset0, sent_asset1]).unwrap();
-    let note_script = CodeBuilder::default().compile_note_script("begin nop end").unwrap();
+    let note_script = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_SCRIPT).unwrap();
     let serial_num = RandomCoin::new(Word::from([1, 2, 3, 4u32])).draw_word();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteStorage::default());
 
@@ -142,7 +143,7 @@ async fn test_send_note_script_basic_fungible_faucet() -> anyhow::Result<()> {
     let assets = NoteAssets::new(vec![Asset::Fungible(
         FungibleAsset::new(sender_basic_fungible_faucet_account.id(), 10).unwrap(),
     )])?;
-    let note_script = CodeBuilder::default().compile_note_script("begin nop end").unwrap();
+    let note_script = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_SCRIPT).unwrap();
     let serial_num = RandomCoin::new(Word::from([1, 2, 3, 4u32])).draw_word();
     let recipient = NoteRecipient::new(serial_num, note_script, NoteStorage::default());
 


### PR DESCRIPTION
## Summary

`CodeBuilder::compile_note_script` assembled note sources with `assemble_program` and wrapped them with `NoteScript::new`, which rejects valid post-migration note scripts that use `@note_script` and `pub proc main` with the `"procedure exports are not allowed"` error.

This change compiles note scripts as **MASM libraries** with `assemble_library`, builds `NoteScript` via **`NoteScript::from_library`**, and applies the builder’s advice map to the **library** (`apply_advice_map_to_library`) before constructing the script.

See also: [Note scripts are MASM libraries with `@note_script`](https://docs.miden.xyz/next/builder/migration/note-changes#note-scripts-are-masm-libraries-with-note_script)

## Changes

- **`miden-standards`**: `compile_note_script` uses `assemble_library` + `NoteScript::from_library`; unit tests cover library-shaped note scripts (including advice map).
- **`miden-protocol`**: Default / mock note script sources and tests updated to library note format where they assumed executable programs.
- **`miden-agglayer`**: Note script build path compiles `.masm` as libraries and serializes `NoteScript`; embedded loaders use `NoteScript::from_bytes`; note assembly sources use `@note_script pub proc main` where required.
- **`miden-testing`**: Inline note MASM and helpers aligned with the same model.

Closes: https://github.com/0xMiden/protocol/issues/2811