### PR TITLE
test(mock-chain): refactor MockChainNote to wrap OutputNote

### DIFF
--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -128,7 +128,11 @@ async fn proposed_block_aggregates_account_state_transition() -> anyhow::Result<
     chain.prove_next_block()?;
 
     // Create three transactions on the same account that build on top of each other.
-    let executed_tx0 = chain.create_authenticated_notes_tx(account1.id(), [note0.id()]).await?;
+    let executed_tx0 = chain
+        .build_tx_context(account1.id(), &[], &[note0])?
+        .build()?
+        .execute()
+        .await?;
 
     account1.apply_delta(executed_tx0.account_delta())?;
     let executed_tx1 = chain.create_authenticated_notes_tx(account1.clone(), [note1.id()]).await?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -1057,7 +1057,7 @@ async fn adding_amount_zero_fungible_asset_to_account_vault_works() -> anyhow::R
     let chain = builder.build()?;
 
     let tx = chain
-        .build_tx_context(account, &[input_note.id()], &[])?
+        .build_tx_context(account, &[], &[input_note])?
         .build()?
         .execute()
         .await?;

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -239,7 +239,6 @@ impl MockChain {
         account_tree: AccountTree,
         account_authenticators: BTreeMap<AccountId, AccountAuthenticator>,
         secret_key: SecretKey,
-        genesis_notes: Vec<Note>,
     ) -> anyhow::Result<Self> {
         let mut chain = MockChain {
             chain: Blockchain::default(),
@@ -259,20 +258,6 @@ impl MockChain {
         chain
             .apply_block(genesis_block)
             .context("failed to build account from builder")?;
-
-        // Update committed_notes with full note details for genesis notes.
-        // This is needed because apply_block only stores headers for private notes,
-        // but tests need full note details to create input notes.
-        for note in genesis_notes {
-            if let Some(MockChainNote::Private(_, _, inclusion_proof)) =
-                chain.committed_notes.get(&note.id())
-            {
-                chain.committed_notes.insert(
-                    note.id(),
-                    MockChainNote::Public(note.clone(), inclusion_proof.clone()),
-                );
-            }
-        }
 
         debug_assert_eq!(chain.blocks.len(), 1);
         debug_assert_eq!(chain.committed_accounts.len(), chain.account_tree.num_accounts());
@@ -944,21 +929,10 @@ impl MockChain {
             )
             .context("failed to create inclusion proof for output note")?;
 
-            if let OutputNote::Public(public_note) = created_note {
-                self.committed_notes.insert(
-                    public_note.id(),
-                    MockChainNote::Public(public_note.as_note().clone(), note_inclusion_proof),
-                );
-            } else {
-                self.committed_notes.insert(
-                    created_note.id(),
-                    MockChainNote::Private(
-                        created_note.id(),
-                        created_note.metadata().clone(),
-                        note_inclusion_proof,
-                    ),
-                );
-            }
+            self.committed_notes.insert(
+                created_note.id(),
+                MockChainNote::new(created_note.clone(), note_inclusion_proof),
+            );
         }
 
         debug_assert_eq!(

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -208,16 +208,6 @@ impl MockChainBuilder {
         )
         .context("failed to create genesis account tree")?;
 
-        // Extract full notes before shrinking for later use in MockChain
-        let full_notes: Vec<Note> = self
-            .notes
-            .iter()
-            .filter_map(|note| match note {
-                RawOutputNote::Full(n) => Some(n.clone()),
-                _ => None,
-            })
-            .collect();
-
         let proven_notes: Vec<_> = self
             .notes
             .into_iter()
@@ -281,7 +271,6 @@ impl MockChainBuilder {
             account_tree,
             self.account_authenticators,
             validator_secret_key,
-            full_notes,
         )
     }
 

--- a/crates/miden-testing/src/mock_chain/note.rs
+++ b/crates/miden-testing/src/mock_chain/note.rs
@@ -1,52 +1,47 @@
 use miden_processor::serde::DeserializationError;
 use miden_protocol::note::{Note, NoteId, NoteInclusionProof, NoteMetadata};
-use miden_protocol::transaction::InputNote;
+use miden_protocol::transaction::{InputNote, OutputNote};
 use miden_tx::utils::serde::{ByteReader, ByteWriter, Deserializable, Serializable};
 
 // MOCK CHAIN NOTE
 // ================================================================================================
 
-/// Represents a note that is stored in the mock chain.
-#[allow(clippy::large_enum_variant)]
+/// Represents a note stored in the mock chain.
+///
+/// Mirrors real chain behavior: public notes carry full details while private notes carry only
+/// a [`NoteHeader`] (id + metadata). Full details for private notes are expected to be held
+/// locally, off-chain.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MockChainNote {
-    /// Details for a private note only include its [`NoteMetadata`] and [`NoteInclusionProof`].
-    /// Other details needed to consume the note are expected to be stored locally, off-chain.
-    Private(NoteId, NoteMetadata, NoteInclusionProof),
-    /// Contains the full [`Note`] object alongside its [`NoteInclusionProof`].
-    Public(Note, NoteInclusionProof),
+pub struct MockChainNote {
+    note: OutputNote,
+    proof: NoteInclusionProof,
 }
 
 impl MockChainNote {
-    /// Returns the note's inclusion details.
+    pub fn new(note: OutputNote, proof: NoteInclusionProof) -> Self {
+        Self { note, proof }
+    }
+
+    /// Returns the note's inclusion proof.
     pub fn inclusion_proof(&self) -> &NoteInclusionProof {
-        match self {
-            MockChainNote::Private(_, _, inclusion_proof)
-            | MockChainNote::Public(_, inclusion_proof) => inclusion_proof,
-        }
+        &self.proof
     }
 
     /// Returns the note's metadata.
     pub fn metadata(&self) -> &NoteMetadata {
-        match self {
-            MockChainNote::Private(_, metadata, _) => metadata,
-            MockChainNote::Public(note, _) => note.metadata(),
-        }
+        self.note.metadata()
     }
 
     /// Returns the note's ID.
     pub fn id(&self) -> NoteId {
-        match self {
-            MockChainNote::Private(id, ..) => *id,
-            MockChainNote::Public(note, _) => note.id(),
-        }
+        self.note.id()
     }
 
     /// Returns the underlying note if it is public.
     pub fn note(&self) -> Option<&Note> {
-        match self {
-            MockChainNote::Private(..) => None,
-            MockChainNote::Public(note, _) => Some(note),
+        match &self.note {
+            OutputNote::Public(note) => Some(note.as_note()),
+            OutputNote::Private(_) => None,
         }
     }
 }
@@ -55,11 +50,14 @@ impl TryFrom<MockChainNote> for InputNote {
     type Error = anyhow::Error;
 
     fn try_from(value: MockChainNote) -> Result<Self, Self::Error> {
-        match value {
-            MockChainNote::Private(..) => Err(anyhow::anyhow!(
+        match value.note {
+            OutputNote::Public(note) => Ok(InputNote::Authenticated {
+                note: note.into_note(),
+                proof: value.proof,
+            }),
+            OutputNote::Private(_) => Err(anyhow::anyhow!(
                 "private notes in the mock chain cannot be converted into input notes due to missing details"
             )),
-            MockChainNote::Public(note, proof) => Ok(InputNote::Authenticated { note, proof }),
         }
     }
 }
@@ -69,38 +67,15 @@ impl TryFrom<MockChainNote> for InputNote {
 
 impl Serializable for MockChainNote {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        match self {
-            MockChainNote::Private(id, metadata, proof) => {
-                0u8.write_into(target);
-                id.write_into(target);
-                metadata.write_into(target);
-                proof.write_into(target);
-            },
-            MockChainNote::Public(note, proof) => {
-                1u8.write_into(target);
-                note.write_into(target);
-                proof.write_into(target);
-            },
-        }
+        self.note.write_into(target);
+        self.proof.write_into(target);
     }
 }
 
 impl Deserializable for MockChainNote {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let note_type = u8::read_from(source)?;
-        match note_type {
-            0 => {
-                let id = NoteId::read_from(source)?;
-                let metadata = NoteMetadata::read_from(source)?;
-                let proof = NoteInclusionProof::read_from(source)?;
-                Ok(MockChainNote::Private(id, metadata, proof))
-            },
-            1 => {
-                let note = Note::read_from(source)?;
-                let proof = NoteInclusionProof::read_from(source)?;
-                Ok(MockChainNote::Public(note, proof))
-            },
-            _ => Err(DeserializationError::InvalidValue(format!("Unknown note type: {note_type}"))),
-        }
+        let note = OutputNote::read_from(source)?;
+        let proof = NoteInclusionProof::read_from(source)?;
+        Ok(Self { note, proof })
     }
 }

--- a/crates/miden-testing/src/tx_context/builder.rs
+++ b/crates/miden-testing/src/tx_context/builder.rs
@@ -14,7 +14,7 @@ use miden_protocol::account::{Account, AccountHeader, AccountId};
 use miden_protocol::assembly::DefaultSourceManager;
 use miden_protocol::assembly::debuginfo::SourceManagerSync;
 use miden_protocol::block::account_tree::AccountWitness;
-use miden_protocol::note::{Note, NoteId, NoteScript, NoteScriptRoot};
+use miden_protocol::note::{Note, NoteId, NoteScript, NoteScriptRoot, NoteType};
 use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE;
 use miden_protocol::testing::noop_auth_component::NoopAuthComponent;
 use miden_protocol::transaction::{
@@ -283,20 +283,29 @@ impl TransactionContextBuilder {
                 // If no specific transaction inputs was provided, initialize an ad-hoc mockchain
                 // to generate valid block header/MMR data
 
+                let input_notes = self.input_notes;
+
                 let mut builder = MockChain::builder();
-                for i in self.input_notes {
-                    builder.add_output_note(RawOutputNote::Full(i));
+                for note in &input_notes {
+                    builder.add_output_note(RawOutputNote::Full(note.clone()));
                 }
                 let mut mock_chain = builder.build()?;
 
                 mock_chain.prove_next_block().context("failed to prove first block")?;
                 mock_chain.prove_next_block().context("failed to prove second block")?;
 
-                let input_note_ids: Vec<NoteId> =
-                    mock_chain.committed_notes().values().map(MockChainNote::id).collect();
+                let mut public_note_ids: Vec<NoteId> = vec![];
+                let mut private_notes: Vec<Note> = vec![];
+                for note in input_notes {
+                    if matches!(note.metadata().note_type(), NoteType::Public) {
+                        public_note_ids.push(note.id());
+                    } else {
+                        private_notes.push(note);
+                    }
+                }
 
                 mock_chain
-                    .get_transaction_inputs(&self.account, &input_note_ids, &[])
+                    .get_transaction_inputs(&self.account, &public_note_ids, &private_notes)
                     .context("failed to get transaction inputs from mock chain")?
             },
         };

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -582,7 +582,7 @@ async fn test_public_note_creation_with_script_from_datastore() -> anyhow::Resul
     // Note: There is intentionally no call to extend_expected_output_notes here, so the
     // transaction host is forced to request the script from the data store during execution.
     let executed_transaction = mock_chain
-        .build_tx_context(faucet.id(), &[trigger_note.id()], &[])?
+        .build_tx_context(faucet.id(), &[], &[trigger_note])?
         .add_note_script(output_note_script)
         .with_source_manager(source_manager)
         .build()?
@@ -1097,7 +1097,7 @@ async fn test_network_faucet_transfer_ownership() -> anyhow::Result<()> {
 
     // Execute transfer_ownership via note script (nominates new owner)
     let tx_context = mock_chain
-        .build_tx_context(faucet.id(), &[transfer_note.id()], &[])?
+        .build_tx_context(faucet.id(), &[], &[transfer_note])?
         .with_source_manager(source_manager.clone())
         .build()?;
     let executed_transaction = tx_context.execute().await?;
@@ -1311,7 +1311,7 @@ async fn test_network_faucet_renounce_ownership() -> anyhow::Result<()> {
 
     // Execute renounce_ownership
     let tx_context = mock_chain
-        .build_tx_context(faucet.id(), &[renounce_note.id()], &[])?
+        .build_tx_context(faucet.id(), &[], &[renounce_note])?
         .with_source_manager(source_manager.clone())
         .build()?;
     let executed_transaction = tx_context.execute().await?;
@@ -1333,7 +1333,7 @@ async fn test_network_faucet_renounce_ownership() -> anyhow::Result<()> {
     mock_chain.prove_next_block()?;
 
     let tx_context = mock_chain
-        .build_tx_context(updated_faucet.id(), &[transfer_note.id()], &[])?
+        .build_tx_context(updated_faucet.id(), &[], &[transfer_note])?
         .with_source_manager(source_manager.clone())
         .build()?;
     let result = tx_context.execute().await;
@@ -1503,7 +1503,7 @@ async fn test_network_faucet_non_owner_cannot_burn_when_owner_only_policy_active
 
     let source_manager = Arc::new(DefaultSourceManager::default());
     let tx_context = mock_chain
-        .build_tx_context(faucet.id(), &[set_policy_note.id()], &[])?
+        .build_tx_context(faucet.id(), &[], &[set_policy_note])?
         .with_source_manager(source_manager.clone())
         .build()?;
     let executed_transaction = tx_context.execute().await?;
@@ -1561,7 +1561,7 @@ async fn test_network_faucet_owner_can_burn_when_owner_only_policy_active() -> a
 
     let source_manager = Arc::new(DefaultSourceManager::default());
     let tx_context = mock_chain
-        .build_tx_context(faucet.id(), &[set_policy_note.id()], &[])?
+        .build_tx_context(faucet.id(), &[], &[set_policy_note])?
         .with_source_manager(source_manager.clone())
         .build()?;
     let executed_transaction = tx_context.execute().await?;

--- a/crates/miden-testing/tests/scripts/p2id.rs
+++ b/crates/miden-testing/tests/scripts/p2id.rs
@@ -170,7 +170,7 @@ async fn prove_consume_multiple_notes() -> anyhow::Result<()> {
     mock_chain.prove_next_block()?;
 
     let tx_context = mock_chain
-        .build_tx_context(account.id(), &[note_1.id(), note_2.id()], &[])?
+        .build_tx_context(account.id(), &[], &[note_1, note_2])?
         .build()?;
 
     let executed_transaction = tx_context.execute().await?;
@@ -280,7 +280,7 @@ async fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
     let tx_script = CodeBuilder::default().compile_tx_script(tx_script_src)?;
 
     let tx_context = mock_chain
-        .build_tx_context(account.id(), &[input_note_1.id(), input_note_2.id()], &[])?
+        .build_tx_context(account.id(), &[], &[input_note_1, input_note_2])?
         .extend_expected_output_notes(vec![
             RawOutputNote::Full(output_note_1),
             RawOutputNote::Full(output_note_2),

--- a/crates/miden-testing/tests/scripts/pswap.rs
+++ b/crates/miden-testing/tests/scripts/pswap.rs
@@ -474,13 +474,20 @@ async fn pswap_fill_test(
         expected_notes.push(RawOutputNote::Full(Note::from(remainder)));
     }
 
-    let mut tx_builder = mock_chain
-        .build_tx_context(consumer_id, &[pswap_note.id()], &[])?
-        .extend_expected_output_notes(expected_notes);
+    let pswap_note_id = pswap_note.id();
+    let mut tx_builder = if matches!(note_type, NoteType::Public) {
+        mock_chain
+            .build_tx_context(consumer_id, &[pswap_note_id], &[])?
+            .extend_expected_output_notes(expected_notes)
+    } else {
+        mock_chain
+            .build_tx_context(consumer_id, &[], &[pswap_note])?
+            .extend_expected_output_notes(expected_notes)
+    };
 
     if !use_network_account {
         let mut note_args_map = BTreeMap::new();
-        note_args_map.insert(pswap_note.id(), PswapNote::create_args(fill_amount, 0)?);
+        note_args_map.insert(pswap_note_id, PswapNote::create_args(fill_amount, 0)?);
         tx_builder = tx_builder.extend_note_args(note_args_map);
     }
 


### PR DESCRIPTION
Closes #2307

## Summary

Replaces the `MockChainNote` enum with a struct holding `OutputNote` and `NoteInclusionProof`, following the approach suggested by @PhilippGackstatter.

**Before:** `MockChainNote` was an enum with two variants:
- `Private(NoteId, NoteMetadata, NoteInclusionProof)` — hand-rolled header storage
- `Public(Note, NoteInclusionProof)` — full note details

This required a workaround in `from_genesis_block` that silently re-promoted private genesis notes to `MockChainNote::Public` so tests could consume them — which defeated the purpose of the privacy distinction.

**After:** `MockChainNote` is a struct:
```rust
pub struct MockChainNote {
    note: OutputNote,
    proof: NoteInclusionProof,
}
```

`OutputNote` already encodes visibility in its variants (`Public(PublicOutputNote)` / `Private(PrivateNoteHeader)`), so `MockChainNote` now correctly mirrors real chain behaviour: private notes store only a header, public notes store full details.

## Changes

- `note.rs` — `MockChainNote` changed from enum to struct; serialization delegates to `OutputNote`
- `chain.rs` — `apply_block` stores `OutputNote` directly; `from_genesis_block` loses the `genesis_notes` param and workaround loop
- `chain_builder.rs` — removes `full_notes` extraction and updates the `from_genesis_block` call

## Test plan

- [ ] `cargo test -p miden-testing` (blocked locally by `miden-core-lib` build script, same as #2027)
- [ ] No remaining references to `MockChainNote::Public` or `MockChainNote::Private` in the codebase
- [ ] `mock_chain_serialization` test passes with the new format