### PR TITLE
refactor(agglayer): rename faucet registry flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Made deserialization of `AccountCode` more robust ([#2788](https://github.com/0xMiden/protocol/pull/2788)).
 - Fixed `output_note::add_asset` and `output_note::set_attachment` to no longer accept invalid note indices ([#2824](https://github.com/0xMiden/protocol/pull/2824)).
 - Fixed auth components to use initial storage state for authentication ([#2677](https://github.com/0xMiden/protocol/issues/2677)).
+- Renamed the AggLayer faucet registry flag constant for clarity ([#2812](https://github.com/0xMiden/protocol/issues/2812)).
 
 ## 0.14.5 (2026-04-23)
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -25,7 +25,7 @@ const TOKEN_REGISTRY_MAP_SLOT = word("agglayer::bridge::token_registry_map")
 
 # Flags
 const GER_KNOWN_FLAG = 1
-const IS_FAUCET_REGISTERED_FLAG = 1
+const FAUCET_REGISTERED_FLAG = 1
 
 # Offset in the local memory of the `hash_token_address` procedure
 const TOKEN_ADDR_HASH_PTR = 0
@@ -129,16 +129,16 @@ pub proc register_faucet
     # --- 1. Register faucet in faucet_registry ---
 
     # set_map_item expects [slot_id(2), KEY, VALUE] and returns [OLD_VALUE].
-    # Build KEY = [0, 0, suffix, prefix] and VALUE = [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0]
-    push.0.0.0.IS_FAUCET_REGISTERED_FLAG
-    # => [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0,
+    # Build KEY = [0, 0, suffix, prefix] and VALUE = [FAUCET_REGISTERED_FLAG, 0, 0, 0]
+    push.0.0.0.FAUCET_REGISTERED_FLAG
+    # => [FAUCET_REGISTERED_FLAG, 0, 0, 0,
     #     faucet_id_suffix, faucet_id_prefix, origin_token_addr(5),
     #     faucet_id_suffix, faucet_id_prefix, pad(9)]
 
     movup.5 movup.5 push.0.0
     # => [
     #     [0, 0, faucet_id_suffix, faucet_id_prefix],
-    #     [IS_FAUCET_REGISTERED_FLAG, 0, 0, 0],
+    #     [FAUCET_REGISTERED_FLAG, 0, 0, 0],
     #      origin_token_addr(5), faucet_id_suffix, faucet_id_prefix, pad(9)
     #    ]
 


### PR DESCRIPTION
Closes #2812.

Renames the faucet registration flag to `FAUCET_REGISTERED_FLAG`. The old `IS_` prefix made it sound like a boolean value, but this is always the sentinel value written for registered faucets.

I also updated the nearby stack comments and added the changelog entry.

Checked with `git diff --check`.