### PR TITLE
fix(vault): reject duplicate non-fungible entries during deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Made deserialization of `AccountCode` more robust ([#2788](https://github.com/0xMiden/protocol/pull/2788)).
 - Fixed `output_note::add_asset` and `output_note::set_attachment` to no longer accept invalid note indices ([#2824](https://github.com/0xMiden/protocol/pull/2824)).
 - Fixed auth components to use initial storage state for authentication ([#2677](https://github.com/0xMiden/protocol/issues/2677)).
+- Reject duplicate non-fungible asset entries during `AccountVaultDelta` deserialization ([#2870](https://github.com/0xMiden/protocol/pull/2870)).
 
 ## 0.14.5 (2026-04-23)
 

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -576,6 +576,7 @@ pub enum NonFungibleDeltaAction {
 mod tests {
     use super::{AccountVaultDelta, Deserializable, NonFungibleAssetDelta, Serializable};
     use crate::utils::ByteWriter;
+    use alloc::vec::Vec;
     use crate::account::AccountId;
     use crate::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
     use crate::testing::account_id::{

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -575,7 +575,7 @@ pub enum NonFungibleDeltaAction {
 #[cfg(test)]
 mod tests {
     use super::{AccountVaultDelta, Deserializable, NonFungibleAssetDelta, Serializable};
-    use crate::utils::ByteWriter;
+    use crate::utils::serde::ByteWriter;
     use alloc::vec::Vec;
     use crate::account::AccountId;
     use crate::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -574,7 +574,8 @@ pub enum NonFungibleDeltaAction {
 
 #[cfg(test)]
 mod tests {
-    use super::{AccountVaultDelta, Deserializable, Serializable};
+    use super::{AccountVaultDelta, Deserializable, NonFungibleAssetDelta, Serializable};
+    use crate::utils::ByteWriter;
     use crate::account::AccountId;
     use crate::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
     use crate::testing::account_id::{
@@ -686,5 +687,27 @@ mod tests {
         } else {
             assert!(result.is_err());
         }
+    }
+
+    #[test]
+    fn deserialize_non_fungible_delta_rejects_duplicates() {
+        let account_id = NonFungibleAsset::mock_issuer();
+        let asset = NonFungibleAsset::new(
+            &NonFungibleAssetDetails::new(account_id, vec![1, 2, 3]).unwrap(),
+        )
+        .unwrap();
+
+        let mut bytes = Vec::new();
+
+        // num_added = 2 (duplicate)
+        bytes.write_usize(2);
+        bytes.write(&asset);
+        bytes.write(&asset);
+
+        // num_removed = 0
+        bytes.write_usize(0);
+
+        let result = NonFungibleAssetDelta::read_from_bytes(&bytes);
+        assert!(result.is_err());
     }
 }

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -4,12 +4,7 @@ use alloc::string::ToString;
 use alloc::vec::Vec;
 
 use super::{
-    AccountDeltaError,
-    ByteReader,
-    ByteWriter,
-    Deserializable,
-    DeserializationError,
-    Serializable,
+    AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
 use crate::account::AccountType;
 use crate::asset::{Asset, AssetVaultKey, FungibleAsset, NonFungibleAsset};
@@ -542,7 +537,7 @@ impl Serializable for NonFungibleAssetDelta {
 impl Deserializable for NonFungibleAssetDelta {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let mut delta = Self::default();
-        
+
         let num_added = source.read_usize()?;
         for _ in 0..num_added {
             let added_asset: NonFungibleAsset = source.read()?;
@@ -550,7 +545,7 @@ impl Deserializable for NonFungibleAssetDelta {
                 .apply_action(added_asset, NonFungibleDeltaAction::Add)
                 .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
         }
-        
+
         let num_removed = source.read_usize()?;
         for _ in 0..num_removed {
             let removed_asset: NonFungibleAsset = source.read()?;
@@ -558,7 +553,7 @@ impl Deserializable for NonFungibleAssetDelta {
                 .apply_action(removed_asset, NonFungibleDeltaAction::Remove)
                 .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
         }
-        
+
         Ok(delta)
     }
 }
@@ -575,14 +570,13 @@ pub enum NonFungibleDeltaAction {
 #[cfg(test)]
 mod tests {
     use super::{AccountVaultDelta, Deserializable, NonFungibleAssetDelta, Serializable};
-    use crate::utils::serde::ByteWriter;
-    use alloc::vec::Vec;
     use crate::account::AccountId;
     use crate::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
     use crate::testing::account_id::{
-        ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
-        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
+        ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
     };
+    use crate::utils::serde::ByteWriter;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_serde_account_vault() {
@@ -702,8 +696,8 @@ mod tests {
 
         // num_added = 2 (duplicate)
         bytes.write_usize(2);
-        bytes.write(&asset);
-        bytes.write(&asset);
+        bytes.write(asset);
+        bytes.write(asset);
 
         // num_removed = 0
         bytes.write_usize(0);

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -541,21 +541,25 @@ impl Serializable for NonFungibleAssetDelta {
 
 impl Deserializable for NonFungibleAssetDelta {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let mut map = BTreeMap::new();
-
+        let mut delta = Self::default();
+        
         let num_added = source.read_usize()?;
         for _ in 0..num_added {
             let added_asset: NonFungibleAsset = source.read()?;
-            map.insert(added_asset.vault_key(), (added_asset, NonFungibleDeltaAction::Add));
+            delta
+                .apply_action(added_asset, NonFungibleDeltaAction::Add)
+                .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
         }
-
+        
         let num_removed = source.read_usize()?;
         for _ in 0..num_removed {
             let removed_asset: NonFungibleAsset = source.read()?;
-            map.insert(removed_asset.vault_key(), (removed_asset, NonFungibleDeltaAction::Remove));
+            delta
+                .apply_action(removed_asset, NonFungibleDeltaAction::Remove)
+                .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
         }
-
-        Ok(Self::new(map))
+        
+        Ok(delta)
     }
 }
 

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -4,7 +4,12 @@ use alloc::string::ToString;
 use alloc::vec::Vec;
 
 use super::{
-    AccountDeltaError, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    AccountDeltaError,
+    ByteReader,
+    ByteWriter,
+    Deserializable,
+    DeserializationError,
+    Serializable,
 };
 use crate::account::AccountType;
 use crate::asset::{Asset, AssetVaultKey, FungibleAsset, NonFungibleAsset};
@@ -569,14 +574,16 @@ pub enum NonFungibleDeltaAction {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::{AccountVaultDelta, Deserializable, NonFungibleAssetDelta, Serializable};
     use crate::account::AccountId;
     use crate::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
     use crate::testing::account_id::{
-        ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET, ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
+        ACCOUNT_ID_PRIVATE_FUNGIBLE_FAUCET,
+        ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
     };
     use crate::utils::serde::ByteWriter;
-    use alloc::vec::Vec;
 
     #[test]
     fn test_serde_account_vault() {


### PR DESCRIPTION
NonFungibleAssetDelta::read_from used map.insert which silently overwrites duplicates. Replaced with apply_action to enforce the same invariants as add() / remove().