### PR TITLE
perf(test-dev): cut workspace build time ~14% via upstream rayon-sequentialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,8 +1589,7 @@ dependencies = [
 [[package]]
 name = "miden-ace-codegen"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5e3d08008b5f9dd3e6145e55e4d3c1a4e47a74383dd8d0d64003455ee94510"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1620,8 +1619,7 @@ dependencies = [
 [[package]]
 name = "miden-air"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d980fa23010e53c43077cf0182e6e88acd1a099abbf8a98cd298aa69b86688dc"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "miden-ace-codegen",
  "miden-core",
@@ -1636,8 +1634,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb53abd723b7dd8ff1210b7d126f0d9e1d9127ea0e7f6a46471845d060cc43"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "env_logger",
  "log",
@@ -1654,8 +1651,7 @@ dependencies = [
 [[package]]
 name = "miden-assembly-syntax"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ead435c8dccfd3b9bd97779cfa0d74cc14c767a9740f162bf7cd49a0da26bd"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -1687,8 +1683,7 @@ dependencies = [
 [[package]]
 name = "miden-core"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7c7eecda385bcc66aea99ee3279ae7c78f38e3541f4c1d67d309ac32314ff4"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "derive_more",
  "log",
@@ -1709,8 +1704,7 @@ dependencies = [
 [[package]]
 name = "miden-core-lib"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bc06c94dcb75e3e44220fe7623ab99585e7828f19b80534c48a9971d31bfd8"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -1780,8 +1774,7 @@ dependencies = [
 [[package]]
 name = "miden-debug-types"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206f5346bef744da1ffae9874a22170a2d0c27dd20947d89182d16f5d86348f7"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1863,8 +1856,7 @@ dependencies = [
 [[package]]
 name = "miden-mast-package"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae69cd4dc25b0993eb5fafcc99987abd3502d8a7a902248af4a597537dce600"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1912,8 +1904,7 @@ dependencies = [
 [[package]]
 name = "miden-package-registry"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1d77c6f5942f3111fc56a19d638076ea77df3628efa97c7955259c609ca8dd"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1928,8 +1919,7 @@ dependencies = [
 [[package]]
 name = "miden-processor"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70508a4a75989a47f03a0681df412b80040c76230c3d850f8f2b80f7a986d4aa"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "itertools 0.14.0",
  "miden-air",
@@ -1938,7 +1928,6 @@ dependencies = [
  "miden-utils-diagnostics",
  "miden-utils-indexing",
  "paste",
- "rayon",
  "thiserror",
  "tracing",
 ]
@@ -1946,8 +1935,7 @@ dependencies = [
 [[package]]
 name = "miden-project"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6338d92713845f57b137e4305db11ee8614b0cec9b1516470233ce64d53f6376"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1998,8 +1986,7 @@ dependencies = [
 [[package]]
 name = "miden-prover"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59b5dbdac3a8596fc201de028c17ed5060ad554901259222420afd186f2b467"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "bincode",
  "miden-air",
@@ -2112,8 +2099,7 @@ dependencies = [
 [[package]]
 name = "miden-utils-core-derive"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f74ef56bd44d23c805f662cd4f4639b04df6e0204d78806ede0e6f93d9695a5"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2123,8 +2109,7 @@ dependencies = [
 [[package]]
 name = "miden-utils-diagnostics"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b3aa61e0ee0f8a5b3f44250b73879437f9e10b6061c3ae743fd1cdb1f56321"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -2135,8 +2120,7 @@ dependencies = [
 [[package]]
 name = "miden-utils-indexing"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57419a0557e580e04125542f4383910fb997660633e15ad4570ce1ff2ae80557"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "miden-crypto",
  "proptest",
@@ -2147,8 +2131,7 @@ dependencies = [
 [[package]]
 name = "miden-utils-sync"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8a579c0c7cf44c123129045339f53b1f26f0aa2dc508494e97360d3ccab80e"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "lock_api",
  "loom",
@@ -2159,8 +2142,7 @@ dependencies = [
 [[package]]
 name = "miden-verifier"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cd4ca9a8b90c48d5fc6f5707c46cc44b17285f2f705cbe44e5b56c430a85c8"
+source = "git+https://github.com/0xMiden/miden-vm.git?branch=mmagician-claude%2Freduce-cross-crate-monomorphization#26e90858a0484bb87c7435f39bf964c07a9efe5a"
 dependencies = [
  "bincode",
  "miden-air",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,24 @@ serde_json      = { default-features = false, version = "1.0" }
 thiserror       = { default-features = false, version = "2.0" }
 tokio           = { default-features = false, features = ["sync"], version = "1" }
 walkdir         = { version = "2.5" }
+
+# Temporary: points at miden-vm experimental branch that sequentializes
+# rayon in trace generation. See PR description for rationale and
+# benchmark numbers. To be removed once the upstream change ships in a
+# miden-vm 0.23.x release.
+[patch.crates-io]
+miden-air               = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-assembly          = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-assembly-syntax   = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-core              = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-core-lib          = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-debug-types       = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-mast-package      = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-package-registry  = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-processor         = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-project           = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-prover            = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-utils-diagnostics = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-utils-indexing    = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-utils-sync        = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }
+miden-verifier          = { branch = "mmagician-claude/reduce-cross-crate-monomorphization", git = "https://github.com/0xMiden/miden-vm.git" }


### PR DESCRIPTION
Pending upstream merge of [`0xMiden/miden-vm#mmagician-claude/reduce-cross-crate-monomorphization`](https://github.com/0xMiden/miden-vm/tree/mmagician-claude/reduce-cross-crate-monomorphization) (commit `26e90858a`, not yet PR'd there).

## Summary

`miden-processor` declares `rayon` as an unconditional dependency and uses it in four sites in `trace/parallel/mod.rs` and one in `trace/chiplets/mod.rs`. The upstream branch above replaces those with sequential equivalents and drops the `rayon` dep entirely. This avoids pulling `rayon-core`'s generic `StackJob`/`join_context` machinery into every downstream test binary, where it gets monomorphized for many distinct closures.

This protocol PR adds a temporary `[patch.crates-io]` block pointing all `miden-vm` crates at the upstream branch. Once the upstream change merges and a `miden-vm` 0.23.x release ships, the patch block is removed with no other protocol-side change required.

## Benchmarks (clean builds)

Protocol `next` at `01077765c`, `miden-vm` 0.23.0. All times exclude the `prove` test filter for test-exec measurements.

### 60-core x86_64 server (linux)

- Clean build (`make test-release-build`, `--no-default-features`):
  - Baseline: 13m 40s wall
  - Patched: 11m 46s wall
  - Saved: 1m 54s (~14% wall)
- Test execution only (cached build, filtered to exclude `prove`): 63.9s both variants — no regression

### 8-core MacBook Air M2 (4 perf + 4 efficiency)

- Clean build (`make test-release-build`, `--no-default-features`):
  - Baseline: 11m 16s wall / 2449s CPU time (362% utilization)
  - Patched: 9m 13s wall / 2159s CPU time (390% utilization)
  - Saved: 2m 03s wall (~18%) / 290s CPU time (~12%)
- `make test-dev` (rebuild with default features + 1023 tests, excluding `prove`):
  - Baseline: 9m 25s wall / 1889s CPU time
  - Patched: 8m 11s wall / 1676s CPU time
  - Saved: 1m 14s wall (~13%) / 213s CPU time (~11%)

## Reproducing locally

`make test-dev` and `make test-release-build` use different feature flags and don't share build artifacts. Use the pair below to get clean numbers:

```bash
# Patched (this branch)
git clone https://github.com/0xMiden/miden-base.git protocol
cd protocol
git checkout mmagician-claude/build-time-fix-prototype
cargo clean
time make test-release-build      # times clean build of test binaries
time make test-release             # reuses build artifacts; times only test execution

# Baseline (compare against)
git checkout next
cargo clean
time make test-release-build
time make test-release
```

Note `make test-release` runs ALL tests including `prove`, which adds a few minutes. Use this raw command if you want to exactly reproduce the filtered numbers above (excluding `prove` tests):

```bash
time BUILD_GENERATED_FILES_IN_SRC=1 cargo nextest run \
    --cargo-profile test-dev --no-default-features \
    --features concurrent,testing,std \
    --filter-expr "not test(prove)"
```

CPU% and CPU time from `time`'s output are useful — CPU time confirms the underlying work reduction; wall time is what you feel. Cross-machine numbers very welcome.

Towards #2643.