### PR TITLE
fix: PartialBlockchain deserialization skips an important safety checkfix/partial-blockchain-deser-mmr-check

### DIFF
--- a/crates/miden-protocol/src/transaction/partial_blockchain.rs
+++ b/crates/miden-protocol/src/transaction/partial_blockchain.rs
@@ -254,17 +254,23 @@ impl PartialBlockchain {
 impl Serializable for PartialBlockchain {
     fn write_into<W: miden_crypto::utils::ByteWriter>(&self, target: &mut W) {
         self.mmr.write_into(target);
-        self.blocks.write_into(target);
+        self.blocks.values().cloned().collect::<Vec<_>>().write_into(target);
     }
+
 }
 
 impl Deserializable for PartialBlockchain {
     fn read_from<R: miden_crypto::utils::ByteReader>(
-        source: &mut R,
+    source: &mut R,
     ) -> Result<Self, miden_crypto::utils::DeserializationError> {
         let mmr = PartialMmr::read_from(source)?;
-        let blocks = BTreeMap::<BlockNumber, BlockHeader>::read_from(source)?;
-        Ok(Self { mmr, blocks })
+        let blocks = Vec::<BlockHeader>::read_from(source)?;
+    
+        Self::new(mmr, blocks).map_err(|e| {
+            miden_crypto::utils::DeserializationError::InvalidValue(format!(
+                "PartialBlockchain failed MMR integrity check during deserialization: {e}"
+            ))
+        })
     }
 }
 


### PR DESCRIPTION
## Issue

`PartialBlockchain::new()` verifies every stored block header against the MMR before returning. 

`Deserializable::read_from()` constructs the struct directly and skips this check entirely.

This means a deserialized `PartialBlockchain` can contain block headers with arbitrary `note_root` values while still passing the chain commitment check, because that check only covers the MMR peaks not the individual block headers stored in the `.blocks` map.

`authenticate_unauthenticated_note` reads `note_root` directly from the stored header to verify note inclusion proofs. A tampered header with a crafted `note_root` causes invalid note inclusion proofs to pass verification, allowing notes that were never committed to the chain to be treated as authenticated.

---

## Fix

`crates/miden-protocol/src/transaction/partial_blockchain.rs`

```rust
// after
fn read_from<R: miden_crypto::utils::ByteReader>(
    source: &mut R,
) -> Result<Self, miden_crypto::utils::DeserializationError> {
    let mmr = PartialMmr::read_from(source)?;
    let blocks = Vec::<BlockHeader>::read_from(source)?;

    Self::new(mmr, blocks).map_err(|e| {
        miden_crypto::utils::DeserializationError::InvalidValue(format!(
            "PartialBlockchain failed MMR integrity check during deserialization: {e}"
        ))
    })
}
```
```rust
// after
fn write_into<W: miden_crypto::utils::ByteWriter>(&self, target: &mut W) {
    self.mmr.write_into(target);
    self.blocks.values().cloned().collect::<Vec<_>>().write_into(target);
}
```

---

## Why

PR #1308 added the safe constructor with the MMR check but the `Deserializable` impl was not updated to use it.