### PR TITLE
feat: Introduce `AccountCodeInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@
 - [BREAKING] Removed `AccountType` and renamed `AccountStorageMode` to `AccountType` ([#2939](https://github.com/0xMiden/protocol/pull/2939), [#2942](https://github.com/0xMiden/protocol/pull/2942)).
 - [BREAKING] Updated note nullifiers to include note metadata and attachments commitment ([#2953](https://github.com/0xMiden/protocol/pull/2953)).
 - Exposed `token_config_slot_value` on `FungibleFaucet` to allow reading the token config word directly from the account storage ([#2954](https://github.com/0xMiden/protocol/pull/2954)).
-- [BREAKING] Introduced `AccountCodeInterface` ([#2621](https://github.com/0xMiden/protocol/pull/2621)).
+- [BREAKING] Introduced `AccountCodeInterface` ([#2924](https://github.com/0xMiden/protocol/pull/2924)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - [BREAKING] Removed `AccountType` and renamed `AccountStorageMode` to `AccountType` ([#2939](https://github.com/0xMiden/protocol/pull/2939), [#2942](https://github.com/0xMiden/protocol/pull/2942)).
 - [BREAKING] Updated note nullifiers to include note metadata and attachments commitment ([#2953](https://github.com/0xMiden/protocol/pull/2953)).
 - Exposed `token_config_slot_value` on `FungibleFaucet` to allow reading the token config word directly from the account storage ([#2954](https://github.com/0xMiden/protocol/pull/2954)).
+- [BREAKING] Introduced `AccountCodeInterface` ([#2621](https://github.com/0xMiden/protocol/pull/2621)).
 
 ### Fixes
 

--- a/crates/miden-protocol/src/account/interface/code_interface.rs
+++ b/crates/miden-protocol/src/account/interface/code_interface.rs
@@ -1,0 +1,186 @@
+use alloc::collections::BTreeSet;
+
+use crate::account::AccountId;
+use crate::account::code::AccountCode;
+use crate::account::code::procedure::AccountProcedureRoot;
+use crate::errors::AccountCodeInterfaceError;
+
+/// The set of procedures an account exposes.
+///
+/// This is the next-generation replacement for the enum-based interface in `miden-standards`. It
+/// is intentionally minimal: it only carries the account's ID and the set of procedure roots that
+/// make up its callable surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountCodeInterface {
+    account_id: AccountId,
+    procedures: BTreeSet<AccountProcedureRoot>,
+}
+
+impl AccountCodeInterface {
+    /// Constructs a new [`AccountCodeInterface`] from the given account ID and set of procedure
+    /// roots.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the number of procedures is outside the
+    /// `[AccountCode::MIN_NUM_PROCEDURES, AccountCode::MAX_NUM_PROCEDURES]` range.
+    pub fn new(
+        account_id: AccountId,
+        procedures: BTreeSet<AccountProcedureRoot>,
+    ) -> Result<Self, AccountCodeInterfaceError> {
+        let count = procedures.len();
+        if count < AccountCode::MIN_NUM_PROCEDURES {
+            return Err(AccountCodeInterfaceError::TooFewProcedures { actual: count });
+        }
+        if count > AccountCode::MAX_NUM_PROCEDURES {
+            return Err(AccountCodeInterfaceError::TooManyProcedures { actual: count });
+        }
+        Ok(Self { account_id, procedures })
+    }
+
+    /// Returns the ID of the account this interface belongs to.
+    pub fn id(&self) -> AccountId {
+        self.account_id
+    }
+
+    /// Returns the set of procedure roots exposed by this interface.
+    pub fn procedures(&self) -> &BTreeSet<AccountProcedureRoot> {
+        &self.procedures
+    }
+
+    /// Returns `true` if every procedure root yielded by `procedures` is contained in this
+    /// interface.
+    pub fn contains(&self, procedures: impl IntoIterator<Item = AccountProcedureRoot>) -> bool {
+        procedures
+            .into_iter()
+            .all(|procedure_root| self.procedures.contains(&procedure_root))
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use rstest::rstest;
+
+    use super::*;
+    use crate::Word;
+    use crate::account::{AccountBuilder, PartialAccount};
+    use crate::testing::add_component::AddComponent;
+    use crate::testing::noop_auth_component::NoopAuthComponent;
+
+    fn procedure(value: u32) -> AccountProcedureRoot {
+        AccountProcedureRoot::from_raw(Word::from([value, value, value, value]))
+    }
+
+    fn build_code_interface(values: &[u32]) -> AccountCodeInterface {
+        let procedures: BTreeSet<AccountProcedureRoot> =
+            values.iter().copied().map(procedure).collect();
+        AccountCodeInterface::new(dummy_account_id(), procedures).unwrap()
+    }
+
+    fn dummy_account_id() -> AccountId {
+        AccountId::try_from(
+            crate::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
+        )
+        .unwrap()
+    }
+
+    #[rstest]
+    #[case::empty(vec![])]
+    #[case::subset(vec![1, 2])]
+    #[case::exact(vec![1, 2, 3])]
+    fn contains_returns_true(#[case] query: Vec<u32>) {
+        let interface = build_code_interface(&[1, 2, 3]);
+        let query: Vec<AccountProcedureRoot> = query.into_iter().map(procedure).collect();
+        assert!(interface.contains(query));
+    }
+
+    #[rstest]
+    #[case::missing_one(vec![1, 4])]
+    #[case::all_missing(vec![10, 11])]
+    fn contains_returns_false(#[case] query: Vec<u32>) {
+        let interface = build_code_interface(&[1, 2, 3]);
+        let query: Vec<AccountProcedureRoot> = query.into_iter().map(procedure).collect();
+        assert!(!interface.contains(query));
+    }
+
+    #[test]
+    fn new_rejects_too_few_procedures() {
+        let procedures: BTreeSet<AccountProcedureRoot> = BTreeSet::new();
+        let err = AccountCodeInterface::new(dummy_account_id(), procedures).unwrap_err();
+        assert_matches::assert_matches!(
+            err,
+            AccountCodeInterfaceError::TooFewProcedures { actual: 0 }
+        );
+
+        let one_procedure: BTreeSet<AccountProcedureRoot> = [procedure(1)].into_iter().collect();
+        let err = AccountCodeInterface::new(dummy_account_id(), one_procedure).unwrap_err();
+        assert_matches::assert_matches!(
+            err,
+            AccountCodeInterfaceError::TooFewProcedures { actual: 1 }
+        );
+    }
+
+    #[test]
+    fn new_rejects_too_many_procedures() {
+        let procedures: BTreeSet<AccountProcedureRoot> =
+            (0..=AccountCode::MAX_NUM_PROCEDURES as u32).map(procedure).collect();
+        let expected = AccountCode::MAX_NUM_PROCEDURES + 1;
+        let err = AccountCodeInterface::new(dummy_account_id(), procedures).unwrap_err();
+        assert_matches::assert_matches!(
+            err,
+            AccountCodeInterfaceError::TooManyProcedures { actual } if actual == expected
+        );
+    }
+
+    #[test]
+    fn new_accepts_min_and_max_procedures() {
+        let min: BTreeSet<AccountProcedureRoot> =
+            (0..AccountCode::MIN_NUM_PROCEDURES as u32).map(procedure).collect();
+        AccountCodeInterface::new(dummy_account_id(), min).unwrap();
+
+        let max: BTreeSet<AccountProcedureRoot> =
+            (0..AccountCode::MAX_NUM_PROCEDURES as u32).map(procedure).collect();
+        AccountCodeInterface::new(dummy_account_id(), max).unwrap();
+    }
+
+    #[test]
+    fn account_code_interface_matches_code_procedures() -> anyhow::Result<()> {
+        let account = AccountBuilder::new([7; 32])
+            .with_auth_component(NoopAuthComponent)
+            .with_component(AddComponent)
+            .build()?;
+
+        let code_interface = account.code_interface();
+        let expected: BTreeSet<AccountProcedureRoot> =
+            account.code().procedures().iter().copied().collect();
+
+        assert_eq!(code_interface.id(), account.id());
+        assert_eq!(code_interface.procedures(), &expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn partial_account_code_interface_matches_code_procedures() -> anyhow::Result<()> {
+        let account = AccountBuilder::new([8; 32])
+            .with_auth_component(NoopAuthComponent)
+            .with_component(AddComponent)
+            .build()?;
+        let partial = PartialAccount::from(&account);
+
+        let code_interface = partial.code_interface();
+        let expected: BTreeSet<AccountProcedureRoot> =
+            partial.code().procedures().iter().copied().collect();
+
+        assert_eq!(code_interface.id(), partial.id());
+        assert_eq!(code_interface.procedures(), &expected);
+
+        Ok(())
+    }
+}

--- a/crates/miden-protocol/src/account/interface/mod.rs
+++ b/crates/miden-protocol/src/account/interface/mod.rs
@@ -1,2 +1,5 @@
+mod code_interface;
+pub use code_interface::AccountCodeInterface;
+
 mod name;
 pub use name::AccountComponentName;

--- a/crates/miden-protocol/src/account/mod.rs
+++ b/crates/miden-protocol/src/account/mod.rs
@@ -41,7 +41,7 @@ pub mod component;
 pub use component::{AccountComponent, AccountComponentCode, AccountComponentMetadata};
 
 pub mod interface;
-pub use interface::AccountComponentName;
+pub use interface::{AccountCodeInterface, AccountComponentName};
 
 mod patch;
 pub use patch::{
@@ -246,6 +246,13 @@ impl Account {
     /// Returns a reference to the code of this account.
     pub fn code(&self) -> &AccountCode {
         &self.code
+    }
+
+    /// Returns the public interface of this account: its ID and the set of procedure roots it
+    /// exposes.
+    pub fn code_interface(&self) -> AccountCodeInterface {
+        AccountCodeInterface::new(self.id(), self.code.procedures().iter().copied().collect())
+            .expect("account code procedure count is enforced by AccountCode invariants")
     }
 
     /// Returns nonce for this account.

--- a/crates/miden-protocol/src/account/partial.rs
+++ b/crates/miden-protocol/src/account/partial.rs
@@ -5,7 +5,7 @@ use miden_core::{Felt, ZERO};
 
 use super::{Account, AccountCode, AccountId, PartialStorage};
 use crate::Word;
-use crate::account::{AccountHeader, validate_account_seed};
+use crate::account::{AccountCodeInterface, AccountHeader, validate_account_seed};
 use crate::asset::PartialVault;
 use crate::crypto::SequentialCommit;
 use crate::errors::AccountError;
@@ -93,6 +93,13 @@ impl PartialAccount {
     /// Returns a reference to the account code.
     pub fn code(&self) -> &AccountCode {
         &self.code
+    }
+
+    /// Returns the public interface of this account: its ID and the set of procedure roots it
+    /// exposes.
+    pub fn code_interface(&self) -> AccountCodeInterface {
+        AccountCodeInterface::new(self.id, self.code.procedures().iter().copied().collect())
+            .expect("account code procedure count is enforced by AccountCode invariants")
     }
 
     /// Returns a reference to the partial storage representation of the account.

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -251,6 +251,23 @@ pub enum StorageSlotNameError {
     TooLong,
 }
 
+// ACCOUNT CODE INTERFACE ERROR
+// ================================================================================================
+
+#[derive(Debug, Error)]
+pub enum AccountCodeInterfaceError {
+    #[error(
+        "account code interface must contain at least {} procedures, but only {actual} were given",
+        AccountCode::MIN_NUM_PROCEDURES
+    )]
+    TooFewProcedures { actual: usize },
+    #[error(
+        "account code interface contains {actual} procedures but it may contain at most {} procedures",
+        AccountCode::MAX_NUM_PROCEDURES
+    )]
+    TooManyProcedures { actual: usize },
+}
+
 // ACCOUNT COMPONENT NAME ERROR
 // ================================================================================================
 

--- a/crates/miden-standards/src/account/faucets/fungible/mod.rs
+++ b/crates/miden-standards/src/account/faucets/fungible/mod.rs
@@ -11,6 +11,7 @@ use miden_protocol::account::component::{
 use miden_protocol::account::{
     Account,
     AccountBuilder,
+    AccountCodeInterface,
     AccountComponent,
     AccountComponentName,
     AccountProcedureRoot,
@@ -35,7 +36,6 @@ use super::{
 use crate::account::access::{AccessControl, PausableManager};
 use crate::account::account_component_code;
 use crate::account::auth::{AuthNetworkAccount, AuthSingleSigAcl, AuthSingleSigAclConfig, NoAuth};
-use crate::account::interface::{AccountComponentInterface, AccountInterface, AccountInterfaceExt};
 use crate::account::policies::TokenPolicyManager;
 use crate::{AuthMethod, procedure_root};
 
@@ -463,10 +463,10 @@ impl FungibleFaucet {
 
     /// Checks that the account contains the fungible faucet interface.
     fn try_from_interface(
-        interface: AccountInterface,
+        interface: AccountCodeInterface,
         storage: &AccountStorage,
     ) -> Result<Self, FungibleFaucetError> {
-        if !interface.components().contains(&AccountComponentInterface::FungibleFaucet) {
+        if !interface.contains(FungibleFaucet::code().procedure_roots()) {
             return Err(FungibleFaucetError::MissingFungibleFaucetInterface);
         }
 
@@ -541,9 +541,7 @@ impl TryFrom<Account> for FungibleFaucet {
     type Error = FungibleFaucetError;
 
     fn try_from(account: Account) -> Result<Self, Self::Error> {
-        let account_interface = AccountInterface::from_account(&account);
-
-        FungibleFaucet::try_from_interface(account_interface, account.storage())
+        FungibleFaucet::try_from_interface(account.code_interface(), account.storage())
     }
 }
 
@@ -551,9 +549,7 @@ impl TryFrom<&Account> for FungibleFaucet {
     type Error = FungibleFaucetError;
 
     fn try_from(account: &Account) -> Result<Self, Self::Error> {
-        let account_interface = AccountInterface::from_account(account);
-
-        FungibleFaucet::try_from_interface(account_interface, account.storage())
+        FungibleFaucet::try_from_interface(account.code_interface(), account.storage())
     }
 }
 


### PR DESCRIPTION
Introduces `AccountCodeInterface` as motivated in https://github.com/0xMiden/protocol/issues/2621.

This is a more general version of `AccountInterface` that avoids the dependency on the to-be-removed `AccountComponentInterface` enum.

I renamed `AccountInterface` to `AccountCodeInterface` because it conceptually deals with the code of an account, so this seemed more precise and less generic.

Also replaces a usage of the old `AccountInterface` with the new one.