### PR TITLE
cleanup(kernel): drop unused input-note memory setters

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
@@ -1598,19 +1598,6 @@ pub proc get_input_note_metadata
     mem_loadw_le
 end
 
-#! Sets the metadata for an input note located at the specified memory address.
-#!
-#! Inputs:  [note_ptr, NOTE_METADATA]
-#! Outputs: [NOTE_METADATA]
-#!
-#! Where:
-#! - note_ptr is the memory address at which the input note data begins.
-#! - NOTE_METADATA is the metadata of the input note.
-pub proc set_input_note_metadata
-    add.INPUT_NOTE_METADATA_OFFSET
-    mem_storew_le
-end
-
 #! Returns the attachment of an input note located at the specified memory address.
 #!
 #! Inputs:  [note_ptr]
@@ -1623,19 +1610,6 @@ pub proc get_input_note_attachments_commitment
     padw
     movup.4 add.INPUT_NOTE_ATTACHMENTS_COMMITMENT_OFFSET
     mem_loadw_le
-end
-
-#! Sets the attachment for an input note located at the specified memory address.
-#!
-#! Inputs:  [note_ptr, NOTE_ATTACHMENTS_COMMITMENT]
-#! Outputs: [NOTE_ATTACHMENTS_COMMITMENT]
-#!
-#! Where:
-#! - note_ptr is the memory address at which the input note data begins.
-#! - NOTE_ATTACHMENTS_COMMITMENT is the commitment to all attachments of the input note.
-pub proc set_input_note_attachments_commitment
-    add.INPUT_NOTE_ATTACHMENTS_COMMITMENT_OFFSET
-    mem_storew_le
 end
 
 #! Returns the note's args.


### PR DESCRIPTION
`memory::set_input_note_metadata` and `memory::set_input_note_attachments_commitment` are never called.

Spotted while reviewing #2959.