### PR TITLE
chore: add standardized `NetworkAccountNoteAllowlist` slot for network account detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [BREAKING] Removed unused `payback_attachment` from `SwapNoteStorage` and `attachment` from `MintNoteStorage` ([#2789](https://github.com/0xMiden/protocol/pull/2789)).
 - Automatically enable `concurrent` feature in `miden-tx` for `std` context ([#2791](https://github.com/0xMiden/protocol/pull/2791)).
 - Added `AuthNetworkAccount` auth component that rejects transactions which execute a tx script or consume input notes outside of a fixed allowlist of note script roots ([#2817](https://github.com/0xMiden/protocol/pull/2817)).
+- Added standardized `NetworkAccountNoteAllowlist` slot for detecting network accounts ([#2883](https://github.com/0xMiden/protocol/pull/2883)).
 - Added trace row counts to `bench-tx.json` ([#2794](https://github.com/0xMiden/protocol/pull/2794)).
 - Added `tx::get_tx_script_root` kernel procedure returning the root of the executed transaction script (empty word if no script was executed) ([#2816](https://github.com/0xMiden/protocol/pull/2816)).
 - Added `TransactionScript::from_package()` method to create `TransactionScript` from `miden-mast-package::Package` ([#2779](https://github.com/0xMiden/protocol/pull/2779)).

--- a/crates/miden-protocol/src/testing/mod.rs
+++ b/crates/miden-protocol/src/testing/mod.rs
@@ -9,6 +9,7 @@ pub mod component_metadata;
 pub mod constants;
 pub mod noop_auth_component;
 pub mod note;
+pub mod note_script_root;
 pub mod partial_blockchain;
 pub mod random_secret_key;
 pub mod slot_name;

--- a/crates/miden-protocol/src/testing/note_script_root.rs
+++ b/crates/miden-protocol/src/testing/note_script_root.rs
@@ -1,0 +1,9 @@
+use crate::Word;
+use crate::note::NoteScriptRoot;
+
+impl NoteScriptRoot {
+    /// Creates a [`NoteScriptRoot`] from an array of u32s for testing purposes.
+    pub fn from_array(array: [u32; 4]) -> Self {
+        Self::from_raw(Word::from(array))
+    }
+}

--- a/crates/miden-standards/src/account/auth/mod.rs
+++ b/crates/miden-standards/src/account/auth/mod.rs
@@ -14,4 +14,4 @@ mod guarded_multisig;
 pub use guarded_multisig::{AuthGuardedMultisig, AuthGuardedMultisigConfig, GuardianConfig};
 
 mod network_account;
-pub use network_account::AuthNetworkAccount;
+pub use network_account::{AuthNetworkAccount, NetworkAccountNoteAllowlist};

--- a/crates/miden-standards/src/account/auth/mod.rs
+++ b/crates/miden-standards/src/account/auth/mod.rs
@@ -14,4 +14,8 @@ mod guarded_multisig;
 pub use guarded_multisig::{AuthGuardedMultisig, AuthGuardedMultisigConfig, GuardianConfig};
 
 mod network_account;
-pub use network_account::{AuthNetworkAccount, NetworkAccountNoteAllowlist};
+pub use network_account::{
+    AuthNetworkAccount,
+    NetworkAccountNoteAllowlist,
+    NetworkAccountNoteAllowlistError,
+};

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -1,5 +1,5 @@
 use alloc::vec;
-use std::collections::BTreeSet;
+use alloc::collections::BTreeSet;
 
 use miden_protocol::account::component::{
     AccountComponentMetadata,

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -1,5 +1,5 @@
-use alloc::vec;
 use alloc::collections::BTreeSet;
+use alloc::vec;
 
 use miden_protocol::account::component::{
     AccountComponentMetadata,

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -1,37 +1,16 @@
+use alloc::vec;
 use alloc::vec::Vec;
 
+use miden_protocol::Word;
 use miden_protocol::account::component::{
     AccountComponentMetadata,
-    SchemaType,
     StorageSchema,
     StorageSlotSchema,
 };
-use miden_protocol::account::{
-    AccountComponent,
-    AccountType,
-    StorageMap,
-    StorageMapKey,
-    StorageSlot,
-    StorageSlotName,
-};
-use miden_protocol::utils::sync::LazyLock;
-use miden_protocol::{Felt, Word};
+use miden_protocol::account::{AccountComponent, AccountType, StorageSlotName};
 
+use super::NetworkAccountNoteAllowlist;
 use crate::account::components::network_account_auth_library;
-
-// CONSTANTS
-// ================================================================================================
-
-static ALLOWED_NOTE_SCRIPTS_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
-    StorageSlotName::new("miden::standards::auth::network_account::allowed_note_scripts")
-        .expect("storage slot name should be valid")
-});
-
-// A flag value used as the storage map entry for each allowed script root. Its only job is to be
-// distinguishable from the storage map's default empty word, letting the MASM allowlist check
-// detect "this key is present" without caring about its contents. Any non-empty word would serve;
-// we pick `[1, 0, 0, 0]` for readability when inspecting storage.
-const ALLOWED_FLAG: Word = Word::new([Felt::new(1), Felt::new(0), Felt::new(0), Felt::new(0)]);
 
 // AUTH NETWORK ACCOUNT
 // ================================================================================================
@@ -48,14 +27,13 @@ const ALLOWED_FLAG: Word = Word::new([Felt::new(1), Felt::new(0), Felt::new(0), 
 /// - no transaction script was executed, and
 /// - every consumed input note has a script root present in the component's allowlist.
 ///
-/// The allowlist is stored in a storage map at a well-known slot (see
-/// [`Self::allowed_note_scripts_slot`]) so off-chain services can identify a network account by
-/// inspecting its storage.
+/// The allowlist is stored in the standardized [`NetworkAccountNoteAllowlist`] slot so off-chain
+/// services can identify a network account by checking for this slot.
 ///
 /// The allowlist is fixed at account creation; there is intentionally no procedure to mutate it
 /// after deployment.
 pub struct AuthNetworkAccount {
-    allowed_script_roots: Vec<Word>,
+    allowlist: NetworkAccountNoteAllowlist,
 }
 
 impl AuthNetworkAccount {
@@ -65,29 +43,24 @@ impl AuthNetworkAccount {
     /// Creates a new [`AuthNetworkAccount`] component with the provided list of allowed
     /// input-note script roots.
     pub fn new(allowed_script_roots: Vec<Word>) -> Self {
-        Self { allowed_script_roots }
+        Self {
+            allowlist: NetworkAccountNoteAllowlist::new(allowed_script_roots),
+        }
     }
 
     /// Returns the storage slot holding the allowlist of allowed input-note script roots.
     pub fn allowed_note_scripts_slot() -> &'static StorageSlotName {
-        &ALLOWED_NOTE_SCRIPTS_SLOT_NAME
+        NetworkAccountNoteAllowlist::slot_name()
     }
 
     /// Returns the storage slot schema for the allowlist slot.
     pub fn allowed_note_scripts_slot_schema() -> (StorageSlotName, StorageSlotSchema) {
-        (
-            Self::allowed_note_scripts_slot().clone(),
-            StorageSlotSchema::map(
-                "Allowed input note script roots",
-                SchemaType::native_word(),
-                SchemaType::native_word(),
-            ),
-        )
+        NetworkAccountNoteAllowlist::slot_schema()
     }
 
     /// Returns the [`AccountComponentMetadata`] for this component.
     pub fn component_metadata() -> AccountComponentMetadata {
-        let storage_schema = StorageSchema::new(vec![Self::allowed_note_scripts_slot_schema()])
+        let storage_schema = StorageSchema::new(vec![NetworkAccountNoteAllowlist::slot_schema()])
             .expect("storage schema should be valid");
 
         AccountComponentMetadata::new(Self::NAME, AccountType::all())
@@ -101,17 +74,7 @@ impl AuthNetworkAccount {
 
 impl From<AuthNetworkAccount> for AccountComponent {
     fn from(component: AuthNetworkAccount) -> Self {
-        let map_entries = component
-            .allowed_script_roots
-            .into_iter()
-            .map(|root| (StorageMapKey::new(root), ALLOWED_FLAG));
-
-        let storage_slots = vec![StorageSlot::with_map(
-            AuthNetworkAccount::allowed_note_scripts_slot().clone(),
-            StorageMap::with_entries(map_entries)
-                .expect("allowlist entries should produce a valid storage map"),
-        )];
-
+        let storage_slots = vec![component.allowlist.into_storage_slot()];
         let metadata = AuthNetworkAccount::component_metadata();
 
         AccountComponent::new(network_account_auth_library(), storage_slots, metadata).expect(
@@ -126,7 +89,7 @@ impl From<AuthNetworkAccount> for AccountComponent {
 
 #[cfg(test)]
 mod tests {
-    use miden_protocol::account::{AccountBuilder, StorageMapKey};
+    use miden_protocol::account::{AccountBuilder, StorageSlotContent};
 
     use super::*;
     use crate::account::wallets::BasicWallet;
@@ -153,30 +116,16 @@ mod tests {
     }
 
     #[test]
-    fn allowlist_storage_contains_expected_entries() {
-        use miden_protocol::account::StorageSlotContent;
-
+    fn auth_network_account_uses_standardized_allowlist_slot() {
         let root_a = Word::from([1u32, 2, 3, 4]);
-        let root_b = Word::from([5u32, 6, 7, 8]);
-
-        let component: AccountComponent = AuthNetworkAccount::new(vec![root_a, root_b]).into();
+        let component: AccountComponent = AuthNetworkAccount::new(vec![root_a]).into();
 
         let storage_slots = component.storage_slots();
         assert_eq!(storage_slots.len(), 1);
+        assert_eq!(storage_slots[0].name(), NetworkAccountNoteAllowlist::slot_name());
 
-        let StorageSlotContent::Map(map) = storage_slots[0].content() else {
+        let StorageSlotContent::Map(_) = storage_slots[0].content() else {
             panic!("allowlist slot must be a map");
         };
-
-        assert_eq!(
-            map.get(&StorageMapKey::new(root_a)),
-            ALLOWED_FLAG,
-            "root_a should resolve to the flag value"
-        );
-        assert_eq!(
-            map.get(&StorageMapKey::new(root_b)),
-            ALLOWED_FLAG,
-            "root_b should resolve to the flag value"
-        );
     }
 }

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -1,13 +1,13 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use miden_protocol::Word;
 use miden_protocol::account::component::{
     AccountComponentMetadata,
     StorageSchema,
     StorageSlotSchema,
 };
 use miden_protocol::account::{AccountComponent, AccountType, StorageSlotName};
+use miden_protocol::note::NoteScriptRoot;
 
 use super::NetworkAccountNoteAllowlist;
 use crate::account::components::network_account_auth_library;
@@ -42,7 +42,7 @@ impl AuthNetworkAccount {
 
     /// Creates a new [`AuthNetworkAccount`] component with the provided list of allowed
     /// input-note script roots.
-    pub fn new(allowed_script_roots: Vec<Word>) -> Self {
+    pub fn new(allowed_script_roots: Vec<NoteScriptRoot>) -> Self {
         Self {
             allowlist: NetworkAccountNoteAllowlist::new(allowed_script_roots),
         }
@@ -96,8 +96,8 @@ mod tests {
 
     #[test]
     fn auth_network_account_component_builds() {
-        let root_a = Word::from([1u32, 2, 3, 4]);
-        let root_b = Word::from([5u32, 6, 7, 8]);
+        let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
+        let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
 
         let _account = AccountBuilder::new([0; 32])
             .with_auth_component(AuthNetworkAccount::new(vec![root_a, root_b]))
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn auth_network_account_uses_standardized_allowlist_slot() {
-        let root_a = Word::from([1u32, 2, 3, 4]);
+        let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let component: AccountComponent = AuthNetworkAccount::new(vec![root_a]).into();
 
         let storage_slots = component.storage_slots();

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -1,5 +1,5 @@
 use alloc::vec;
-use alloc::vec::Vec;
+use std::collections::BTreeSet;
 
 use miden_protocol::account::component::{
     AccountComponentMetadata,
@@ -42,7 +42,7 @@ impl AuthNetworkAccount {
 
     /// Creates a new [`AuthNetworkAccount`] component with the provided list of allowed
     /// input-note script roots.
-    pub fn new(allowed_script_roots: Vec<NoteScriptRoot>) -> Self {
+    pub fn with_allowlist(allowed_script_roots: BTreeSet<NoteScriptRoot>) -> Self {
         Self {
             allowlist: NetworkAccountNoteAllowlist::new(allowed_script_roots),
         }
@@ -100,7 +100,9 @@ mod tests {
         let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
 
         let _account = AccountBuilder::new([0; 32])
-            .with_auth_component(AuthNetworkAccount::new(vec![root_a, root_b]))
+            .with_auth_component(AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([
+                root_a, root_b,
+            ])))
             .with_component(BasicWallet)
             .build()
             .expect("account building with AuthNetworkAccount failed");
@@ -109,7 +111,7 @@ mod tests {
     #[test]
     fn auth_network_account_with_empty_allowlist_builds() {
         let _account = AccountBuilder::new([0; 32])
-            .with_auth_component(AuthNetworkAccount::new(Vec::new()))
+            .with_auth_component(AuthNetworkAccount::with_allowlist(BTreeSet::new()))
             .with_component(BasicWallet)
             .build()
             .expect("account building with empty allowlist failed");
@@ -118,7 +120,8 @@ mod tests {
     #[test]
     fn auth_network_account_uses_standardized_allowlist_slot() {
         let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
-        let component: AccountComponent = AuthNetworkAccount::new(vec![root_a]).into();
+        let component: AccountComponent =
+            AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([root_a])).into();
 
         let storage_slots = component.storage_slots();
         assert_eq!(storage_slots.len(), 1);

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -9,7 +9,7 @@ use miden_protocol::account::component::{
 use miden_protocol::account::{AccountComponent, AccountType, StorageSlotName};
 use miden_protocol::note::NoteScriptRoot;
 
-use super::NetworkAccountNoteAllowlist;
+use super::{NetworkAccountNoteAllowlist, NetworkAccountNoteAllowlistError};
 use crate::account::components::network_account_auth_library;
 
 // AUTH NETWORK ACCOUNT
@@ -42,10 +42,17 @@ impl AuthNetworkAccount {
 
     /// Creates a new [`AuthNetworkAccount`] component with the provided list of allowed
     /// input-note script roots.
-    pub fn with_allowlist(allowed_script_roots: BTreeSet<NoteScriptRoot>) -> Self {
-        Self {
-            allowlist: NetworkAccountNoteAllowlist::new(allowed_script_roots),
-        }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `allowed_script_roots` is empty since the account could not consume any
+    /// notes.
+    pub fn with_allowlist(
+        allowed_script_roots: BTreeSet<NoteScriptRoot>,
+    ) -> Result<Self, NetworkAccountNoteAllowlistError> {
+        Ok(Self {
+            allowlist: NetworkAccountNoteAllowlist::new(allowed_script_roots)?,
+        })
     }
 
     /// Returns the storage slot holding the allowlist of allowed input-note script roots.
@@ -100,28 +107,28 @@ mod tests {
         let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
 
         let _account = AccountBuilder::new([0; 32])
-            .with_auth_component(AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([
-                root_a, root_b,
-            ])))
+            .with_auth_component(
+                AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([root_a, root_b]))
+                    .expect("non-empty allowlist should construct"),
+            )
             .with_component(BasicWallet)
             .build()
             .expect("account building with AuthNetworkAccount failed");
     }
 
     #[test]
-    fn auth_network_account_with_empty_allowlist_builds() {
-        let _account = AccountBuilder::new([0; 32])
-            .with_auth_component(AuthNetworkAccount::with_allowlist(BTreeSet::new()))
-            .with_component(BasicWallet)
-            .build()
-            .expect("account building with empty allowlist failed");
+    fn auth_network_account_with_empty_allowlist_is_rejected() {
+        let result = AuthNetworkAccount::with_allowlist(BTreeSet::new());
+        assert!(matches!(result, Err(NetworkAccountNoteAllowlistError::EmptyAllowlist)));
     }
 
     #[test]
     fn auth_network_account_uses_standardized_allowlist_slot() {
         let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let component: AccountComponent =
-            AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([root_a])).into();
+            AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([root_a]))
+                .expect("non-empty allowlist should construct")
+                .into();
 
         let storage_slots = component.storage_slots();
         assert_eq!(storage_slots.len(), 1);

--- a/crates/miden-standards/src/account/auth/network_account/mod.rs
+++ b/crates/miden-standards/src/account/auth/network_account/mod.rs
@@ -2,4 +2,4 @@ mod auth_network_account;
 pub use auth_network_account::AuthNetworkAccount;
 
 mod note_allowlist;
-pub use note_allowlist::NetworkAccountNoteAllowlist;
+pub use note_allowlist::{NetworkAccountNoteAllowlist, NetworkAccountNoteAllowlistError};

--- a/crates/miden-standards/src/account/auth/network_account/mod.rs
+++ b/crates/miden-standards/src/account/auth/network_account/mod.rs
@@ -1,0 +1,5 @@
+mod auth_network_account;
+pub use auth_network_account::AuthNetworkAccount;
+
+mod note_allowlist;
+pub use note_allowlist::NetworkAccountNoteAllowlist;

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -1,7 +1,14 @@
 use alloc::vec::Vec;
 
 use miden_protocol::account::component::{SchemaType, StorageSlotSchema};
-use miden_protocol::account::{StorageMap, StorageMapKey, StorageSlot, StorageSlotName};
+use miden_protocol::account::{
+    AccountStorage,
+    StorageMap,
+    StorageMapKey,
+    StorageSlot,
+    StorageSlotContent,
+    StorageSlotName,
+};
 use miden_protocol::utils::sync::LazyLock;
 use miden_protocol::{Felt, Word};
 
@@ -48,6 +55,11 @@ impl NetworkAccountNoteAllowlist {
         &SLOT_NAME
     }
 
+    /// Returns the allowed input-note script roots in this allowlist.
+    pub fn allowed_script_roots(&self) -> &[Word] {
+        &self.allowed_script_roots
+    }
+
     /// Returns the schema entry for the allowlist slot.
     pub fn slot_schema() -> (StorageSlotName, StorageSlotSchema) {
         (
@@ -75,14 +87,62 @@ impl NetworkAccountNoteAllowlist {
     }
 }
 
+// TRAIT IMPLEMENTATIONS
+// ================================================================================================
+
+impl TryFrom<&AccountStorage> for NetworkAccountNoteAllowlist {
+    type Error = NetworkAccountNoteAllowlistError;
+
+    /// Reconstructs a [`NetworkAccountNoteAllowlist`] from account storage by reading the
+    /// allowlist slot and collecting its keys.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The standardized allowlist slot is not present in storage.
+    /// - The slot is present but is not a [`StorageSlotContent::Map`].
+    fn try_from(storage: &AccountStorage) -> Result<Self, Self::Error> {
+        let slot = storage
+            .get(Self::slot_name())
+            .ok_or(NetworkAccountNoteAllowlistError::SlotNotFound)?;
+
+        let StorageSlotContent::Map(map) = slot.content() else {
+            return Err(NetworkAccountNoteAllowlistError::UnexpectedSlotType);
+        };
+
+        let allowed_script_roots = map.entries().map(|(key, _value)| Word::from(*key)).collect();
+
+        Ok(Self::new(allowed_script_roots))
+    }
+}
+
+// NETWORK ACCOUNT NOTE ALLOWLIST ERROR
+// ================================================================================================
+
+/// Errors that can occur when reconstructing a [`NetworkAccountNoteAllowlist`] from storage.
+#[derive(Debug, thiserror::Error)]
+pub enum NetworkAccountNoteAllowlistError {
+    #[error(
+        "network account allowlist storage slot {} not found in account storage",
+        NetworkAccountNoteAllowlist::slot_name()
+    )]
+    SlotNotFound,
+    #[error(
+        "network account allowlist storage slot {} must be a map",
+        NetworkAccountNoteAllowlist::slot_name()
+    )]
+    UnexpectedSlotType,
+}
+
 // TESTS
 // ================================================================================================
 
 #[cfg(test)]
 mod tests {
-    use miden_protocol::account::StorageSlotContent;
+    use miden_protocol::account::{AccountBuilder, StorageSlotContent};
 
     use super::*;
+    use crate::account::auth::network_account::AuthNetworkAccount;
+    use crate::account::wallets::BasicWallet;
 
     #[test]
     fn allowlist_storage_slot_contains_expected_entries() {
@@ -118,5 +178,30 @@ mod tests {
         };
 
         assert_eq!(map.entries().count(), 0);
+    }
+
+    #[test]
+    fn allowlist_round_trips_through_account_storage() {
+        use alloc::collections::BTreeSet;
+
+        let root_a = Word::from([1u32, 2, 3, 4]);
+        let root_b = Word::from([5u32, 6, 7, 8]);
+        let root_c = Word::from([9u32, 10, 11, 12]);
+        let original_roots = vec![root_a, root_b, root_c];
+
+        let account = AccountBuilder::new([0; 32])
+            .with_auth_component(AuthNetworkAccount::new(original_roots.clone()))
+            .with_component(BasicWallet)
+            .build()
+            .expect("account building with AuthNetworkAccount failed");
+
+        let allowlist = NetworkAccountNoteAllowlist::try_from(account.storage())
+            .expect("allowlist should be reconstructable from account storage");
+
+        // The map's ordering is determined by the StorageMapKey, so compare as sets.
+        let expected: BTreeSet<Word> = original_roots.into_iter().collect();
+        let actual: BTreeSet<Word> = allowlist.allowed_script_roots().iter().copied().collect();
+
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -1,4 +1,4 @@
-use core::collections::BTreeSet;
+use alloc::collections::BTreeSet;
 
 use miden_protocol::account::component::{SchemaType, StorageSlotSchema};
 use miden_protocol::account::{

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use std::collections::BTreeSet;
 
 use miden_protocol::account::component::{SchemaType, StorageSlotSchema};
 use miden_protocol::account::{
@@ -42,12 +42,12 @@ const ALLOWED_FLAG: Word = Word::new([Felt::ONE, Felt::ZERO, Felt::ZERO, Felt::Z
 /// allowed.
 #[derive(Debug, Clone)]
 pub struct NetworkAccountNoteAllowlist {
-    allowed_script_roots: Vec<NoteScriptRoot>,
+    allowed_script_roots: BTreeSet<NoteScriptRoot>,
 }
 
 impl NetworkAccountNoteAllowlist {
     /// Creates a new allowlist from the provided list of allowed input-note script roots.
-    pub fn new(allowed_script_roots: Vec<NoteScriptRoot>) -> Self {
+    pub fn new(allowed_script_roots: BTreeSet<NoteScriptRoot>) -> Self {
         Self { allowed_script_roots }
     }
 
@@ -57,7 +57,7 @@ impl NetworkAccountNoteAllowlist {
     }
 
     /// Returns the allowed input-note script roots in this allowlist.
-    pub fn allowed_script_roots(&self) -> &[NoteScriptRoot] {
+    pub fn allowed_script_roots(&self) -> &BTreeSet<NoteScriptRoot> {
         &self.allowed_script_roots
     }
 
@@ -153,7 +153,8 @@ mod tests {
         let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
 
-        let slot = NetworkAccountNoteAllowlist::new(vec![root_a, root_b]).into_storage_slot();
+        let slot = NetworkAccountNoteAllowlist::new(BTreeSet::from_iter([root_a, root_b]))
+            .into_storage_slot();
 
         assert_eq!(slot.name(), NetworkAccountNoteAllowlist::slot_name());
 
@@ -175,7 +176,7 @@ mod tests {
 
     #[test]
     fn empty_allowlist_produces_empty_map() {
-        let slot = NetworkAccountNoteAllowlist::new(Vec::new()).into_storage_slot();
+        let slot = NetworkAccountNoteAllowlist::new(BTreeSet::new()).into_storage_slot();
 
         let StorageSlotContent::Map(map) = slot.content() else {
             panic!("allowlist slot must be a map");
@@ -191,10 +192,10 @@ mod tests {
         let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
         let root_c = NoteScriptRoot::from_array([9, 10, 11, 12]);
-        let original_roots = vec![root_a, root_b, root_c];
+        let original_roots = BTreeSet::from_iter([root_a, root_b, root_c]);
 
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(AuthNetworkAccount::new(original_roots.clone()))
+            .with_auth_component(AuthNetworkAccount::with_allowlist(original_roots.clone()))
             .with_component(BasicWallet)
             .build()
             .expect("account building with AuthNetworkAccount failed");

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -9,6 +9,7 @@ use miden_protocol::account::{
     StorageSlotContent,
     StorageSlotName,
 };
+use miden_protocol::note::NoteScriptRoot;
 use miden_protocol::utils::sync::LazyLock;
 use miden_protocol::{Felt, Word};
 
@@ -41,12 +42,12 @@ const ALLOWED_FLAG: Word = Word::new([Felt::ONE, Felt::ZERO, Felt::ZERO, Felt::Z
 /// allowed.
 #[derive(Debug, Clone)]
 pub struct NetworkAccountNoteAllowlist {
-    allowed_script_roots: Vec<Word>,
+    allowed_script_roots: Vec<NoteScriptRoot>,
 }
 
 impl NetworkAccountNoteAllowlist {
     /// Creates a new allowlist from the provided list of allowed input-note script roots.
-    pub fn new(allowed_script_roots: Vec<Word>) -> Self {
+    pub fn new(allowed_script_roots: Vec<NoteScriptRoot>) -> Self {
         Self { allowed_script_roots }
     }
 
@@ -56,7 +57,7 @@ impl NetworkAccountNoteAllowlist {
     }
 
     /// Returns the allowed input-note script roots in this allowlist.
-    pub fn allowed_script_roots(&self) -> &[Word] {
+    pub fn allowed_script_roots(&self) -> &[NoteScriptRoot] {
         &self.allowed_script_roots
     }
 
@@ -78,7 +79,7 @@ impl NetworkAccountNoteAllowlist {
         let entries = self
             .allowed_script_roots
             .into_iter()
-            .map(|root| (StorageMapKey::new(root), ALLOWED_FLAG));
+            .map(|root| (StorageMapKey::new(root.as_word()), ALLOWED_FLAG));
 
         let storage_map = StorageMap::with_entries(entries)
             .expect("allowlist entries should produce a valid storage map");
@@ -109,7 +110,10 @@ impl TryFrom<&AccountStorage> for NetworkAccountNoteAllowlist {
             return Err(NetworkAccountNoteAllowlistError::UnexpectedSlotType);
         };
 
-        let allowed_script_roots = map.entries().map(|(key, _value)| Word::from(*key)).collect();
+        let allowed_script_roots = map
+            .entries()
+            .map(|(key, _value)| NoteScriptRoot::from_raw(key.as_word()))
+            .collect();
 
         Ok(Self::new(allowed_script_roots))
     }
@@ -146,8 +150,8 @@ mod tests {
 
     #[test]
     fn allowlist_storage_slot_contains_expected_entries() {
-        let root_a = Word::from([1u32, 2, 3, 4]);
-        let root_b = Word::from([5u32, 6, 7, 8]);
+        let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
+        let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
 
         let slot = NetworkAccountNoteAllowlist::new(vec![root_a, root_b]).into_storage_slot();
 
@@ -158,12 +162,12 @@ mod tests {
         };
 
         assert_eq!(
-            map.get(&StorageMapKey::new(root_a)),
+            map.get(&StorageMapKey::new(root_a.as_word())),
             ALLOWED_FLAG,
             "root_a should resolve to the flag value"
         );
         assert_eq!(
-            map.get(&StorageMapKey::new(root_b)),
+            map.get(&StorageMapKey::new(root_b.as_word())),
             ALLOWED_FLAG,
             "root_b should resolve to the flag value"
         );
@@ -184,9 +188,9 @@ mod tests {
     fn allowlist_round_trips_through_account_storage() {
         use alloc::collections::BTreeSet;
 
-        let root_a = Word::from([1u32, 2, 3, 4]);
-        let root_b = Word::from([5u32, 6, 7, 8]);
-        let root_c = Word::from([9u32, 10, 11, 12]);
+        let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
+        let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
+        let root_c = NoteScriptRoot::from_array([9, 10, 11, 12]);
         let original_roots = vec![root_a, root_b, root_c];
 
         let account = AccountBuilder::new([0; 32])
@@ -199,8 +203,9 @@ mod tests {
             .expect("allowlist should be reconstructable from account storage");
 
         // The map's ordering is determined by the StorageMapKey, so compare as sets.
-        let expected: BTreeSet<Word> = original_roots.into_iter().collect();
-        let actual: BTreeSet<Word> = allowlist.allowed_script_roots().iter().copied().collect();
+        let expected: BTreeSet<NoteScriptRoot> = original_roots.into_iter().collect();
+        let actual: BTreeSet<NoteScriptRoot> =
+            allowlist.allowed_script_roots().iter().copied().collect();
 
         assert_eq!(actual, expected);
     }

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -47,8 +47,19 @@ pub struct NetworkAccountNoteAllowlist {
 
 impl NetworkAccountNoteAllowlist {
     /// Creates a new allowlist from the provided list of allowed input-note script roots.
-    pub fn new(allowed_script_roots: BTreeSet<NoteScriptRoot>) -> Self {
-        Self { allowed_script_roots }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `allowed_script_roots` is empty since the account could not consume any
+    /// notes.
+    pub fn new(
+        allowed_script_roots: BTreeSet<NoteScriptRoot>,
+    ) -> Result<Self, NetworkAccountNoteAllowlistError> {
+        if allowed_script_roots.is_empty() {
+            return Err(NetworkAccountNoteAllowlistError::EmptyAllowlist);
+        }
+
+        Ok(Self { allowed_script_roots })
     }
 
     /// Returns the [`StorageSlotName`] of the standardized allowlist slot.
@@ -115,16 +126,22 @@ impl TryFrom<&AccountStorage> for NetworkAccountNoteAllowlist {
             .map(|(key, _value)| NoteScriptRoot::from_raw(key.as_word()))
             .collect();
 
-        Ok(Self::new(allowed_script_roots))
+        Self::new(allowed_script_roots)
     }
 }
 
 // NETWORK ACCOUNT NOTE ALLOWLIST ERROR
 // ================================================================================================
 
-/// Errors that can occur when reconstructing a [`NetworkAccountNoteAllowlist`] from storage.
+/// Errors that can occur when constructing a [`NetworkAccountNoteAllowlist`] or reconstructing one
+/// from storage.
 #[derive(Debug, thiserror::Error)]
 pub enum NetworkAccountNoteAllowlistError {
+    #[error(
+        "network account allowlist must contain at least one allowed note script root: an empty \
+         allowlist would prevent the account from consuming any notes"
+    )]
+    EmptyAllowlist,
     #[error(
         "network account allowlist storage slot {} not found in account storage",
         NetworkAccountNoteAllowlist::slot_name()
@@ -154,6 +171,7 @@ mod tests {
         let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
 
         let slot = NetworkAccountNoteAllowlist::new(BTreeSet::from_iter([root_a, root_b]))
+            .expect("non-empty allowlist should construct")
             .into_storage_slot();
 
         assert_eq!(slot.name(), NetworkAccountNoteAllowlist::slot_name());
@@ -175,14 +193,9 @@ mod tests {
     }
 
     #[test]
-    fn empty_allowlist_produces_empty_map() {
-        let slot = NetworkAccountNoteAllowlist::new(BTreeSet::new()).into_storage_slot();
-
-        let StorageSlotContent::Map(map) = slot.content() else {
-            panic!("allowlist slot must be a map");
-        };
-
-        assert_eq!(map.entries().count(), 0);
+    fn empty_allowlist_is_rejected() {
+        let result = NetworkAccountNoteAllowlist::new(BTreeSet::new());
+        assert!(matches!(result, Err(NetworkAccountNoteAllowlistError::EmptyAllowlist)));
     }
 
     #[test]
@@ -195,7 +208,10 @@ mod tests {
         let original_roots = BTreeSet::from_iter([root_a, root_b, root_c]);
 
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(AuthNetworkAccount::with_allowlist(original_roots.clone()))
+            .with_auth_component(
+                AuthNetworkAccount::with_allowlist(original_roots.clone())
+                    .expect("non-empty allowlist should construct"),
+            )
             .with_component(BasicWallet)
             .build()
             .expect("account building with AuthNetworkAccount failed");

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use core::collections::BTreeSet;
 
 use miden_protocol::account::component::{SchemaType, StorageSlotSchema};
 use miden_protocol::account::{

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -1,0 +1,122 @@
+use alloc::vec::Vec;
+
+use miden_protocol::account::component::{SchemaType, StorageSlotSchema};
+use miden_protocol::account::{StorageMap, StorageMapKey, StorageSlot, StorageSlotName};
+use miden_protocol::utils::sync::LazyLock;
+use miden_protocol::{Felt, Word};
+
+// CONSTANTS
+// ================================================================================================
+
+static SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
+    StorageSlotName::new("miden::standards::auth::network_account::allowed_note_scripts")
+        .expect("storage slot name should be valid")
+});
+
+// A flag value used as the storage map entry for each allowed script root. Its only job is to be
+// distinguishable from the storage map's default empty word, letting the MASM allowlist check
+// detect "this key is present" without caring about its contents. Any non-empty word would serve;
+// we pick `[1, 0, 0, 0]` for readability when inspecting storage.
+const ALLOWED_FLAG: Word = Word::new([Felt::ONE, Felt::ZERO, Felt::ZERO, Felt::ZERO]);
+
+// NETWORK ACCOUNT NOTE ALLOWLIST
+// ================================================================================================
+
+/// A standardized storage slot holding the allowlist of input-note script roots that a network
+/// account is willing to consume.
+///
+/// The presence of this slot is what defines an account as a "network account": it is the
+/// abstraction shared by every network-account component, so off-chain services (like the network
+/// transaction builder) can identify a network account and filter notes by inspecting account
+/// storage for this slot, independent of which component the account uses.
+///
+/// The slot is a [`StorageMap`] keyed by note script root; any non-empty value marks a root as
+/// allowed.
+#[derive(Debug, Clone)]
+pub struct NetworkAccountNoteAllowlist {
+    allowed_script_roots: Vec<Word>,
+}
+
+impl NetworkAccountNoteAllowlist {
+    /// Creates a new allowlist from the provided list of allowed input-note script roots.
+    pub fn new(allowed_script_roots: Vec<Word>) -> Self {
+        Self { allowed_script_roots }
+    }
+
+    /// Returns the [`StorageSlotName`] of the standardized allowlist slot.
+    pub fn slot_name() -> &'static StorageSlotName {
+        &SLOT_NAME
+    }
+
+    /// Returns the schema entry for the allowlist slot.
+    pub fn slot_schema() -> (StorageSlotName, StorageSlotSchema) {
+        (
+            Self::slot_name().clone(),
+            StorageSlotSchema::map(
+                "Allowed input note script roots",
+                SchemaType::native_word(),
+                SchemaType::native_word(),
+            ),
+        )
+    }
+
+    /// Consumes this allowlist and returns the [`StorageSlot`] suitable for inclusion in an
+    /// [`AccountComponent`](miden_protocol::account::AccountComponent)'s storage layout.
+    pub fn into_storage_slot(self) -> StorageSlot {
+        let entries = self
+            .allowed_script_roots
+            .into_iter()
+            .map(|root| (StorageMapKey::new(root), ALLOWED_FLAG));
+
+        let storage_map = StorageMap::with_entries(entries)
+            .expect("allowlist entries should produce a valid storage map");
+
+        StorageSlot::with_map(Self::slot_name().clone(), storage_map)
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::account::StorageSlotContent;
+
+    use super::*;
+
+    #[test]
+    fn allowlist_storage_slot_contains_expected_entries() {
+        let root_a = Word::from([1u32, 2, 3, 4]);
+        let root_b = Word::from([5u32, 6, 7, 8]);
+
+        let slot = NetworkAccountNoteAllowlist::new(vec![root_a, root_b]).into_storage_slot();
+
+        assert_eq!(slot.name(), NetworkAccountNoteAllowlist::slot_name());
+
+        let StorageSlotContent::Map(map) = slot.content() else {
+            panic!("allowlist slot must be a map");
+        };
+
+        assert_eq!(
+            map.get(&StorageMapKey::new(root_a)),
+            ALLOWED_FLAG,
+            "root_a should resolve to the flag value"
+        );
+        assert_eq!(
+            map.get(&StorageMapKey::new(root_b)),
+            ALLOWED_FLAG,
+            "root_b should resolve to the flag value"
+        );
+    }
+
+    #[test]
+    fn empty_allowlist_produces_empty_map() {
+        let slot = NetworkAccountNoteAllowlist::new(Vec::new()).into_storage_slot();
+
+        let StorageSlotContent::Map(map) = slot.content() else {
+            panic!("allowlist slot must be a map");
+        };
+
+        assert_eq!(map.entries().count(), 0);
+    }
+}

--- a/crates/miden-testing/src/tx_context/context.rs
+++ b/crates/miden-testing/src/tx_context/context.rs
@@ -404,7 +404,6 @@ impl MastForestStore for TransactionContext {
 
 #[cfg(test)]
 mod tests {
-    use miden_protocol::Felt;
     use miden_standards::code_builder::CodeBuilder;
 
     use super::*;
@@ -448,12 +447,7 @@ mod tests {
         assert_eq!(retrieved_script2, note_script2);
 
         // Fetching a non-existent one returns None
-        let non_existent_root = NoteScriptRoot::from_raw(Word::from([
-            Felt::new(1),
-            Felt::new(2),
-            Felt::new(3),
-            Felt::new(4),
-        ]));
+        let non_existent_root = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let result = tx_context.get_note_script(non_existent_root).await;
         assert!(matches!(result, Ok(None)));
     }

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -2,6 +2,7 @@ use core::slice;
 
 use miden_protocol::Word;
 use miden_protocol::account::{Account, AccountBuilder, AccountStorageMode, AccountType};
+use miden_protocol::note::NoteScriptRoot;
 use miden_protocol::transaction::RawOutputNote;
 use miden_standards::account::auth::AuthNetworkAccount;
 use miden_standards::account::wallets::BasicWallet;
@@ -20,7 +21,9 @@ use miden_testing::{MockChain, assert_transaction_executor_error};
 /// allowlist of input-note script roots.
 fn build_allowlist_account(allowed_script_roots: Vec<Word>) -> anyhow::Result<Account> {
     Ok(AccountBuilder::new([0; 32])
-        .with_auth_component(AuthNetworkAccount::new(allowed_script_roots))
+        .with_auth_component(AuthNetworkAccount::new(
+            allowed_script_roots.into_iter().map(NoteScriptRoot::from_raw).collect(),
+        ))
         .with_component(BasicWallet)
         .account_type(AccountType::RegularAccountUpdatableCode)
         .storage_mode(AccountStorageMode::Public)

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -17,13 +17,23 @@ use miden_testing::{MockChain, assert_transaction_executor_error};
 // HELPER FUNCTIONS
 // ================================================================================================
 
+/// A placeholder script root used when a test needs an [`AuthNetworkAccount`] account whose
+/// allowlist contents are not material to the test logic (e.g. for bootstrap accounts that only
+/// exist to seed a [`NoteBuilder`]). The constructor rejects empty allowlists, so tests must
+/// supply at least one root.
+fn placeholder_script_root() -> Word {
+    NoteScriptRoot::from_array([1, 0, 0, 0]).into()
+}
+
 /// Builds a minimal account that uses the [`AuthNetworkAccount`] auth component with the provided
 /// allowlist of input-note script roots.
 fn build_allowlist_account(allowed_script_roots: Vec<Word>) -> anyhow::Result<Account> {
+    let auth_component = AuthNetworkAccount::with_allowlist(
+        allowed_script_roots.into_iter().map(NoteScriptRoot::from_raw).collect(),
+    )?;
+
     Ok(AccountBuilder::new([0; 32])
-        .with_auth_component(AuthNetworkAccount::with_allowlist(
-            allowed_script_roots.into_iter().map(NoteScriptRoot::from_raw).collect(),
-        ))
+        .with_auth_component(auth_component)
         .with_component(BasicWallet)
         .account_type(AccountType::RegularAccountUpdatableCode)
         .storage_mode(AccountStorageMode::Public)
@@ -37,7 +47,8 @@ fn build_allowlist_account(allowed_script_roots: Vec<Word>) -> anyhow::Result<Ac
 /// allowlist and input notes are otherwise valid.
 #[tokio::test]
 async fn test_auth_network_account_rejects_tx_script() -> anyhow::Result<()> {
-    let account = build_allowlist_account(Vec::new())?;
+    // Allowlist contents don't matter — the tx-script check rejects before any allowlist lookup.
+    let account = build_allowlist_account(vec![placeholder_script_root()])?;
 
     let mut builder = MockChain::builder();
     builder.add_account(account.clone())?;
@@ -62,8 +73,9 @@ async fn test_auth_network_account_rejects_tx_script() -> anyhow::Result<()> {
 /// the others are.
 #[tokio::test]
 async fn test_auth_network_account_rejects_when_any_note_disallowed() -> anyhow::Result<()> {
-    // Build a template note with the default code to learn the "allowed" script root.
-    let bootstrap_account = build_allowlist_account(Vec::new())?;
+    // Build a template note with the default code to learn the "allowed" script root. The
+    // bootstrap account never executes a transaction, so its allowlist contents don't matter.
+    let bootstrap_account = build_allowlist_account(vec![placeholder_script_root()])?;
     let template_allowed = NoteBuilder::new(bootstrap_account.id(), &mut rand::rng())
         .build()
         .expect("failed to build template allowed note");
@@ -124,8 +136,9 @@ async fn test_auth_network_account_rejects_when_any_note_disallowed() -> anyhow:
 #[tokio::test]
 async fn test_auth_network_account_accepts_allowed_note() -> anyhow::Result<()> {
     // First build a template note so we know its script root, then use that root to configure the
-    // account's allowlist.
-    let bootstrap_account = build_allowlist_account(Vec::new())?;
+    // account's allowlist. The bootstrap account never executes a transaction, so its allowlist
+    // contents don't matter.
+    let bootstrap_account = build_allowlist_account(vec![placeholder_script_root()])?;
     let template_note = NoteBuilder::new(bootstrap_account.id(), &mut rand::rng())
         .build()
         .expect("failed to build template note");

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -21,7 +21,7 @@ use miden_testing::{MockChain, assert_transaction_executor_error};
 /// allowlist of input-note script roots.
 fn build_allowlist_account(allowed_script_roots: Vec<Word>) -> anyhow::Result<Account> {
     Ok(AccountBuilder::new([0; 32])
-        .with_auth_component(AuthNetworkAccount::new(
+        .with_auth_component(AuthNetworkAccount::with_allowlist(
             allowed_script_roots.into_iter().map(NoteScriptRoot::from_raw).collect(),
         ))
         .with_component(BasicWallet)


### PR DESCRIPTION
Added standardized `NetworkAccountNoteAllowlist` slot for detecting network accounts as part of https://github.com/0xMiden/protocol/issues/2285. The motivation for this was outlined in https://github.com/0xMiden/protocol/pull/2817#discussion_r3180166023.

This is the first of two (?) steps towards removing `AccountStorageMode::Network`.

Also implements reconstructing such a storage slot from account storage. This would eventually use `AccountStorageInterface` (https://github.com/0xMiden/protocol/issues/2623).

Changes internal representation to use `NoteScriptRoot` for more type safety.

Requesting review from @Mirko-von-Leipzig mainly for the overall approach, not necessarily the details, though a review is of course appreciated :slightly_smiling_face: 