### PR TITLE
fix: output note index out of bounds in asset and attachment API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ### Fixes
 
 - Made deserialization of `AccountCode` more robust ([#2788](https://github.com/0xMiden/protocol/pull/2788)).
-
+- Fixed `output_note::add_asset` and `output_note::set_attachment` to no longer accept invalid note indices ([#2824](https://github.com/0xMiden/protocol/pull/2824)).
 
 ## 0.14.3 (2026-04-07)
 

--- a/crates/miden-protocol/asm/kernels/transaction/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/api.masm
@@ -1118,11 +1118,15 @@ end
 #!
 #! Panics if:
 #! - the procedure is called when the active account is not the native one.
+#! - the note index points to a non-existent output note.
 #!
 #! Invocation: dynexec
 pub proc output_note_add_asset
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
+    # => [ASSET_KEY, ASSET_VALUE, note_idx, pad(7)]
+
+    dup.8 exec.output_note::assert_note_index_in_bounds drop
     # => [ASSET_KEY, ASSET_VALUE, note_idx, pad(7)]
 
     exec.output_note::add_asset
@@ -1150,6 +1154,9 @@ end
 pub proc output_note_set_attachment
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
+    # => [note_idx, attachment_scheme, attachment_kind, ATTACHMENT, pad(9)]
+
+    exec.output_note::assert_note_index_in_bounds
     # => [note_idx, attachment_scheme, attachment_kind, ATTACHMENT, pad(9)]
 
     exec.output_note::set_attachment

--- a/crates/miden-protocol/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/output_note.masm
@@ -39,7 +39,7 @@ const ERR_OUTPUT_NOTE_ATTACHMENT_KIND_NONE_MUST_HAVE_ATTACHMENT_SCHEME_NONE="att
 
 const ERR_OUTPUT_NOTE_ATTACHMENT_KIND_NONE_MUST_BE_EMPTY_WORD="attachment kind None requires ATTACHMENT to be set to an empty word"
 
-const ERR_NOTE_INVALID_INDEX="failed to find note at the given index; index must be within [0, num_of_notes]"
+const ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED="adding a fungible asset to a note cannot exceed the max_amount of 9223372036854775807"
 
 const ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS="non-fungible asset that already exists in the note cannot be added again"
 
@@ -185,16 +185,11 @@ end
 #! - note_idx is the index of the note to which the asset is added.
 #!
 #! Panics if:
-#! - the note index points to a non-existent output note.
 #! - the asset key or value are malformed (e.g., invalid faucet ID).
 #! - the max amount of fungible assets is exceeded.
 #! - the non-fungible asset already exists in the note.
 #! - the total number of ASSETs exceeds the maximum of 64.
 pub proc add_asset
-    # check if the note exists, it must be within [0, num_of_notes]
-    dup.8 exec.memory::get_num_output_notes lte assert.err=ERR_NOTE_INVALID_INDEX
-    # => [ASSET_KEY, ASSET_VALUE, note_idx]
-
     # validate the asset
     exec.asset::validate
     # => [ASSET_KEY, ASSET_VALUE, note_idx]
@@ -247,13 +242,9 @@ end
 #! - ATTACHMENT is the attachment to be set.
 #!
 #! Panics if:
-#! - the note index points to a non-existent output note.
 #! - the attachment kind or scheme does not fit into a u32.
 #! - the attachment kind is an unknown variant.
 pub proc set_attachment
-    dup exec.memory::get_num_output_notes lte assert.err=ERR_NOTE_INVALID_INDEX
-    # => [note_idx, attachment_scheme, attachment_kind, ATTACHMENT]
-
     exec.memory::get_output_note_ptr dup
     # => [note_ptr, note_ptr, attachment_scheme, attachment_kind, ATTACHMENT]
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -8,6 +8,7 @@ use miden_protocol::crypto::rand::RandomCoin;
 use miden_protocol::errors::tx_kernel::{
     ERR_NON_FUNGIBLE_ASSET_ALREADY_EXISTS,
     ERR_NOTE_NUM_OF_ASSETS_EXCEED_LIMIT,
+    ERR_OUTPUT_NOTE_INDEX_OUT_OF_BOUNDS,
     ERR_TX_NUMBER_OF_OUTPUT_NOTES_EXCEEDS_LIMIT,
 };
 use miden_protocol::note::{
@@ -56,6 +57,7 @@ use miden_standards::note::{
 };
 use miden_standards::testing::mock_account::MockAccountExt;
 use miden_standards::testing::note::NoteBuilder;
+use rstest::rstest;
 
 use super::{TestSetup, setup_test};
 use crate::kernel_tests::tx::ExecutionOutputExt;
@@ -1396,6 +1398,78 @@ async fn test_network_note() -> anyhow::Result<()> {
     // TryFrom<Note> fails for a private note.
     assert!(AccountTargetNetworkNote::try_from(private_network_note).is_err());
 
+    Ok(())
+}
+
+/// Test that output_note procedures abort when given an out-of-bounds note index (equal to
+/// num_output_notes).
+///
+/// Each case creates one note via `mock::util::create_default_note` (index 0), then calls the
+/// procedure under test with index 1, which is out of bounds. The bounds assertion fires before
+/// any parameter validation, so dummy values are sufficient.
+#[rstest]
+#[case::add_asset(8, 0, "add_asset")]
+#[case::get_assets_info(0, 0, "get_assets_info")]
+#[case::get_assets(0, 1, "get_assets")]
+#[case::get_recipient(0, 0, "get_recipient")]
+#[case::get_metadata(0, 0, "get_metadata")]
+#[case::set_attachment(0, 6, "set_attachment")]
+#[case::set_word_attachment(0, 5, "set_word_attachment")]
+#[case::set_array_attachment(0, 5, "set_array_attachment")]
+#[tokio::test]
+async fn test_output_note_index_out_of_bounds(
+    #[case] params_above: usize,
+    #[case] params_below: usize,
+    #[case] procedure_name: &str,
+) -> anyhow::Result<()> {
+    let tx_context = TransactionContextBuilder::with_existing_mock_account().build()?;
+
+    let push_below = if params_below > 0 {
+        format!("repeat.{params_below} push.99 end")
+    } else {
+        String::new()
+    };
+    let push_above = if params_above > 0 {
+        format!("repeat.{params_above} push.99 end")
+    } else {
+        String::new()
+    };
+
+    // Create one note (index 0), then try to call the procedure with index 1.
+    let code = format!(
+        "
+        use miden::protocol::output_note
+        use mock::util
+
+        use $kernel::prologue
+
+        begin
+            exec.prologue::prepare_transaction
+
+            exec.util::create_default_note
+            # => [note_idx = 0]
+            drop
+            # => []
+
+            # push garbage parameters that should sit below note_idx
+            {push_below}
+
+            # push the out-of-bounds index (1 == num_output_notes)
+            push.1
+            # => [note_idx = 1, params_below...]
+
+            # push garbage parameters that should sit above note_idx
+            {push_above}
+
+            # call the procedure under test with the invalid index
+            exec.output_note::{procedure_name}
+        end
+        ",
+    );
+
+    let exec_output = tx_context.execute_code(&code).await;
+
+    assert_execution_error!(exec_output, ERR_OUTPUT_NOTE_INDEX_OUT_OF_BOUNDS);
     Ok(())
 }
 


### PR DESCRIPTION
Cherry-picks https://github.com/0xMiden/protocol/pull/2792 into next while resolving merge conflicts.