### PR TITLE
Increment crate versions to v0.14.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.14.6 (2026-05-05)
+## 0.14.6 (2026-05-09)
 
 - Fixed asset callback against native account panicking ([#2868](https://github.com/0xMiden/protocol/pull/2868)).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "miden-protocol",
  "proc-macro2",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.14.5"
+version = "0.14.6"
 dependencies = [
  "miden-protocol",
  "miden-tx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.90"
-version      = "0.14.5"
+version      = "0.14.6"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
This PR increments crate versions in the `main` branch to v0.14.6.