### PR TITLE
chore: re-export MIN_STACK_DEPTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added trace row counts to `bench-tx.json` ([#2794](https://github.com/0xMiden/protocol/pull/2794)).
 - Added `tx::get_tx_script_root` kernel procedure returning the root of the executed transaction script (empty word if no script was executed) ([#2816](https://github.com/0xMiden/protocol/pull/2816)).
 - Added `TransactionScript::from_package()` method to create `TransactionScript` from `miden-mast-package::Package` ([#2779](https://github.com/0xMiden/protocol/pull/2779)).
+- Re-exported `MIN_STACK_DEPTH` from `miden-processor` ([#2856](https://github.com/0xMiden/protocol/pull/2856)).
 
 ### Fixes
 

--- a/crates/miden-protocol/src/lib.rs
+++ b/crates/miden-protocol/src/lib.rs
@@ -77,6 +77,6 @@ pub mod vm {
         TargetType,
     };
     pub use miden_processor::trace::RowIndex;
-    pub use miden_processor::{FutureMaybeSend, StackInputs, StackOutputs};
+    pub use miden_processor::{FutureMaybeSend, MIN_STACK_DEPTH, StackInputs, StackOutputs};
     pub use miden_verifier::ExecutionProof;
 }


### PR DESCRIPTION
Adds a missing re-export for the `MIN_STACK_DEPTH`.