### PR TITLE
chore: expose `FungibleFaucet::token_config_slot_value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [BREAKING] Renamed `set_attachment` to `add_attachment`, `set_word_attachment` to `add_word_attachment`, and `set_array_attachment` to `add_array_attachment` in `miden::protocol::output_note` ([#2795](https://github.com/0xMiden/protocol/pull/2795), [#2849](https://github.com/0xMiden/protocol/pull/2849)).
 - [BREAKING] Remove `AccountStorageMode::Network`; network accounts are now identified via `NetworkAccountNoteAllowlist` ([#2900](https://github.com/0xMiden/protocol/pull/2900)).
 - [BREAKING] Add `NetworkAccount` wrapper for convenient network account identification ([#2915](https://github.com/0xMiden/protocol/pull/2915)).
+- Exposed `token_config_slot_value` on `FungibleFaucet` to allow reading the token config word directly from the account storage ([#2954](https://github.com/0xMiden/protocol/pull/2954)).
 
 ### Changes
 

--- a/crates/miden-standards/src/account/faucets/fungible/mod.rs
+++ b/crates/miden-standards/src/account/faucets/fungible/mod.rs
@@ -336,7 +336,7 @@ impl FungibleFaucet {
     }
 
     /// Returns the single storage slot for the token config word.
-    fn token_config_slot_value(&self) -> StorageSlot {
+    pub fn token_config_slot_value(&self) -> StorageSlot {
         let word = Word::new([
             self.token_supply.into(),
             self.max_supply.into(),


### PR DESCRIPTION
Expose function to allow genesis creation.

[original discussion](https://github.com/0xMiden/node/pull/2078#discussion_r3256857400)