### PR TITLE
chore(agglayer): address review nits from #2955

### DIFF
--- a/crates/miden-agglayer/src/faucet.rs
+++ b/crates/miden-agglayer/src/faucet.rs
@@ -273,8 +273,7 @@ impl AggLayerFaucet {
 impl From<AggLayerFaucet> for AccountComponent {
     fn from(agglayer_faucet: AggLayerFaucet) -> Self {
         // Bring in all of the FungibleFaucet's storage slots (token config + name +
-        // mutability + description + logo URI + external link). Conversion metadata lives on
-        // the bridge, so the faucet adds no bridge-specific slots.
+        // mutability + description + logo URI + external link).
         agglayer_faucet_component(agglayer_faucet.faucet.into_storage_slots())
     }
 }

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -174,7 +174,7 @@ pub fn create_existing_bridge_account(
 /// Creates a complete agglayer faucet account builder with the specified configuration.
 ///
 /// The builder includes:
-/// - The `AggLayerFaucet` component (token metadata only; conversion metadata lives on the bridge).
+/// - The `AggLayerFaucet` component (token metadata only).
 /// - The `Ownable2Step` component (bridge account ID as owner for mint authorization).
 /// - A [`TokenPolicyManager`] (owner-controlled) configured with `MintPolicyConfig::OwnerOnly` and
 ///   `BurnPolicyConfig::OwnerOnly`. The manager additionally registers `BurnAllowAll::root()` as an

--- a/crates/miden-testing/tests/agglayer/bridge_in.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_in.rs
@@ -189,17 +189,9 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
         .expect("destination address is not an embedded Miden AccountId")
         .into_account_id();
 
-    // For mainnet and rollup fixtures, create the destination account so we can consume the P2ID
-    // note. The mock account is built from the destination ID encoded in the JSON test vector,
-    // since the claim note targets this account ID.
     let destination_account =
-        if matches!(data_source, ClaimDataSource::L1ToMiden | ClaimDataSource::L2ToMiden) {
-            let dest = Account::mock(u128::from(destination_account_id), IncrNonceAuthComponent);
-            builder.add_account(dest.clone())?;
-            Some(dest)
-        } else {
-            None
-        };
+        Account::mock(u128::from(destination_account_id), IncrNonceAuthComponent);
+    builder.add_account(destination_account.clone())?;
 
     // CREATE SENDER ACCOUNT (for creating the claim note)
     // --------------------------------------------------------------------------------------------
@@ -388,38 +380,34 @@ async fn test_bridge_in_claim_to_p2id(#[case] data_source: ClaimDataSource) -> a
 
     assert_eq!(RawOutputNote::Full(expected_output_p2id_note.clone()), *output_note);
 
-    // TX4: CONSUME THE P2ID NOTE WITH THE DESTINATION ACCOUNT (simulated case only)
+    // TX4: CONSUME THE P2ID NOTE WITH THE DESTINATION ACCOUNT
     // --------------------------------------------------------------------------------------------
-    // For the simulated case, we control the destination account and can verify the full
-    // end-to-end flow including P2ID consumption and balance updates.
-    if let Some(destination_account) = destination_account {
-        // Add the faucet transaction to the chain and prove the next block so the P2ID note is
-        // committed and can be consumed.
-        mock_chain.add_pending_executed_transaction(&mint_executed)?;
-        mock_chain.prove_next_block()?;
+    // Add the faucet transaction to the chain and prove the next block so the P2ID note is
+    // committed and can be consumed.
+    mock_chain.add_pending_executed_transaction(&mint_executed)?;
+    mock_chain.prove_next_block()?;
 
-        // Execute the consume transaction for the destination account. Pass the account
-        // directly since the JSON-encoded destination decodes to a private account ID.
-        let consume_tx_context = mock_chain
-            .build_tx_context(
-                destination_account.clone(),
-                &[],
-                slice::from_ref(&expected_output_p2id_note),
-            )?
-            .build()?;
-        let consume_executed_transaction = consume_tx_context.execute().await?;
+    // Execute the consume transaction for the destination account. Pass the account
+    // directly since the JSON-encoded destination decodes to a private account ID.
+    let consume_tx_context = mock_chain
+        .build_tx_context(
+            destination_account.clone(),
+            &[],
+            slice::from_ref(&expected_output_p2id_note),
+        )?
+        .build()?;
+    let consume_executed_transaction = consume_tx_context.execute().await?;
 
-        // Verify the destination account received the minted asset
-        let mut destination_account = destination_account.clone();
-        destination_account.apply_delta(consume_executed_transaction.account_delta())?;
+    // Verify the destination account received the minted asset
+    let mut destination_account = destination_account;
+    destination_account.apply_delta(consume_executed_transaction.account_delta())?;
 
-        let balance = destination_account.vault().get_balance(expected_asset.vault_key())?;
-        assert_eq!(
-            balance.as_u64(),
-            miden_claim_amount.as_canonical_u64(),
-            "destination account balance does not match"
-        );
-    }
+    let balance = destination_account.vault().get_balance(expected_asset.vault_key())?;
+    assert_eq!(
+        balance.as_u64(),
+        miden_claim_amount.as_canonical_u64(),
+        "destination account balance does not match"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #2955

### Commit 1 — `docs(agglayer): drop port-narrative phrases from faucet docstrings`

Addresses:
- [src/lib.rs:177](https://github.com/0xMiden/protocol/pull/2955#discussion_r3272173891)
- [src/faucet.rs:277](https://github.com/0xMiden/protocol/pull/2955#discussion_r3272166806)

### Commit 2 — `test(agglayer): always construct deterministic destination account`

Addresses:
- [tests/agglayer/bridge_in.rs:201](https://github.com/0xMiden/protocol/pull/2955#discussion_r3272199574)

The conditional `matches!(data_source, ClaimDataSource::L1ToMiden | ClaimDataSource::L2ToMiden)` was removed. Also, flattened `Option<Account>` to `Account`, and re-indented the `if let Some(...)` consume block to match the pattern in the file's other tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)