### PR TITLE
refactor: remove simple const-wrapper procs from kernel memory module

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction/lib/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/account.masm
@@ -9,8 +9,11 @@ use $kernel::constants::EMPTY_SMT_ROOT
 use $kernel::constants::STORAGE_SLOT_TYPE_MAP
 use $kernel::constants::STORAGE_SLOT_TYPE_VALUE
 use $kernel::memory
-use $kernel::memory::ACCT_ID_SUFFIX_OFFSET
+use $kernel::memory::ACCOUNT_DATA_LENGTH
 use $kernel::memory::ACCT_ID_PREFIX_OFFSET
+use $kernel::memory::ACCT_ID_SUFFIX_OFFSET
+use $kernel::memory::MAX_FOREIGN_ACCOUNT_PTR
+use $kernel::memory::NATIVE_ACCOUNT_DATA_PTR
 use miden::core::collections::smt
 use miden::core::collections::sorted_array
 use miden::core::crypto::hashes::poseidon2
@@ -1793,7 +1796,7 @@ end
 pub proc get_account_data_ptr
     # move pointer one account block back so that the first account pointer in the cycle will point
     # to the native account
-    exec.memory::get_native_account_data_ptr exec.memory::get_account_data_length sub
+    push.NATIVE_ACCOUNT_DATA_PTR push.ACCOUNT_DATA_LENGTH sub
     # => [curr_account_ptr, foreign_account_id_suffix, foreign_account_id_prefix]
 
     # push the pad element onto the stack: it will represent the `is_equal_id` flag during the cycle
@@ -1810,7 +1813,7 @@ pub proc get_account_data_ptr
         # => [curr_account_ptr, foreign_account_id_suffix, foreign_account_id_prefix]
 
         # move the current account pointer to the next account data block
-        exec.memory::get_account_data_length add
+        add.ACCOUNT_DATA_LENGTH
         # => [curr_account_ptr', foreign_account_id_suffix, foreign_account_id_prefix]
 
         dup add.ACCT_ID_PREFIX_OFFSET mem_load
@@ -1834,7 +1837,7 @@ pub proc get_account_data_ptr
 
     # check that the loading of one more account won't exceed the maximum number of the foreign
     # accounts which can be loaded.
-    dup exec.memory::get_max_foreign_account_ptr lte
+    dup push.MAX_FOREIGN_ACCOUNT_PTR lte
     assert.err=ERR_FOREIGN_ACCOUNT_MAX_NUMBER_EXCEEDED
     # => [curr_account_ptr, foreign_account_id_suffix, foreign_account_id_prefix, is_equal_id]
 

--- a/crates/miden-protocol/asm/kernels/transaction/lib/epilogue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/epilogue.masm
@@ -6,6 +6,8 @@ use $kernel::asset_vault
 use $kernel::constants::NOTE_MEM_SIZE
 use $kernel::fungible_asset
 use $kernel::memory
+use $kernel::memory::OUTPUT_NOTE_SECTION_OFFSET
+use $kernel::memory::OUTPUT_VAULT_ROOT_PTR
 use $kernel::note
 
 use miden::core::crypto::hashes::poseidon2
@@ -92,7 +94,7 @@ proc copy_output_notes_to_advice_map
         # => [OUTPUT_NOTES_COMMITMENT, output_notes_end_ptr]
 
         # compute the start boundary of the output notes section
-        exec.memory::get_output_note_data_offset movdn.4
+        push.OUTPUT_NOTE_SECTION_OFFSET movdn.4
         # => [OUTPUT_NOTES_COMMITMENT, output_note_ptr, output_notes_end_ptr]
 
         # insert created data into the advice map
@@ -149,7 +151,7 @@ proc build_output_vault
         # => [num_assets, note_data_ptr, output_notes_end_ptr]
 
         # prepare stack for reading output note assets
-        exec.memory::get_output_vault_root_ptr dup.2 exec.memory::get_output_note_asset_data_ptr dup
+        push.OUTPUT_VAULT_ROOT_PTR dup.2 exec.memory::get_output_note_asset_data_ptr dup
         # => [assets_start_ptr, assets_start_ptr, output_vault_root_ptr, num_assets, note_data_ptr,
         #     output_notes_end_ptr]
 

--- a/crates/miden-protocol/asm/kernels/transaction/lib/faucet.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/faucet.masm
@@ -4,6 +4,7 @@ use $kernel::asset_vault
 use $kernel::fungible_asset
 use $kernel::non_fungible_asset
 use $kernel::memory
+use $kernel::memory::INPUT_VAULT_ROOT_PTR
 
 # FUNGIBLE ASSETS
 # ==================================================================================================
@@ -30,7 +31,7 @@ pub proc mint_fungible_asset
     exec.fungible_asset::validate_origin
     # => [ASSET_KEY, ASSET_VALUE]
 
-    exec.memory::get_input_vault_root_ptr
+    push.INPUT_VAULT_ROOT_PTR
     movdn.8
     # => [ASSET_KEY, ASSET_VALUE, input_vault_root_ptr]
 
@@ -61,7 +62,7 @@ proc burn_fungible_asset
     exec.fungible_asset::validate_origin
     # => [ASSET_KEY, ASSET_VALUE]
 
-    exec.memory::get_input_vault_root_ptr
+    push.INPUT_VAULT_ROOT_PTR
     movdn.8
     # => [ASSET_KEY, ASSET_VALUE, input_vault_root_ptr]
 
@@ -100,7 +101,7 @@ proc mint_non_fungible_asset
     exec.non_fungible_asset::validate_origin
     # => [ASSET_KEY, ASSET_VALUE]
 
-    exec.memory::get_input_vault_root_ptr
+    push.INPUT_VAULT_ROOT_PTR
     movdn.8
     # => [ASSET_KEY, ASSET_VALUE, input_vault_root_ptr]
 
@@ -131,7 +132,7 @@ proc burn_non_fungible_asset
     # => [ASSET_KEY, ASSET_VALUE]
 
     # remove the non-fungible asset from the input vault for asset preservation
-    exec.memory::get_input_vault_root_ptr
+    push.INPUT_VAULT_ROOT_PTR
     movdn.8
     # => [ASSET_KEY, ASSET_VALUE, input_vault_root_ptr]
 

--- a/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
@@ -348,18 +348,6 @@ pub proc set_active_input_note_ptr
     mem_store.ACTIVE_INPUT_NOTE_PTR
 end
 
-#! Returns the pointer to the memory address at which the input vault root is stored.
-#!
-#! Inputs:  []
-#! Outputs: [input_vault_root_ptr]
-#!
-#! Where:
-#! - input_vault_root_ptr is a pointer to the memory address at which the input vault root is
-#!   stored.
-pub proc get_input_vault_root_ptr
-    push.INPUT_VAULT_ROOT_PTR
-end
-
 #! Returns the input vault root.
 #!
 #! Inputs:  []
@@ -380,18 +368,6 @@ end
 #! - INPUT_VAULT_ROOT is the input vault root.
 pub proc set_input_vault_root
     mem_storew_le.INPUT_VAULT_ROOT_PTR
-end
-
-#! Returns the pointer to the memory address at which the output vault root is stored.
-#!
-#! Inputs:  []
-#! Outputs: [output_vault_root_ptr]
-#!
-#! Where:
-#! - output_vault_root_ptr is the pointer to the memory address at which the output vault root is
-#!   stored.
-pub proc get_output_vault_root_ptr
-    push.OUTPUT_VAULT_ROOT_PTR
 end
 
 #! Returns the output vault root.
@@ -579,19 +555,6 @@ pub proc get_init_native_account_vault_root
     padw mem_loadw_le.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
 end
 
-#! Returns the memory address of the vault root of the native account at the beginning of the
-#! transaction.
-#!
-#! Inputs:  []
-#! Outputs: [native_account_initial_vault_root_ptr]
-#!
-#! Where:
-#! - native_account_initial_vault_root_ptr is the memory pointer to the initial vault root of the
-#!   native account.
-pub proc get_init_native_account_vault_root_ptr
-    push.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
-end
-
 #! Sets the storage commitment of the native account at the beginning of the transaction.
 #!
 #! Inputs:  [INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT]
@@ -636,17 +599,6 @@ end
 #! - INPUT_NOTES_COMMITMENT is the notes' commitment.
 pub proc set_nullifier_commitment
     mem_storew_le.INPUT_NOTES_COMMITMENT_PTR
-end
-
-#! Returns the memory address of the transaction script root.
-#!
-#! Inputs:  []
-#! Outputs: [tx_script_root_ptr]
-#!
-#! Where:
-#! - tx_script_root_ptr is the pointer to the memory where transaction script root is stored.
-pub proc get_tx_script_root_ptr
-    push.TX_SCRIPT_ROOT_PTR
 end
 
 #! Sets the transaction script root.
@@ -708,17 +660,6 @@ end
 
 # BLOCK DATA
 # -------------------------------------------------------------------------------------------------
-
-#! Returns a pointer to the block data section.
-#!
-#! Inputs:  []
-#! Outputs: [ptr]
-#!
-#! Where:
-#! - ptr is a pointer to the block data section.
-pub proc get_block_data_ptr
-    push.BLOCK_DATA_SECTION_OFFSET
-end
 
 #! Returns the previous block commitment of the transaction reference block.
 #!
@@ -883,17 +824,6 @@ end
 # CHAIN DATA
 # -------------------------------------------------------------------------------------------------
 
-#! Returns a pointer to the partial blockchain section.
-#!
-#! Inputs:  []
-#! Outputs: [ptr]
-#!
-#! Where:
-#! - ptr is the pointer to the partial blockchain section.
-pub proc get_partial_blockchain_ptr
-    push.PARTIAL_BLOCKCHAIN_PTR
-end
-
 #! Sets the number of leaves in the partial blockchain.
 #!
 #! Inputs:  [num_leaves]
@@ -905,53 +835,8 @@ pub proc set_partial_blockchain_num_leaves
     mem_store.PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR
 end
 
-#! Returns a pointer to start of the partial blockchain peaks section.
-#!
-#! Inputs:  []
-#! Outputs: [ptr]
-#!
-#! Where:
-#! - ptr is the pointer to the start of the partial blockchain peaks section.
-pub proc get_partial_blockchain_peaks_ptr
-    push.PARTIAL_BLOCKCHAIN_PEAKS_PTR
-end
-
 # ACCOUNT DATA
 # -------------------------------------------------------------------------------------------------
-
-#! Returns the memory pointer at which the native account data is stored.
-#!
-#! Inputs:  []
-#! Outputs: [ptr]
-#!
-#! Where:
-#! - ptr is the memory address at which the native account data is stored.
-pub proc get_native_account_data_ptr
-    push.NATIVE_ACCOUNT_DATA_PTR
-end
-
-#! Returns the length of the memory interval that the account data occupies.
-#!
-#! Inputs:  []
-#! Outputs: [account_data_length]
-#!
-#! Where:
-#! - account_data_length is the length of the memory interval that the account data occupies.
-pub proc get_account_data_length
-    push.ACCOUNT_DATA_LENGTH
-end
-
-#! Returns the largest memory address which can be used to load the foreign account data.
-#!
-#! Inputs:  []
-#! Outputs: [max_foreign_account_ptr]
-#!
-#! Where:
-#! - max_foreign_account_ptr is the largest memory address which can be used to load the foreign
-#!   account data.
-pub proc get_max_foreign_account_ptr
-    push.MAX_FOREIGN_ACCOUNT_PTR
-end
 
 #! Sets the memory pointer of the active account data to the native account (8192).
 #!
@@ -1226,7 +1111,7 @@ pub proc get_account_initial_vault_root_ptr
     # => [account_vault_root_ptr]
 
     # for native account, use the initial vault root pointer
-    exec.get_init_native_account_vault_root_ptr
+    push.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
     # => [native_account_initial_vault_root_ptr, account_vault_root_ptr]
 
     # get the flag indicating whether the active account is native
@@ -1454,7 +1339,7 @@ end
 #! Where:
 #! - storage_slots_section_ptr is the memory pointer to the native account's storage slots section.
 pub proc get_native_account_active_storage_slots_ptr
-    exec.get_native_account_data_ptr add.ACCT_ACTIVE_STORAGE_SLOTS_SECTION_OFFSET
+    push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_ACTIVE_STORAGE_SLOTS_SECTION_OFFSET
 end
 
 #! Returns the memory pointer to the initial storage slots of the native account.
@@ -1465,7 +1350,7 @@ end
 #! Where:
 #! - account_initial_storage_slots_ptr is the memory pointer to the initial storage slot values.
 pub proc get_native_account_initial_storage_slots_ptr
-  exec.get_native_account_data_ptr add.ACCT_INITIAL_STORAGE_SLOTS_SECTION_OFFSET
+  push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_INITIAL_STORAGE_SLOTS_SECTION_OFFSET
 end
 
 #! Returns the memory pointer to the initial storage slots of the active account.
@@ -1860,17 +1745,6 @@ end
 
 # OUTPUT NOTES
 # -------------------------------------------------------------------------------------------------
-
-#! Returns the offset of the output note data segment.
-#!
-#! Inputs:  []
-#! Outputs: [offset]
-#!
-#! Where:
-#! - offset is the offset of the output note data segment.
-pub proc get_output_note_data_offset
-    push.OUTPUT_NOTE_SECTION_OFFSET
-end
 
 #! Computes a pointer to the memory address at which the data associated with an output note with
 #! index `i` is stored.

--- a/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
@@ -14,6 +14,9 @@ use $kernel::constants::MAX_INPUT_NOTES_PER_TX
 use $kernel::constants::MAX_NOTE_STORAGE_ITEMS
 use $kernel::constants::NOTE_TREE_DEPTH
 use $kernel::memory
+use $kernel::memory::BLOCK_DATA_SECTION_OFFSET
+use $kernel::memory::INPUT_VAULT_ROOT_PTR
+use $kernel::memory::PARTIAL_BLOCKCHAIN_PTR
 
 # CONSTS
 # =================================================================================================
@@ -195,7 +198,7 @@ end
 #!   transaction.
 #! - NOTE_ROOT is the root of the tree with all notes created in the block.
 proc process_block_data
-    exec.memory::get_block_data_ptr
+    push.BLOCK_DATA_SECTION_OFFSET
     # => [block_data_ptr, block_num]
 
     # read block data and compute its sub commitment
@@ -259,7 +262,7 @@ end
 #! - num_blocks is the number of blocks in the MMR.
 #! - PEAK_1 .. PEAK_N are the MMR peaks.
 proc process_chain_data
-    exec.memory::get_partial_blockchain_ptr dup
+    push.PARTIAL_BLOCKCHAIN_PTR dup
     # => [partial_blockchain_ptr, partial_blockchain_ptr]
 
     # save the MMR peaks to memory and verify it matches the block's CHAIN_COMMITMENT
@@ -479,7 +482,7 @@ proc authenticate_note
     # Load the BLOCK_COMMITMENT from the PARTIAL_BLOCKCHAIN
     # ---------------------------------------------------------------------------------------------
 
-    exec.memory::get_partial_blockchain_ptr adv_push.1
+    push.PARTIAL_BLOCKCHAIN_PTR adv_push.1
     # => [block_num, partial_blockchain_ptr, NOTE_COMMITMENT]
 
     exec.mmr::get
@@ -688,7 +691,7 @@ proc add_input_note_assets_to_vault
     # prepare the stack
     # ---------------------------------------------------------------------------------------------
 
-    exec.memory::get_input_vault_root_ptr
+    push.INPUT_VAULT_ROOT_PTR
     # => [input_vault_root_ptr, note_ptr]
 
     dup.1 exec.memory::get_input_note_assets_ptr

--- a/crates/miden-protocol/asm/kernels/transaction/main.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/main.masm
@@ -2,6 +2,7 @@ use miden::core::word
 
 use $kernel::epilogue
 use $kernel::memory
+use $kernel::memory::TX_SCRIPT_ROOT_PTR
 use $kernel::note
 use $kernel::prologue
 
@@ -136,7 +137,7 @@ proc main
     emit.TX_SCRIPT_PROCESSING_START_EVENT
 
     # get the memory address of the transaction script root and load it to the stack
-    exec.memory::get_tx_script_root_ptr
+    push.TX_SCRIPT_ROOT_PTR
     padw dup.4 mem_loadw_le
     # => [TX_SCRIPT_ROOT, tx_script_root_ptr, pad(16)]
 

--- a/crates/miden-protocol/asm/kernels/transaction/tx_script_main.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/tx_script_main.masm
@@ -1,6 +1,7 @@
 use miden::core::word
 
 use $kernel::memory
+use $kernel::memory::TX_SCRIPT_ROOT_PTR
 use $kernel::prologue
 
 # ERRORS
@@ -45,7 +46,7 @@ proc main
     # ---------------------------------------------------------------------------------------------
 
     # get the memory address of the transaction script root and load it to the stack
-    exec.memory::get_tx_script_root_ptr
+    push.TX_SCRIPT_ROOT_PTR
     padw dup.4 mem_loadw_le
     # => [TX_SCRIPT_ROOT, tx_script_root_ptr]
 


### PR DESCRIPTION
Replace procedures that only pushed a single constant (e.g. `get_output_vault_root_ptr`, `get_tx_script_root_ptr`) with direct constant imports in callers. Removes 11 such wrapper procs from `memory.masm` and updates each call site to use `push.CONSTANT_NAME` after importing with `use $kernel::memory::CONSTANT_NAME`.

Closes #2415