### PR TITLE
docs: fix grammar errors and typos in protocol documentation

### DIFF
--- a/docs/src/asset.md
+++ b/docs/src/asset.md
@@ -80,7 +80,7 @@ Two assets issued by the same faucet with _different_ callback flags are conside
 
 It is recommended that faucets issue all of their assets with the same flag to ensure all assets issued by a faucet are treated as one type of asset. This is ensured when using `faucet::create_fungible_asset` or `faucet::create_non_fungible_asset`.
 
-**Faucet callback procedures.** A faucet registers callbacks by storing the procedure root (hash) of one if its public account procedures in a well-known storage slot. Two callbacks are supported:
+**Faucet callback procedures.** A faucet registers callbacks by storing the procedure root (hash) of one of its public account procedures in a well-known storage slot. Two callbacks are supported:
 
 | Callback | Storage slot name | Triggered when |
 |---|---|---|

--- a/docs/src/blockchain.md
+++ b/docs/src/blockchain.md
@@ -17,7 +17,7 @@ Miden's blockchain protocol aims for the following:
 
 ## Batch production
 
-To reduce the required space on the blockchain, transaction proofs are not directly put into blocks. First, they are batched together by verifying them in the batch producer. The purpose of the batch producer is to generate a single proof that some number of proven transactions have been verified. This involves recursively verifying individual transaction proofs inside the Miden VM. As with any program that runs in the Miden VM, there is a proof of correct execution running the Miden verifier to verify transaction proofs. This results into a single batch proof.
+To reduce the required space on the blockchain, transaction proofs are not directly put into blocks. First, they are batched together by verifying them in the batch producer. The purpose of the batch producer is to generate a single proof that some number of proven transactions have been verified. This involves recursively verifying individual transaction proofs inside the Miden VM. As with any program that runs in the Miden VM, there is a proof of correct execution running the Miden verifier to verify transaction proofs. This results in a single batch proof.
 
 <p style={{textAlign: 'center'}}>
     <img src={require('./img/blockchain/batching.png').default} style={{width: '50%'}} alt="Batch diagram"/>
@@ -38,14 +38,14 @@ The block producer ensures:
 
 1. **Account DB integrity**: The Block `N+1` Account DB commitment must be authenticated against all previous and resulting account commitments across transactions, ensuring valid state transitions and preventing execution on stale states.
 2. **Nullifier DB integrity**: Nullifiers of newly created notes are added to the Nullifier DB. The Block `N+1` Nullifier DB commitment must be authenticated against all new nullifiers to guarantee completeness.
-3. **Block hash references**: Check that all block hashes references by batches are in the chain.
+3. **Block hash references**: Check that all block hashes referenced by batches are in the chain.
 4. **Double-spend prevention**: Each consumed note’s nullifier is checked against prior consumption. The Block `N` Nullifier DB commitment is authenticated against all provided nullifiers for consumed notes, ensuring no nullifier is reused.
 5. **Global note uniqueness**: All created and consumed notes must be unique across batches.
-6. **Batch expiration**: The block height of the created block must be smaller then or equal to the lowest batch expiration.
+6. **Batch expiration**: The block height of the created block must be smaller than or equal to the lowest batch expiration.
 7. **Block time increase**: The block timestamp must increase monotonically from the previous block.
 8. **Note erasure of erasable notes**: If an erasable note is created and consumed in different batches, it is erased now. If, however, an erasable note is consumed but not created within the block, the batch it contains is rejected. The Miden operator's mempool should preemptively filter such transactions.
 
-In final `Block` contains:
+The final `Block` contains:
 - The commitments to the current global [state](state).
 - The newly created nullifiers.
 - The commitments to newly created notes.

--- a/docs/src/protocol_library.md
+++ b/docs/src/protocol_library.md
@@ -4,7 +4,7 @@ sidebar_position: 8
 
 # Miden Protocol Library
 
-The Miden protocol library provides a set of procedures that wrap transaction kernel procedures to provide a more convenient interface for common operations. These can be invoked by account code, note scripts, and transaction scripts, though some have restriction from where they can be called. The procedures are organized into modules corresponding to different functional areas.
+The Miden protocol library provides a set of procedures that wrap transaction kernel procedures to provide a more convenient interface for common operations. These can be invoked by account code, note scripts, and transaction scripts, though some have restrictions from where they can be called. The procedures are organized into modules corresponding to different functional areas.
 
 ## Contexts
 

--- a/docs/src/state.md
+++ b/docs/src/state.md
@@ -72,7 +72,7 @@ Notes are recorded in an append-only accumulator, a [Merkle Mountain Range](http
 
 Using a Merkle Mountain Range (append-only accumulator) is important for two reasons:
 
-1. Membership witnesses (that a note exists in the database) against such an accumulator needs to be updated very infrequently.
+1. Membership witnesses (that a note exists in the database) against such an accumulator need to be updated very infrequently.
 2. Old membership witnesses can be extended to a new accumulator value, but this extension does not need to be done by the original witness holder.
  
 Both of these properties are needed for supporting local transactions using client-side proofs and privacy. In an append-only data structure, witness data does not become stale when the data structure is updated. That means users can generate valid proofs even if they don’t have the latest `State` of this database; so there is no need to query the operator on a constantly changing `State`.


### PR DESCRIPTION
Fix grammar errors and typos across protocol documentation pages.

Changes:
- asset.md: `"one if its"` → `"one of its"`
- state.md: `"needs to be"` → `"need to be"` (subject-verb agreement)
- blockchain.md:
  - `"smaller then"` → `"smaller than"`
  - `"In final"` → `"The final"`
  - `"hashes references"` → `"hashes referenced"`
  - `"results into"` → `"results in"`
- protocol_library.md: `"have restriction"` → `"have restrictions"`

**Test plan**
Documentation-only change; no code paths affected.