### PR TITLE
fix: call validate() when deserializing ProvenBlock and SignedBlock

### DIFF
--- a/crates/miden-protocol/src/block/proven_block.rs
+++ b/crates/miden-protocol/src/block/proven_block.rs
@@ -231,13 +231,12 @@ impl Serializable for ProvenBlock {
 
 impl Deserializable for ProvenBlock {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let block = Self {
-            header: BlockHeader::read_from(source)?,
-            body: BlockBody::read_from(source)?,
-            signature: Signature::read_from(source)?,
-            proof: BlockProof::read_from(source)?,
-        };
-
-        Ok(block)
+        let header    = BlockHeader::read_from(source)?;
+        let body      = BlockBody::read_from(source)?;
+        let signature = Signature::read_from(source)?;
+        let proof     = BlockProof::read_from(source)?;
+    
+        ProvenBlock::new(header, body, signature, proof)
+            .map_err(|e| DeserializationError::InvalidValue(e.to_string()))
     }
 }

--- a/crates/miden-protocol/src/block/signed_block.rs
+++ b/crates/miden-protocol/src/block/signed_block.rs
@@ -201,12 +201,11 @@ impl Serializable for SignedBlock {
 
 impl Deserializable for SignedBlock {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let block = Self {
-            header: BlockHeader::read_from(source)?,
-            body: BlockBody::read_from(source)?,
-            signature: Signature::read_from(source)?,
-        };
-
-        Ok(block)
+        let header    = BlockHeader::read_from(source)?;
+        let body      = BlockBody::read_from(source)?;
+        let signature = Signature::read_from(source)?;
+    
+        SignedBlock::new(header, body, signature)
+            .map_err(|e| DeserializationError::InvalidValue(e.to_string()))
     }
 }


### PR DESCRIPTION
## Issue

`ProvenBlock::new()` calls `validate()` which checks the validator signature, the tx commitment, and the note root before returning. `Deserializable::read_from()` constructs the struct directly and none of these checks run.

Any `ProvenBlock` received from an external source via deserialization is accepted without signature verification or commitment consistency checks. Same issue exists in `SignedBlock::read_from()`.

---

## Fix

`crates/miden-protocol/src/block/proven_block.rs`

```
// after
fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
    let header    = BlockHeader::read_from(source)?;
    let body      = BlockBody::read_from(source)?;
    let signature = Signature::read_from(source)?;
    let proof     = BlockProof::read_from(source)?;

    ProvenBlock::new(header, body, signature, proof)
        .map_err(|e| DeserializationError::InvalidValue(e.to_string()))
}
```

`crates/miden-protocol/src/block/signed_block.rs`

```
// after
fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
    let header    = BlockHeader::read_from(source)?;
    let body      = BlockBody::read_from(source)?;
    let signature = Signature::read_from(source)?;

    SignedBlock::new(header, body, signature)
        .map_err(|e| DeserializationError::InvalidValue(e.to_string()))
}
```

---

## Why

PR #1260 applied this same pattern to `ProvenBatch`. `ProvenBlock` and `SignedBlock` were not updated at the same time.