### PR TITLE
fix(protocol): encode note metadata v1 as one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Re-exported `MIN_STACK_DEPTH` from `miden-processor` ([#2856](https://github.com/0xMiden/protocol/pull/2856)).
 - [BREAKING] Renamed `note::build_recipient_hash` to `note::compute_recipient` and `note::build_recipient` to `note::compute_and_store_recipient` ([#2875](https://github.com/0xMiden/protocol/issues/2875)).
 - [BREAKING] Renamed account ID version 0 to version 1 and made encoded version 0 invalid ([#2842](https://github.com/0xMiden/protocol/issues/2842)).
+- [BREAKING] Changed note metadata version 1 to encode as `1`, leaving encoded version `0` invalid.
 - Documented the `miden::protocol::account_id` module in the protocol library docs ([#2607](https://github.com/0xMiden/protocol/issues/2607)).
 
 ### Fixes

--- a/crates/miden-protocol/asm/kernels/transaction/lib/output_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/output_note.masm
@@ -8,6 +8,7 @@ use $kernel::note::NOTE_TYPE_PUBLIC
 use $kernel::constants::MAX_OUTPUT_NOTES_PER_TX
 use $kernel::util::note::ATTACHMENT_KIND_NONE
 use $kernel::util::note::ATTACHMENT_KIND_ARRAY
+use $kernel::util::note::NOTE_METADATA_VERSION_1
 use $kernel::asset::ASSET_SIZE
 use $kernel::asset::ASSET_VALUE_MEMORY_OFFSET
 use miden::core::word
@@ -327,9 +328,9 @@ pub proc build_metadata_header
     # => [sender_id_suffix, sender_id_prefix, tag, note_type]
 
     # The lower 8 bits of the account ID suffix are guaranteed to be zero by construction.
-    # Encode note_type at bit 4, leaving version at 0 (in bits 0..=3).
+    # Encode note_type at bit 4 and version at bits 0..=3.
     # Shifting note_type left by 4 is equivalent to multiplying by 16.
-    movup.3 mul.16 add
+    movup.3 mul.16 add.NOTE_METADATA_VERSION_1 add
     # => [sender_id_suffix_type_version, sender_id_prefix, tag]
 
     # Build metadata header.

--- a/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
@@ -289,7 +289,7 @@ end
 #! for a new account.
 #!
 #! Applies the following validation to the new account:
-#! - assert that the account ID is valid.
+#! - assert that the account ID uses the supported version and is otherwise valid.
 #! - assert that the account vault is empty.
 #! - assert that the account nonce is set to 0.
 #! - read the account seed from the advice provider and assert it satisfies seed requirements.

--- a/crates/miden-protocol/asm/shared_modules/account_id.masm
+++ b/crates/miden-protocol/asm/shared_modules/account_id.masm
@@ -147,7 +147,7 @@ end
 #! - account_id_{suffix,prefix} are the suffix and prefix felts of the account ID.
 #!
 #! Panics if:
-#! - account_id_prefix does not contain version one.
+#! - account_id_prefix contains an unsupported account ID version.
 #! - account_id_prefix does not contain either the public, network or private storage mode.
 #! - account_id_suffix does not have its most significant bit set to zero.
 #! - account_id_suffix does not have its lower 8 bits set to zero.

--- a/crates/miden-protocol/asm/shared_utils/util/note.masm
+++ b/crates/miden-protocol/asm/shared_utils/util/note.masm
@@ -11,8 +11,11 @@ pub const ATTACHMENT_KIND_WORD=1
 #! A note attachment consisting of the commitment to a set of felts.
 pub const ATTACHMENT_KIND_ARRAY=2
 
-# Note type constants. These encode the note type in the lower byte of the metadata header.
+# Metadata header constants. These encode fields in the lower byte of the metadata header.
 # See NoteType in the Rust protocol crate for details.
+
+#! Version 1 of the note metadata encoding.
+pub const NOTE_METADATA_VERSION_1=1
 
 #! The note type of private notes.
 pub const NOTE_TYPE_PRIVATE=0

--- a/crates/miden-protocol/src/note/metadata.rs
+++ b/crates/miden-protocol/src/note/metadata.rs
@@ -1,6 +1,14 @@
 use super::{
-    AccountId, ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, NoteTag,
-    NoteType, Serializable, Word,
+    AccountId,
+    ByteReader,
+    ByteWriter,
+    Deserializable,
+    DeserializationError,
+    Felt,
+    NoteTag,
+    NoteType,
+    Serializable,
+    Word,
 };
 use crate::Hasher;
 use crate::errors::NoteError;
@@ -443,6 +451,8 @@ fn unmerge_attachment_kind_scheme(
 
 #[cfg(test)]
 mod tests {
+
+    use alloc::string::ToString;
 
     use super::*;
     use crate::note::NoteAttachmentScheme;

--- a/crates/miden-protocol/src/note/metadata.rs
+++ b/crates/miden-protocol/src/note/metadata.rs
@@ -1,14 +1,6 @@
 use super::{
-    AccountId,
-    ByteReader,
-    ByteWriter,
-    Deserializable,
-    DeserializationError,
-    Felt,
-    NoteTag,
-    NoteType,
-    Serializable,
-    Word,
+    AccountId, ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, NoteTag,
+    NoteType, Serializable, Word,
 };
 use crate::Hasher;
 use crate::errors::NoteError;
@@ -85,7 +77,7 @@ impl NoteMetadata {
     ///
     /// If we make this public, we may want to instead consider introducing a `NoteMetadataVersion`
     /// struct, similar to `AccountIdVersion`.
-    const VERSION_1: u8 = 0;
+    const VERSION_1: u8 = 1;
 
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
@@ -482,5 +474,30 @@ mod tests {
         assert_eq!(header, metadata.to_header());
 
         Ok(())
+    }
+
+    #[test]
+    fn note_metadata_header_encodes_v1_as_one() {
+        let sender = AccountId::try_from(ACCOUNT_ID_MAX_ONES).unwrap();
+        let metadata = NoteMetadata::new(sender, NoteType::Private);
+
+        let header = metadata.to_header_word();
+        let version = header[0].as_canonical_u64() & 0b1111;
+
+        assert_eq!(version, NoteMetadata::VERSION_1 as u64);
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn note_metadata_header_rejects_zero_version() {
+        let sender = AccountId::try_from(ACCOUNT_ID_MAX_ONES).unwrap();
+        let metadata = NoteMetadata::new(sender, NoteType::Private);
+        let mut header = metadata.to_header_word();
+
+        let header0 = header[0].as_canonical_u64() & !0b1111;
+        header[0] = Felt::try_from(header0).expect("header should still be a valid felt");
+
+        let err = NoteMetadataHeader::try_from(header).expect_err("version 0 should be rejected");
+        assert!(err.to_string().contains("unsupported note metadata version 0"), "{err}");
     }
 }


### PR DESCRIPTION
Follow-up from the discussion on #2880.

This changes note metadata v1 to encode as 1 instead of using the zero encoding. The MASM output-note header builder is updated to use the same version value, and the Rust metadata tests now cover both the v1 encoding and rejection of version 0 headers.

Checks:
- rustfmt --check crates/miden-protocol/src/note/metadata.rs
- git diff --check

I also tried:
- cargo test -p miden-protocol note_metadata
- cargo test -p miden-testing test_build_metadata_header

Both cargo runs were blocked locally by miden-core-lib v0.22.1 failing in its build script with: project 'miden-core' is missing its manifest path.