### PR TITLE
Enforce uniqueness of procedure roots in AccountCode deserialization

### DIFF
--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use miden_core::mast::MastForest;
 use miden_core::prettier::PrettyPrint;
-
+use alloc::collections::BTreeSet;
 use super::{
     AccountError,
     ByteReader,
@@ -285,11 +285,12 @@ impl Deserializable for AccountCode {
             )));
         }
 
+        let mut seen = BTreeSet::new();
         let procedures = source
             .read_many_iter(num_procedures)?
-            .collect::<Result<Vec<AccountProcedureRoot>, _>>()?;
-
-        // make sure that all account procedures are in the MAST forest
+            .collect::<Result<Vec, _>>()?;
+        
+        // make sure that all account procedures are in the MAST forest and are unique
         for procedure in procedures.iter() {
             if mast.find_procedure_root(procedure.as_word()).is_none() {
                 return Err(DeserializationError::InvalidValue(format!(
@@ -297,8 +298,14 @@ impl Deserializable for AccountCode {
                     procedure.as_word()
                 )));
             }
+            if !seen.insert(procedure.as_word()) {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "duplicate procedure root {} in account code",
+                    procedure.as_word()
+                )));
+            }
         }
-
+        
         Ok(Self::from_parts(mast, procedures))
     }
 }


### PR DESCRIPTION
## Issue

`AccountProcedureBuilder::add_procedure()` deduplicates procedure roots before inserting them — if a root is already present, it is skipped. This ensures `from_components()` always produces an `AccountCode` with unique procedure roots.

`AccountCode::read_from()` does not apply the same check. It reads procedure roots directly from bytes into a `Vec` and passes them straight to `from_parts()`, which also has no uniqueness check. A serialized `AccountCode` with a duplicate procedure root in its procedure list will deserialize successfully and pass the MAST forest membership check, but the commitment computed by `build_procedure_commitment()` will include the duplicate in the hash, producing a different value than what `from_components()` would compute for the same account.

```rust
// from_components path — deduplicates
fn add_procedure(&mut self, proc_root: AccountProcedureRoot) {
    if !self.procedures.contains(&proc_root) {
        self.procedures.push(proc_root);
    }
}

// read_from path — no dedup, raw collect into Vec
let procedures = source
    .read_many_iter(num_procedures)?
    .collect::<Result<Vec<AccountProcedureRoot>, _>>()?;

// from_parts has no uniqueness check either
Ok(Self::from_parts(mast, procedures))
```

---

## Fix

`crates/miden-protocol/src/account/code/mod.rs`

```rust
// before
let procedures = source
    .read_many_iter(num_procedures)?
    .collect::<Result<Vec<AccountProcedureRoot>, _>>()?;

// make sure that all account procedures are in the MAST forest
for procedure in procedures.iter() {
    if mast.find_procedure_root(procedure.as_word()).is_none() {
        return Err(DeserializationError::InvalidValue(format!(
            "procedure with root {} is missing from account code's MAST forest",
            procedure.as_word()
        )));
    }
}

Ok(Self::from_parts(mast, procedures))
```

```rust
// after
let mut seen = BTreeSet::new();
let procedures = source
    .read_many_iter(num_procedures)?
    .collect::<Result<Vec<AccountProcedureRoot>, _>>()?;

// make sure that all account procedures are in the MAST forest and are unique
for procedure in procedures.iter() {
    if mast.find_procedure_root(procedure.as_word()).is_none() {
        return Err(DeserializationError::InvalidValue(format!(
            "procedure with root {} is missing from account code's MAST forest",
            procedure.as_word()
        )));
    }
    if !seen.insert(procedure.as_word()) {
        return Err(DeserializationError::InvalidValue(format!(
            "duplicate procedure root {} in account code",
            procedure.as_word()
        )));
    }
}

Ok(Self::from_parts(mast, procedures))
```

Add `BTreeSet` to the imports at the top of the file if not already present:

```rust
use alloc::collections::BTreeSet;
```

---

## Why

`from_components()` explicitly deduplicates via `add_procedure()`. `read_from()` skips this step. The fix brings `read_from()` in line with the invariant that `from_components()` already enforces.