### PR TITLE
fix: tag AggLayer claim notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Made deserialization of `AccountCode` more robust ([#2788](https://github.com/0xMiden/protocol/pull/2788)).
 - Fixed `output_note::add_asset` and `output_note::set_attachment` to no longer accept invalid note indices ([#2824](https://github.com/0xMiden/protocol/pull/2824)).
 - Fixed auth components to use initial storage state for authentication ([#2677](https://github.com/0xMiden/protocol/issues/2677)).
+- Set AggLayer CLAIM note tags to the target bridge account ([#2845](https://github.com/0xMiden/protocol/pull/2845)).
 
 ## 0.14.5 (2026-04-23)
 

--- a/crates/miden-agglayer/src/claim_note.rs
+++ b/crates/miden-agglayer/src/claim_note.rs
@@ -7,7 +7,15 @@ use miden_protocol::account::AccountId;
 use miden_protocol::crypto::SequentialCommit;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::NoteError;
-use miden_protocol::note::{Note, NoteAssets, NoteMetadata, NoteRecipient, NoteStorage, NoteType};
+use miden_protocol::note::{
+    Note,
+    NoteAssets,
+    NoteMetadata,
+    NoteRecipient,
+    NoteStorage,
+    NoteTag,
+    NoteType,
+};
 use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint};
 
 use crate::utils::Keccak256Output;
@@ -185,8 +193,9 @@ pub fn create_claim_note<R: FeltRng>(
         .map_err(|e| NoteError::other(e.to_string()))?
         .into();
 
-    let metadata =
-        NoteMetadata::new(sender_account_id, NoteType::Public).with_attachment(attachment);
+    let metadata = NoteMetadata::new(sender_account_id, NoteType::Public)
+        .with_tag(NoteTag::with_account_target(target_bridge_id))
+        .with_attachment(attachment);
 
     let recipient = NoteRecipient::new(rng.draw_word(), claim_script(), note_storage);
     let assets = NoteAssets::new(vec![])?;

--- a/crates/miden-testing/tests/agglayer/bridge_in.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_in.rs
@@ -24,7 +24,7 @@ use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::crypto::SequentialCommit;
 use miden_protocol::crypto::rand::FeltRng;
-use miden_protocol::note::NoteType;
+use miden_protocol::note::{NoteTag, NoteType};
 use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE;
 use miden_protocol::transaction::RawOutputNote;
 use miden_standards::account::wallets::BasicWallet;
@@ -239,6 +239,7 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
         sender_account.id(),
         builder.rng_mut(),
     )?;
+    assert_eq!(claim_note.metadata().tag(), NoteTag::with_account_target(bridge_account.id()));
 
     // Add the claim note to the builder before building the mock chain
     builder.add_output_note(RawOutputNote::Full(claim_note.clone()));


### PR DESCRIPTION
## What changed

This sets the CLAIM note tag to the target bridge account with NoteTag::with_account_target(target_bridge_id), while keeping the existing network account target attachment.

I also added a focused assertion in the bridge-in test so the claim note metadata keeps carrying the expected bridge tag, and added the changelog entry required by CI.

Fixes #2787.

## Verification

- git diff --check
- cargo test -p miden-testing test_bridge_in_claim_to_p2id --no-run (blocked locally by miden-core-lib build script: project 'miden-core' is missing its manifest path)