### PR TITLE
Remove obsolete NoteScript constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.14.5 (2026-04-23)
 
 - Fixed note script compilation: all note scripts are now compiled as libraries ([#2822](https://github.com/0xMiden/protocol/pull/2822)).
+- Removed the obsolete `NoteScript::new()` constructor; note scripts should be created from libraries.
 
 ## 0.14.4 (2026-04-09)
 

--- a/crates/miden-protocol/src/note/script.rs
+++ b/crates/miden-protocol/src/note/script.rs
@@ -18,7 +18,7 @@ use crate::utils::serde::{
     DeserializationError,
     Serializable,
 };
-use crate::vm::{AdviceMap, Program};
+use crate::vm::AdviceMap;
 use crate::{PrettyPrint, Word};
 
 /// The attribute name used to mark the entrypoint procedure in a note script library.
@@ -40,18 +40,6 @@ pub struct NoteScript {
 impl NoteScript {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
-
-    /// Returns a new [NoteScript] instantiated from the provided program.
-    ///
-    /// TODO: since the note script now should be created from `Library`, not `Program`, this
-    /// constructor should be removed:
-    /// (<https://github.com/0xMiden/protocol/pull/2822#discussion_r3132965577>).
-    pub fn new(code: Program) -> Self {
-        Self {
-            entrypoint: code.entrypoint(),
-            mast: code.mast_forest().clone(),
-        }
-    }
 
     /// Returns a new [NoteScript] deserialized from the provided bytes.
     ///


### PR DESCRIPTION
Closes #2823.

`NoteScript::new()` still accepted a `Program` after note script compilation moved over to library sources. The other construction paths now cover the supported cases, so this removes the leftover constructor and its TODO.

I also added a changelog note since this is public API surface.

Testing:
- `git diff --check`
- `cargo test -p miden-protocol note_script --lib` did not finish locally: after fetching dependencies, `miden-core-lib v0.22.1` failed in its build script with `project 'miden-core' is missing its manifest path`.