### PR TITLE
fix: bind MINT note to its faucet via asset-in-storage (#2798)

### DIFF
--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -9,6 +9,7 @@ use miden::core::crypto::hashes::keccak256
 use miden::core::crypto::hashes::poseidon2
 use miden::core::mem
 use miden::core::word
+use miden::protocol::asset
 use miden::protocol::note
 use miden::protocol::note::NOTE_TYPE_PUBLIC
 use miden::protocol::output_note
@@ -61,16 +62,18 @@ const CGI_CHAIN_HASH_HI_SLOT_NAME = word("agglayer::bridge::cgi_chain_hash_hi")
 const CLAIM_PROOF_DATA_WORD_LEN = 134
 const CLAIM_LEAF_DATA_WORD_LEN = 8
 
-# MINT note storage layout (public mode, 14 felts total):
+# MINT note storage layout (public mode, 22 felts total):
 # - P2ID_SCRIPT_ROOT  [0..3]   : 4 felts
 # - SERIAL_NUM        [4..7]   : 4 felts
-# - tag               [8]      : 1 felt
-# - amount            [9]      : 1 felt
-# - 0                 [10]     : 1 felt (padding)
-# - 0                 [11]     : 1 felt (padding)
-# - account_id_suffix [12]     : 1 felt
-# - account_id_prefix [13]     : 1 felt
-const MINT_NOTE_NUM_STORAGE_ITEMS = 14
+# - ASSET_KEY         [8..11]  : 4 felts (vault key of the fungible asset to mint)
+# - ASSET_VALUE       [12..15] : 4 felts (value word of the asset; [amount, 0, 0, 0])
+# - tag               [16]     : 1 felt
+# - 0                 [17]     : 1 felt (padding)
+# - 0                 [18]     : 1 felt (padding)
+# - 0                 [19]     : 1 felt (padding so the P2ID storage below is word-aligned)
+# - account_id_suffix [20]     : 1 felt
+# - account_id_prefix [21]     : 1 felt
+const MINT_NOTE_NUM_STORAGE_ITEMS = 22
 
 # Global memory pointers
 # -------------------------------------------------------------------------------------------------
@@ -141,11 +144,12 @@ const OUTPUT_NOTE_ASSET_AMOUNT_MEM_ADDR_7 = CLAIM_LEAF_DATA_START_PTR + 20
 const MINT_NOTE_STORAGE_MEM_ADDR_0 = 800
 const MINT_NOTE_STORAGE_OUTPUT_SCRIPT_ROOT = 800
 const MINT_NOTE_STORAGE_OUTPUT_SERIAL_NUM = 804
-const MINT_NOTE_STORAGE_DEST_TAG = 808
-const MINT_NOTE_STORAGE_NATIVE_AMOUNT = 809
-# padding at 810, 811
-const MINT_NOTE_STORAGE_OUTPUT_NOTE_SUFFIX = 812
-const MINT_NOTE_STORAGE_OUTPUT_NOTE_PREFIX = 813
+const MINT_NOTE_STORAGE_ASSET_KEY = 808
+const MINT_NOTE_STORAGE_ASSET_VALUE = 812
+const MINT_NOTE_STORAGE_DEST_TAG = 816
+# padding at 817, 818, 819 so the P2ID storage below stays word-aligned
+const MINT_NOTE_STORAGE_OUTPUT_NOTE_SUFFIX = 820
+const MINT_NOTE_STORAGE_OUTPUT_NOTE_PREFIX = 821
 
 # Local memory offsets
 # -------------------------------------------------------------------------------------------------
@@ -820,9 +824,12 @@ end
 
 #! Builds a PUBLIC MINT output note targeting the AggLayer Faucet.
 #!
-#! The MINT note uses public mode (18 storage items) so the AggLayer Faucet creates a PUBLIC P2ID
-#! note on consumption. This procedure orchestrates three steps:
-#! 1. Write all 18 MINT note storage items to global memory.
+#! The MINT note uses public mode (22 storage items) so the AggLayer Faucet creates a PUBLIC
+#! P2ID note on consumption. The 22 items include the fungible asset (`ASSET_KEY` +
+#! `ASSET_VALUE`) for the resolved faucet at the resolved native amount, so the faucet's
+#! `mint_and_send` can verify the asset's faucet ID against the active account at consumption
+#! time. This procedure orchestrates three steps:
+#! 1. Write all 22 MINT note storage items to global memory.
 #! 2. Build the MINT note recipient digest from the storage.
 #! 3. Create the output note, and set the attachment.
 #!
@@ -831,7 +838,7 @@ end
 #!
 #! Invocation: exec
 proc build_mint_output_note
-    # Step 1: Write all 18 MINT note storage items to global memory
+    # Step 1: Write all 22 MINT note storage items to global memory
     exec.write_mint_note_storage
     # => [faucet_id_suffix, faucet_id_prefix]
 
@@ -844,67 +851,83 @@ proc build_mint_output_note
     # => []
 end
 
-#! Writes all 14 MINT note storage items to global memory.
+#! Writes all 22 MINT note storage items to global memory.
 #!
 #! Storage layout:
-#! - [0-3]: P2ID_SCRIPT_ROOT (script root of the P2ID note)
-#! - [4-7]: SERIAL_NUM (serial number for the P2ID note, derived from PROOF_DATA_KEY)
-#! - [8]: tag (note tag for the P2ID output note, targeting the destination account)
-#! - [9]: amount (the scaled-down Miden amount to mint)
-#! - [10]: 0 (padding)
-#! - [11]: 0 (padding)
-#! - [12]: account_id_suffix (destination account suffix)
-#! - [13]: account_id_prefix (destination account prefix)
+#! - [0..3]:   P2ID_SCRIPT_ROOT (script root of the P2ID note)
+#! - [4..7]:   SERIAL_NUM (serial number for the P2ID note, derived from PROOF_DATA_KEY)
+#! - [8..11]:  ASSET_KEY (vault key of the fungible asset that the AggLayer faucet must mint)
+#! - [12..15]: ASSET_VALUE (value word of the asset: [native_amount, 0, 0, 0])
+#! - [16]:     dest_tag (note tag for the P2ID output note, targeting the destination account)
+#! - [17..19]: padding (so the P2ID storage below stays word-aligned at [20..21])
+#! - [20]:     account_id_suffix (destination account suffix)
+#! - [21]:     account_id_prefix (destination account prefix)
 #!
-#! Inputs:  [destination_id_suffix, destination_id_prefix]
-#! Outputs: []
+#! AggLayer fungible faucets do not declare callbacks, so `enable_callbacks = 0` is passed
+#! to `asset::create_fungible_asset` when assembling the ASSET word pair.
+#!
+#! Inputs:  [destination_id_suffix, destination_id_prefix, faucet_id_suffix, faucet_id_prefix]
+#! Outputs: [faucet_id_suffix, faucet_id_prefix]
 #!
 #! Invocation: exec
 proc write_mint_note_storage
-    # Write P2ID storage items first (before prefix is consumed): [12..13]
-    # Write destination_id_suffix [12]
+    # Write P2ID destination first so we can consume destination_id_prefix for the tag.
+    # destination_id_suffix [20]
     dup mem_store.MINT_NOTE_STORAGE_OUTPUT_NOTE_SUFFIX
-    # => [destination_id_suffix, destination_id_prefix]
-
-    # Write destination_id_prefix [13]
+    # destination_id_prefix [21]
     dup.1 mem_store.MINT_NOTE_STORAGE_OUTPUT_NOTE_PREFIX
-    # => [destination_id_suffix, destination_id_prefix]
+    # => [destination_id_suffix, destination_id_prefix, faucet_id_suffix, faucet_id_prefix]
 
     drop
-    # => [destination_id_prefix]
+    # => [destination_id_prefix, faucet_id_suffix, faucet_id_prefix]
 
-    # Get the native amount from the pre-computed miden_claim_amount
-    mem_load.CLAIM_OUTPUT_NOTE_FAUCET_AMOUNT
-    # => [native_amount, destination_id_prefix]
-
-    # Compute the note tag for the destination account (consumes prefix)
-    swap
-    # => [destination_id_prefix, native_amount]
-
+    # Compute and write the destination tag [16] (consumes destination_id_prefix)
     exec.note_tag::create_account_target
-    # => [dest_tag, native_amount]
+    # => [dest_tag, faucet_id_suffix, faucet_id_prefix]
 
-    # Write tag to MINT note storage [8]
     mem_store.MINT_NOTE_STORAGE_DEST_TAG
-    # => [native_amount]
+    # => [faucet_id_suffix, faucet_id_prefix]
 
-    # Write amount to MINT note storage [9]
-    mem_store.MINT_NOTE_STORAGE_NATIVE_AMOUNT
-    # => []
+    # Build ASSET_KEY + ASSET_VALUE for the faucet's fungible asset at the resolved
+    # native amount. Duplicate faucet_id so the original stays on the stack as
+    # `write_mint_note_storage`'s output contract.
+    dup.1 dup.1
+    # => [faucet_id_suffix, faucet_id_prefix, faucet_id_suffix(orig), faucet_id_prefix(orig)]
+
+    mem_load.CLAIM_OUTPUT_NOTE_FAUCET_AMOUNT
+    # => [native_amount, faucet_id_suffix, faucet_id_prefix, faucet_id_suffix(orig), faucet_id_prefix(orig)]
+
+    # Reorder to feed asset::create_fungible_asset:
+    #   [enable_callbacks, faucet_id_suffix, faucet_id_prefix, amount]
+    movdn.2
+    # => [faucet_id_suffix, faucet_id_prefix, native_amount, faucet_id_suffix(orig), faucet_id_prefix(orig)]
+    push.0
+    # => [0, faucet_id_suffix, faucet_id_prefix, native_amount, faucet_id_suffix(orig), faucet_id_prefix(orig)]
+
+    exec.asset::create_fungible_asset
+    # => [ASSET_KEY, ASSET_VALUE, faucet_id_suffix(orig), faucet_id_prefix(orig)]
+
+    # Write ASSET_KEY [8..11]
+    mem_storew_le.MINT_NOTE_STORAGE_ASSET_KEY dropw
+    # => [ASSET_VALUE, faucet_id_suffix(orig), faucet_id_prefix(orig)]
+
+    # Write ASSET_VALUE [12..15]
+    mem_storew_le.MINT_NOTE_STORAGE_ASSET_VALUE dropw
+    # => [faucet_id_suffix(orig), faucet_id_prefix(orig)]
 
     # Write P2ID_SCRIPT_ROOT to MINT note storage [0..3]
     procref.::miden::standards::notes::p2id::main
-    # => [P2ID_SCRIPT_ROOT]
+    # => [P2ID_SCRIPT_ROOT, faucet_id_suffix(orig), faucet_id_prefix(orig)]
 
     mem_storew_le.MINT_NOTE_STORAGE_OUTPUT_SCRIPT_ROOT dropw
-    # => []
+    # => [faucet_id_suffix(orig), faucet_id_prefix(orig)]
 
     # Write SERIAL_NUM (PROOF_DATA_KEY) to MINT note storage [4..7]
     padw mem_loadw_be.CLAIM_PROOF_DATA_KEY_MEM_ADDR
-    # => [SERIAL_NUM]
+    # => [SERIAL_NUM, faucet_id_suffix(orig), faucet_id_prefix(orig)]
 
     mem_storew_le.MINT_NOTE_STORAGE_OUTPUT_SERIAL_NUM dropw
-    # => []
+    # => [faucet_id_suffix(orig), faucet_id_prefix(orig)]
 end
 
 #! Builds the MINT note recipient digest from the storage items already written to global memory.

--- a/crates/miden-agglayer/asm/agglayer/faucet/mod.masm
+++ b/crates/miden-agglayer/asm/agglayer/faucet/mod.masm
@@ -163,7 +163,7 @@ pub use ::miden::standards::faucets::fungible::receive_and_burn
 #!
 #! See `miden::standards::faucets::fungible::mint_and_send` for more details.
 #!
-#! Inputs:  [amount, tag, note_type, RECIPIENT, pad(9)]
+#! Inputs:  [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 #! Outputs: [note_idx, pad(15)]
 #!
 #! Invocation: call

--- a/crates/miden-standards/asm/standards/faucets/fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/fungible.masm
@@ -30,6 +30,11 @@ pub const TOKEN_CONFIG_SLOT = word("miden::standards::faucets::fungible::token_c
 
 # The local memory address at which the token config slot content is stored.
 const TOKEN_CONFIG_SLOT_LOCAL = 0
+# The local memory address at which the MINT note's stored ASSET_KEY is stashed across the
+# mint policy and supply checks (`mint_and_send`). Used to enforce the faucet-bind at
+# `faucet::mint` time: the kernel panics if the stashed key's faucet ID does not equal
+# the active account.
+const MINT_ASSET_KEY_LOCAL = 4
 const ASSET_PTR = 0
 
 const ERR_MAX_SUPPLY_NOT_MUTABLE = "max supply is not mutable"
@@ -205,18 +210,24 @@ end
 # MINT AND SEND
 # =================================================================================================
 
-#! Mints fungible assets to the provided recipient by creating a note.
+#! Mints the asset stored in the MINT note and sends it to the provided recipient.
 #!
-#! This procedure first executes the active mint policy configured via the `TokenPolicyManager`
-#! and then mints the asset and creates an output note with that asset for the recipient.
+#! This procedure first stashes the asset's vault key, then extracts the amount from
+#! `ASSET_VALUE` for the supply checks. It runs the active mint policy and then asks the
+#! kernel to mint the asset via `faucet::mint`, which panics if the stashed `ASSET_KEY`'s
+#! faucet ID does not match the active account. This is the load-bearing bind: a MINT note
+#! carrying an asset for faucet A cannot be minted by faucet B even if both share an owner.
 #!
-#! Inputs:  [amount, tag, note_type, RECIPIENT, pad(9)]
+#! Inputs:  [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 #! Outputs: [note_idx, pad(15)]
 #!
 #! Where:
-#! - amount is the amount to be minted and sent.
-#! - tag is the tag to be included in the note.
-#! - note_type is the type of the note that holds the asset.
+#! - ASSET_KEY is the vault key of the asset to mint. Its faucet ID must equal the active
+#!   account.
+#! - ASSET_VALUE is the value word of the asset to mint. For fungible assets it is
+#!   `[amount, 0, 0, 0]`; the amount is what the supply checks operate on.
+#! - tag is the tag to be included in the output note.
+#! - note_type is the type of the output note that holds the asset.
 #! - RECIPIENT is the recipient of the asset, i.e.,
 #!   hash(hash(hash(serial_num, [0; 4]), script_root), storage_commitment).
 #! - note_idx is the index of the created note.
@@ -227,10 +238,22 @@ end
 #! - the token supply exceeds the maximum supply.
 #! - the maximum supply exceeds the maximum representable fungible asset amount.
 #! - the token supply after minting is greater than the maximum allowed supply.
+#! - the stashed ASSET_KEY's faucet ID does not match the active account (enforced by the
+#!   kernel `faucet::mint` syscall).
 #!
 #! Invocation: call
-@locals(4)
+@locals(8)
 pub proc mint_and_send
+    # Stash ASSET_KEY in locals. The kernel `faucet::mint` call at the end of this procedure
+    # panics if the stashed key's faucet ID does not equal the active account, which is the
+    # root-cause bind for #2798.
+    loc_storew_le.MINT_ASSET_KEY_LOCAL dropw
+    # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(6)]
+
+    # ASSET_VALUE for a fungible asset is `[amount, 0, 0, 0]`. Keep amount, drop the rest.
+    movdn.3 drop drop drop
+    # => [amount, tag, note_type, RECIPIENT, pad(...)]
+
     exec.policy_manager::execute_mint_policy
     # => [new_amount, new_tag, new_note_type, NEW_RECIPIENT, pad(9)]
 
@@ -306,22 +329,27 @@ pub proc mint_and_send
     movdn.6 exec.output_note::create
     # => [note_idx, amount]
 
-    dup movup.2
-    # => [amount, note_idx, note_idx]
-
     # Mint the asset.
     # ---------------------------------------------------------------------------------------------
 
-    # creating the asset
-    exec.faucet::create_fungible_asset
+    # Rebuild ASSET_VALUE = [amount, 0, 0, 0] from the (possibly policy-adjusted) amount so that
+    # what we mint matches what the supply update accounted for.
+    dup movup.2
+    # => [amount, note_idx, note_idx]
+
+    push.0 push.0 push.0 movup.3
+    # => [ASSET_VALUE, note_idx, note_idx]
+
+    # Load the stashed ASSET_KEY on top of ASSET_VALUE. We use the *stored* key (not a freshly
+    # derived one) so that the kernel `faucet::mint` below can verify the faucet binding.
+    padw loc_loadw_le.MINT_ASSET_KEY_LOCAL
     # => [ASSET_KEY, ASSET_VALUE, note_idx, note_idx]
 
     dupw.1 dupw.1
     # => [ASSET_KEY, ASSET_VALUE, ASSET_KEY, ASSET_VALUE, note_idx, note_idx]
 
-    # mint the asset; this is needed to satisfy asset preservation logic.
-    # this ensures that the asset's faucet ID matches the native account's ID.
-    # this is ensured because create_fungible_asset creates the asset with the native account's ID
+    # Kernel-enforced faucet bind: panics if the stashed ASSET_KEY's faucet ID does not equal
+    # the active account. Also performs the asset preservation update.
     exec.faucet::mint
     # => [ASSET_KEY, ASSET_VALUE, note_idx, note_idx]
 

--- a/crates/miden-standards/asm/standards/notes/mint.masm
+++ b/crates/miden-standards/asm/standards/notes/mint.masm
@@ -5,32 +5,37 @@ use miden::standards::faucets::fungible->faucet
 # CONSTANTS
 # =================================================================================================
 
-const MINT_NOTE_NUM_STORAGE_ITEMS_PRIVATE=6
-const MINT_NOTE_MIN_NUM_STORAGE_ITEMS_PUBLIC=12
+const MINT_NOTE_NUM_STORAGE_ITEMS_PRIVATE=13
+const MINT_NOTE_MIN_NUM_STORAGE_ITEMS_PUBLIC=20
 
 use miden::protocol::note::NOTE_TYPE_PUBLIC
 use miden::protocol::note::NOTE_TYPE_PRIVATE
 
-# Memory addresses of MINT note storage (private mode)
+# Memory addresses of MINT note storage (private mode, 13 items total)
 const STORAGE_PTR = 0
 const PRIVATE_RECIPIENT_PTR = STORAGE_PTR
-const PRIVATE_TAG_PTR = STORAGE_PTR + 4
-const PRIVATE_AMOUNT_PTR = STORAGE_PTR + 5
+const PRIVATE_ASSET_KEY_PTR = STORAGE_PTR + 4
+const PRIVATE_ASSET_VALUE_PTR = STORAGE_PTR + 8
+const PRIVATE_TAG_PTR = STORAGE_PTR + 12
 
-# Memory addresses of MINT note storage (public mode)
+# Memory addresses of MINT note storage (public mode, 20+ items total)
 const PUBLIC_SCRIPT_ROOT_PTR = STORAGE_PTR
 const PUBLIC_SERIAL_NUM_PTR = STORAGE_PTR + 4
-const PUBLIC_TAG_PTR = STORAGE_PTR + 8
-const PUBLIC_AMOUNT_PTR = STORAGE_PTR + 9
-const PUBLIC_OUTPUT_NOTE_STORAGE_PTR = STORAGE_PTR + 12
+const PUBLIC_ASSET_KEY_PTR = STORAGE_PTR + 8
+const PUBLIC_ASSET_VALUE_PTR = STORAGE_PTR + 12
+const PUBLIC_TAG_PTR = STORAGE_PTR + 16
+const PUBLIC_OUTPUT_NOTE_STORAGE_PTR = STORAGE_PTR + 20
 
 # ERRORS
 # =================================================================================================
 
-const ERR_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS="MINT script expects exactly 6 storage items for private or 12+ storage items for public output notes"
+const ERR_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS="MINT script expects exactly 13 storage items for private or 20+ storage items for public output notes"
 
-#! Network Faucet MINT script: mints assets by calling the network faucet's mint_and_send
-#! function.
+#! Network Faucet MINT script: mints the asset stored in the note by calling the network
+#! faucet's mint_and_send function. The asset's faucet ID is verified against the active
+#! account inside mint_and_send (via the kernel's faucet::mint syscall), so this script
+#! cannot be redirected to mint against an unrelated faucet.
+#!
 #! This note is intended to be executed against a network fungible faucet account.
 #!
 #! Requires that the account exposes:
@@ -40,28 +45,30 @@ const ERR_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS="MINT script expects exactly 6
 #! Outputs: [pad(16)]
 #!
 #! Note storage supports two modes. Depending on the number of note storage items,
-#! a private or public note is created on consumption of the MINT note:
+#! a private or public output note is created on consumption of the MINT note:
 #!
-#! Private mode (6 storage items) - creates a private note:
-#! - RECIPIENT: The recipient digest (4 elements)
-#! - tag: Note tag for the output note
-#! - amount: The amount to mint
+#! Private mode (13 storage items) - creates a private note:
+#! - RECIPIENT:   The recipient digest (4 elements, word 0)
+#! - ASSET_KEY:   The vault key of the asset to mint (4 elements, word 1)
+#! - ASSET_VALUE: The value word of the asset to mint (4 elements, word 2)
+#! - tag:         Note tag for the output note (1 element)
 #!
-#! Public mode (12+ storage items) - creates a public note with variable-length storage:
-#! - SCRIPT_ROOT: Script root of the output note (4 elements)
-#! - SERIAL_NUM: Serial number of the output note (4 elements)
-#! - tag: Note tag for the output note
-#! - amount: The amount to mint
-#! - padding
-#! - padding
-#! - [STORAGE]: Variable-length storage for the output note (Vec<Felt>)
-#!              The number of output note storage items = num_mint_note_storage_items - 12
-#!
-#! The padding is necessary since note::compute_and_store_recipient expects a word-aligned storage_ptr.
+#! Public mode (20+ storage items) - creates a public note with variable-length storage:
+#! - SCRIPT_ROOT: Script root of the output note (4 elements, word 0)
+#! - SERIAL_NUM:  Serial number of the output note (4 elements, word 1)
+#! - ASSET_KEY:   The vault key of the asset to mint (4 elements, word 2)
+#! - ASSET_VALUE: The value word of the asset to mint (4 elements, word 3)
+#! - tag:         Note tag for the output note (1 element)
+#! - padding:     3 elements so the variable storage starts at a word boundary
+#! - [STORAGE]:   Variable-length storage for the output note (Vec<Felt>)
+#!                The number of output note storage items = num_mint_note_storage_items - 20
 #!
 #! Panics if:
 #! - account does not expose mint_and_send procedure.
-#! - the number of storage items is not exactly 6 for private or less than 12 for public output notes.
+#! - the number of storage items is not exactly 13 for private or less than 20 for public output
+#!   notes.
+#! - the ASSET_KEY's faucet ID does not match the active account (enforced inside
+#!   `mint_and_send` via the kernel's `faucet::mint` syscall).
 @note_script
 pub proc main
     dropw
@@ -100,10 +107,18 @@ pub proc main
         exec.note::compute_and_store_recipient
         # => [RECIPIENT, pad(12)]
 
-        # push note_type, and load tag and amount
+        # push note_type and tag, then ASSET_VALUE and ASSET_KEY on top
         push.NOTE_TYPE_PUBLIC
-        mem_load.PUBLIC_TAG_PTR mem_load.PUBLIC_AMOUNT_PTR
-        # => [amount, tag, note_type, RECIPIENT, pad(12)]
+        # => [note_type, RECIPIENT, pad(12)]
+
+        mem_load.PUBLIC_TAG_PTR
+        # => [tag, note_type, RECIPIENT, pad(12)]
+
+        padw mem_loadw_le.PUBLIC_ASSET_VALUE_PTR
+        # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+
+        padw mem_loadw_le.PUBLIC_ASSET_KEY_PTR
+        # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
     else
         # private output note creation
 
@@ -113,18 +128,27 @@ pub proc main
         mem_loadw_le.PRIVATE_RECIPIENT_PTR
         # => [RECIPIENT, pad(12)]
 
-        # push note_type, and load tag and amount
+        # push note_type and tag, then ASSET_VALUE and ASSET_KEY on top
         push.NOTE_TYPE_PRIVATE
-        mem_load.PRIVATE_TAG_PTR mem_load.PRIVATE_AMOUNT_PTR
-        # => [amount, tag, note_type, RECIPIENT, pad(12)]
+        # => [note_type, RECIPIENT, pad(12)]
+
+        mem_load.PRIVATE_TAG_PTR
+        # => [tag, note_type, RECIPIENT, pad(12)]
+
+        padw mem_loadw_le.PRIVATE_ASSET_VALUE_PTR
+        # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+
+        padw mem_loadw_le.PRIVATE_ASSET_KEY_PTR
+        # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
     end
-    # => [amount, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
 
-    # mint_and_send expects 9 pad elements, returns 15 and 12 are provided here.
-    # so the total number of pads after calling is 12 + (15-9) = 18
+    # mint_and_send consumes [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)] from the
+    # operand stack and returns [note_idx, pad(15)]. Conceptually we have 26 elements going into
+    # the call and 26 coming back out; drop 10 to return to pad(16) as required by @note_script.
     call.faucet::mint_and_send
-    # => [note_idx, pad(18))]
+    # => [note_idx, pad(25)]
 
-    drop drop drop
+    dropw dropw drop drop
     # => [pad(16)]
 end

--- a/crates/miden-standards/src/account/interface/component.rs
+++ b/crates/miden-standards/src/account/interface/component.rs
@@ -168,8 +168,9 @@ impl AccountComponentInterface {
     /// ```masm
     ///     push.{note information}
     ///
-    ///     push.{asset amount}
-    ///     call.::miden::standards::faucets::fungible::mint_and_send dropw dropw drop
+    ///     push.{ASSET_VALUE} push.{ASSET_KEY}
+    ///     call.::miden::standards::faucets::fungible::mint_and_send
+    ///     swapdw dropw dropw swapdw dropw dropw
     /// ```
     ///
     /// # Errors:
@@ -222,13 +223,18 @@ impl AccountComponentInterface {
 
                     body.push_str(&format!(
                         "
-                        push.{amount}
+                        push.{ASSET_VALUE}
+                        push.{ASSET_KEY}
+                        # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(16)]
+
                         call.::miden::standards::faucets::fungible::mint_and_send
-                        # => [note_idx, pad(25)]
-                        swapdw dropw dropw swap drop
+                        # => [note_idx, pad(32)]
+
+                        swapdw dropw dropw swapdw dropw dropw
                         # => [note_idx, pad(16)]\n
                         ",
-                        amount = asset.unwrap_fungible().amount()
+                        ASSET_KEY = asset.to_key_word(),
+                        ASSET_VALUE = asset.to_value_word(),
                     ));
                 },
                 AccountComponentInterface::BasicWallet => {

--- a/crates/miden-standards/src/account/interface/mod.rs
+++ b/crates/miden-standards/src/account/interface/mod.rs
@@ -140,8 +140,9 @@ impl AccountInterface {
     ///
     ///     push.{note information}
     ///
-    ///     push.{asset amount}
-    ///     call.::miden::standards::faucets::fungible::mint_and_send dropw dropw drop
+    ///     push.{ASSET_VALUE} push.{ASSET_KEY}
+    ///     call.::miden::standards::faucets::fungible::mint_and_send
+    ///     swapdw dropw dropw swapdw dropw dropw
     /// end
     /// ```
     ///

--- a/crates/miden-standards/src/note/mint.rs
+++ b/crates/miden-standards/src/note/mint.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 use miden_protocol::account::AccountId;
+use miden_protocol::asset::Asset;
 use miden_protocol::assembly::Path;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::NoteError;
@@ -46,7 +47,16 @@ impl MintNote {
     // --------------------------------------------------------------------------------------------
 
     /// Expected number of storage items of the MINT note (private mode).
-    pub const NUM_STORAGE_ITEMS_PRIVATE: usize = 6;
+    ///
+    /// Layout: RECIPIENT(4) + ASSET_KEY(4) + ASSET_VALUE(4) + tag(1).
+    pub const NUM_STORAGE_ITEMS_PRIVATE: usize = 13;
+
+    /// Minimum number of storage items of the MINT note (public mode).
+    ///
+    /// Layout: SCRIPT_ROOT(4) + SERIAL_NUM(4) + ASSET_KEY(4) + ASSET_VALUE(4) + tag(1) +
+    /// padding(3) + variable output-note storage. The variable portion starts at offset 20
+    /// (word-aligned) and must contain at least zero items.
+    pub const MIN_NUM_STORAGE_ITEMS_PUBLIC: usize = 20;
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
@@ -64,25 +74,27 @@ impl MintNote {
     // BUILDERS
     // --------------------------------------------------------------------------------------------
 
-    /// Generates a MINT note - a note that instructs a network faucet to mint fungible assets.
+    /// Generates a MINT note: a note that instructs a network faucet to mint the asset
+    /// embedded in its storage.
     ///
-    /// This script enables the creation of a PUBLIC note that, when consumed by a network faucet,
-    /// will mint the specified amount of fungible assets and create either a PRIVATE or PUBLIC
-    /// output note depending on the input configuration. The MINT note uses note-based
-    /// authentication, checking if the note sender equals the faucet owner to authorize
-    /// minting.
+    /// The MINT script reads the asset (`ASSET_KEY` + `ASSET_VALUE`) directly from the note's
+    /// storage and passes it to the faucet's `mint_and_send` procedure. The kernel's
+    /// `faucet::mint` syscall (invoked inside `mint_and_send`) panics if the stored asset's
+    /// faucet ID does not equal the active account, so a MINT note bound to faucet A cannot
+    /// be redirected to faucet B even when both share an owner.
     ///
     /// MINT notes are always PUBLIC (for network execution). Output notes can be either PRIVATE
-    /// or PUBLIC depending on the MintNoteStorage variant used.
+    /// or PUBLIC depending on the [`MintNoteStorage`] variant used.
     ///
     /// The passed-in `rng` is used to generate a serial number for the note. The note's tag
     /// is automatically set to the faucet's account ID for proper routing.
     ///
     /// # Parameters
-    /// - `faucet_id`: The account ID of the network faucet that will mint the assets
+    /// - `faucet_id`: The account ID of the network faucet that will mint the asset. Must equal
+    ///   `mint_storage.asset().faucet_id()` or `faucet::mint` will panic at consumption time.
     /// - `sender`: The account ID of the note creator (must be the faucet owner)
     /// - `mint_storage`: The storage configuration specifying private or public output mode
-    /// - `attachment`: The [`NoteAttachments`] of the MINT note
+    /// - `attachments`: The [`NoteAttachments`] of the MINT note
     /// - `rng`: Random number generator for creating the serial number
     ///
     /// # Errors
@@ -117,65 +129,76 @@ impl MintNote {
 // ================================================================================================
 
 /// Represents the different storage formats for MINT notes.
-/// - Private: Creates a private output note using a precomputed recipient digest (6 MINT note
-///   storage items)
+///
+/// - Private: Creates a private output note using a precomputed recipient digest
+///   (13 MINT note storage items: RECIPIENT + ASSET_KEY + ASSET_VALUE + tag).
 /// - Public: Creates a public output note by providing script root, serial number, and
-///   variable-length storage (12+ MINT note storage items: 12 fixed + variable number of output
-///   note storage items)
+///   variable-length storage (20+ MINT note storage items: 20 fixed + variable output note
+///   storage items, with the variable section word-aligned at offset 20).
+///
+/// The asset (`ASSET_KEY` + `ASSET_VALUE`, 8 felts) is embedded in storage so that the
+/// faucet executing the MINT note can be checked against the asset's faucet ID at mint time.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MintNoteStorage {
     Private {
         recipient_digest: Word,
-        amount: Felt,
+        asset: Asset,
         tag: Felt,
     },
     Public {
         recipient: NoteRecipient,
-        amount: Felt,
+        asset: Asset,
         tag: Felt,
     },
 }
 
 impl MintNoteStorage {
-    pub fn new_private(recipient_digest: Word, amount: Felt, tag: Felt) -> Self {
-        Self::Private { recipient_digest, amount, tag }
+    pub fn new_private(recipient_digest: Word, asset: Asset, tag: Felt) -> Self {
+        Self::Private { recipient_digest, asset, tag }
     }
 
     pub fn new_public(
         recipient: NoteRecipient,
-        amount: Felt,
+        asset: Asset,
         tag: Felt,
     ) -> Result<Self, NoteError> {
-        // Calculate total number of storage items that will be created:
-        // 12 fixed items (SCRIPT_ROOT, SERIAL_NUM, tag, amount, 2 padding) + variable recipient
-        // number of storage items
-        const FIXED_PUBLIC_STORAGE_ITEMS: usize = 12;
         let total_storage_items =
-            FIXED_PUBLIC_STORAGE_ITEMS + recipient.storage().num_items() as usize;
+            MintNote::MIN_NUM_STORAGE_ITEMS_PUBLIC + recipient.storage().num_items() as usize;
 
         if total_storage_items > MAX_NOTE_STORAGE_ITEMS {
             return Err(NoteError::TooManyStorageItems(total_storage_items));
         }
 
-        Ok(Self::Public { recipient, amount, tag })
+        Ok(Self::Public { recipient, asset, tag })
+    }
+
+    /// Returns the asset that will be minted on consumption.
+    pub fn asset(&self) -> Asset {
+        match self {
+            Self::Private { asset, .. } | Self::Public { asset, .. } => *asset,
+        }
     }
 }
 
 impl From<MintNoteStorage> for NoteStorage {
     fn from(mint_storage: MintNoteStorage) -> Self {
         match mint_storage {
-            MintNoteStorage::Private { recipient_digest, amount, tag } => {
+            MintNoteStorage::Private { recipient_digest, asset, tag } => {
                 let mut storage_values = Vec::with_capacity(MintNote::NUM_STORAGE_ITEMS_PRIVATE);
                 storage_values.extend_from_slice(recipient_digest.as_elements());
-                storage_values.extend_from_slice(&[tag, amount]);
+                storage_values.extend_from_slice(&asset.as_elements());
+                storage_values.push(tag);
                 NoteStorage::new(storage_values)
                     .expect("number of storage items should not exceed max storage items")
             },
-            MintNoteStorage::Public { recipient, amount, tag } => {
+            MintNoteStorage::Public { recipient, asset, tag } => {
                 let mut storage_values = Vec::new();
                 storage_values.extend_from_slice(recipient.script().root().as_elements());
                 storage_values.extend_from_slice(recipient.serial_num().as_elements());
-                storage_values.extend_from_slice(&[tag, amount, Felt::ZERO, Felt::ZERO]);
+                storage_values.extend_from_slice(&asset.as_elements());
+                // tag followed by 3 padding felts so the variable storage that follows starts at
+                // a word-aligned offset (20).
+                storage_values.extend_from_slice(&[tag, Felt::ZERO, Felt::ZERO, Felt::ZERO]);
                 storage_values.extend_from_slice(recipient.storage().items());
                 NoteStorage::new(storage_values)
                     .expect("number of storage items should not exceed max storage items")

--- a/crates/miden-testing/src/kernel_tests/tx/test_callbacks.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_callbacks.rs
@@ -662,7 +662,13 @@ async fn test_faucet_with_callback_calls_itself() -> anyhow::Result<()> {
             push.{note_type}
             push.{tag}
             push.{amount}
-            # => [amount, tag, note_type, RECIPIENT, pad(9)]
+            push.{faucet_id_prefix}
+            push.{faucet_id_suffix}
+            push.1
+            # => [enable_callbacks=1, faucet_id_suffix, faucet_id_prefix, amount, tag, note_type, RECIPIENT, pad(...)]
+
+            exec.::miden::protocol::asset::create_fungible_asset
+            # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(...)]
 
             call.::miden::standards::faucets::fungible::mint_and_send
             # => [note_idx, pad(15)]
@@ -672,6 +678,8 @@ async fn test_faucet_with_callback_calls_itself() -> anyhow::Result<()> {
         end
         ",
         note_type = NoteType::Private as u8,
+        faucet_id_suffix = faucet.id().suffix(),
+        faucet_id_prefix = faucet.id().prefix().as_felt(),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(tx_script_code)?;

--- a/crates/miden-testing/tests/agglayer/bridge_in.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_in.rs
@@ -28,6 +28,7 @@ use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::crypto::SequentialCommit;
 use miden_protocol::crypto::rand::FeltRng;
+use miden_protocol::errors::tx_kernel::ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN;
 use miden_protocol::note::NoteType;
 use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE;
 use miden_protocol::transaction::RawOutputNote;
@@ -427,6 +428,180 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
             "destination account balance does not match"
         );
     }
+    Ok(())
+}
+
+/// Regression test for issue #2798: a MINT note produced by `claim` for faucet A cannot be
+/// consumed by a different same-bridge faucet B.
+///
+/// The MINT note now embeds the full `ASSET` (`ASSET_KEY` + `ASSET_VALUE`) in its storage. When
+/// `fungible::mint_and_send` runs, it feeds the stored `ASSET_KEY` (carrying faucet A's ID) to
+/// the kernel `faucet::mint` syscall. If the active account is faucet B, the kernel's
+/// `validate_origin` panics with `ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN`.
+#[tokio::test]
+async fn test_mint_cannot_be_consumed_by_unrelated_faucet() -> anyhow::Result<()> {
+    let data_source = ClaimDataSource::L1ToMiden;
+    let mut builder = MockChain::builder();
+
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    let bridge_seed = builder.rng_mut().draw_word();
+    let bridge_account =
+        create_existing_bridge_account(bridge_seed, bridge_admin.id(), ger_manager.id());
+    builder.add_account(bridge_account.clone())?;
+
+    let (proof_data, leaf_data, ger, _cgi_chain_hash) = data_source.get_data();
+
+    let token_symbol_a = "AGGA";
+    let token_symbol_b = "AGGB";
+    let decimals = 8u8;
+    let max_supply = Felt::new(FungibleAsset::MAX_AMOUNT);
+    let scale = 10u8;
+
+    // faucet_A is the bridge's registered faucet for the claim's origin token address.
+    let faucet_a_seed = builder.rng_mut().draw_word();
+    let faucet_a = create_existing_agglayer_faucet(
+        faucet_a_seed,
+        token_symbol_a,
+        decimals,
+        max_supply,
+        Felt::ZERO,
+        bridge_account.id(),
+        &leaf_data.origin_token_address,
+        leaf_data.origin_network,
+        scale,
+        leaf_data.metadata_hash,
+    );
+    builder.add_account(faucet_a.clone())?;
+
+    // faucet_B is owned by the same bridge but tied to a different origin token. It is the
+    // attacker's target: the claimant tries to direct faucet_A's MINT note here.
+    let faucet_b_seed = builder.rng_mut().draw_word();
+    // Flip one byte of the address so the new EthAddress is distinct from faucet_A's.
+    let mut other_bytes = leaf_data.origin_token_address.into_bytes();
+    other_bytes[0] ^= 0x01;
+    let other_token_address = miden_agglayer::EthAddress::new(other_bytes);
+    let faucet_b = create_existing_agglayer_faucet(
+        faucet_b_seed,
+        token_symbol_b,
+        decimals,
+        max_supply,
+        Felt::ZERO,
+        bridge_account.id(),
+        &other_token_address,
+        leaf_data.origin_network,
+        scale,
+        leaf_data.metadata_hash,
+    );
+    builder.add_account(faucet_b.clone())?;
+
+    assert_ne!(faucet_a.id(), faucet_b.id(), "test setup: faucet IDs must differ");
+
+    // The destination is also baked into the fixture; create it so the bridge claim succeeds.
+    let destination_account_id = EthEmbeddedAccountId::try_from(leaf_data.destination_address)
+        .expect("destination address is not an embedded Miden AccountId")
+        .into_account_id();
+    let dest =
+        Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE, IncrNonceAuthComponent);
+    assert_eq!(dest.id(), destination_account_id);
+    builder.add_account(dest)?;
+
+    let sender_account_builder =
+        Account::builder(builder.rng_mut().random()).with_component(BasicWallet);
+    let sender_account = builder.add_account_from_builder(
+        Auth::IncrNonce,
+        sender_account_builder,
+        AccountState::Exists,
+    )?;
+
+    let miden_claim_amount = leaf_data
+        .amount
+        .scale_to_token_amount(scale as u32)
+        .expect("amount should scale successfully");
+
+    let claim_inputs = ClaimNoteStorage {
+        proof_data,
+        leaf_data: leaf_data.clone(),
+        miden_claim_amount,
+    };
+
+    let claim_note = create_claim_note(
+        claim_inputs,
+        bridge_account.id(),
+        sender_account.id(),
+        builder.rng_mut(),
+    )?;
+    builder.add_output_note(RawOutputNote::Full(claim_note.clone()));
+
+    // Register faucet_A (only) in the bridge for the claim's origin token address.
+    let config_note = ConfigAggBridgeNote::create(
+        faucet_a.id(),
+        &leaf_data.origin_token_address,
+        bridge_admin.id(),
+        bridge_account.id(),
+        builder.rng_mut(),
+    )?;
+    builder.add_output_note(RawOutputNote::Full(config_note.clone()));
+
+    let update_ger_note =
+        UpdateGerNote::create(ger, ger_manager.id(), bridge_account.id(), builder.rng_mut())?;
+    builder.add_output_note(RawOutputNote::Full(update_ger_note.clone()));
+
+    let mut mock_chain = builder.clone().build()?;
+
+    // TX0: register faucet_A.
+    let config_executed = mock_chain
+        .build_tx_context(bridge_account.id(), &[config_note.id()], &[])?
+        .build()?
+        .execute()
+        .await?;
+    mock_chain.add_pending_executed_transaction(&config_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // TX1: store GER.
+    let update_ger_executed = mock_chain
+        .build_tx_context(bridge_account.id(), &[update_ger_note.id()], &[])?
+        .build()?
+        .execute()
+        .await?;
+    mock_chain.add_pending_executed_transaction(&update_ger_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // TX2: claim → produces MINT note bound to faucet_A's asset.
+    let faucet_a_foreign_inputs = mock_chain.get_foreign_account_inputs(faucet_a.id())?;
+    let claim_executed = mock_chain
+        .build_tx_context(bridge_account.id(), &[], &[claim_note])?
+        .foreign_accounts(vec![faucet_a_foreign_inputs])
+        .build()?
+        .execute()
+        .await
+        .context("CLAIM execution should succeed")?;
+
+    assert_eq!(claim_executed.output_notes().num_notes(), 1);
+    let mint_output_note = claim_executed.output_notes().get_note(0);
+
+    mock_chain.add_pending_executed_transaction(&claim_executed)?;
+    mock_chain.prove_next_block()?;
+
+    // ATTACK: try to consume the MINT note against faucet_B (wrong faucet).
+    //
+    // Before #2798's fix the MINT carried only `amount`, so faucet_B would happily mint its own
+    // wrapped asset and ship it via the P2ID output note. With the asset embedded in the MINT
+    // note's storage, faucet_B feeds faucet_A's `ASSET_KEY` into the kernel's `faucet::mint`,
+    // and the kernel rejects it because the active account is faucet_B, not faucet_A.
+    let attack_tx_context = mock_chain
+        .build_tx_context(faucet_b.id(), &[mint_output_note.id()], &[])?
+        .add_note_script(P2idNote::script())
+        .build()?;
+
+    let attack_result = attack_tx_context.execute().await;
+    assert_transaction_executor_error!(attack_result, ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN);
+
     Ok(())
 }
 

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -74,18 +74,21 @@ pub struct FaucetTestParams {
 }
 
 /// Creates minting script code for fungible asset distribution
-pub fn create_mint_script_code(params: &FaucetTestParams) -> String {
+pub fn create_mint_script_code(params: &FaucetTestParams, faucet_id: AccountId) -> String {
     format!(
         "
             begin
-                # pad the stack before call
-                padw padw push.0
-
                 push.{recipient}
                 push.{note_type}
                 push.{tag}
                 push.{amount}
-                # => [amount, tag, note_type, RECIPIENT, pad(9)]
+                push.{faucet_id_prefix}
+                push.{faucet_id_suffix}
+                push.0
+                # => [enable_callbacks=0, faucet_id_suffix, faucet_id_prefix, amount, tag, note_type, RECIPIENT, ...]
+
+                exec.::miden::protocol::asset::create_fungible_asset
+                # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, ...]
 
                 call.::miden::standards::faucets::fungible::mint_and_send
                 # => [note_idx, pad(15)]
@@ -98,6 +101,8 @@ pub fn create_mint_script_code(params: &FaucetTestParams) -> String {
         recipient = params.recipient,
         tag = u32::from(params.tag),
         amount = params.amount,
+        faucet_id_suffix = faucet_id.suffix(),
+        faucet_id_prefix = faucet_id.prefix().as_felt(),
     )
 }
 
@@ -108,7 +113,7 @@ pub async fn execute_mint_transaction(
     params: &FaucetTestParams,
 ) -> anyhow::Result<ExecutedTransaction> {
     let source_manager = Arc::new(DefaultSourceManager::default());
-    let tx_script_code = create_mint_script_code(params);
+    let tx_script_code = create_mint_script_code(params, faucet.id());
     let tx_script = CodeBuilder::with_source_manager(source_manager.clone())
         .compile_tx_script(tx_script_code)?;
     let tx_context = mock_chain
@@ -275,14 +280,17 @@ async fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() -> anyho
     let tx_script_code = format!(
         "
             begin
-                # pad the stack before call
-                padw padw push.0
-
                 push.{recipient}
                 push.{note_type}
                 push.{tag}
                 push.{amount}
-                # => [amount, tag, note_type, RECIPIENT, pad(9)]
+                push.{faucet_id_prefix}
+                push.{faucet_id_suffix}
+                push.0
+                # => [0, faucet_id_suffix, faucet_id_prefix, amount, tag, note_type, RECIPIENT, ...]
+
+                exec.::miden::protocol::asset::create_fungible_asset
+                # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, ...]
 
                 call.::miden::standards::faucets::fungible::mint_and_send
                 # => [note_idx, pad(15)]
@@ -294,6 +302,8 @@ async fn faucet_contract_mint_fungible_asset_fails_exceeds_max_supply() -> anyho
             ",
         note_type = NoteType::Private as u8,
         recipient = recipient,
+        faucet_id_suffix = faucet.id().suffix(),
+        faucet_id_prefix = faucet.id().prefix().as_felt(),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(tx_script_code)?;
@@ -540,7 +550,13 @@ async fn test_public_note_creation_with_script_from_datastore() -> anyhow::Resul
                 push.{note_type}
                 push.{tag}
                 push.{amount}
-                # => [amount, tag, note_type, RECIPIENT]
+                push.{faucet_id_prefix}
+                push.{faucet_id_suffix}
+                push.0
+                # => [0, faucet_id_suffix, faucet_id_prefix, amount, tag, note_type, RECIPIENT]
+
+                exec.::miden::protocol::asset::create_fungible_asset
+                # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT]
 
                 call.::miden::standards::faucets::fungible::mint_and_send
                 # => [note_idx, pad(15)]
@@ -561,6 +577,8 @@ async fn test_public_note_creation_with_script_from_datastore() -> anyhow::Resul
         serial_num = serial_num,
         tag = u32::from(tag),
         amount = amount,
+        faucet_id_suffix = faucet.id().suffix(),
+        faucet_id_prefix = faucet.id().prefix().as_felt(),
     );
 
     // Create the trigger note that will call mint
@@ -689,7 +707,8 @@ async fn network_faucet_mint() -> anyhow::Result<()> {
     let recipient = p2id_mint_output_note.recipient().digest();
 
     // Create the MINT note using the helper function
-    let mint_storage = MintNoteStorage::new_private(recipient, amount, output_note_tag.into());
+    let mint_storage =
+        MintNoteStorage::new_private(recipient, mint_asset, output_note_tag.into());
 
     let mut rng = RandomCoin::new([Felt::from(42u32); 4].into());
     let mint_note = MintNote::create(
@@ -781,7 +800,7 @@ async fn test_network_faucet_owner_can_mint() -> anyhow::Result<()> {
     )?;
     let recipient = p2id_note.recipient().digest();
 
-    let mint_inputs = MintNoteStorage::new_private(recipient, amount, output_note_tag.into());
+    let mint_inputs = MintNoteStorage::new_private(recipient, mint_asset, output_note_tag.into());
 
     let mut rng = RandomCoin::new([Felt::from(42u32); 4].into());
     let mint_note = MintNote::create(
@@ -932,7 +951,7 @@ async fn test_network_faucet_non_owner_cannot_mint() -> anyhow::Result<()> {
     )?;
     let recipient = p2id_note.recipient().digest();
 
-    let mint_inputs = MintNoteStorage::new_private(recipient, amount, output_note_tag.into());
+    let mint_inputs = MintNoteStorage::new_private(recipient, mint_asset, output_note_tag.into());
 
     // Create mint note from NON-OWNER
     let mut rng = RandomCoin::new([Felt::from(42u32); 4].into());
@@ -1032,7 +1051,7 @@ async fn test_network_faucet_transfer_ownership() -> anyhow::Result<()> {
     let recipient = p2id_note.recipient().digest();
 
     // Sanity Check: Prove that the initial owner can mint assets
-    let mint_inputs = MintNoteStorage::new_private(recipient, amount, output_note_tag.into());
+    let mint_inputs = MintNoteStorage::new_private(recipient, mint_asset, output_note_tag.into());
 
     let mut rng = RandomCoin::new([Felt::from(42u32); 4].into());
     let mint_note = MintNote::create(
@@ -1614,7 +1633,7 @@ async fn test_mint_note_output_note_types(#[case] note_type: NoteType) -> anyhow
         NoteType::Private => {
             let output_note_tag = NoteTag::with_account_target(target_account.id());
             let recipient = p2id_mint_output_note.recipient().digest();
-            MintNoteStorage::new_private(recipient, amount, output_note_tag.into())
+            MintNoteStorage::new_private(recipient, mint_asset, output_note_tag.into())
         },
         NoteType::Public => {
             let output_note_tag = NoteTag::with_account_target(target_account.id());
@@ -1623,7 +1642,7 @@ async fn test_mint_note_output_note_types(#[case] note_type: NoteType) -> anyhow
                 vec![target_account.id().suffix(), target_account.id().prefix().as_felt()];
             let note_storage = NoteStorage::new(p2id_storage)?;
             let recipient = NoteRecipient::new(serial_num, p2id_script, note_storage);
-            MintNoteStorage::new_public(recipient, amount, output_note_tag.into())?
+            MintNoteStorage::new_public(recipient, mint_asset, output_note_tag.into())?
         },
     };
 
@@ -1708,13 +1727,17 @@ async fn multiple_mints_in_single_tx_produce_correct_amounts() -> anyhow::Result
         "
             begin
                 # --- First mint: mint {amount_1} tokens to recipient_1 ---
-                padw padw push.0
-
                 push.{recipient_1}
                 push.{note_type}
                 push.{tag}
                 push.{amount_1}
-                # => [amount_1, tag, note_type, RECIPIENT_1, pad(9)]
+                push.{faucet_id_prefix}
+                push.{faucet_id_suffix}
+                push.0
+                # => [0, faucet_id_suffix, faucet_id_prefix, amount_1, tag, note_type, RECIPIENT_1]
+
+                exec.::miden::protocol::asset::create_fungible_asset
+                # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT_1]
 
                 call.::miden::standards::faucets::fungible::mint_and_send
                 # => [note_idx, pad(15)]
@@ -1723,13 +1746,17 @@ async fn multiple_mints_in_single_tx_produce_correct_amounts() -> anyhow::Result
                 dropw dropw dropw dropw
 
                 # --- Second mint: mint {amount_2} tokens to recipient_2 ---
-                padw padw push.0
-
                 push.{recipient_2}
                 push.{note_type}
                 push.{tag}
                 push.{amount_2}
-                # => [amount_2, tag, note_type, RECIPIENT_2, pad(9)]
+                push.{faucet_id_prefix}
+                push.{faucet_id_suffix}
+                push.0
+                # => [0, faucet_id_suffix, faucet_id_prefix, amount_2, tag, note_type, RECIPIENT_2]
+
+                exec.::miden::protocol::asset::create_fungible_asset
+                # => [ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT_2]
 
                 call.::miden::standards::faucets::fungible::mint_and_send
                 # => [note_idx, pad(15)]
@@ -1740,6 +1767,8 @@ async fn multiple_mints_in_single_tx_produce_correct_amounts() -> anyhow::Result
             ",
         note_type = note_type as u8,
         tag = u32::from(tag),
+        faucet_id_suffix = faucet.id().suffix(),
+        faucet_id_prefix = faucet.id().prefix().as_felt(),
     );
 
     let source_manager = Arc::new(DefaultSourceManager::default());


### PR DESCRIPTION
## Summary

Closes #2798.

A valid claim used to generate a MINT note that carried only the *amount* in its storage. Because every AggLayer faucet shares the bridge as owner, the `owner_only` mint policy passed for any same-bridge faucet, so a claimant could redirect a proven claim for token A into a mint-and-export on route B.

This PR embeds the full ASSET (`ASSET_KEY` + `ASSET_VALUE`, 8 felts) in the MINT note's storage. `fungible::mint_and_send` stashes the stored `ASSET_KEY`, runs the mint policy unchanged on the extracted amount, and then feeds the stashed key into the kernel `faucet::mint` syscall. The kernel's existing `validate_origin` panics with `ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN` if the active account differs from the stored faucet ID, so a MINT bound to faucet A cannot be minted by faucet B.

### Key changes

- **`crates/miden-standards/asm/standards/notes/mint.masm`**: storage layout 13 (private) / 20+ (public) items; new pointers for `ASSET_KEY` and `ASSET_VALUE` in both modes; `main` pushes both words ahead of `tag` / `note_type` / `RECIPIENT` for the call.
- **`crates/miden-standards/asm/standards/faucets/fungible.masm`**: new `mint_and_send` signature `[ASSET_KEY, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]`; stashes ASSET_KEY in `MINT_ASSET_KEY_LOCAL`; the kernel `faucet::mint` enforces the bind.
- **`crates/miden-standards/src/note/mint.rs`**: `MintNoteStorage` now carries `asset: Asset`; serialization uses `Asset::as_elements()`; new `MIN_NUM_STORAGE_ITEMS_PUBLIC = 20`.
- **`crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm`**: MINT layout grows from 14 to 22 items; `write_mint_note_storage` builds the ASSET via `miden::protocol::asset::create_fungible_asset` with `enable_callbacks = 0` (AggLayer faucets do not declare callbacks).
- **`crates/miden-standards/src/account/interface/component.rs`**: `send_note_body` code generator for the `FungibleFaucet` interface emits `push.{ASSET_VALUE} push.{ASSET_KEY}` with an expanded cleanup.

The `NetworkAccountTarget` attachment stays on MINT notes for routing; it is no longer security-load-bearing.

## Design note

The original proposal called for an explicit `ERR_MINT_FAUCET_ID_MISMATCH` assertion at the top of `mint_and_send`. Doing this cleanly would require manual normalization of metadata bits (`ASSET_KEY[2]` encodes the faucet ID's suffix with low 8 bits replaced by `[7 zeros | callbacks_bit]`, while `active_account::get_id` returns the full 64-bit suffix). The kernel's `faucet::mint` syscall already does this comparison correctly via `validate_origin` (`asset::key_to_faucet_id` + `account_id::is_equal`). So the explicit check was dropped in favor of feeding the stashed (not re-derived) `ASSET_KEY` into `faucet::mint`. The bind is still load-bearing, just enforced by the kernel.

## Test plan

- [x] `cargo build -p miden-standards -p miden-agglayer -p miden-testing`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test -p miden-standards --lib` (108/108)
- [x] `cargo test -p miden-testing --test lib scripts::faucet` (23/23)
- [x] `cargo test -p miden-testing --test lib agglayer` (48/48 incl. new regression)
- [x] `cargo test -p miden-testing --lib kernel_tests::tx::test_callbacks::test_faucet_with_callback_calls_itself`
- [x] `cargo test -p miden-testing --test lib scripts::send_note::test_send_note_script_fungible_faucet`
- [x] `cargo test -p miden-testing` (full)

The new regression test `test_mint_cannot_be_consumed_by_unrelated_faucet` in `crates/miden-testing/tests/agglayer/bridge_in.rs` stands up two AggLayer faucets, runs the bridge's `claim` for faucet A's token, then attempts to consume the resulting MINT note against faucet B and asserts `ERR_FUNGIBLE_ASSET_FAUCET_IS_NOT_ORIGIN`.