### PR TITLE
Nullifier update follow-up refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Features
 
 - Added lock/unlock path for Miden-native tokens in the AggLayer bridge: `is_native` flag in `faucet_registry_map`, bridge-local `faucet_metadata_map` (replacing FPI to faucets for conversion data), and `lock_asset` / `unlock_and_send` procedures so the bridge holds native assets in its own vault instead of burn/mint via a faucet ([#2771](https://github.com/0xMiden/protocol/pull/2771)).
-- [BREAKING] Renamed `NoteId` to `NoteDetailsCommitment`, new `NoteId` struct now includes the NoteMetadata ([#1731](https://github.com/0xMiden/protocol/issues/1731)).
-- [BREAKING] Updated note nullifiers to include note metadata and attachments commitment ([#1731](https://github.com/0xMiden/protocol/issues/1731)).
+- [BREAKING] Renamed `NoteId` to `NoteDetailsCommitment`, new `NoteId` struct now includes the NoteMetadata ([#2861](https://github.com/0xMiden/protocol/pull/2861)).
+- [BREAKING] Updated note nullifiers to include note metadata and attachments commitment ([#2953](https://github.com/0xMiden/protocol/pull/2953)).
 - [BREAKING] Renamed `native_asset_id` to `fee_faucet_id` ([#2718](https://github.com/0xMiden/protocol/pull/2718)).
 - [BREAKING] Removed redundant outputs from kernel procedures: `note::write_assets_to_memory`, `active_note::get_assets`, `input_note::get_assets`, `output_note::get_assets`, `active_note::get_storage`, and `faucet::mint` no longer return values identical to their inputs ([#2523](https://github.com/0xMiden/protocol/issues/2523)).
 - Added PSWAP (partial swap) note for decentralized partial-fill asset exchange with remainder note re-creation ([#2636](https://github.com/0xMiden/protocol/pull/2636)).

--- a/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
@@ -1531,6 +1531,18 @@ pub proc get_input_note_nullifier
     mul.4 padw movup.4 add.INPUT_NOTE_NULLIFIER_SECTION_PTR mem_loadw_le
 end
 
+#! Stores the nullifier of the input note with `idx` in the nullifier memory section.
+#!
+#! Inputs:  [idx, NULLIFIER]
+#! Outputs: [NULLIFIER]
+#!
+#! Where:
+#! - idx is the index of the input note.
+#! - NULLIFIER is the nullifier of the input note.
+pub proc set_input_note_nullifier
+    mul.4 add.INPUT_NOTE_NULLIFIER_SECTION_PTR mem_storew_le
+end
+
 #! Returns a pointer to the start of the input note core data segment for the note located at the
 #! specified memory address.
 #!

--- a/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
@@ -1506,31 +1506,6 @@ pub proc set_input_note_details_commitment
     mem_storew_le
 end
 
-#! Computes a pointer to the memory address at which the nullifier associated a note with `idx` is
-#! stored.
-#!
-#! Inputs:  [idx]
-#! Outputs: [nullifier_ptr]
-#!
-#! Where:
-#! - idx is the index of the input note.
-#! - nullifier_ptr is the memory address of the nullifier for note idx.
-pub proc get_input_note_nullifier_ptr
-    mul.4 add.INPUT_NOTE_NULLIFIER_SECTION_PTR
-end
-
-#! Returns the nullifier of an input note with `idx`.
-#!
-#! Inputs:  [idx]
-#! Outputs: [nullifier]
-#!
-#! Where:
-#! - idx is the index of the input note.
-#! - nullifier is the nullifier of the input note.
-pub proc get_input_note_nullifier
-    mul.4 padw movup.4 add.INPUT_NOTE_NULLIFIER_SECTION_PTR mem_loadw_le
-end
-
 #! Stores the nullifier of the input note with `idx` in the nullifier memory section.
 #!
 #! Inputs:  [idx, NULLIFIER]

--- a/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
@@ -528,8 +528,9 @@ proc authenticate_note
     # => []
 end
 
-#! Copies the input note's nullifier preimage from the advice stack to memory and computes its
-#! nullifier.
+#! Copies the input note's nullifier preimage from the advice stack into the note's core data
+#! in memory, computes the nullifier, stores it in the nullifier memory section, and returns it
+#! on the operand stack.
 #!
 #! Inputs:
 #!   Operand stack: [idx]
@@ -572,7 +573,7 @@ proc process_input_note_details
     # => [NULLIFIER, idx]
 
     # save NULLIFIER to memory
-    movup.4 exec.memory::get_input_note_nullifier_ptr mem_storew_le
+    movup.4 exec.memory::set_input_note_nullifier
     # => [NULLIFIER]
 end
 
@@ -870,28 +871,28 @@ proc process_input_note
     dup exec.add_input_note_assets_to_vault
     # => [note_ptr, NULLIFIER, CAPACITY]
 
-    # note details commitment
-    # ---------------------------------------------------------------------------------------------
-
-    dup exec.compute_input_note_details_commitment
-    # => [NOTE_DETAILS_COMMITMENT, note_ptr, NULLIFIER, CAPACITY]
-
-    # save note details commitment to memory
-    dup.4 exec.memory::set_input_note_details_commitment
-    # => [NOTE_DETAILS_COMMITMENT, note_ptr, NULLIFIER, CAPACITY]
-
     # note metadata commitment
     # ---------------------------------------------------------------------------------------------
 
     # compute NOTE_METADATA_COMMITMENT
-    movup.4 exec.compute_note_metadata_commitment
-    # => [NOTE_METADATA_COMMITMENT, NOTE_DETAILS_COMMITMENT, NULLIFIER, CAPACITY]
+    dup exec.compute_note_metadata_commitment
+    # => [NOTE_METADATA_COMMITMENT, note_ptr, NULLIFIER, CAPACITY]
+
+    # note details commitment
+    # ---------------------------------------------------------------------------------------------
+
+    dup.4 exec.compute_input_note_details_commitment
+    # => [NOTE_DETAILS_COMMITMENT, NOTE_METADATA_COMMITMENT, note_ptr, NULLIFIER, CAPACITY]
+
+    # save note details commitment to memory
+    movup.8 exec.memory::set_input_note_details_commitment
+    # => [NOTE_DETAILS_COMMITMENT, NOTE_METADATA_COMMITMENT, note_ptr, NULLIFIER, CAPACITY]
 
     # note authentication
     # ---------------------------------------------------------------------------------------------
 
     # NOTE_ID: `hash(NOTE_DETAILS_COMMITMENT || NOTE_METADATA_COMMITMENT)`
-    swapw exec.poseidon2::merge
+    exec.poseidon2::merge
     # => [NOTE_ID, NULLIFIER, CAPACITY]
 
     adv_push

--- a/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/prologue.masm
@@ -886,7 +886,7 @@ proc process_input_note
 
     # save note details commitment to memory
     movup.8 exec.memory::set_input_note_details_commitment
-    # => [NOTE_DETAILS_COMMITMENT, NOTE_METADATA_COMMITMENT, note_ptr, NULLIFIER, CAPACITY]
+    # => [NOTE_DETAILS_COMMITMENT, NOTE_METADATA_COMMITMENT, NULLIFIER, CAPACITY]
 
     # note authentication
     # ---------------------------------------------------------------------------------------------

--- a/crates/miden-protocol/src/note/nullifier.rs
+++ b/crates/miden-protocol/src/note/nullifier.rs
@@ -18,6 +18,11 @@ use super::{
 };
 use crate::note::{NoteDetails, NoteMetadata, NoteScriptRoot};
 
+// CONSTANTS
+// ================================================================================================
+
+const NULLIFIER_PREFIX_SHIFT: u8 = 48;
+
 // NULLIFIER
 // ================================================================================================
 
@@ -66,6 +71,18 @@ impl Nullifier {
             metadata.to_metadata_word(),
             metadata.attachments_commitment(),
         )
+    }
+
+    /// Returns the most significant felt (the last element in array)
+    pub fn most_significant_felt(&self) -> Felt {
+        self.as_elements()[3]
+    }
+
+    /// Returns the prefix of this nullifier.
+    ///
+    /// Nullifier prefix is defined as the 16 most significant bits of the nullifier value.
+    pub fn prefix(&self) -> u16 {
+        (self.as_word()[3].as_canonical_u64() >> NULLIFIER_PREFIX_SHIFT) as u16
     }
 
     /// Creates a Nullifier from a hex string. Assumes that the string starts with "0x" and

--- a/crates/miden-protocol/src/note/nullifier.rs
+++ b/crates/miden-protocol/src/note/nullifier.rs
@@ -16,12 +16,7 @@ use super::{
     Word,
     ZERO,
 };
-use crate::note::{NoteDetails, NoteMetadata};
-
-// CONSTANTS
-// ================================================================================================
-
-const NULLIFIER_PREFIX_SHIFT: u8 = 48;
+use crate::note::{NoteDetails, NoteMetadata, NoteScriptRoot};
 
 // NULLIFIER
 // ================================================================================================
@@ -44,7 +39,7 @@ pub struct Nullifier(Word);
 impl Nullifier {
     /// Returns a new note [Nullifier] instantiated from the provided note components.
     pub fn new(
-        script_root: Word,
+        script_root: NoteScriptRoot,
         storage_commitment: Word,
         asset_commitment: Word,
         serial_num: Word,
@@ -64,25 +59,13 @@ impl Nullifier {
     /// Returns a new note [Nullifier] instantiated from the provided note details and metadata.
     pub fn from_details_and_metadata(details: &NoteDetails, metadata: &NoteMetadata) -> Self {
         Self::new(
-            details.script().root().into(),
+            details.script().root(),
             details.storage().commitment(),
             details.assets().commitment(),
             details.serial_num(),
             metadata.to_metadata_word(),
             metadata.attachments_commitment(),
         )
-    }
-
-    /// Returns the most significant felt (the last element in array)
-    pub fn most_significant_felt(&self) -> Felt {
-        self.as_elements()[3]
-    }
-
-    /// Returns the prefix of this nullifier.
-    ///
-    /// Nullifier prefix is defined as the 16 most significant bits of the nullifier value.
-    pub fn prefix(&self) -> u16 {
-        (self.as_word()[3].as_canonical_u64() >> NULLIFIER_PREFIX_SHIFT) as u16
     }
 
     /// Creates a Nullifier from a hex string. Assumes that the string starts with "0x" and

--- a/crates/miden-protocol/src/transaction/kernel/memory.rs
+++ b/crates/miden-protocol/src/transaction/kernel/memory.rs
@@ -365,11 +365,11 @@ pub const NOTE_MEM_SIZE: MemoryAddress = 1024;
 // Each nullifier occupies a single word. A data section for each note consists of exactly 1024
 // elements and is laid out like so:
 //
-// ┌──────┬────────┬────────┬────────────┬────────────┬──────────┬─────────────┬───────────┬───────┬
-// │ NOTE │ SERIAL │ SCRIPT │  STORAGE   │   ASSETS   │ METADATA │ ATTACHMENTS │ RECIPIENT │ NOTE  │
-// │  ID  │  NUM   │  ROOT  │ COMMITMENT │ COMMITMENT │          │  COMMITMENT │           │ ARGS  │
-// ├──────┼────────┼────────┼────────────┼────────────┼──────────┼─────────────┼───────────┼───────┼
-// 0      4        8        12           16           20         24            28          32
+// ┌──────────────┬────────┬────────┬────────────┬────────────┬──────────┬─────────────┬───────────┬───────┬
+// │ NOTE DETAILS │ SERIAL │ SCRIPT │  STORAGE   │   ASSETS   │ METADATA │ ATTACHMENTS │ RECIPIENT │ NOTE  │
+// │  COMMITMENT  │  NUM   │  ROOT  │ COMMITMENT │ COMMITMENT │          │  COMMITMENT │           │ ARGS  │
+// ├──────────────┼────────┼────────┼────────────┼────────────┼──────────┼─────────────┼───────────┼───────┼
+// 0              4        8        12           16           20         24            28          32
 //
 // ┬─────────┬────────┬───────┬─────────┬─────┬────────┬─────────┬─────────┐
 // │ STORAGE │  NUM   │ ASSET │  ASSET  │ ... │ ASSET  │  ASSET  │ PADDING │


### PR DESCRIPTION
This tiny PR addresses the comments left after https://github.com/0xMiden/protocol/pull/2953 was merged. It namely:
- Updates the changelog to reference PRs instead of issues
- Creates a `memory::set_input_note_nullifier` helper procedure to store the computed nullifier
- Removes unused `get_input_note_nullifier_ptr` and `get_input_note_nullifier` memory getters 
- Updates the doc comments of some `masm` procedures to reflect their purpose more clearly
- Slightly optimizes the `process_input_note` procedure body
- Uses `NoteScriptRoot` instead of a plain `Word` in the `Nullifier` struct

Addresses follow-up comments from the https://github.com/0xMiden/protocol/pull/2953 PR.