### PR TITLE
feat(protocol): add `NoteScriptRoot` newtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added trace row counts to `bench-tx.json` ([#2794](https://github.com/0xMiden/protocol/pull/2794)).
 - Added `tx::get_tx_script_root` kernel procedure returning the root of the executed transaction script (empty word if no script was executed) ([#2816](https://github.com/0xMiden/protocol/pull/2816)).
 - Added `TransactionScript::from_package()` method to create `TransactionScript` from `miden-mast-package::Package` ([#2779](https://github.com/0xMiden/protocol/pull/2779)).
+- [BREAKING] Added `NoteScriptRoot` newtype wrapping note script roots ([#2851](https://github.com/0xMiden/protocol/pull/2851)).
 
 ### Fixes
 

--- a/crates/miden-agglayer/src/b2agg_note.rs
+++ b/crates/miden-agglayer/src/b2agg_note.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 
 use miden_assembly::Library;
 use miden_assembly::serde::Deserializable;
-use miden_core::{Felt, Word};
+use miden_core::Felt;
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::NoteError;
@@ -19,6 +19,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteType,
 };
@@ -64,7 +65,7 @@ impl B2AggNote {
     }
 
     /// Returns the B2AGG note script root.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         B2AGG_SCRIPT.root()
     }
 

--- a/crates/miden-agglayer/src/config_note.rs
+++ b/crates/miden-agglayer/src/config_note.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 
 use miden_assembly::Library;
 use miden_assembly::serde::Deserializable;
-use miden_core::{Felt, Word};
+use miden_core::Felt;
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::NoteError;
@@ -22,6 +22,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteType,
 };
@@ -68,7 +69,7 @@ impl ConfigAggBridgeNote {
     }
 
     /// Returns the CONFIG_AGG_BRIDGE note script root.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         CONFIG_AGG_BRIDGE_SCRIPT.root()
     }
 

--- a/crates/miden-agglayer/src/update_ger_note.rs
+++ b/crates/miden-agglayer/src/update_ger_note.rs
@@ -10,7 +10,6 @@ use alloc::vec;
 
 use miden_assembly::Library;
 use miden_assembly::serde::Deserializable;
-use miden_core::Word;
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::NoteError;
@@ -21,6 +20,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteType,
 };
@@ -65,7 +65,7 @@ impl UpdateGerNote {
     }
 
     /// Returns the UPDATE_GER note script root.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         UPDATE_GER_SCRIPT.root()
     }
 

--- a/crates/miden-protocol/src/note/mod.rs
+++ b/crates/miden-protocol/src/note/mod.rs
@@ -57,7 +57,7 @@ mod recipient;
 pub use recipient::NoteRecipient;
 
 mod script;
-pub use script::NoteScript;
+pub use script::{NoteScript, NoteScriptRoot};
 
 mod file;
 pub use file::NoteFile;

--- a/crates/miden-protocol/src/note/nullifier.rs
+++ b/crates/miden-protocol/src/note/nullifier.rs
@@ -100,7 +100,7 @@ impl Debug for Nullifier {
 impl From<&NoteDetails> for Nullifier {
     fn from(note: &NoteDetails) -> Self {
         Self::new(
-            note.script().root(),
+            note.script().root().into(),
             note.storage().commitment(),
             note.assets().commitment(),
             note.serial_num(),

--- a/crates/miden-protocol/src/note/recipient.rs
+++ b/crates/miden-protocol/src/note/recipient.rs
@@ -77,7 +77,7 @@ impl NoteRecipient {
 
 fn compute_recipient_digest(serial_num: Word, script: &NoteScript, storage: &NoteStorage) -> Word {
     let serial_num_hash = Hasher::merge(&[serial_num, Word::empty()]);
-    let merge_script = Hasher::merge(&[serial_num_hash, script.root()]);
+    let merge_script = Hasher::merge(&[serial_num_hash, script.root().into()]);
     Hasher::merge(&[merge_script, storage.commitment()])
 }
 

--- a/crates/miden-protocol/src/note/script.rs
+++ b/crates/miden-protocol/src/note/script.rs
@@ -1,10 +1,11 @@
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Display;
 use core::num::TryFromIntError;
 
 use miden_core::mast::MastNodeExt;
+use miden_crypto_derive::WordWrapper;
 use miden_mast_package::Package;
 
 use super::Felt;
@@ -23,6 +24,49 @@ use crate::{PrettyPrint, Word};
 
 /// The attribute name used to mark the entrypoint procedure in a note script library.
 const NOTE_SCRIPT_ATTRIBUTE: &str = "note_script";
+
+// NOTE SCRIPT ROOT
+// ================================================================================================
+
+/// The MAST root of a [`NoteScript`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, WordWrapper)]
+pub struct NoteScriptRoot(Word);
+
+impl NoteScriptRoot {
+    /// Returns a reference to the underlying [`Word`].
+    pub fn as_inner(&self) -> &Word {
+        &self.0
+    }
+}
+
+impl From<NoteScriptRoot> for Word {
+    fn from(root: NoteScriptRoot) -> Self {
+        root.0
+    }
+}
+
+impl Display for NoteScriptRoot {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Serializable for NoteScriptRoot {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write(self.0);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
+    }
+}
+
+impl Deserializable for NoteScriptRoot {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let word: Word = source.read()?;
+        Ok(Self::from_raw(word))
+    }
+}
 
 // NOTE SCRIPT
 // ================================================================================================
@@ -161,8 +205,8 @@ impl NoteScript {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the commitment of this note script (i.e., the script's MAST root).
-    pub fn root(&self) -> Word {
-        self.mast[self.entrypoint].digest()
+    pub fn root(&self) -> NoteScriptRoot {
+        NoteScriptRoot::from_raw(self.mast[self.entrypoint].digest())
     }
 
     /// Returns a reference to the [MastForest] backing this note script.

--- a/crates/miden-protocol/src/note/script.rs
+++ b/crates/miden-protocol/src/note/script.rs
@@ -32,13 +32,6 @@ const NOTE_SCRIPT_ATTRIBUTE: &str = "note_script";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, WordWrapper)]
 pub struct NoteScriptRoot(Word);
 
-impl NoteScriptRoot {
-    /// Returns a reference to the underlying [`Word`].
-    pub fn as_inner(&self) -> &Word {
-        &self.0
-    }
-}
-
 impl From<NoteScriptRoot> for Word {
     fn from(root: NoteScriptRoot) -> Self {
         root.0

--- a/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
+++ b/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
@@ -351,7 +351,7 @@ impl TransactionAdviceInputs {
 
             // note details / metadata
             note_data.extend(recipient.serial_num());
-            note_data.extend(*recipient.script().root().as_inner());
+            note_data.extend(Word::from(recipient.script().root()));
             note_data.extend(*recipient.storage().commitment());
             note_data.extend(*assets.commitment());
             note_data.extend(*note_arg);

--- a/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
+++ b/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
@@ -351,7 +351,7 @@ impl TransactionAdviceInputs {
 
             // note details / metadata
             note_data.extend(recipient.serial_num());
-            note_data.extend(*recipient.script().root());
+            note_data.extend(*recipient.script().root().as_inner());
             note_data.extend(*recipient.storage().commitment());
             note_data.extend(*assets.commitment());
             note_data.extend(*note_arg);

--- a/crates/miden-protocol/src/transaction/tx_args.rs
+++ b/crates/miden-protocol/src/transaction/tx_args.rs
@@ -169,15 +169,16 @@ impl TransactionArgs {
         let script_encoded: Vec<Felt> = script.into();
 
         // Build the advice map entries
+        let script_root: Word = script.root().into();
         let sn_hash = Hasher::merge(&[note_recipient.serial_num(), Word::empty()]);
-        let sn_script_hash = Hasher::merge(&[sn_hash, script.root()]);
+        let sn_script_hash = Hasher::merge(&[sn_hash, script_root]);
 
         let new_elements = vec![
             (sn_hash, concat_words(note_recipient.serial_num(), Word::empty())),
-            (sn_script_hash, concat_words(sn_hash, script.root())),
+            (sn_script_hash, concat_words(sn_hash, script_root)),
             (note_recipient.digest(), concat_words(sn_script_hash, storage.commitment())),
             (storage.commitment(), storage.to_elements()),
-            (script.root(), script_encoded),
+            (script_root, script_encoded),
         ];
 
         self.advice_inputs.extend(AdviceInputs::default().with_map(new_elements));

--- a/crates/miden-standards/src/note/burn.rs
+++ b/crates/miden-standards/src/note/burn.rs
@@ -1,4 +1,3 @@
-use miden_protocol::Word;
 use miden_protocol::account::AccountId;
 use miden_protocol::assembly::Path;
 use miden_protocol::asset::Asset;
@@ -11,6 +10,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteTag,
     NoteType,
@@ -55,7 +55,7 @@ impl BurnNote {
     }
 
     /// Returns the BURN note script root.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         BURN_SCRIPT.root()
     }
 

--- a/crates/miden-standards/src/note/mint.rs
+++ b/crates/miden-standards/src/note/mint.rs
@@ -11,6 +11,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteTag,
     NoteType,
@@ -56,7 +57,7 @@ impl MintNote {
     }
 
     /// Returns the MINT note script root.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         MINT_SCRIPT.root()
     }
 

--- a/crates/miden-standards/src/note/mod.rs
+++ b/crates/miden-standards/src/note/mod.rs
@@ -2,10 +2,9 @@ use alloc::boxed::Box;
 use alloc::string::ToString;
 use core::error::Error;
 
-use miden_protocol::Word;
 use miden_protocol::account::AccountId;
 use miden_protocol::block::BlockNumber;
-use miden_protocol::note::{Note, NoteScript};
+use miden_protocol::note::{Note, NoteScript, NoteScriptRoot};
 
 use crate::account::faucets::{BasicFungibleFaucet, NetworkFungibleFaucet};
 use crate::account::interface::{AccountComponentInterface, AccountInterface, AccountInterfaceExt};
@@ -66,7 +65,7 @@ impl StandardNote {
 
     /// Returns a [`StandardNote`] instance based on the provided script root. Returns `None` if
     /// the provided root does not match any standard note script.
-    pub fn from_script_root(root: Word) -> Option<Self> {
+    pub fn from_script_root(root: NoteScriptRoot) -> Option<Self> {
         if root == P2idNote::script_root() {
             return Some(Self::P2ID);
         }
@@ -129,7 +128,7 @@ impl StandardNote {
     }
 
     /// Returns the script root of the current [StandardNote] instance.
-    pub fn script_root(&self) -> Word {
+    pub fn script_root(&self) -> NoteScriptRoot {
         match self {
             Self::P2ID => P2idNote::script_root(),
             Self::P2IDE => P2ideNote::script_root(),

--- a/crates/miden-standards/src/note/p2id.rs
+++ b/crates/miden-standards/src/note/p2id.rs
@@ -12,6 +12,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteTag,
     NoteType,
@@ -56,7 +57,7 @@ impl P2idNote {
     }
 
     /// Returns the P2ID (Pay-to-ID) note script root.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         P2ID_SCRIPT.root()
     }
 

--- a/crates/miden-standards/src/note/p2ide.rs
+++ b/crates/miden-standards/src/note/p2ide.rs
@@ -13,6 +13,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteTag,
     NoteType,
@@ -65,7 +66,7 @@ impl P2ideNote {
     }
 
     /// Returns the P2IDE (Pay-to-ID extended) note script root.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         P2IDE_SCRIPT.root()
     }
 

--- a/crates/miden-standards/src/note/pswap.rs
+++ b/crates/miden-standards/src/note/pswap.rs
@@ -771,7 +771,7 @@ mod tests {
         assert_eq!(pswap.note_type(), NoteType::Public);
 
         let script = PswapNote::script();
-        assert!(*script.root().as_inner() != Word::default(), "Script root should not be zero");
+        assert!(Word::from(script.root()) != Word::default(), "Script root should not be zero");
         assert_eq!(note.metadata().sender(), creator_id);
         assert_eq!(note.metadata().note_type(), NoteType::Public);
         assert_eq!(note.assets().num_assets(), 1);

--- a/crates/miden-standards/src/note/pswap.rs
+++ b/crates/miden-standards/src/note/pswap.rs
@@ -12,6 +12,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteTag,
     NoteType,
@@ -256,7 +257,7 @@ impl PswapNote {
     }
 
     /// Returns the root hash of the PSWAP note script.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         PSWAP_SCRIPT.root()
     }
 
@@ -770,7 +771,7 @@ mod tests {
         assert_eq!(pswap.note_type(), NoteType::Public);
 
         let script = PswapNote::script();
-        assert!(script.root() != Word::default(), "Script root should not be zero");
+        assert!(*script.root().as_inner() != Word::default(), "Script root should not be zero");
         assert_eq!(note.metadata().sender(), creator_id);
         assert_eq!(note.metadata().note_type(), NoteType::Public);
         assert_eq!(note.assets().num_assets(), 1);

--- a/crates/miden-standards/src/note/swap.rs
+++ b/crates/miden-standards/src/note/swap.rs
@@ -14,6 +14,7 @@ use miden_protocol::note::{
     NoteMetadata,
     NoteRecipient,
     NoteScript,
+    NoteScriptRoot,
     NoteStorage,
     NoteTag,
     NoteType,
@@ -59,7 +60,7 @@ impl SwapNote {
     }
 
     /// Returns the SWAP note script root.
-    pub fn script_root() -> Word {
+    pub fn script_root() -> NoteScriptRoot {
         SWAP_SCRIPT.root()
     }
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -610,6 +610,6 @@ async fn test_active_note_get_script_root() -> anyhow::Result<()> {
     let exec_output = tx_context.execute_code(code).await?;
 
     let script_root = tx_context.input_notes().get_note(0).note().script().root();
-    assert_eq!(exec_output.get_stack_word(0), script_root);
+    assert_eq!(exec_output.get_stack_word(0), Word::from(script_root));
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -610,6 +610,6 @@ async fn test_active_note_get_script_root() -> anyhow::Result<()> {
     let exec_output = tx_context.execute_code(code).await?;
 
     let script_root = tx_context.input_notes().get_note(0).note().script().root();
-    assert_eq!(exec_output.get_stack_word(0), Word::from(script_root));
+    assert_eq!(exec_output.get_stack_word(0), script_root.into());
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -168,7 +168,7 @@ fn note_setup_stack_assertions(exec_output: &ExecutionOutput, inputs: &Transacti
     // assert that the stack contains the note storage at the end of execution
     assert_eq!(
         exec_output.get_stack_word(0),
-        inputs.input_notes().get_note(0).note().script().root()
+        Word::from(inputs.input_notes().get_note(0).note().script().root())
     );
     assert_eq!(exec_output.get_stack_word(4), Word::empty());
     assert_eq!(exec_output.get_stack_word(8), Word::empty());

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -168,7 +168,7 @@ fn note_setup_stack_assertions(exec_output: &ExecutionOutput, inputs: &Transacti
     // assert that the stack contains the note storage at the end of execution
     assert_eq!(
         exec_output.get_stack_word(0),
-        Word::from(inputs.input_notes().get_note(0).note().script().root())
+        inputs.input_notes().get_note(0).note().script().root().into()
     );
     assert_eq!(exec_output.get_stack_word(4), Word::empty());
     assert_eq!(exec_output.get_stack_word(8), Word::empty());

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -465,7 +465,7 @@ fn input_notes_memory_assertions(
 
         assert_eq!(
             exec_output.get_note_mem_word(note_idx, INPUT_NOTE_SCRIPT_ROOT_OFFSET),
-            note.script().root(),
+            Word::from(note.script().root()),
             "note script root should be stored at the correct offset"
         );
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -465,7 +465,7 @@ fn input_notes_memory_assertions(
 
         assert_eq!(
             exec_output.get_note_mem_word(note_idx, INPUT_NOTE_SCRIPT_ROOT_OFFSET),
-            Word::from(note.script().root()),
+            note.script().root().into(),
             "note script root should be stored at the correct offset"
         );
 

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -14,7 +14,7 @@ use miden_protocol::account::{Account, AccountHeader, AccountId};
 use miden_protocol::assembly::DefaultSourceManager;
 use miden_protocol::assembly::debuginfo::SourceManagerSync;
 use miden_protocol::block::account_tree::AccountWitness;
-use miden_protocol::note::{Note, NoteId, NoteScript};
+use miden_protocol::note::{Note, NoteId, NoteScript, NoteScriptRoot};
 use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE;
 use miden_protocol::testing::noop_auth_component::NoopAuthComponent;
 use miden_protocol::transaction::{
@@ -81,7 +81,7 @@ pub struct TransactionContextBuilder {
     tx_inputs: Option<TransactionInputs>,
     auth_args: Word,
     signatures: Vec<(PublicKeyCommitment, Word, Signature)>,
-    note_scripts: BTreeMap<Word, NoteScript>,
+    note_scripts: BTreeMap<NoteScriptRoot, NoteScript>,
     is_lazy_loading_enabled: bool,
     is_debug_mode_enabled: bool,
 }

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -18,7 +18,7 @@ use miden_protocol::assembly::{Assembler, SourceManager, SourceManagerSync};
 use miden_protocol::asset::{Asset, AssetVaultKey, AssetWitness};
 use miden_protocol::block::account_tree::AccountWitness;
 use miden_protocol::block::{BlockHeader, BlockNumber};
-use miden_protocol::note::{Note, NoteScript};
+use miden_protocol::note::{Note, NoteScript, NoteScriptRoot};
 use miden_protocol::transaction::{
     AccountInputs,
     ExecutedTransaction,
@@ -61,7 +61,7 @@ pub struct TransactionContext {
     pub(super) mast_store: TransactionMastStore,
     pub(super) authenticator: Option<BasicAuthenticator>,
     pub(super) source_manager: Arc<dyn SourceManagerSync>,
-    pub(super) note_scripts: BTreeMap<Word, NoteScript>,
+    pub(super) note_scripts: BTreeMap<NoteScriptRoot, NoteScript>,
     pub(super) is_lazy_loading_enabled: bool,
     pub(super) is_debug_mode_enabled: bool,
 }
@@ -387,7 +387,7 @@ impl DataStore for TransactionContext {
 
     fn get_note_script(
         &self,
-        script_root: Word,
+        script_root: NoteScriptRoot,
     ) -> impl FutureMaybeSend<Result<Option<NoteScript>, DataStoreError>> {
         async move { Ok(self.note_scripts.get(&script_root).cloned()) }
     }
@@ -448,8 +448,12 @@ mod tests {
         assert_eq!(retrieved_script2, note_script2);
 
         // Fetching a non-existent one returns None
-        let non_existent_root =
-            Word::from([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+        let non_existent_root = NoteScriptRoot::from_raw(Word::from([
+            Felt::new(1),
+            Felt::new(2),
+            Felt::new(3),
+            Felt::new(4),
+        ]));
         let result = tx_context.get_note_script(non_existent_root).await;
         assert!(matches!(result, Ok(None)));
     }

--- a/crates/miden-tx/src/executor/data_store.rs
+++ b/crates/miden-tx/src/executor/data_store.rs
@@ -5,7 +5,7 @@ use miden_processor::{FutureMaybeSend, MastForestStore, Word};
 use miden_protocol::account::{AccountId, PartialAccount, StorageMapKey, StorageMapWitness};
 use miden_protocol::asset::{AssetVaultKey, AssetWitness};
 use miden_protocol::block::{BlockHeader, BlockNumber};
-use miden_protocol::note::NoteScript;
+use miden_protocol::note::{NoteScript, NoteScriptRoot};
 use miden_protocol::transaction::{AccountInputs, PartialBlockchain};
 
 use crate::DataStoreError;
@@ -84,6 +84,6 @@ pub trait DataStore: MastForestStore {
     /// retrieve the script.
     fn get_note_script(
         &self,
-        script_root: Word,
+        script_root: NoteScriptRoot,
     ) -> impl FutureMaybeSend<Result<Option<NoteScript>, DataStoreError>>;
 }

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -22,7 +22,7 @@ use miden_protocol::assembly::{SourceFile, SourceManagerSync, SourceSpan};
 use miden_protocol::asset::{AssetVaultKey, AssetWitness, FungibleAsset};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::merkle::smt::SmtProof;
-use miden_protocol::note::{NoteMetadata, NoteRecipient, NoteScript, NoteStorage};
+use miden_protocol::note::{NoteMetadata, NoteRecipient, NoteScript, NoteScriptRoot, NoteStorage};
 use miden_protocol::transaction::{
     InputNote,
     InputNotes,
@@ -387,6 +387,7 @@ where
         serial_num: Word,
     ) -> Result<Vec<AdviceMutation>, TransactionKernelError> {
         // Resolve standard note scripts directly, avoiding a data store round-trip.
+        let script_root = NoteScriptRoot::from_raw(script_root);
         let note_script: Option<NoteScript> =
             if let Some(standard_note) = StandardNote::from_script_root(script_root) {
                 Some(standard_note.script())
@@ -414,7 +415,7 @@ where
                 self.base_host.output_note_from_recipient(note_idx, metadata, recipient)?;
 
                 Ok(vec![AdviceMutation::extend_map(AdviceMap::from_iter([(
-                    script_root,
+                    Word::from(script_root),
                     script_felts,
                 )]))])
             },
@@ -428,7 +429,8 @@ where
                 Ok(Vec::new())
             },
             None => Err(TransactionKernelError::other(format!(
-                "note script with root {script_root} not found in data store for public note"
+                "note script with root {} not found in data store for public note",
+                Word::from(script_root),
             ))),
         }
     }


### PR DESCRIPTION
Wraps note script roots in a `NoteScriptRoot` newtype (analogous to `AccountProcedureRoot`) so APIs that take or return them are harder to misuse than bare `Word`s. Migrates `NoteScript::root`, all `XxxNote::script_root` getters, `StandardNote::from_script_root`, and `DataStore::get_note_script`.

Closes #2850.