### PR TITLE
refactor(agglayer): move ProofData and LeafData to types module

### DIFF
--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -14,7 +14,7 @@ use miden_utils_sync::LazyLock;
 use thiserror::Error;
 
 use super::agglayer_bridge_component_library;
-use crate::claim_note::CgiChainHash;
+use crate::types::CgiChainHash;
 pub use crate::{
     B2AggNote,
     ClaimNote,

--- a/crates/miden-agglayer/src/claim_note.rs
+++ b/crates/miden-agglayer/src/claim_note.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use miden_assembly::Library;
 use miden_assembly::serde::Deserializable;
-use miden_core::{Felt, Word};
+use miden_core::Felt;
 use miden_protocol::account::AccountId;
 use miden_protocol::crypto::SequentialCommit;
 use miden_protocol::crypto::rand::FeltRng;
@@ -23,8 +23,7 @@ use miden_protocol::note::{
 use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint};
 use miden_utils_sync::LazyLock;
 
-use crate::utils::Keccak256Output;
-use crate::{EthAddress, EthAmount, GlobalIndex, MetadataHash};
+use crate::types::{LeafData, ProofData};
 
 // NOTE SCRIPT
 // ================================================================================================
@@ -95,121 +94,6 @@ impl ClaimNote {
         let assets = NoteAssets::new(vec![])?;
 
         Ok(Note::with_attachments(assets, metadata, recipient, attachments))
-    }
-}
-
-// CLAIM NOTE TYPE ALIASES
-// ================================================================================================
-
-/// SMT node representation (32-byte Keccak256 hash)
-pub type SmtNode = Keccak256Output;
-
-/// Exit root representation (32-byte Keccak256 hash)
-pub type ExitRoot = Keccak256Output;
-
-/// Leaf value representation (32-byte Keccak256 hash)
-pub type LeafValue = Keccak256Output;
-
-/// Claimed Global Index (CGI) chain hash representation (32-byte Keccak256 hash)
-pub type CgiChainHash = Keccak256Output;
-
-/// Proof data for CLAIM note creation.
-/// Contains SMT proofs and root hashes using typed representations.
-#[derive(Clone)]
-pub struct ProofData {
-    /// SMT proof for local exit root (32 SMT nodes)
-    pub smt_proof_local_exit_root: [SmtNode; 32],
-    /// SMT proof for rollup exit root (32 SMT nodes)
-    pub smt_proof_rollup_exit_root: [SmtNode; 32],
-    /// Global index (uint256 as 32 bytes)
-    pub global_index: GlobalIndex,
-    /// Mainnet exit root hash
-    pub mainnet_exit_root: ExitRoot,
-    /// Rollup exit root hash
-    pub rollup_exit_root: ExitRoot,
-}
-
-impl SequentialCommit for ProofData {
-    type Commitment = Word;
-
-    fn to_elements(&self) -> Vec<Felt> {
-        const PROOF_DATA_ELEMENT_COUNT: usize = 536; // 32*8 + 32*8 + 8 + 8 + 8 (proofs + global_index + 2 exit roots)
-        let mut elements = Vec::with_capacity(PROOF_DATA_ELEMENT_COUNT);
-
-        // Convert SMT proof elements to felts (each node is 8 felts)
-        for node in self.smt_proof_local_exit_root.iter() {
-            elements.extend(node.to_elements());
-        }
-
-        for node in self.smt_proof_rollup_exit_root.iter() {
-            elements.extend(node.to_elements());
-        }
-
-        // Global index (uint256 as 32 bytes)
-        elements.extend(self.global_index.to_elements());
-
-        // Mainnet and rollup exit roots
-        elements.extend(self.mainnet_exit_root.to_elements());
-        elements.extend(self.rollup_exit_root.to_elements());
-
-        elements
-    }
-}
-
-/// Leaf data for CLAIM note creation.
-/// Contains network, address, amount, and metadata using typed representations.
-#[derive(Clone)]
-pub struct LeafData {
-    /// Origin network identifier (uint32)
-    pub origin_network: u32,
-    /// Origin token address
-    pub origin_token_address: EthAddress,
-    /// Destination network identifier (uint32)
-    pub destination_network: u32,
-    /// Destination address
-    pub destination_address: EthAddress,
-    /// Amount of tokens (uint256)
-    pub amount: EthAmount,
-    /// Metadata hash (32 bytes)
-    pub metadata_hash: MetadataHash,
-}
-
-impl SequentialCommit for LeafData {
-    type Commitment = Word;
-
-    fn to_elements(&self) -> Vec<Felt> {
-        const LEAF_DATA_ELEMENT_COUNT: usize = 32; // 1 + 1 + 5 + 1 + 5 + 8 + 8 + 3 (leafType + networks + addresses + amount + metadata + padding)
-        let mut elements = Vec::with_capacity(LEAF_DATA_ELEMENT_COUNT);
-
-        // LeafType (uint32 as Felt): 0u32 for transfer Ether / ERC20 tokens, 1u32 for message
-        // passing.
-        // for a `CLAIM` note, leafType is always 0 (transfer Ether / ERC20 tokens)
-        elements.push(Felt::ZERO);
-
-        // Origin network (encode as little-endian bytes for keccak)
-        let origin_network = u32::from_le_bytes(self.origin_network.to_be_bytes());
-        elements.push(Felt::from(origin_network));
-
-        // Origin token address (5 u32 felts)
-        elements.extend(self.origin_token_address.to_elements());
-
-        // Destination network (encode as little-endian bytes for keccak)
-        let destination_network = u32::from_le_bytes(self.destination_network.to_be_bytes());
-        elements.push(Felt::from(destination_network));
-
-        // Destination address (5 u32 felts)
-        elements.extend(self.destination_address.to_elements());
-
-        // Amount (uint256 as 8 u32 felts)
-        elements.extend(self.amount.to_elements());
-
-        // Metadata hash (8 u32 felts)
-        elements.extend(self.metadata_hash.to_elements());
-
-        // Padding
-        elements.extend(vec![Felt::ZERO; 3]);
-
-        elements
     }
 }
 

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -28,21 +28,14 @@ pub mod eth_types;
 pub mod faucet;
 #[cfg(feature = "testing")]
 pub mod testing;
+pub mod types;
 pub mod update_ger_note;
 pub mod utils;
 
 pub use b2agg_note::B2AggNote;
 pub use bridge::{AggLayerBridge, AgglayerBridgeError};
-pub use claim_note::{
-    CgiChainHash,
-    ClaimNote,
-    ClaimNoteStorage,
-    ExitRoot,
-    LeafData,
-    LeafValue,
-    ProofData,
-    SmtNode,
-};
+pub use claim_note::{ClaimNote, ClaimNoteStorage};
+pub use types::{CgiChainHash, ExitRoot, LeafData, LeafValue, ProofData, SmtNode};
 pub use config_note::{ConfigAggBridgeNote, ConversionMetadata};
 #[cfg(any(test, feature = "testing"))]
 pub use eth_types::GlobalIndexExt;

--- a/crates/miden-agglayer/src/testing/mod.rs
+++ b/crates/miden-agglayer/src/testing/mod.rs
@@ -16,7 +16,7 @@ use miden_protocol::utils::hex_to_bytes;
 use miden_protocol::utils::sync::LazyLock;
 use serde::Deserialize;
 
-use crate::claim_note::{ProofData, SmtNode};
+use crate::types::{ProofData, SmtNode};
 use crate::{CgiChainHash, EthAddress, EthAmount, ExitRoot, GlobalIndex, LeafData, MetadataHash};
 
 // EMBEDDED TEST VECTOR JSON FILES

--- a/crates/miden-agglayer/src/types.rs
+++ b/crates/miden-agglayer/src/types.rs
@@ -1,0 +1,123 @@
+use alloc::vec::Vec;
+
+use miden_core::{Felt, Word};
+use miden_protocol::crypto::SequentialCommit;
+
+use crate::eth_types::{EthAddress, EthAmount, GlobalIndex, MetadataHash};
+use crate::utils::Keccak256Output;
+
+// TYPE ALIASES
+// ================================================================================================
+
+/// SMT node representation (32-byte Keccak256 hash)
+pub type SmtNode = Keccak256Output;
+
+/// Exit root representation (32-byte Keccak256 hash)
+pub type ExitRoot = Keccak256Output;
+
+/// Leaf value representation (32-byte Keccak256 hash)
+pub type LeafValue = Keccak256Output;
+
+/// Claimed Global Index (CGI) chain hash representation (32-byte Keccak256 hash)
+pub type CgiChainHash = Keccak256Output;
+
+// PROOF DATA
+// ================================================================================================
+
+/// Proof data for AggLayer claim verification.
+/// Contains SMT proofs and root hashes using typed representations.
+#[derive(Clone)]
+pub struct ProofData {
+    /// SMT proof for local exit root (32 SMT nodes)
+    pub smt_proof_local_exit_root: [SmtNode; 32],
+    /// SMT proof for rollup exit root (32 SMT nodes)
+    pub smt_proof_rollup_exit_root: [SmtNode; 32],
+    /// Global index (uint256 as 32 bytes)
+    pub global_index: GlobalIndex,
+    /// Mainnet exit root hash
+    pub mainnet_exit_root: ExitRoot,
+    /// Rollup exit root hash
+    pub rollup_exit_root: ExitRoot,
+}
+
+impl SequentialCommit for ProofData {
+    type Commitment = Word;
+
+    fn to_elements(&self) -> Vec<Felt> {
+        const PROOF_DATA_ELEMENT_COUNT: usize = 536; // 32*8 + 32*8 + 8 + 8 + 8 (proofs + global_index + 2 exit roots)
+        let mut elements = Vec::with_capacity(PROOF_DATA_ELEMENT_COUNT);
+
+        for node in self.smt_proof_local_exit_root.iter() {
+            elements.extend(node.to_elements());
+        }
+
+        for node in self.smt_proof_rollup_exit_root.iter() {
+            elements.extend(node.to_elements());
+        }
+
+        elements.extend(self.global_index.to_elements());
+        elements.extend(self.mainnet_exit_root.to_elements());
+        elements.extend(self.rollup_exit_root.to_elements());
+
+        elements
+    }
+}
+
+// LEAF DATA
+// ================================================================================================
+
+/// Leaf data for AggLayer claim verification.
+/// Contains network, address, amount, and metadata using typed representations.
+#[derive(Clone)]
+pub struct LeafData {
+    /// Origin network identifier (uint32)
+    pub origin_network: u32,
+    /// Origin token address
+    pub origin_token_address: EthAddress,
+    /// Destination network identifier (uint32)
+    pub destination_network: u32,
+    /// Destination address
+    pub destination_address: EthAddress,
+    /// Amount of tokens (uint256)
+    pub amount: EthAmount,
+    /// Metadata hash (32 bytes)
+    pub metadata_hash: MetadataHash,
+}
+
+impl SequentialCommit for LeafData {
+    type Commitment = Word;
+
+    fn to_elements(&self) -> Vec<Felt> {
+        const LEAF_DATA_ELEMENT_COUNT: usize = 32; // 1 + 1 + 5 + 1 + 5 + 8 + 8 + 3 (leafType + networks + addresses + amount + metadata + padding)
+        let mut elements = Vec::with_capacity(LEAF_DATA_ELEMENT_COUNT);
+
+        // LeafType (uint32 as Felt): 0u32 for transfer Ether / ERC20 tokens, 1u32 for message
+        // passing. For a CLAIM note, leafType is always 0.
+        elements.push(Felt::ZERO);
+
+        // Origin network (encode as little-endian bytes for keccak)
+        let origin_network = u32::from_le_bytes(self.origin_network.to_be_bytes());
+        elements.push(Felt::from(origin_network));
+
+        // Origin token address (5 u32 felts)
+        elements.extend(self.origin_token_address.to_elements());
+
+        // Destination network (encode as little-endian bytes for keccak)
+        let destination_network = u32::from_le_bytes(self.destination_network.to_be_bytes());
+        elements.push(Felt::from(destination_network));
+
+        // Destination address (5 u32 felts)
+        elements.extend(self.destination_address.to_elements());
+
+        // Amount (uint256 as 8 u32 felts)
+        elements.extend(self.amount.to_elements());
+
+        // Metadata hash (8 u32 felts)
+        elements.extend(self.metadata_hash.to_elements());
+
+        // Padding
+        elements.extend([Felt::ZERO; 3]);
+
+        elements
+    }
+}


### PR DESCRIPTION
## Summary

  `ProofData`, `LeafData`, and the associated type aliases (`SmtNode`, `ExitRoot`, `LeafValue`, `CgiChainHash`)
  currently live in `claim_note.rs`, but they are general AggLayer bridge data structures with no inherent coupling to
  CLAIM-note construction.

  This PR moves them to a new `crates/miden-agglayer/src/types.rs` module, making their scope clear and allowing them to
   be referenced across the agglayer crate without implying a dependency on `claim_note`.

  ## Changes

  - `types.rs` *(new)* — home for `ProofData`, `LeafData`, and the four type aliases
  - `claim_note.rs` — removed moved definitions, imports from `crate::types`
  - `lib.rs` — added `pub mod types`; re-exports updated accordingly
  - `bridge.rs`, `testing/mod.rs` — direct `claim_note` imports updated to `crate::types`

  The public API of the crate is unchanged.

  Closes #2907