### PR TITLE
Use `AssetAmount` more extensively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Documented the `miden::protocol::account_id` module in the protocol library docs ([#2607](https://github.com/0xMiden/protocol/issues/2607)).
 - [BREAKING] Renamed `procedure_digest!` to `procedure_root!` and return `AccountProcedureRoot` instead of `Word` ([#2621](https://github.com/0xMiden/protocol/issues/2621)).
 - [BREAKING] Replaced the `FungibleFaucetBuilder` with a `bon` builder on `FungibleFaucet` ([#2916](https://github.com/0xMiden/protocol/pull/2916)).
+- [BREAKING] `FungibleAsset::amount()` and `AssetVault::get_balance()` now return `AssetAmount` ([#2928](https://github.com/0xMiden/protocol/pull/2928)).
 
 ### Fixes
 

--- a/crates/miden-agglayer/src/faucet.rs
+++ b/crates/miden-agglayer/src/faucet.rs
@@ -135,19 +135,18 @@ impl AggLayerFaucet {
         // Use the symbol as the display name; AggLayer faucets do not use a separate token name.
         let name = TokenName::new(symbol.to_string().as_str())
             .expect("symbol fits within token name capacity");
-        let max_supply_amount = AssetAmount::new(max_supply.as_canonical_u64()).map_err(|_| {
+        let max_supply_amount = AssetAmount::try_from(max_supply).map_err(|_| {
             FungibleFaucetError::MaxSupplyTooLarge {
                 actual: max_supply.as_canonical_u64(),
                 max: AssetAmount::MAX,
             }
         })?;
-        let token_supply_amount =
-            AssetAmount::new(token_supply.as_canonical_u64()).map_err(|_| {
-                FungibleFaucetError::MaxSupplyTooLarge {
-                    actual: token_supply.as_canonical_u64(),
-                    max: AssetAmount::MAX,
-                }
-            })?;
+        let token_supply_amount = AssetAmount::try_from(token_supply).map_err(|_| {
+            FungibleFaucetError::MaxSupplyTooLarge {
+                actual: token_supply.as_canonical_u64(),
+                max: AssetAmount::MAX,
+            }
+        })?;
         let faucet = FungibleFaucet::builder()
             .name(name)
             .symbol(symbol)
@@ -169,7 +168,13 @@ impl AggLayerFaucet {
     /// # Errors
     /// Returns an error if the token supply exceeds the max supply.
     pub fn with_token_supply(mut self, token_supply: Felt) -> Result<Self, FungibleFaucetError> {
-        self.faucet = self.faucet.with_token_supply(token_supply)?;
+        let token_supply_amount = AssetAmount::try_from(token_supply).map_err(|_| {
+            FungibleFaucetError::MaxSupplyTooLarge {
+                actual: token_supply.as_canonical_u64(),
+                max: AssetAmount::MAX,
+            }
+        })?;
+        self.faucet = self.faucet.with_token_supply(token_supply_amount)?;
         Ok(self)
     }
 

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -216,7 +216,7 @@ impl FungibleAssetDelta {
     /// # Errors
     /// Returns an error if the delta would overflow.
     pub fn add(&mut self, asset: FungibleAsset) -> Result<(), AccountDeltaError> {
-        let amount: i64 = asset.amount().try_into().expect("Amount it too high");
+        let amount: i64 = asset.amount().as_i64();
         self.add_delta(asset.vault_key(), amount)
     }
 
@@ -225,7 +225,7 @@ impl FungibleAssetDelta {
     /// # Errors
     /// Returns an error if the delta would overflow.
     pub fn remove(&mut self, asset: FungibleAsset) -> Result<(), AccountDeltaError> {
-        let amount: i64 = asset.amount().try_into().expect("Amount it too high");
+        let amount: i64 = asset.amount().as_i64();
         self.add_delta(asset.vault_key(), -amount)
     }
 

--- a/crates/miden-protocol/src/asset/asset_amount.rs
+++ b/crates/miden-protocol/src/asset/asset_amount.rs
@@ -40,15 +40,32 @@ impl AssetAmount {
         }
         Ok(Self(amount))
     }
+
+    /// Returns an `AssetAmount` of zero.
+    pub const fn zero() -> Self {
+        Self(0)
+    }
+
+    /// Returns the underlying `u64` value.
+    pub const fn as_u64(&self) -> u64 {
+        self.0
+    }
+
+    /// Returns the underlying value as an `i64`.
+    ///
+    /// SAFETY: this cast never truncates or wraps because [`Self::MAX`] (`2^63 - 2^31`) is
+    /// strictly less than [`i64::MAX`] (`2^63 - 1`), so every valid `AssetAmount` fits in a
+    /// non-negative `i64`.
+    pub const fn as_i64(&self) -> i64 {
+        self.0 as i64
+    }
 }
 
 impl Add for AssetAmount {
     type Output = Result<Self, AssetError>;
 
     fn add(self, other: Self) -> Self::Output {
-        let raw = u64::from(self)
-            .checked_add(u64::from(other))
-            .expect("even MAX + MAX should not overflow u64");
+        let raw = self.0.checked_add(other.0).expect("even MAX + MAX should not overflow u64");
         Self::new(raw)
     }
 }
@@ -57,12 +74,13 @@ impl Sub for AssetAmount {
     type Output = Result<Self, AssetError>;
 
     fn sub(self, other: Self) -> Self::Output {
-        let raw = u64::from(self).checked_sub(u64::from(other)).ok_or(
-            AssetError::FungibleAssetAmountNotSufficient {
-                minuend: u64::from(self),
-                subtrahend: u64::from(other),
-            },
-        )?;
+        let raw =
+            self.0
+                .checked_sub(other.0)
+                .ok_or(AssetError::FungibleAssetAmountNotSufficient {
+                    minuend: self.0,
+                    subtrahend: other.0,
+                })?;
         Ok(Self(raw))
     }
 }
@@ -93,6 +111,14 @@ impl TryFrom<u64> for AssetAmount {
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         Self::new(value)
+    }
+}
+
+impl TryFrom<Felt> for AssetAmount {
+    type Error = AssetError;
+
+    fn try_from(value: Felt) -> Result<Self, Self::Error> {
+        Self::new(value.as_canonical_u64())
     }
 }
 

--- a/crates/miden-protocol/src/asset/asset_amount.rs
+++ b/crates/miden-protocol/src/asset/asset_amount.rs
@@ -29,6 +29,9 @@ impl AssetAmount {
     /// negative value in a field element.
     pub const MAX: u64 = 2u64.pow(63) - 2u64.pow(31);
 
+    /// The zero amount.
+    pub const ZERO: Self = Self(0);
+
     /// Returns a new `AssetAmount` if `amount` does not exceed [`Self::MAX`].
     ///
     /// # Errors
@@ -39,11 +42,6 @@ impl AssetAmount {
             return Err(AssetError::FungibleAssetAmountTooBig(amount));
         }
         Ok(Self(amount))
-    }
-
-    /// Returns an `AssetAmount` of zero.
-    pub const fn zero() -> Self {
-        Self(0)
     }
 
     /// Returns the underlying `u64` value.

--- a/crates/miden-protocol/src/asset/fungible.rs
+++ b/crates/miden-protocol/src/asset/fungible.rs
@@ -124,8 +124,8 @@ impl FungibleAsset {
     }
 
     /// Returns the amount of this asset.
-    pub fn amount(&self) -> u64 {
-        self.amount.into()
+    pub fn amount(&self) -> AssetAmount {
+        self.amount
     }
 
     /// Returns true if this and the other asset were issued from the same faucet.
@@ -151,13 +151,7 @@ impl FungibleAsset {
 
     /// Returns the asset's value encoded to a [`Word`].
     pub fn to_value_word(&self) -> Word {
-        Word::new([
-            Felt::try_from(u64::from(self.amount))
-                .expect("fungible asset should only allow amounts that fit into a felt"),
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-        ])
+        Word::new([Felt::from(self.amount), Felt::ZERO, Felt::ZERO, Felt::ZERO])
     }
 
     // OPERATIONS
@@ -233,13 +227,13 @@ impl Serializable for FungibleAsset {
         // All assets should serialize their faucet ID at the first position to allow them to be
         // distinguishable during deserialization.
         target.write(self.faucet_id);
-        target.write(u64::from(self.amount));
+        target.write(self.amount.as_u64());
         target.write(self.callbacks);
     }
 
     fn get_size_hint(&self) -> usize {
         self.faucet_id.get_size_hint()
-            + u64::from(self.amount).get_size_hint()
+            + self.amount.as_u64().get_size_hint()
             + self.callbacks.get_size_hint()
     }
 }

--- a/crates/miden-protocol/src/asset/vault/mod.rs
+++ b/crates/miden-protocol/src/asset/vault/mod.rs
@@ -6,6 +6,7 @@ use miden_crypto::merkle::InnerNodeInfo;
 use super::{
     AccountType,
     Asset,
+    AssetAmount,
     ByteReader,
     ByteWriter,
     Deserializable,
@@ -103,11 +104,11 @@ impl AssetVault {
     }
 
     /// Returns the balance of the asset issued by the specified faucet. If the vault does not
-    /// contain such an asset, 0 is returned.
+    /// contain such an asset, zero is returned.
     ///
     /// # Errors
     /// Returns an error if the specified ID is not an ID of a fungible asset faucet.
-    pub fn get_balance(&self, faucet_id: AccountId) -> Result<u64, AssetVaultError> {
+    pub fn get_balance(&self, faucet_id: AccountId) -> Result<AssetAmount, AssetVaultError> {
         if !matches!(faucet_id.account_type(), AccountType::FungibleFaucet) {
             return Err(AssetVaultError::NotAFungibleFaucetId(faucet_id));
         }
@@ -312,7 +313,7 @@ impl AssetVault {
                 .expect("asset vault should store valid assets");
 
         // If the asset's amount is 0, we consider it absent from the vault.
-        if current_asset.amount() == 0 {
+        if current_asset.amount() == AssetAmount::zero() {
             return Err(AssetVaultError::FungibleAssetNotFound(other_asset));
         }
 
@@ -325,7 +326,7 @@ impl AssetVault {
         // leaf.
         #[cfg(debug_assertions)]
         {
-            if new_asset.amount() == 0 {
+            if new_asset.amount() == AssetAmount::zero() {
                 assert!(new_asset.to_value_word().is_empty())
             }
         }

--- a/crates/miden-protocol/src/asset/vault/mod.rs
+++ b/crates/miden-protocol/src/asset/vault/mod.rs
@@ -313,7 +313,7 @@ impl AssetVault {
                 .expect("asset vault should store valid assets");
 
         // If the asset's amount is 0, we consider it absent from the vault.
-        if current_asset.amount() == AssetAmount::zero() {
+        if current_asset.amount() == AssetAmount::ZERO {
             return Err(AssetVaultError::FungibleAssetNotFound(other_asset));
         }
 
@@ -326,7 +326,7 @@ impl AssetVault {
         // leaf.
         #[cfg(debug_assertions)]
         {
-            if new_asset.amount() == AssetAmount::zero() {
+            if new_asset.amount() == AssetAmount::ZERO {
                 assert!(new_asset.to_value_word().is_empty())
             }
         }

--- a/crates/miden-protocol/src/testing/tx.rs
+++ b/crates/miden-protocol/src/testing/tx.rs
@@ -1,14 +1,15 @@
+use crate::asset::AssetAmount;
 use crate::note::NoteId;
 use crate::transaction::ExecutedTransaction;
 
 impl ExecutedTransaction {
     /// A Rust implementation of the compute_fee epilogue procedure.
-    pub fn compute_fee(&self) -> u64 {
+    pub fn compute_fee(&self) -> AssetAmount {
         // Round up the number of cycles to the next power of two and take log2 of it.
         let verification_cycles = self.measurements().trace_length().ilog2();
         let fee_amount =
             self.block_header().fee_parameters().verification_base_fee() * verification_cycles;
-        fee_amount as u64
+        AssetAmount::from(fee_amount)
     }
 
     /// Returns `true` if the transaction consumes the note with the given ID.

--- a/crates/miden-protocol/src/transaction/kernel/mod.rs
+++ b/crates/miden-protocol/src/transaction/kernel/mod.rs
@@ -224,7 +224,7 @@ impl TransactionKernel {
         outputs.extend(account_update_commitment);
         outputs.push(fee.faucet_id().suffix());
         outputs.push(fee.faucet_id().prefix().as_felt());
-        outputs.push(Felt::try_from(fee.amount()).expect("amount should fit into felt"));
+        outputs.push(Felt::from(fee.amount()));
         outputs.push(Felt::from(expiration_block_num));
 
         StackOutputs::new(&outputs).expect("number of stack inputs should be <= 16")

--- a/crates/miden-standards/src/account/faucets/fungible/mod.rs
+++ b/crates/miden-standards/src/account/faucets/fungible/mod.rs
@@ -103,8 +103,8 @@ procedure_root!(
 /// [`TokenPolicyManager`]: crate::account::policies::TokenPolicyManager
 #[derive(Debug, Clone)]
 pub struct FungibleFaucet {
-    token_supply: Felt,
-    max_supply: Felt,
+    token_supply: AssetAmount,
+    max_supply: AssetAmount,
     decimals: u8,
     symbol: TokenSymbol,
     /// Embeds name, optional fields, and mutability flags.
@@ -130,8 +130,8 @@ impl FungibleFaucet {
     ///     .name(TokenName::new("My Token")?)
     ///     .symbol(TokenSymbol::new("MTK")?)
     ///     .decimals(8)
-    ///     .max_supply(AssetAmount::new(1_000_000)?)
-    ///     .token_supply(AssetAmount::new(100)?)
+    ///     .max_supply(AssetAmount::from(1_000_000u32))
+    ///     .token_supply(AssetAmount::from(100u32))
     ///     .description(Description::new("A test token")?)
     ///     .logo_uri(LogoURI::new("https://example.com/logo.png")?)
     ///     .build()?;
@@ -214,16 +214,16 @@ impl FungibleFaucet {
             });
         }
 
-        if u64::from(token_supply) > u64::from(max_supply) {
+        if token_supply > max_supply {
             return Err(FungibleFaucetError::TokenSupplyExceedsMaxSupply {
-                token_supply: u64::from(token_supply),
-                max_supply: u64::from(max_supply),
+                token_supply: token_supply.as_u64(),
+                max_supply: max_supply.as_u64(),
             });
         }
 
         Ok(Self {
-            token_supply: token_supply.into(),
-            max_supply: max_supply.into(),
+            token_supply,
+            max_supply,
             decimals,
             symbol,
             metadata,
@@ -255,12 +255,12 @@ impl FungibleFaucet {
     }
 
     /// Returns the current token supply (amount issued).
-    pub fn token_supply(&self) -> Felt {
+    pub fn token_supply(&self) -> AssetAmount {
         self.token_supply
     }
 
     /// Returns the maximum token supply.
-    pub fn max_supply(&self) -> Felt {
+    pub fn max_supply(&self) -> AssetAmount {
         self.max_supply
     }
 
@@ -338,8 +338,8 @@ impl FungibleFaucet {
     /// Returns the single storage slot for the token config word.
     fn token_config_slot_value(&self) -> StorageSlot {
         let word = Word::new([
-            self.token_supply,
-            self.max_supply,
+            self.token_supply.into(),
+            self.max_supply.into(),
             Felt::from(self.decimals),
             self.symbol.clone().into(),
         ]);
@@ -355,11 +355,14 @@ impl FungibleFaucet {
     ///
     /// Returns an error if:
     /// - the token supply exceeds the max supply.
-    pub fn with_token_supply(mut self, token_supply: Felt) -> Result<Self, FungibleFaucetError> {
-        if token_supply.as_canonical_u64() > self.max_supply.as_canonical_u64() {
+    pub fn with_token_supply(
+        mut self,
+        token_supply: AssetAmount,
+    ) -> Result<Self, FungibleFaucetError> {
+        if token_supply > self.max_supply {
             return Err(FungibleFaucetError::TokenSupplyExceedsMaxSupply {
-                token_supply: token_supply.as_canonical_u64(),
-                max_supply: self.max_supply.as_canonical_u64(),
+                token_supply: token_supply.as_u64(),
+                max_supply: self.max_supply.as_u64(),
             });
         }
 
@@ -422,17 +425,15 @@ impl FungibleFaucet {
                 max: Self::MAX_DECIMALS,
             }
         })?;
-        let max_supply_raw = max_supply.as_canonical_u64();
-        let max_supply = AssetAmount::new(max_supply_raw).map_err(|_| {
+        let max_supply = AssetAmount::try_from(max_supply).map_err(|_| {
             FungibleFaucetError::MaxSupplyTooLarge {
-                actual: max_supply_raw,
+                actual: max_supply.as_canonical_u64(),
                 max: AssetAmount::MAX,
             }
         })?;
-        let token_supply_raw = token_supply.as_canonical_u64();
-        let token_supply = AssetAmount::new(token_supply_raw).map_err(|_| {
+        let token_supply = AssetAmount::try_from(token_supply).map_err(|_| {
             FungibleFaucetError::MaxSupplyTooLarge {
-                actual: token_supply_raw,
+                actual: token_supply.as_canonical_u64(),
                 max: AssetAmount::MAX,
             }
         })?;

--- a/crates/miden-standards/src/account/faucets/fungible/tests.rs
+++ b/crates/miden-standards/src/account/faucets/fungible/tests.rs
@@ -30,7 +30,7 @@ fn faucet_contract_creation() {
         204, 149, 90, 166, 68, 100, 73, 106, 168, 125, 237, 138, 16,
     ];
 
-    let max_supply = AssetAmount::new(123).unwrap();
+    let max_supply = AssetAmount::from(123u32);
     let token_symbol_string = "POL";
     let token_symbol = TokenSymbol::try_from(token_symbol_string).unwrap();
     let token_name_string = "polygon";
@@ -130,7 +130,7 @@ fn faucet_create_from_account() {
         .name(TokenName::new("POL").unwrap())
         .symbol(token_symbol)
         .decimals(10)
-        .max_supply(AssetAmount::new(100).unwrap())
+        .max_supply(AssetAmount::from(100u32))
         .build()
         .expect("failed to create faucet");
 

--- a/crates/miden-standards/src/account/interface/test.rs
+++ b/crates/miden-standards/src/account/interface/test.rs
@@ -59,7 +59,7 @@ fn test_basic_wallet_default_notes() {
                 .name(TokenName::new("POL").unwrap())
                 .symbol(TokenSymbol::new("POL").expect("invalid token symbol"))
                 .decimals(10)
-                .max_supply(AssetAmount::new(100).unwrap())
+                .max_supply(AssetAmount::from(100u32))
                 .build()
                 .expect("failed to create faucet"),
         )
@@ -325,7 +325,7 @@ fn test_fungible_faucet_custom_notes() {
                 .name(TokenName::new("POL").unwrap())
                 .symbol(TokenSymbol::new("POL").expect("invalid token symbol"))
                 .decimals(10)
-                .max_supply(AssetAmount::new(100).unwrap())
+                .max_supply(AssetAmount::from(100u32))
                 .build()
                 .expect("failed to create faucet"),
         )

--- a/crates/miden-standards/src/note/pswap.rs
+++ b/crates/miden-standards/src/note/pswap.rs
@@ -117,7 +117,7 @@ impl PswapNoteStorage {
 
     /// Returns the requested token amount.
     pub fn requested_asset_amount(&self) -> u64 {
-        self.requested_asset.amount()
+        self.requested_asset.amount().as_u64()
     }
 }
 
@@ -129,8 +129,7 @@ impl From<PswapNoteStorage> for NoteStorage {
             Felt::from(storage.requested_asset.callbacks().as_u8()),
             storage.requested_asset.faucet_id().suffix(),
             storage.requested_asset.faucet_id().prefix().as_felt(),
-            Felt::try_from(storage.requested_asset.amount())
-                .expect("asset amount should fit in a felt"),
+            Felt::from(storage.requested_asset.amount()),
             // Payback note type [4]
             Felt::from(storage.payback_note_type.as_u8()),
             // Creator ID [5-6]
@@ -381,9 +380,9 @@ impl PswapNote {
                 ));
             },
         };
-        let fill_amount = payback_asset.amount();
+        let fill_amount = payback_asset.amount().as_u64();
 
-        let total_offered_amount = self.offered_asset.amount();
+        let total_offered_amount = self.offered_asset.amount().as_u64();
         let requested_faucet_id = self.storage.requested_faucet_id();
         let total_requested_amount = self.storage.requested_asset_amount();
 
@@ -403,8 +402,8 @@ impl PswapNote {
         // MASM which calls calculate_tokens_offered_for_requested twice. This is necessary
         // because the account fill portion goes to the consumer's vault while the total
         // determines the remainder note's offered amount.
-        let account_fill_amount = account_fill_asset.as_ref().map_or(0, |a| a.amount());
-        let note_fill_amount = note_fill_asset.as_ref().map_or(0, |a| a.amount());
+        let account_fill_amount = account_fill_asset.as_ref().map_or(0, |a| a.amount().as_u64());
+        let note_fill_amount = note_fill_asset.as_ref().map_or(0, |a| a.amount().as_u64());
         let payout_for_account_fill = Self::calculate_output_amount(
             total_offered_amount,
             total_requested_amount,
@@ -456,7 +455,7 @@ impl PswapNote {
     /// Returns an error if the calculated payout is not a valid asset amount.
     pub fn calculate_offered_for_requested(&self, fill_amount: u64) -> Result<u64, NoteError> {
         let total_requested = self.storage.requested_asset_amount();
-        let total_offered = self.offered_asset.amount();
+        let total_offered = self.offered_asset.amount().as_u64();
 
         Self::calculate_output_amount(total_offered, total_requested, fill_amount)
     }
@@ -873,7 +872,7 @@ mod tests {
             Felt::from(requested_asset.callbacks().as_u8()),
             requested_asset.faucet_id().suffix(),
             requested_asset.faucet_id().prefix().as_felt(),
-            Felt::try_from(requested_asset.amount()).unwrap(),
+            Felt::from(requested_asset.amount()),
             Felt::from(NoteType::Private.as_u8()), // payback_note_type
             creator_id.prefix().as_felt(),
             creator_id.suffix(),
@@ -931,13 +930,13 @@ mod tests {
             panic!("expected fungible payback asset");
         };
         assert_eq!(fa.faucet_id(), requested_faucet);
-        assert_eq!(fa.amount(), 30);
+        assert_eq!(fa.amount().as_u64(), 30);
 
         // Remainder must exist with the unfilled 50 - 30 = 20 of requested, and the
         // offered amount reduced proportionally (100 - 30*2 = 40).
         let remainder = remainder.expect("partial fill should produce remainder");
         assert_eq!(remainder.storage().requested_asset_amount(), 20);
-        assert_eq!(remainder.offered_asset().amount(), 40);
+        assert_eq!(remainder.offered_asset().amount().as_u64(), 40);
         assert_eq!(remainder.storage().creator_account_id(), creator_id);
     }
 
@@ -969,7 +968,7 @@ mod tests {
             panic!("expected fungible payback asset");
         };
         assert_eq!(fa.faucet_id(), requested_faucet);
-        assert_eq!(fa.amount(), 50);
+        assert_eq!(fa.amount().as_u64(), 50);
 
         // Full fill → no remainder note.
         assert!(remainder.is_none(), "full fill must not produce a remainder");

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -1091,7 +1091,8 @@ async fn test_get_init_balance_addition() -> anyhow::Result<()> {
     let initial_balance = account
         .vault()
         .get_balance(faucet_existing_asset)
-        .expect("faucet_id should be a fungible faucet ID");
+        .expect("faucet_id should be a fungible faucet ID")
+        .as_u64();
 
     let add_existing_source = format!(
         r#"
@@ -1123,7 +1124,7 @@ async fn test_get_init_balance_addition() -> anyhow::Result<()> {
         suffix = faucet_existing_asset.suffix(),
         prefix = faucet_existing_asset.prefix().as_felt(),
         final_balance =
-            initial_balance + fungible_asset_for_note_existing.unwrap_fungible().amount(),
+            initial_balance + fungible_asset_for_note_existing.unwrap_fungible().amount().as_u64(),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(add_existing_source)?;
@@ -1145,7 +1146,8 @@ async fn test_get_init_balance_addition() -> anyhow::Result<()> {
     let initial_balance = account
         .vault()
         .get_balance(faucet_new_asset)
-        .expect("faucet_id should be a fungible faucet ID");
+        .expect("faucet_id should be a fungible faucet ID")
+        .as_u64();
 
     let add_new_source = format!(
         r#"
@@ -1176,7 +1178,8 @@ async fn test_get_init_balance_addition() -> anyhow::Result<()> {
     "#,
         suffix = faucet_new_asset.suffix(),
         prefix = faucet_new_asset.prefix().as_felt(),
-        final_balance = initial_balance + fungible_asset_for_note_new.unwrap_fungible().amount(),
+        final_balance =
+            initial_balance + fungible_asset_for_note_new.unwrap_fungible().amount().as_u64(),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(add_new_source)?;
@@ -1223,7 +1226,8 @@ async fn test_get_init_balance_subtraction() -> anyhow::Result<()> {
     let initial_balance = account
         .vault()
         .get_balance(faucet_existing_asset)
-        .expect("faucet_id should be a fungible faucet ID");
+        .expect("faucet_id should be a fungible faucet ID")
+        .as_u64();
 
     let expected_output_note =
         create_public_p2any_note(ACCOUNT_ID_SENDER.try_into()?, [fungible_asset_for_note_existing]);
@@ -1271,7 +1275,7 @@ async fn test_get_init_balance_subtraction() -> anyhow::Result<()> {
         suffix = faucet_existing_asset.suffix(),
         prefix = faucet_existing_asset.prefix().as_felt(),
         final_balance =
-            initial_balance - fungible_asset_for_note_existing.unwrap_fungible().amount(),
+            initial_balance - fungible_asset_for_note_existing.unwrap_fungible().amount().as_u64(),
     );
 
     let tx_script = CodeBuilder::with_mock_libraries().compile_tx_script(remove_existing_source)?;
@@ -1710,7 +1714,7 @@ async fn test_faucet_has_callbacks(
         .name(TokenName::new("").expect("empty string is a valid token name"))
         .symbol("CBK".try_into()?)
         .decimals(8)
-        .max_supply(AssetAmount::new(1_000_000)?)
+        .max_supply(AssetAmount::from(1_000_000u32))
         .build()?;
 
     let account = AccountBuilder::new([1u8; 32])

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -472,13 +472,17 @@ async fn fungible_asset_delta() -> anyhow::Result<()> {
         .account_delta()
         .vault()
         .added_assets()
-        .map(|asset| (asset.unwrap_fungible().faucet_id(), asset.unwrap_fungible().amount()))
+        .map(|asset| {
+            (asset.unwrap_fungible().faucet_id(), asset.unwrap_fungible().amount().as_u64())
+        })
         .collect::<BTreeMap<_, _>>();
     let mut removed_assets = executed_tx
         .account_delta()
         .vault()
         .removed_assets()
-        .map(|asset| (asset.unwrap_fungible().faucet_id(), asset.unwrap_fungible().amount()))
+        .map(|asset| {
+            (asset.unwrap_fungible().faucet_id(), asset.unwrap_fungible().amount().as_u64())
+        })
         .collect::<BTreeMap<_, _>>();
 
     assert_eq!(added_assets.len(), 2);
@@ -486,17 +490,20 @@ async fn fungible_asset_delta() -> anyhow::Result<()> {
 
     assert_eq!(
         added_assets.remove(&original_asset2.faucet_id()).unwrap(),
-        added_asset2.amount() - removed_asset2.amount()
+        added_asset2.amount().as_u64() - removed_asset2.amount().as_u64()
     );
-    assert_eq!(added_assets.remove(&added_asset4.faucet_id()).unwrap(), added_asset4.amount());
+    assert_eq!(
+        added_assets.remove(&added_asset4.faucet_id()).unwrap(),
+        added_asset4.amount().as_u64()
+    );
 
     assert_eq!(
         removed_assets.remove(&original_asset0.faucet_id()).unwrap(),
-        removed_asset0.amount() - added_asset0.amount()
+        removed_asset0.amount().as_u64() - added_asset0.amount().as_u64()
     );
     assert_eq!(
         removed_assets.remove(&original_asset3.faucet_id()).unwrap(),
-        removed_asset3.amount()
+        removed_asset3.amount().as_u64()
     );
 
     Ok(())

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset_vault.rs
@@ -60,7 +60,7 @@ async fn get_balance_returns_correct_amount() -> anyhow::Result<()> {
 
     assert_eq!(
         exec_output.get_stack_element(0).as_canonical_u64(),
-        tx_context.account().vault().get_balance(faucet_id).unwrap()
+        tx_context.account().vault().get_balance(faucet_id).unwrap().as_u64()
     );
 
     Ok(())

--- a/crates/miden-testing/src/kernel_tests/tx/test_callbacks.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_callbacks.rs
@@ -766,7 +766,7 @@ fn add_faucet_with_callbacks(
         .name(TokenName::new("").expect("empty string is a valid token name"))
         .symbol("SYM".try_into()?)
         .decimals(8)
-        .max_supply(AssetAmount::new(1_000_000)?)
+        .max_supply(AssetAmount::from(1_000_000u32))
         .build()?;
 
     let callback_storage_slots = callbacks.into_storage_slots();

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -140,7 +140,7 @@ async fn test_transaction_epilogue() -> anyhow::Result<()> {
         exec_output
             .get_stack_element(TransactionOutputs::FEE_AMOUNT_ELEMENT_IDX)
             .as_canonical_u64(),
-        fee_asset.amount()
+        fee_asset.amount().as_u64()
     );
     assert_eq!(
         exec_output

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -33,7 +33,7 @@ async fn create_account_with_fees() -> anyhow::Result<()> {
         .context("failed to execute account-creating transaction")?;
 
     let expected_fee = tx.compute_fee();
-    assert_eq!(expected_fee, tx.fee().amount().as_u64());
+    assert_eq!(expected_fee, tx.fee().amount());
 
     // We expect that the new account contains the note_amount minus the paid fee.
     let added_asset = FungibleAsset::new(chain.fee_faucet_id(), note_amount)?.sub(tx.fee())?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -33,7 +33,7 @@ async fn create_account_with_fees() -> anyhow::Result<()> {
         .context("failed to execute account-creating transaction")?;
 
     let expected_fee = tx.compute_fee();
-    assert_eq!(expected_fee, tx.fee().amount());
+    assert_eq!(expected_fee, tx.fee().amount().as_u64());
 
     // We expect that the new account contains the note_amount minus the paid fee.
     let added_asset = FungibleAsset::new(chain.fee_faucet_id(), note_amount)?.sub(tx.fee())?;

--- a/crates/miden-testing/src/standards/token_metadata.rs
+++ b/crates/miden-testing/src/standards/token_metadata.rs
@@ -509,7 +509,7 @@ fn faucet_with_metadata_storage_layout() {
 
     // Verify roundtrip via try_from
     let restored = FungibleFaucet::try_from(account.storage()).unwrap();
-    assert_eq!(restored.token_supply(), AssetAmount::zero());
+    assert_eq!(restored.token_supply(), AssetAmount::ZERO);
     assert_eq!(restored.max_supply().as_u64(), 1_000_000);
     assert_eq!(restored.decimals(), 8);
     assert_eq!(restored.description().map(|d| d.as_str()), Some(desc_text));
@@ -950,7 +950,7 @@ async fn set_max_supply_mutable_owner_succeeds() -> anyhow::Result<()> {
     assert_eq!(restored.max_supply().as_u64(), new_max_supply, "max_supply should be updated");
     assert_eq!(
         restored.token_supply(),
-        AssetAmount::zero(),
+        AssetAmount::ZERO,
         "token_supply should remain unchanged"
     );
 

--- a/crates/miden-testing/src/standards/token_metadata.rs
+++ b/crates/miden-testing/src/standards/token_metadata.rs
@@ -148,7 +148,7 @@ fn build_faucet_metadata() -> FungibleFaucet {
         .name(TokenName::new("T").unwrap())
         .symbol("TST".try_into().unwrap())
         .decimals(2)
-        .max_supply(AssetAmount::new(1_000).unwrap())
+        .max_supply(AssetAmount::from(1_000u32))
         .build()
         .unwrap()
 }
@@ -160,7 +160,7 @@ fn build_pol_faucet_metadata() -> FungibleFaucet {
         .name(TokenName::new("Polygon Token").unwrap())
         .symbol(TokenSymbol::new("POL").unwrap())
         .decimals(8)
-        .max_supply(AssetAmount::new(1_000_000).unwrap())
+        .max_supply(AssetAmount::from(1_000_000u32))
         .build()
         .unwrap()
 }
@@ -220,7 +220,7 @@ async fn get_name_from_masm() -> anyhow::Result<()> {
         .name(token_name)
         .symbol("TST".try_into().unwrap())
         .decimals(2)
-        .max_supply(AssetAmount::new(1_000).unwrap())
+        .max_supply(AssetAmount::from(1_000u32))
         .build()
         .unwrap();
 
@@ -256,7 +256,7 @@ async fn get_name_zeros_returns_empty() -> anyhow::Result<()> {
         .name(TokenName::new("").expect("empty string is a valid token name"))
         .symbol("TST".try_into().unwrap())
         .decimals(2)
-        .max_supply(AssetAmount::new(1_000).unwrap())
+        .max_supply(AssetAmount::from(1_000u32))
         .build()
         .unwrap();
 
@@ -411,7 +411,7 @@ async fn get_mutability_config() -> anyhow::Result<()> {
         .name(TokenName::new("T").unwrap())
         .symbol("TST".try_into().unwrap())
         .decimals(2)
-        .max_supply(AssetAmount::new(1_000).unwrap())
+        .max_supply(AssetAmount::from(1_000u32))
         .description(Description::new("test").unwrap())
         .is_description_mutable(true)
         .is_max_supply_mutable(true)
@@ -494,7 +494,7 @@ fn faucet_with_metadata_storage_layout() {
         .name(token_name)
         .symbol("TST".try_into().unwrap())
         .decimals(8)
-        .max_supply(AssetAmount::new(1_000_000).unwrap())
+        .max_supply(AssetAmount::from(1_000_000u32))
         .description(description)
         .build()
         .unwrap();
@@ -509,8 +509,8 @@ fn faucet_with_metadata_storage_layout() {
 
     // Verify roundtrip via try_from
     let restored = FungibleFaucet::try_from(account.storage()).unwrap();
-    assert_eq!(restored.token_supply(), Felt::ZERO);
-    assert_eq!(restored.max_supply().as_canonical_u64(), 1_000_000);
+    assert_eq!(restored.token_supply(), AssetAmount::zero());
+    assert_eq!(restored.max_supply().as_u64(), 1_000_000);
     assert_eq!(restored.decimals(), 8);
     assert_eq!(restored.description().map(|d| d.as_str()), Some(desc_text));
 }
@@ -556,7 +556,7 @@ fn verify_faucet_with_max_name_and_description(
     let restored = FungibleFaucet::try_from(account.storage()).unwrap();
     assert_eq!(restored.name().as_str(), max_name);
     assert_eq!(restored.description().map(|d| d.as_str()), Some(desc_text.as_str()));
-    assert_eq!(restored.max_supply().as_canonical_u64(), u64::from(max_supply));
+    assert_eq!(restored.max_supply(), max_supply);
 }
 
 #[test]
@@ -947,12 +947,12 @@ async fn set_max_supply_mutable_owner_succeeds() -> anyhow::Result<()> {
     updated_faucet.apply_delta(executed.account_delta())?;
 
     let restored = FungibleFaucet::try_from(updated_faucet.storage())?;
+    assert_eq!(restored.max_supply().as_u64(), new_max_supply, "max_supply should be updated");
     assert_eq!(
-        restored.max_supply().as_canonical_u64(),
-        new_max_supply,
-        "max_supply should be updated"
+        restored.token_supply(),
+        AssetAmount::zero(),
+        "token_supply should remain unchanged"
     );
-    assert_eq!(restored.token_supply(), Felt::ZERO, "token_supply should remain unchanged");
 
     Ok(())
 }

--- a/crates/miden-testing/tests/agglayer/bridge_in.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_in.rs
@@ -366,7 +366,7 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
 
     // Verify minted amount matches expected scaled value
     assert_eq!(
-        Felt::new(p2id_asset.amount()),
+        Felt::from(p2id_asset.amount()),
         miden_claim_amount,
         "asset amount does not match"
     );
@@ -422,7 +422,7 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
 
         let balance = destination_account.vault().get_balance(agglayer_faucet.id())?;
         assert_eq!(
-            balance,
+            balance.as_u64(),
             miden_claim_amount.as_canonical_u64(),
             "destination account balance does not match"
         );

--- a/crates/miden-testing/tests/agglayer/bridge_out.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_out.rs
@@ -19,7 +19,7 @@ use miden_crypto::rand::FeltRng;
 use miden_protocol::Felt;
 use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::account::{AccountId, AccountIdVersion, AccountStorageMode, AccountType};
-use miden_protocol::asset::{Asset, FungibleAsset};
+use miden_protocol::asset::{Asset, AssetAmount, FungibleAsset};
 use miden_protocol::note::{NoteAssets, NoteType};
 use miden_protocol::transaction::RawOutputNote;
 use miden_standards::account::faucets::FungibleFaucet;
@@ -238,7 +238,7 @@ async fn bridge_out_consecutive() -> anyhow::Result<()> {
     let initial_token_supply = FungibleFaucet::try_from(faucet.storage())?.token_supply();
     assert_eq!(
         initial_token_supply,
-        Felt::new(total_burned),
+        AssetAmount::new(total_burned)?,
         "Initial issuance should match all pending burns"
     );
 
@@ -262,7 +262,7 @@ async fn bridge_out_consecutive() -> anyhow::Result<()> {
     let final_token_supply = FungibleFaucet::try_from(faucet.storage())?.token_supply();
     assert_eq!(
         final_token_supply,
-        Felt::new(initial_token_supply.as_canonical_u64() - total_burned),
+        AssetAmount::new(initial_token_supply.as_u64() - total_burned)?,
         "Token supply should decrease by the sum of 32 bridged amounts"
     );
 
@@ -557,7 +557,8 @@ async fn b2agg_note_reclaim_scenario() -> anyhow::Result<()> {
     let mut mock_chain = builder.build()?;
 
     // Store the initial asset balance of the user account
-    let initial_balance = user_account.vault().get_balance(faucet.id()).unwrap_or(0u64);
+    let initial_balance =
+        user_account.vault().get_balance(faucet.id()).unwrap_or(AssetAmount::zero());
 
     // EXECUTE B2AGG NOTE WITH THE SAME USER ACCOUNT (RECLAIM SCENARIO)
     // --------------------------------------------------------------------------------------------
@@ -579,10 +580,11 @@ async fn b2agg_note_reclaim_scenario() -> anyhow::Result<()> {
 
     // VERIFY ASSETS WERE ADDED BACK TO THE ACCOUNT
     // --------------------------------------------------------------------------------------------
-    let final_balance = user_account.vault().get_balance(faucet.id()).unwrap_or(0u64);
+    let final_balance =
+        user_account.vault().get_balance(faucet.id()).unwrap_or(AssetAmount::zero());
     assert_eq!(
-        final_balance,
-        initial_balance + amount.as_canonical_u64(),
+        final_balance.as_u64(),
+        initial_balance.as_u64() + amount.as_canonical_u64(),
         "User account should have received the assets back from the B2AGG note"
     );
 

--- a/crates/miden-testing/tests/agglayer/bridge_out.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_out.rs
@@ -533,9 +533,8 @@ async fn b2agg_note_reclaim_scenario() -> anyhow::Result<()> {
 
     // CREATE B2AGG NOTE WITH USER ACCOUNT AS SENDER
     // --------------------------------------------------------------------------------------------
-    let amount = Felt::new(50);
-    let bridge_asset: Asset =
-        FungibleAsset::new(faucet.id(), amount.as_canonical_u64()).unwrap().into();
+    let amount = AssetAmount::from(50_u32);
+    let bridge_asset: Asset = FungibleAsset::new(faucet.id(), amount.as_u64()).unwrap().into();
 
     let destination_network = 1u32;
     let destination_address = "0x1234567890abcdef1122334455667788990011aa";
@@ -558,7 +557,7 @@ async fn b2agg_note_reclaim_scenario() -> anyhow::Result<()> {
 
     // Store the initial asset balance of the user account
     let initial_balance =
-        user_account.vault().get_balance(faucet.id()).unwrap_or(AssetAmount::zero());
+        user_account.vault().get_balance(faucet.id()).unwrap_or(AssetAmount::ZERO);
 
     // EXECUTE B2AGG NOTE WITH THE SAME USER ACCOUNT (RECLAIM SCENARIO)
     // --------------------------------------------------------------------------------------------
@@ -580,11 +579,10 @@ async fn b2agg_note_reclaim_scenario() -> anyhow::Result<()> {
 
     // VERIFY ASSETS WERE ADDED BACK TO THE ACCOUNT
     // --------------------------------------------------------------------------------------------
-    let final_balance =
-        user_account.vault().get_balance(faucet.id()).unwrap_or(AssetAmount::zero());
+    let final_balance = user_account.vault().get_balance(faucet.id()).unwrap_or(AssetAmount::ZERO);
     assert_eq!(
-        final_balance.as_u64(),
-        initial_balance.as_u64() + amount.as_canonical_u64(),
+        final_balance,
+        (initial_balance + amount).unwrap(),
         "User account should have received the assets back from the B2AGG note"
     );
 

--- a/crates/miden-testing/tests/auth/guarded_multisig.rs
+++ b/crates/miden-testing/tests/auth/guarded_multisig.rs
@@ -220,8 +220,9 @@ async fn test_guarded_multisig_signature_required(
     assert_eq!(
         multisig_account
             .vault()
-            .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?,
-        10 - output_note_asset.unwrap_fungible().amount()
+            .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?
+            .as_u64(),
+        10 - output_note_asset.unwrap_fungible().amount().as_u64()
     );
 
     Ok(())

--- a/crates/miden-testing/tests/auth/hybrid_multisig.rs
+++ b/crates/miden-testing/tests/auth/hybrid_multisig.rs
@@ -193,8 +193,9 @@ async fn test_multisig_2_of_2_with_note_creation() -> anyhow::Result<()> {
     assert_eq!(
         multisig_account
             .vault()
-            .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?,
-        multisig_starting_balance - output_note_asset.unwrap_fungible().amount()
+            .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?
+            .as_u64(),
+        multisig_starting_balance - output_note_asset.unwrap_fungible().amount().as_u64()
     );
 
     Ok(())

--- a/crates/miden-testing/tests/auth/multisig.rs
+++ b/crates/miden-testing/tests/auth/multisig.rs
@@ -201,8 +201,9 @@ async fn test_multisig_2_of_2_with_note_creation(
     assert_eq!(
         multisig_account
             .vault()
-            .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?,
-        multisig_starting_balance - output_note_asset.unwrap_fungible().amount()
+            .get_balance(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)?
+            .as_u64(),
+        multisig_starting_balance - output_note_asset.unwrap_fungible().amount().as_u64()
     );
 
     Ok(())
@@ -1257,7 +1258,7 @@ async fn test_multisig_proc_threshold_overrides(
     mock_chain.add_pending_executed_transaction(&result.unwrap())?;
     mock_chain.prove_next_block()?;
 
-    assert_eq!(multisig_account.vault().get_balance(FungibleAsset::mock_issuer())?, 6);
+    assert_eq!(multisig_account.vault().get_balance(FungibleAsset::mock_issuer())?.as_u64(), 6);
 
     Ok(())
 }

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -385,11 +385,11 @@ async fn prove_burning_fungible_asset_on_existing_faucet_succeeds() -> anyhow::R
 
     // Check that max_supply at the word's index 0 is 200. The remainder of the word is initialized
     // with the metadata of the faucet which we don't need to check.
-    assert_eq!(token_metadata.max_supply(), Felt::from(max_supply));
+    assert_eq!(token_metadata.max_supply(), AssetAmount::from(max_supply));
 
     // Check that the faucet's token supply has been correctly initialized.
     // The already issued amount should be 100.
-    assert_eq!(token_metadata.token_supply(), Felt::from(token_supply));
+    assert_eq!(token_metadata.token_supply(), AssetAmount::from(token_supply));
 
     // CONSTRUCT AND EXECUTE TX (Success)
     // --------------------------------------------------------------------------------------------
@@ -655,7 +655,7 @@ async fn network_faucet_mint() -> anyhow::Result<()> {
 
     // Check the Network Fungible Faucet's max supply.
     let actual_max_supply = FungibleFaucet::try_from(faucet.storage())?.max_supply();
-    assert_eq!(actual_max_supply.as_canonical_u64(), max_supply);
+    assert_eq!(actual_max_supply.as_u64(), max_supply);
 
     // Check that the creator account ID is stored in the ownership slot.
     // Word: [owner_suffix, owner_prefix, nominated_suffix, nominated_prefix]
@@ -671,7 +671,7 @@ async fn network_faucet_mint() -> anyhow::Result<()> {
     // Check that the faucet's token supply has been correctly initialized.
     // The already issued amount should be 50.
     let initial_token_supply = FungibleFaucet::try_from(faucet.storage())?.token_supply();
-    assert_eq!(initial_token_supply.as_canonical_u64(), token_supply);
+    assert_eq!(initial_token_supply.as_u64(), token_supply);
 
     // CREATE MINT NOTE USING STANDARD NOTE
     // --------------------------------------------------------------------------------------------
@@ -742,7 +742,7 @@ async fn network_faucet_mint() -> anyhow::Result<()> {
 
     // Verify the account's vault now contains the expected fungible asset
     let balance = target_account.vault().get_balance(faucet.id())?;
-    assert_eq!(balance, expected_asset.amount(),);
+    assert_eq!(balance, expected_asset.amount());
 
     Ok(())
 }
@@ -1420,7 +1420,7 @@ async fn network_faucet_burn() -> anyhow::Result<()> {
 
     // Check the initial token issuance before burning
     let initial_token_supply = FungibleFaucet::try_from(faucet.storage())?.token_supply();
-    assert_eq!(initial_token_supply, Felt::new(100));
+    assert_eq!(initial_token_supply, AssetAmount::from(100u32));
 
     // EXECUTE BURN NOTE AGAINST NETWORK FAUCET
     // --------------------------------------------------------------------------------------------
@@ -1439,7 +1439,7 @@ async fn network_faucet_burn() -> anyhow::Result<()> {
     let final_token_supply = FungibleFaucet::try_from(faucet.storage())?.token_supply();
     assert_eq!(
         final_token_supply,
-        Felt::new(initial_token_supply.as_canonical_u64() - burn_amount)
+        AssetAmount::new(initial_token_supply.as_u64() - burn_amount).unwrap()
     );
 
     Ok(())

--- a/crates/miden-testing/tests/scripts/fee.rs
+++ b/crates/miden-testing/tests/scripts/fee.rs
@@ -30,7 +30,7 @@ async fn prove_account_creation_with_fees() -> anyhow::Result<()> {
         .context("failed to execute account-creating transaction")?;
 
     let expected_fee = tx.compute_fee();
-    assert_eq!(expected_fee, tx.fee().amount());
+    assert_eq!(expected_fee, tx.fee().amount().as_u64());
 
     // We expect that the new account contains the amount minus the paid fee.
     let added_asset = FungibleAsset::new(chain.fee_faucet_id(), amount)?.sub(tx.fee())?;

--- a/crates/miden-testing/tests/scripts/fee.rs
+++ b/crates/miden-testing/tests/scripts/fee.rs
@@ -30,7 +30,7 @@ async fn prove_account_creation_with_fees() -> anyhow::Result<()> {
         .context("failed to execute account-creating transaction")?;
 
     let expected_fee = tx.compute_fee();
-    assert_eq!(expected_fee, tx.fee().amount().as_u64());
+    assert_eq!(expected_fee, tx.fee().amount());
 
     // We expect that the new account contains the amount minus the paid fee.
     let added_asset = FungibleAsset::new(chain.fee_faucet_id(), amount)?.sub(tx.fee())?;

--- a/crates/miden-testing/tests/scripts/p2id.rs
+++ b/crates/miden-testing/tests/scripts/p2id.rs
@@ -178,7 +178,7 @@ async fn prove_consume_multiple_notes() -> anyhow::Result<()> {
     account.apply_delta(executed_transaction.account_delta())?;
     let resulting_asset = account.vault().assets().next().unwrap();
     if let Asset::Fungible(asset) = resulting_asset {
-        assert_eq!(asset.amount(), 123u64);
+        assert_eq!(asset.amount().as_u64(), 123);
     } else {
         panic!("Resulting asset should be fungible");
     }
@@ -294,8 +294,8 @@ async fn test_create_consume_multiple_notes() -> anyhow::Result<()> {
 
     account.apply_delta(executed_transaction.account_delta())?;
 
-    assert_eq!(account.vault().get_balance(input_note_faucet_id)?, 111);
-    assert_eq!(account.vault().get_balance(FungibleAsset::mock_issuer())?, 5);
+    assert_eq!(account.vault().get_balance(input_note_faucet_id)?.as_u64(), 111);
+    assert_eq!(account.vault().get_balance(FungibleAsset::mock_issuer())?.as_u64(), 5);
     Ok(())
 }
 

--- a/crates/miden-testing/tests/scripts/pswap.rs
+++ b/crates/miden-testing/tests/scripts/pswap.rs
@@ -224,8 +224,8 @@ async fn pswap_note_alice_reconstructs_and_consumes_p2id() -> anyhow::Result<()>
         "remainder aux should carry amt_payout matching the Rust-side calc",
     );
 
-    let remaining_offered = offered_asset.amount() - amt_payout_from_attachment;
-    let remaining_requested = requested_asset.amount() - fill_amount_from_aux;
+    let remaining_offered = offered_asset.amount().as_u64() - amt_payout_from_attachment;
+    let remaining_requested = requested_asset.amount().as_u64() - fill_amount_from_aux;
 
     let remainder_storage = PswapNoteStorage::builder()
         .requested_asset(FungibleAsset::new(eth_faucet.id(), remaining_requested)?)

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -269,8 +269,8 @@ where
         // Return an error if the balance in the account does not cover the fee.
         if current_fee_asset.amount() < fee_asset.amount() {
             return Err(TransactionKernelError::InsufficientFee {
-                account_balance: current_fee_asset.amount(),
-                tx_fee: fee_asset.amount(),
+                account_balance: current_fee_asset.amount().as_u64(),
+                tx_fee: fee_asset.amount().as_u64(),
             });
         }
 

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -372,7 +372,7 @@ where
                 .read_vault_asset(vault_root, fee_asset_vault_key)
                 .map_err(TransactionExecutorError::FeeAssetRetrievalFailed)?;
             match fee_asset {
-                Some(Asset::Fungible(fee_asset)) => fee_asset.amount(),
+                Some(Asset::Fungible(fee_asset)) => fee_asset.amount().as_u64(),
                 Some(Asset::NonFungible(_)) => {
                     return Err(TransactionExecutorError::FeeAssetMustBeFungible);
                 },


### PR DESCRIPTION
This PR mostly addresses https://github.com/0xMiden/protocol/issues/2781. We can still probably push more usage of `AssetAmount` to more places, but that could be done incrementally in the future.