### PR TITLE
feat: Add `NetworkAccount` wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BREAKING] Add support for multiple attachments per note ([#2795](https://github.com/0xMiden/protocol/pull/2795), [#2849](https://github.com/0xMiden/protocol/pull/2849)):
 - [BREAKING] Renamed `set_attachment` to `add_attachment`, `set_word_attachment` to `add_word_attachment`, and `set_array_attachment` to `add_array_attachment` in `miden::protocol::output_note` ([#2795](https://github.com/0xMiden/protocol/pull/2795), [#2849](https://github.com/0xMiden/protocol/pull/2849)).
 - [BREAKING] Remove `AccountStorageMode::Network`; network accounts are now identified via `NetworkAccountNoteAllowlist` ([#2900](https://github.com/0xMiden/protocol/pull/2900)).
+- [BREAKING] Add `NetworkAccount` wrapper for convenient network account identification ([#2915](https://github.com/0xMiden/protocol/pull/2915)).
 
 ### Changes
 

--- a/crates/miden-standards/src/account/auth/mod.rs
+++ b/crates/miden-standards/src/account/auth/mod.rs
@@ -19,6 +19,7 @@ pub use guarded_multisig::{AuthGuardedMultisig, AuthGuardedMultisigConfig, Guard
 mod network_account;
 pub use network_account::{
     AuthNetworkAccount,
+    NetworkAccount,
     NetworkAccountNoteAllowlist,
     NetworkAccountNoteAllowlistError,
 };

--- a/crates/miden-standards/src/account/auth/network_account/mod.rs
+++ b/crates/miden-standards/src/account/auth/network_account/mod.rs
@@ -1,5 +1,9 @@
 mod auth_network_account;
 pub use auth_network_account::AuthNetworkAccount;
 
+#[allow(clippy::module_inception)]
+mod network_account;
+pub use network_account::NetworkAccount;
+
 mod note_allowlist;
 pub use note_allowlist::{NetworkAccountNoteAllowlist, NetworkAccountNoteAllowlistError};

--- a/crates/miden-standards/src/account/auth/network_account/network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/network_account.rs
@@ -75,7 +75,7 @@ impl NetworkAccount {
     }
 
     /// Returns the [`NetworkAccountNoteAllowlist`] decoded from the underlying account's storage.
-    pub fn allowlist(&self) -> &NetworkAccountNoteAllowlist {
+    pub fn allowed_notes(&self) -> &NetworkAccountNoteAllowlist {
         &self.allowlist
     }
 }
@@ -121,7 +121,7 @@ mod tests {
 
         let network_account = NetworkAccount::new(account).expect("should be a network account");
         let actual: BTreeSet<NoteScriptRoot> =
-            network_account.allowlist().allowed_script_roots().iter().copied().collect();
+            network_account.allowed_notes().allowed_script_roots().iter().copied().collect();
         assert_eq!(actual, roots);
     }
 

--- a/crates/miden-standards/src/account/auth/network_account/network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/network_account.rs
@@ -1,0 +1,153 @@
+use miden_protocol::account::{Account, AccountId, AccountStorage};
+
+use crate::account::auth::network_account::{
+    NetworkAccountNoteAllowlist,
+    NetworkAccountNoteAllowlistError,
+};
+
+// NETWORK ACCOUNT
+// ================================================================================================
+
+/// A wrapper around an [`Account`] that is guaranteed to be a network account.
+///
+/// # Specification
+///
+/// An [`Account`] is a network account if and only if all of the following hold:
+///
+/// - It MUST be public, i.e. [`Account::is_public`] returns `true`. The network needs to read
+///   account storage to identify the account and route notes to it, so private accounts cannot be
+///   network accounts.
+/// - Its storage MUST contain a valid [`NetworkAccountNoteAllowlist`] slot. Concretely:
+///   - the storage slot named [`NetworkAccountNoteAllowlist::slot_name`] MUST be present,
+///   - the slot MUST be a [`StorageMap`](miden_protocol::account::StorageMap) (not a value slot),
+///   - the map MUST be non-empty (the allowlist contains at least one allowed
+///     [`NoteScriptRoot`](miden_protocol::note::NoteScriptRoot)).
+///
+/// The allowlist slot is the shared abstraction across every network-account component, so
+/// off-chain services can identify a network account by inspecting its storage for this slot
+/// without needing to know which specific component the account uses.
+///
+/// The account's [`AccountType`](miden_protocol::account::AccountType) is intentionally
+/// unconstrained: both regular accounts and faucets may be network accounts, matching the fact
+/// that the [`AuthNetworkAccount`](crate::account::auth::network_account::AuthNetworkAccount)
+/// component supports all account types.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NetworkAccount {
+    account: Account,
+    allowlist: NetworkAccountNoteAllowlist,
+}
+
+impl NetworkAccount {
+    /// Attempts to construct a [`NetworkAccount`] from `account`.
+    ///
+    /// Returns an error if:
+    /// - the account is not [`public`](Account::is_public), or
+    /// - the account's storage does not contain a valid [`NetworkAccountNoteAllowlist`] slot (see
+    ///   [`NetworkAccountNoteAllowlist::try_from`] for the exact storage-level checks).
+    pub fn new(account: Account) -> Result<Self, NetworkAccountNoteAllowlistError> {
+        if !account.is_public() {
+            return Err(NetworkAccountNoteAllowlistError::AccountNotPublic(account.id()));
+        }
+
+        let allowlist = NetworkAccountNoteAllowlist::try_from(account.storage())?;
+
+        Ok(Self { account, allowlist })
+    }
+
+    /// Consumes `self` and returns the underlying [`Account`].
+    pub fn into_account(self) -> Account {
+        self.account
+    }
+
+    /// Returns a reference to the underlying [`Account`].
+    pub fn as_account(&self) -> &Account {
+        &self.account
+    }
+
+    /// Returns the [`AccountId`] of the underlying account.
+    pub fn id(&self) -> AccountId {
+        self.account.id()
+    }
+
+    /// Returns a reference to the [`AccountStorage`] of the underlying account.
+    pub fn storage(&self) -> &AccountStorage {
+        self.account.storage()
+    }
+
+    /// Returns the [`NetworkAccountNoteAllowlist`] decoded from the underlying account's storage.
+    pub fn allowlist(&self) -> &NetworkAccountNoteAllowlist {
+        &self.allowlist
+    }
+}
+
+impl TryFrom<Account> for NetworkAccount {
+    type Error = NetworkAccountNoteAllowlistError;
+
+    fn try_from(account: Account) -> Result<Self, Self::Error> {
+        Self::new(account)
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeSet;
+
+    use miden_protocol::account::{AccountBuilder, AccountStorageMode};
+    use miden_protocol::note::NoteScriptRoot;
+
+    use super::*;
+    use crate::account::auth::network_account::AuthNetworkAccount;
+    use crate::account::wallets::BasicWallet;
+
+    fn build_account(storage_mode: AccountStorageMode, roots: BTreeSet<NoteScriptRoot>) -> Account {
+        AccountBuilder::new([0; 32])
+            .storage_mode(storage_mode)
+            .with_auth_component(
+                AuthNetworkAccount::with_allowlist(roots).expect("non-empty allowlist"),
+            )
+            .with_component(BasicWallet)
+            .build()
+            .expect("account building should succeed")
+    }
+
+    #[test]
+    fn public_account_with_allowlist_is_a_network_account() {
+        let root = NoteScriptRoot::from_array([1, 2, 3, 4]);
+        let roots = BTreeSet::from_iter([root]);
+        let account = build_account(AccountStorageMode::Public, roots.clone());
+
+        let network_account = NetworkAccount::new(account).expect("should be a network account");
+        let actual: BTreeSet<NoteScriptRoot> =
+            network_account.allowlist().allowed_script_roots().iter().copied().collect();
+        assert_eq!(actual, roots);
+    }
+
+    #[test]
+    fn private_account_is_rejected_even_with_allowlist() {
+        let root = NoteScriptRoot::from_array([1, 2, 3, 4]);
+        let account = build_account(AccountStorageMode::Private, BTreeSet::from_iter([root]));
+
+        let id = account.id();
+        let err = NetworkAccount::new(account).expect_err("private account must be rejected");
+        assert!(matches!(
+            err,
+            NetworkAccountNoteAllowlistError::AccountNotPublic(account_id) if account_id == id
+        ));
+    }
+
+    #[test]
+    fn public_account_without_allowlist_is_not_a_network_account() {
+        let account = AccountBuilder::new([0; 32])
+            .storage_mode(AccountStorageMode::Public)
+            .with_auth_component(crate::account::auth::NoAuth)
+            .with_component(BasicWallet)
+            .build()
+            .expect("account building should succeed");
+
+        let err = NetworkAccount::new(account).expect_err("missing allowlist must be rejected");
+        assert!(matches!(err, NetworkAccountNoteAllowlistError::SlotNotFound));
+    }
+}

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -2,6 +2,7 @@ use alloc::collections::BTreeSet;
 
 use miden_protocol::account::component::{SchemaType, StorageSlotSchema};
 use miden_protocol::account::{
+    AccountId,
     AccountStorage,
     StorageMap,
     StorageMapKey,
@@ -40,7 +41,7 @@ const ALLOWED_FLAG: Word = Word::new([Felt::ONE, Felt::ZERO, Felt::ZERO, Felt::Z
 ///
 /// The slot is a [`StorageMap`] keyed by note script root; any non-empty value marks a root as
 /// allowed.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NetworkAccountNoteAllowlist {
     allowed_script_roots: BTreeSet<NoteScriptRoot>,
 }
@@ -157,6 +158,8 @@ pub enum NetworkAccountNoteAllowlistError {
         NetworkAccountNoteAllowlist::slot_name()
     )]
     UnexpectedSlotType,
+    #[error("network account must have public storage mode, but account {0} does not")]
+    AccountNotPublic(AccountId),
 }
 
 // TESTS


### PR DESCRIPTION
Adds `NetworkAccount` wrapper for convenient network account identification.

closes https://github.com/0xMiden/protocol/issues/2285