### PR TITLE
ci: add shear and zizmor checks, and move heavy GitHub Actions jobs to WarpBuild

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - warp-ubuntu-latest-x64-8x

--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -45,7 +45,10 @@ runs:
         fi
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      shell: bash
+      run: |
+        rustup +stable update --no-self-update
+        rustup default stable
 
     - name: Cache cargo registry and git index
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -22,16 +22,25 @@ runs:
     - name: Verify tag matches release branch HEAD
       if: ${{ inputs.verify-branch-head == 'true' }}
       shell: bash
+      env:
+        RELEASE_BRANCH: ${{ inputs.release-branch }}
       run: |
-        git fetch origin ${{ inputs.release-branch }} --depth=1
-        branch_sha="$(git rev-parse origin/${{ inputs.release-branch }})"
+        case "$RELEASE_BRANCH" in
+          "" | -* | */* | *..* | *~* | *^* | *:* | *\?* | *\[* | *\\*)
+            echo "::error::Invalid release branch name: $RELEASE_BRANCH"
+            exit 1
+            ;;
+        esac
+
+        git fetch origin "refs/heads/$RELEASE_BRANCH:refs/remotes/origin/$RELEASE_BRANCH" --depth=1
+        branch_sha="$(git rev-parse "refs/remotes/origin/$RELEASE_BRANCH")"
         tag_sha="$(git rev-parse HEAD)"
 
         echo "branch_sha=$branch_sha"
         echo "tag_sha=$tag_sha"
 
         if [ "$branch_sha" != "$tag_sha" ]; then
-          echo "::error::The release/tag commit does not match origin/${{ inputs.release-branch }} HEAD. Aborting."
+          echo "::error::The release/tag commit does not match origin/$RELEASE_BRANCH HEAD. Aborting."
           exit 1
         fi
 

--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -36,10 +36,10 @@ runs:
         fi
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
     - name: Cache cargo registry and git index
-      uses: actions/cache@v4
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |
           ~/.cargo/registry
@@ -53,8 +53,10 @@ runs:
 
     # Install cargo-msrv for MSRV checks
     # Using binstall with --force to avoid stale cached binaries (see PR #2234)
+    # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+    # trip zizmor's impostor-commit audit when they are later retagged.
     - name: Install cargo-binstall
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
       with:
         tool: cargo-binstall
 

--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -26,11 +26,16 @@ runs:
         RELEASE_BRANCH: ${{ inputs.release-branch }}
       run: |
         case "$RELEASE_BRANCH" in
-          "" | -* | */* | *..* | *~* | *^* | *:* | *\?* | *\[* | *\\*)
+          "" | -*)
             echo "::error::Invalid release branch name: $RELEASE_BRANCH"
             exit 1
             ;;
         esac
+
+        if ! git check-ref-format --branch "$RELEASE_BRANCH" >/dev/null 2>&1; then
+          echo "::error::Invalid release branch name: $RELEASE_BRANCH"
+          exit 1
+        fi
 
         git fetch origin "refs/heads/$RELEASE_BRANCH:refs/remotes/origin/$RELEASE_BRANCH" --depth=1
         branch_sha="$(git rev-parse "refs/remotes/origin/$RELEASE_BRANCH")"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,10 +28,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,12 @@ jobs:
         name: build for no-std
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@main
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+              with:
+                  persist-credentials: false
             - name: Cleanup large tools for build space
               uses: ./.github/actions/cleanup-runner
-            - uses: Swatinem/rust-cache@v2
+            - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
               with:
                   # Only update the cache on push onto the next branch. This strikes a nice balance between
                   # cache hits and cache evictions (github has a 10GB cache limit).
@@ -39,18 +41,24 @@ jobs:
 
     check-features:
       name: check all feature combinations
-      runs-on: ubuntu-latest
+      runs-on: warp-ubuntu-latest-x64-8x
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+          with:
+            persist-credentials: false
         - name: Cleanup large tools for build space
           uses: ./.github/actions/cleanup-runner
-        - uses: Swatinem/rust-cache@v2
+        - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
           with:
             save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
         - name: Install rust
           run: rustup update --no-self-update
+        # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+        # trip zizmor's impostor-commit audit when they are later retagged.
         - name: Install cargo-hack
-          uses: taiki-e/install-action@cargo-hack
+          uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+          with:
+            tool: cargo-hack
         - name: Check all feature combinations
           run: make check-features
 
@@ -58,10 +66,12 @@ jobs:
       name: Check benchmarks compilation
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@main
+        - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+          with:
+            persist-credentials: false
         - name: Cleanup large tools for build space
           uses: ./.github/actions/cleanup-runner
-        - uses: Swatinem/rust-cache@v2
+        - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
           with:
             # Only update the cache on push onto the next branch. This strikes a nice balance between
             # cache hits and cache evictions (github has a 10GB cache limit).

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check for changes in changelog
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,25 @@ jobs:
       - name: Check for unused dependencies
         run: make shear
 
+  workspace-inheritance:
+    name: workspace inheritance on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      # Do not pin taiki-e's moving tool shortcut tags by hash. Pin a released
+      # install-action commit and set tool explicitly, or zizmor's
+      # impostor-commit audit can flag stale shortcut-tag hashes.
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-binstall
+      - name: Install workspace inheritance checker
+        run: cargo binstall --no-confirm cargo-workspace-inheritance-check@1.2.0
+      - name: Check workspace inheritance
+        run: cargo workspace-inheritance-check --promotion-threshold 2 --promotion-failure
+
   typos:
     name: spellcheck
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,20 +22,36 @@ jobs:
     name: cargo-deny on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: cargo-deny
       - name: Check dependencies with cargo-deny
         run: cargo deny check
+
+  cargo-shear:
+    name: cargo-shear on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Install cargo-shear
+        run: cargo install cargo-shear --version 1.11.2 --locked
+      - name: Check for unused dependencies
+        run: make shear
 
   typos:
     name: spellcheck
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: typos
       - run: make typos-check
@@ -45,8 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
         with:
           tool: taplo-cli
       - run: make toml-check
@@ -55,10 +73,12 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Only update the cache on push onto the next branch. This strikes a nice balance between
           # cache hits and cache evictions (github has a 10GB cache limit). 
@@ -73,10 +93,12 @@ jobs:
     name: clippy no_std
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Only update the cache on push onto the next branch. This strikes a nice balance between
           # cache hits and cache evictions (github has a 10GB cache limit). 
@@ -92,10 +114,12 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Only update the cache on push onto the next branch. This strikes a nice balance between
           # cache hits and cache evictions (github has a 10GB cache limit). 
@@ -110,10 +134,12 @@ jobs:
     name: doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Only update the cache on push onto the next branch. This strikes a nice balance between
           # cache hits and cache evictions (github has a 10GB cache limit). 
@@ -127,24 +153,17 @@ jobs:
     name: generated files check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - name: Rustup
         run: rustup update --no-self-update
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Rebuild generated files in src
         run: BUILD_GENERATED_FILES_IN_SRC=1 make check
       - name: Diff check
         run: git diff --exit-code
-
-  unused_deps:
-    name: check for unused dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Machete
-        uses: bnjbvr/cargo-machete@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install cargo-shear
-        run: cargo install cargo-shear --version 1.11.2 --locked
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-shear@1.11.2
       - name: Check for unused dependencies
         run: make shear
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo deny check
 
   cargo-shear:
-    name: cargo-shear on ubuntu-latest
+    name: check for unused dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   test:
-    name: test on warpbuild
+    name: test
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,18 +19,25 @@ permissions:
 
 jobs:
   test:
-    name: test
-    runs-on: ubuntu-latest
+    name: test on warpbuild
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: taiki-e/install-action@nextest 
-      - uses: Swatinem/rust-cache@v2
+      # Keep this on a released install-action commit with an explicit tool; shortcut tags can
+      # trip zizmor's impostor-commit audit when they are later retagged.
+      - name: Install nextest
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-nextest
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust
-        run: rustup update --no-self-update 
+        run: rustup update --no-self-update
       - name: Build tests
         run: make test-release-build
       - name: test
@@ -38,12 +45,14 @@ jobs:
 
   doc-tests:
     name: doc-tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: Swatinem/rust-cache@v2
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust

--- a/.github/workflows/workspace-dry-run.yml
+++ b/.github/workflows/workspace-dry-run.yml
@@ -22,9 +22,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Dry-run workspace release
         uses: ./.github/actions/workspace-release

--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -16,13 +16,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event.release.target_commitish }}
 
       - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@63a7064947ceca9989005e118db3a5fecdc9259f # v1.0.0
         id: auth
 
       - name: Publish workspace crates

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main, next]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  merge_group:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          config: zizmor.yml
+          version: 1.23.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ name = "bench-transaction"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "criterion 0.6.0",
+ "criterion",
  "miden-agglayer",
  "miden-core",
  "miden-processor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ name = "bench-note-checker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "criterion 0.6.0",
+ "criterion",
  "miden-protocol",
  "miden-standards",
  "miden-testing",
@@ -581,6 +581,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -591,29 +592,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
  "serde_json",
  "tinytemplate",
  "tokio",
@@ -1351,15 +1329,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1890,7 +1859,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bech32",
- "criterion 0.5.1",
+ "criterion",
  "fs-err",
  "getrandom 0.3.4",
  "miden-assembly",
@@ -2709,7 +2678,7 @@ dependencies = [
  "aligned-vec",
  "backtrace",
  "cfg-if",
- "criterion 0.5.1",
+ "criterion",
  "findshlibs",
  "inferno",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,6 @@ dependencies = [
  "miden-tx",
  "serde",
  "tokio",
- "tokio-test",
 ]
 
 [[package]]
@@ -513,33 +512,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "color-eyre"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors 1.3.0",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
-dependencies = [
- "once_cell",
- "owo-colors 1.3.0",
- "tracing-core",
- "tracing-error",
-]
 
 [[package]]
 name = "colorchoice"
@@ -980,16 +952,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
 ]
 
 [[package]]
@@ -1563,7 +1525,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1607,10 +1569,8 @@ version = "0.15.0"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
- "miden-agglayer",
  "miden-assembly",
  "miden-core",
- "miden-core-lib",
  "miden-crypto",
  "miden-protocol",
  "miden-standards",
@@ -1848,7 +1808,7 @@ dependencies = [
  "indenter",
  "lazy_static",
  "miden-miette-derive",
- "owo-colors 4.3.0",
+ "owo-colors",
  "regex",
  "rustc_version 0.2.3",
  "rustversion",
@@ -1930,7 +1890,6 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bech32",
- "color-eyre",
  "criterion 0.5.1",
  "fs-err",
  "getrandom 0.3.4",
@@ -1996,7 +1955,6 @@ dependencies = [
  "bon",
  "fs-err",
  "miden-assembly",
- "miden-core",
  "miden-core-lib",
  "miden-processor",
  "miden-protocol",
@@ -2013,7 +1971,6 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "hex",
  "itertools 0.14.0",
  "miden-agglayer",
  "miden-assembly",
@@ -2039,16 +1996,12 @@ dependencies = [
 name = "miden-tx"
 version = "0.15.0"
 dependencies = [
- "anyhow",
- "assert_matches",
- "miden-assembly",
  "miden-processor",
  "miden-protocol",
  "miden-prover",
  "miden-standards",
- "miden-tx",
  "miden-verifier",
- "rstest",
+ "rand_chacha",
  "thiserror",
 ]
 
@@ -2307,12 +2260,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "owo-colors"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "owo-colors"
@@ -3671,28 +3618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,16 +3701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-error"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
-dependencies = [
- "tracing",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3793,17 +3708,6 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "sharded-slab",
- "thread_local",
  "tracing-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ alloy-sol-types = { default-features = false, version = "1.5" }
 anyhow          = { default-features = false, features = ["backtrace", "std"], version = "1.0" }
 assert_matches  = { default-features = false, version = "1.5" }
 bon             = { default-features = false, version = "3" }
-criterion       = { default-features = false, version = "0.6" }
+criterion       = { default-features = false, version = "0.5" }
 fs-err          = { default-features = false, version = "3" }
 primitive-types = { default-features = false, version = "0.14" }
 rand            = { default-features = false, version = "0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,11 +62,15 @@ alloy-sol-types = { default-features = false, version = "1.5" }
 anyhow          = { default-features = false, features = ["backtrace", "std"], version = "1.0" }
 assert_matches  = { default-features = false, version = "1.5" }
 bon             = { default-features = false, version = "3" }
+criterion       = { default-features = false, version = "0.6" }
 fs-err          = { default-features = false, version = "3" }
 primitive-types = { default-features = false, version = "0.14" }
 rand            = { default-features = false, version = "0.9" }
 rand_chacha     = { default-features = false, version = "0.9" }
+regex           = { version = "1.11" }
 rstest          = { version = "0.26" }
 serde           = { default-features = false, version = "1.0" }
+serde_json      = { default-features = false, version = "1.0" }
 thiserror       = { default-features = false, version = "2.0" }
 tokio           = { default-features = false, features = ["sync"], version = "1" }
+walkdir         = { version = "2.5" }

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ format: ## Runs Format using nightly toolchain
 format-check: ## Runs Format using nightly toolchain but only in check mode
 	cargo +nightly fmt --all --check
 
+.PHONY: shear
+shear: ## Runs cargo-shear to find unused or misplaced dependencies
+	cargo shear
+
 .PHONY: typos-check
 typos-check: ## Runs spellchecker
 	typos
@@ -60,7 +64,7 @@ lint: ## Runs all linting tasks at once (Clippy, fixing, formatting, typos)
 	@$(BUILD_GENERATED_FILES_IN_SRC) $(MAKE) clippy-no-std
 	@$(BUILD_GENERATED_FILES_IN_SRC) $(MAKE) typos-check
 	@$(BUILD_GENERATED_FILES_IN_SRC) $(MAKE) toml
-	cargo machete
+	@$(BUILD_GENERATED_FILES_IN_SRC) $(MAKE) shear
 
 # --- docs ----------------------------------------------------------------------------------------
 
@@ -172,7 +176,7 @@ check-tools: ## Checks if development tools are installed
 	@command -v typos >/dev/null 2>&1 && echo "[OK] typos is installed" || echo "[MISSING] typos is not installed (run: make install-tools)"
 	@command -v cargo nextest >/dev/null 2>&1 && echo "[OK] cargo-nextest is installed" || echo "[MISSING] cargo-nextest is not installed (run: make install-tools)"
 	@command -v taplo >/dev/null 2>&1 && echo "[OK] taplo is installed" || echo "[MISSING] taplo is not installed (run: make install-tools)"
-	@command -v cargo-machete >/dev/null 2>&1 && echo "[OK] cargo-machete is installed" || echo "[MISSING] cargo-machete is not installed (run: make install-tools)"
+	@command -v cargo-shear >/dev/null 2>&1 && echo "[OK] cargo-shear is installed" || echo "[MISSING] cargo-shear is not installed (run: make install-tools)"
 
 .PHONY: install-tools
 install-tools: ## Installs development tools required by the Makefile (mdbook, typos, nextest, taplo)
@@ -187,7 +191,7 @@ install-tools: ## Installs development tools required by the Makefile (mdbook, t
 	cargo install typos-cli --locked
 	cargo install cargo-nextest --locked
 	cargo install taplo-cli --locked
-	cargo install cargo-machete --locked
+	cargo install cargo-shear --locked
 	@echo "Development tools installation complete!"
 
 # -- documentation ---------------------------------------------------------------------------------

--- a/bin/bench-note-checker/Cargo.toml
+++ b/bin/bench-note-checker/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = { workspace = true }
 serde  = { features = ["derive"], workspace = true }
 
 [dev-dependencies]
-criterion = { features = ["async_tokio", "html_reports"], version = "0.6" }
+criterion = { features = ["async_tokio", "html_reports"], workspace = true }
 tokio     = { features = ["macros", "rt"], workspace = true }
 
 [[bench]]

--- a/bin/bench-note-checker/Cargo.toml
+++ b/bin/bench-note-checker/Cargo.toml
@@ -10,6 +10,10 @@ repository.workspace   = true
 rust-version.workspace = true
 version                = "0.1.0"
 
+[lib]
+doctest = false
+test    = false
+
 [dependencies]
 # Workspace dependencies
 miden-protocol  = { features = ["testing"], workspace = true }
@@ -20,11 +24,10 @@ miden-tx        = { workspace = true }
 # External dependencies
 anyhow = { workspace = true }
 serde  = { features = ["derive"], workspace = true }
-tokio  = { features = ["macros", "rt"], workspace = true }
 
 [dev-dependencies]
-criterion  = { features = ["async_tokio", "html_reports"], version = "0.6" }
-tokio-test = "0.4"
+criterion = { features = ["async_tokio", "html_reports"], version = "0.6" }
+tokio     = { features = ["macros", "rt"], workspace = true }
 
 [[bench]]
 harness = false

--- a/bin/bench-transaction/Cargo.toml
+++ b/bin/bench-transaction/Cargo.toml
@@ -33,8 +33,8 @@ miden-tx        = { features = ["concurrent"], workspace = true }
 anyhow     = { workspace = true }
 rand       = { workspace = true }
 serde      = { features = ["derive", "std"], workspace = true }
-serde_json = { features = ["preserve_order"], package = "serde_json", version = "1.0" }
+serde_json = { features = ["preserve_order", "std"], workspace = true }
 tokio      = { features = ["macros", "rt"], workspace = true }
 
 [dev-dependencies]
-criterion = { features = ["async_tokio", "html_reports"], version = "0.6" }
+criterion = { features = ["async_tokio", "html_reports"], workspace = true }

--- a/bin/bench-transaction/Cargo.toml
+++ b/bin/bench-transaction/Cargo.toml
@@ -10,6 +10,10 @@ repository.workspace   = true
 rust-version.workspace = true
 version                = "0.1.0"
 
+[lib]
+doctest = false
+test    = false
+
 [[bench]]
 harness = false
 name    = "time_counting_benchmarks"

--- a/bin/bench-transaction/Cargo.toml
+++ b/bin/bench-transaction/Cargo.toml
@@ -12,7 +12,6 @@ version                = "0.1.0"
 
 [lib]
 doctest = false
-test    = false
 
 [[bench]]
 harness = false

--- a/crates/miden-agglayer/Cargo.toml
+++ b/crates/miden-agglayer/Cargo.toml
@@ -12,7 +12,8 @@ rust-version.workspace = true
 version.workspace      = true
 
 [lib]
-bench = false
+bench   = false
+doctest = false
 
 [features]
 default = ["std"]
@@ -23,7 +24,6 @@ testing = ["dep:serde", "dep:serde_json", "miden-protocol/testing"]
 # Miden dependencies
 miden-assembly   = { workspace = true }
 miden-core       = { workspace = true }
-miden-core-lib   = { workspace = true }
 miden-protocol   = { workspace = true }
 miden-standards  = { workspace = true }
 miden-utils-sync = { workspace = true }
@@ -41,7 +41,7 @@ serde      = { features = ["alloc", "derive"], optional = true, workspace = true
 serde_json = { default-features = false, features = ["alloc"], optional = true, version = "1.0" }
 
 [dev-dependencies]
-miden-agglayer = { features = ["testing"], path = "." }
+miden-protocol = { features = ["testing"], workspace = true }
 serde          = { features = ["derive"], workspace = true }
 serde_json     = { version = "1.0" }
 
@@ -49,12 +49,8 @@ serde_json     = { version = "1.0" }
 fs-err          = { workspace = true }
 miden-assembly  = { workspace = true }
 miden-core      = { workspace = true }
-miden-core-lib  = { workspace = true }
 miden-crypto    = { workspace = true }
 miden-protocol  = { features = ["testing"], workspace = true }
 miden-standards = { workspace = true }
 regex           = { version = "1.11" }
 walkdir         = { version = "2.5" }
-
-[package.metadata.cargo-machete]
-ignored = ["miden-core-lib", "miden-standards"]

--- a/crates/miden-agglayer/Cargo.toml
+++ b/crates/miden-agglayer/Cargo.toml
@@ -38,12 +38,12 @@ miden-crypto = { workspace = true }
 
 # Optional testing dependencies
 serde      = { features = ["alloc", "derive"], optional = true, workspace = true }
-serde_json = { default-features = false, features = ["alloc"], optional = true, version = "1.0" }
+serde_json = { default-features = false, features = ["alloc"], optional = true, workspace = true }
 
 [dev-dependencies]
 miden-protocol = { features = ["testing"], workspace = true }
 serde          = { features = ["derive"], workspace = true }
-serde_json     = { version = "1.0" }
+serde_json     = { features = ["std"], workspace = true }
 
 [build-dependencies]
 fs-err          = { workspace = true }
@@ -52,5 +52,5 @@ miden-core      = { workspace = true }
 miden-crypto    = { workspace = true }
 miden-protocol  = { features = ["testing"], workspace = true }
 miden-standards = { workspace = true }
-regex           = { version = "1.11" }
-walkdir         = { version = "2.5" }
+regex           = { workspace = true }
+walkdir         = { workspace = true }

--- a/crates/miden-block-prover/Cargo.toml
+++ b/crates/miden-block-prover/Cargo.toml
@@ -13,7 +13,8 @@ rust-version.workspace = true
 version.workspace      = true
 
 [lib]
-bench = false
+bench   = false
+doctest = false
 
 [features]
 testing = []

--- a/crates/miden-protocol/Cargo.toml
+++ b/crates/miden-protocol/Cargo.toml
@@ -63,7 +63,7 @@ getrandom = { features = ["wasm_js"], version = "0.3" }
 [dev-dependencies]
 anyhow         = { features = ["backtrace", "std"], workspace = true }
 assert_matches = { workspace = true }
-criterion      = { default-features = false, features = ["html_reports"], version = "0.5" }
+criterion      = { default-features = false, features = ["html_reports"], workspace = true }
 miden-protocol = { features = ["testing"], path = "." }
 pprof          = { default-features = false, features = ["criterion", "flamegraph"], version = "0.15" }
 rstest         = { workspace = true }
@@ -74,8 +74,8 @@ fs-err         = { workspace = true }
 miden-assembly = { workspace = true }
 miden-core     = { workspace = true }
 miden-core-lib = { workspace = true }
-regex          = { version = "1.11" }
-walkdir        = { version = "2.5" }
+regex          = { workspace = true }
+walkdir        = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["getrandom"]

--- a/crates/miden-protocol/Cargo.toml
+++ b/crates/miden-protocol/Cargo.toml
@@ -63,7 +63,6 @@ getrandom = { features = ["wasm_js"], version = "0.3" }
 [dev-dependencies]
 anyhow         = { features = ["backtrace", "std"], workspace = true }
 assert_matches = { workspace = true }
-color-eyre     = { version = "0.5" }
 criterion      = { default-features = false, features = ["html_reports"], version = "0.5" }
 miden-protocol = { features = ["testing"], path = "." }
 pprof          = { default-features = false, features = ["criterion", "flamegraph"], version = "0.15" }
@@ -77,3 +76,6 @@ miden-core     = { workspace = true }
 miden-core-lib = { workspace = true }
 regex          = { version = "1.11" }
 walkdir        = { version = "2.5" }
+
+[package.metadata.cargo-shear]
+ignored = ["getrandom"]

--- a/crates/miden-standards/Cargo.toml
+++ b/crates/miden-standards/Cargo.toml
@@ -34,11 +34,11 @@ fs-err         = { workspace = true }
 miden-assembly = { workspace = true }
 miden-core-lib = { workspace = true }
 miden-protocol = { workspace = true }
-regex          = { version = "1.11" }
-walkdir        = { version = "2.5" }
+regex          = { workspace = true }
+walkdir        = { workspace = true }
 
 [dev-dependencies]
-anyhow          = "1.0"
+anyhow          = { workspace = true }
 assert_matches  = { workspace = true }
 miden-processor = { features = ["testing"], workspace = true }
 miden-protocol  = { features = ["testing"], workspace = true }

--- a/crates/miden-standards/Cargo.toml
+++ b/crates/miden-standards/Cargo.toml
@@ -32,7 +32,6 @@ thiserror = { workspace = true }
 [build-dependencies]
 fs-err         = { workspace = true }
 miden-assembly = { workspace = true }
-miden-core     = { workspace = true }
 miden-core-lib = { workspace = true }
 miden-protocol = { workspace = true }
 regex          = { version = "1.11" }
@@ -48,3 +47,6 @@ miden-protocol  = { features = ["testing"], workspace = true }
 # enable the `testing` feature. This is a workaround for Cargo's lack of test-specific features.
 # See: https://github.com/rust-lang/cargo/issues/2911#issuecomment-1483256987
 miden-standards = { features = ["testing"], path = "." }
+
+[package.metadata.cargo-shear]
+ignored = ["miden-core-lib"]

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -22,7 +22,6 @@ tx_context_debug = []
 
 [dependencies]
 # Workspace dependencies
-miden-agglayer        = { features = ["testing"], workspace = true }
 miden-block-prover    = { features = ["testing"], workspace = true }
 miden-protocol        = { features = ["testing"], workspace = true }
 miden-standards       = { features = ["testing"], workspace = true }
@@ -30,7 +29,6 @@ miden-tx              = { features = ["testing"], workspace = true }
 miden-tx-batch-prover = { features = ["testing"], workspace = true }
 
 # Miden dependencies
-miden-assembly  = { workspace = true }
 miden-core-lib  = { workspace = true }
 miden-crypto    = { workspace = true }
 miden-processor = { workspace = true }
@@ -45,7 +43,8 @@ thiserror   = { workspace = true }
 [dev-dependencies]
 anyhow          = { features = ["backtrace", "std"], workspace = true }
 assert_matches  = { workspace = true }
-hex             = { version = "0.4" }
+miden-agglayer  = { features = ["testing"], workspace = true }
+miden-assembly  = { workspace = true }
 miden-crypto    = { workspace = true }
 miden-protocol  = { features = ["std"], workspace = true }
 primitive-types = { workspace = true }

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -50,5 +50,5 @@ miden-protocol  = { features = ["std"], workspace = true }
 primitive-types = { workspace = true }
 rstest          = { workspace = true }
 serde           = { features = ["derive"], workspace = true }
-serde_json      = { features = ["arbitrary_precision"], version = "1.0" }
+serde_json      = { features = ["arbitrary_precision", "std"], workspace = true }
 tokio           = { features = ["macros", "rt"], workspace = true }

--- a/crates/miden-tx-batch-prover/Cargo.toml
+++ b/crates/miden-tx-batch-prover/Cargo.toml
@@ -13,7 +13,8 @@ rust-version.workspace = true
 version.workspace      = true
 
 [lib]
-bench = false
+bench   = false
+doctest = false
 
 [features]
 default = ["std"]

--- a/crates/miden-tx/Cargo.toml
+++ b/crates/miden-tx/Cargo.toml
@@ -12,6 +12,9 @@ repository.workspace   = true
 rust-version.workspace = true
 version.workspace      = true
 
+[lib]
+doctest = false
+
 [features]
 concurrent = ["miden-prover/concurrent", "std"]
 default = ["std"]
@@ -39,8 +42,5 @@ miden-verifier  = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-anyhow         = { features = ["backtrace", "std"], workspace = true }
-assert_matches = { workspace = true }
-miden-assembly = { workspace = true }
-miden-tx       = { features = ["testing"], path = "." }
-rstest         = { workspace = true }
+miden-protocol = { features = ["testing"], workspace = true }
+rand_chacha    = { workspace = true }

--- a/crates/miden-tx/src/auth/tx_authenticator.rs
+++ b/crates/miden-tx/src/auth/tx_authenticator.rs
@@ -292,12 +292,15 @@ mod test {
     use miden_protocol::account::auth::AuthSecretKey;
     use miden_protocol::utils::serde::{Deserializable, Serializable};
     use miden_protocol::{Felt, Word};
+    use rand_chacha::ChaCha20Rng;
+    use rand_chacha::rand_core::SeedableRng;
 
     use super::SigningInputs;
 
     #[test]
     fn serialize_auth_key() {
-        let auth_key = AuthSecretKey::new_falcon512_poseidon2();
+        let mut rng = ChaCha20Rng::from_seed([0_u8; 32]);
+        let auth_key = AuthSecretKey::new_falcon512_poseidon2_with_rng(&mut rng);
         let serialized = auth_key.to_bytes();
         let deserialized = AuthSecretKey::read_from_bytes(&serialized).unwrap();
 

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,4 @@
+rules:
+  secrets-outside-env:
+    ignore:
+      - trigger-deploy-docs.yml


### PR DESCRIPTION
1. The dependency check now uses [`cargo-shear`](https://github.com/Boshen/cargo-shear), an upgrade from `cargo-machete`. `cargo shear` looks not only for unused dependencies (better than machete, as shown by this PR's removals), but also for those put in the wrong dependency section.
2. [`zizmor`](https://github.com/zizmorcore/zizmor) scans GitHub Actions files for risky patterns, like loose action pins or unsafe defaults. 
3. The heavier CI jobs now run on beefier [WarpBuild](https://www.warpbuild.com/) runners. CI test 17 -> 7 min.
4. The dependency policy check now also uses [cargo-workspace-inheritance-check](https://github.com/RomarQ/cargo-workspace-inheritance-check). It makes sure crates that are shared across the workspace use one workspace-level dependency entry instead of repeating versions in many crate manifests.

The PR also removes the unused dependencies that `shear` found, pins action versions more tightly, and fixes feature-flag issues.