### PR TITLE
fix: public MINT notes are not bound to the intended faucet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - [BREAKING] Replaced `NoAuth` with the new `AuthNetworkAccount` auth component on the AggLayer bridge and AggLayer faucet, closing the forged-MINT attack surface where any transaction against the bridge could emit a bridge-authored MINT note ([#2797](https://github.com/0xMiden/protocol/issues/2797), [#2818](https://github.com/0xMiden/protocol/pull/2818)).
 - [BREAKING] Keyed the AggLayer faucet token registry by `(origin_token_address, origin_network)` instead of `origin_token_address` alone, preventing same-address cross-network mint collisions on CLAIM ([#2860](https://github.com/0xMiden/protocol/pull/2860)).
 - Fixed `set_procedure_threshold` in the multisig auth component validating per-procedure overrides against initial `num_approvers`.
+- [BREAKING] Bound MINT note consumption to the recorded faucet ID: `mint::main` now asserts that the active account matches the faucet ID embedded in note storage ([#2966](https://github.com/0xMiden/protocol/pull/2966)).
 
 ## 0.14.6 (2026-05-05)
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in_output.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in_output.masm
@@ -19,8 +19,8 @@ use miden::standards::note::execution_hint::ALWAYS
 # - SERIAL_NUM        [4..7]   : 4 felts
 # - tag               [8]      : 1 felt
 # - amount            [9]      : 1 felt
-# - faucet_id_suffix  [10]     : 1 felt (binds MINT consumption to this faucet)
-# - faucet_id_prefix  [11]     : 1 felt (binds MINT consumption to this faucet)
+# - faucet_id_suffix  [10]     : 1 felt
+# - faucet_id_prefix  [11]     : 1 felt
 # - account_id_suffix [12]     : 1 felt
 # - account_id_prefix [13]     : 1 felt
 const MINT_NOTE_NUM_STORAGE_ITEMS = 14
@@ -161,10 +161,7 @@ end
 # MINT-PATH HELPERS (used only by build_mint_output_note)
 # =================================================================================================
 
-#! Writes the destination/output portion of the MINT note storage to global memory.
-#!
-#! The faucet_id at [10..11] is written separately by the caller (see `build_mint_output_note`)
-#! because this procedure does not have it on its top-of-stack inputs.
+#! Writes all 14 MINT note storage items to global memory.
 #!
 #! Storage layout:
 #! - [0-3]: P2ID_SCRIPT_ROOT (script root of the P2ID note)

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in_output.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in_output.masm
@@ -19,8 +19,8 @@ use miden::standards::note::execution_hint::ALWAYS
 # - SERIAL_NUM        [4..7]   : 4 felts
 # - tag               [8]      : 1 felt
 # - amount            [9]      : 1 felt
-# - 0                 [10]     : 1 felt (padding)
-# - 0                 [11]     : 1 felt (padding)
+# - faucet_id_suffix  [10]     : 1 felt (binds MINT consumption to this faucet)
+# - faucet_id_prefix  [11]     : 1 felt (binds MINT consumption to this faucet)
 # - account_id_suffix [12]     : 1 felt
 # - account_id_prefix [13]     : 1 felt
 const MINT_NOTE_NUM_STORAGE_ITEMS = 14
@@ -31,7 +31,8 @@ const MINT_NOTE_STORAGE_OUTPUT_SCRIPT_ROOT = 800
 const MINT_NOTE_STORAGE_OUTPUT_SERIAL_NUM = 804
 const MINT_NOTE_STORAGE_DEST_TAG = 808
 const MINT_NOTE_STORAGE_NATIVE_AMOUNT = 809
-# padding at 810, 811
+const MINT_NOTE_STORAGE_FAUCET_ID_SUFFIX = 810
+const MINT_NOTE_STORAGE_FAUCET_ID_PREFIX = 811
 const MINT_NOTE_STORAGE_OUTPUT_NOTE_SUFFIX = 812
 const MINT_NOTE_STORAGE_OUTPUT_NOTE_PREFIX = 813
 
@@ -58,6 +59,10 @@ const UNLOCK_DEST_PREFIX_LOC = 9
 #!
 #! Invocation: exec
 pub proc build_mint_output_note
+    dup.2 mem_store.MINT_NOTE_STORAGE_FAUCET_ID_SUFFIX
+    dup.3 mem_store.MINT_NOTE_STORAGE_FAUCET_ID_PREFIX
+    # => [destination_id_suffix, destination_id_prefix, faucet_id_suffix, faucet_id_prefix]
+
     # Step 1: Write all MINT note storage items to global memory
     exec.write_mint_note_storage
     # => [faucet_id_suffix, faucet_id_prefix]
@@ -156,15 +161,18 @@ end
 # MINT-PATH HELPERS (used only by build_mint_output_note)
 # =================================================================================================
 
-#! Writes all 14 MINT note storage items to global memory.
+#! Writes the destination/output portion of the MINT note storage to global memory.
+#!
+#! The faucet_id at [10..11] is written separately by the caller (see `build_mint_output_note`)
+#! because this procedure does not have it on its top-of-stack inputs.
 #!
 #! Storage layout:
 #! - [0-3]: P2ID_SCRIPT_ROOT (script root of the P2ID note)
 #! - [4-7]: SERIAL_NUM (serial number for the P2ID note, derived from PROOF_DATA_KEY)
 #! - [8]: tag (note tag for the P2ID output note, targeting the destination account)
 #! - [9]: amount (the scaled-down Miden amount to mint)
-#! - [10]: 0 (padding)
-#! - [11]: 0 (padding)
+#! - [10]: faucet_id_suffix (written by the caller)
+#! - [11]: faucet_id_prefix (written by the caller)
 #! - [12]: account_id_suffix (destination account suffix)
 #! - [13]: account_id_prefix (destination account prefix)
 #!

--- a/crates/miden-standards/asm/standards/notes/mint.masm
+++ b/crates/miden-standards/asm/standards/notes/mint.masm
@@ -66,13 +66,6 @@ const ERR_MINT_WRONG_FAUCET="MINT script consuming account does not match the fa
 #! - [STORAGE]: Variable-length storage for the output note (Vec<Felt>)
 #!              The number of output note storage items = num_mint_note_storage_items - 12
 #!
-#! The faucet_id slot at indices 10-11 of public storage also acts as the word-alignment padding
-#! that note::compute_and_store_recipient expects for the output note storage_ptr at index 12.
-#!
-#! The script binds consumption to the recorded faucet by asserting that the active account ID
-#! equals (faucet_id_prefix, faucet_id_suffix) before invoking mint_and_send. This prevents a
-#! different fungible faucet from consuming the note and minting its own asset to the recipient.
-#!
 #! Panics if:
 #! - account does not expose mint_and_send procedure.
 #! - the number of storage items is not exactly 8 for private or less than 12 for public output notes.
@@ -104,7 +97,7 @@ pub proc main
 
         exec.account_id::is_equal
         # => [is_id_equal, num_storage_items, pad(16)]
-        
+
         assert.err=ERR_MINT_WRONG_FAUCET
         # => [num_storage_items, pad(16)]
 

--- a/crates/miden-standards/asm/standards/notes/mint.masm
+++ b/crates/miden-standards/asm/standards/notes/mint.masm
@@ -1,3 +1,5 @@
+use miden::protocol::account_id
+use miden::protocol::active_account
 use miden::protocol::active_note
 use miden::protocol::note
 use miden::standards::faucets::fungible->faucet
@@ -5,7 +7,7 @@ use miden::standards::faucets::fungible->faucet
 # CONSTANTS
 # =================================================================================================
 
-const MINT_NOTE_NUM_STORAGE_ITEMS_PRIVATE=6
+const MINT_NOTE_NUM_STORAGE_ITEMS_PRIVATE=8
 const MINT_NOTE_MIN_NUM_STORAGE_ITEMS_PUBLIC=12
 
 use miden::protocol::note::NOTE_TYPE_PUBLIC
@@ -16,18 +18,23 @@ const STORAGE_PTR = 0
 const PRIVATE_RECIPIENT_PTR = STORAGE_PTR
 const PRIVATE_TAG_PTR = STORAGE_PTR + 4
 const PRIVATE_AMOUNT_PTR = STORAGE_PTR + 5
+const PRIVATE_FAUCET_ID_SUFFIX_PTR = STORAGE_PTR + 6
+const PRIVATE_FAUCET_ID_PREFIX_PTR = STORAGE_PTR + 7
 
 # Memory addresses of MINT note storage (public mode)
 const PUBLIC_SCRIPT_ROOT_PTR = STORAGE_PTR
 const PUBLIC_SERIAL_NUM_PTR = STORAGE_PTR + 4
 const PUBLIC_TAG_PTR = STORAGE_PTR + 8
 const PUBLIC_AMOUNT_PTR = STORAGE_PTR + 9
+const PUBLIC_FAUCET_ID_SUFFIX_PTR = STORAGE_PTR + 10
+const PUBLIC_FAUCET_ID_PREFIX_PTR = STORAGE_PTR + 11
 const PUBLIC_OUTPUT_NOTE_STORAGE_PTR = STORAGE_PTR + 12
 
 # ERRORS
 # =================================================================================================
 
-const ERR_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS="MINT script expects exactly 6 storage items for private or 12+ storage items for public output notes"
+const ERR_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS="MINT script expects exactly 8 storage items for private or 12+ storage items for public output notes"
+const ERR_MINT_WRONG_FAUCET="MINT script consuming account does not match the faucet recorded in note storage"
 
 #! Network Faucet MINT script: mints assets by calling the network faucet's mint_and_send
 #! function.
@@ -42,26 +49,34 @@ const ERR_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS="MINT script expects exactly 6
 #! Note storage supports two modes. Depending on the number of note storage items,
 #! a private or public note is created on consumption of the MINT note:
 #!
-#! Private mode (6 storage items) - creates a private note:
+#! Private mode (8 storage items) - creates a private note:
 #! - RECIPIENT: The recipient digest (4 elements)
 #! - tag: Note tag for the output note
 #! - amount: The amount to mint
+#! - faucet_id_suffix: Suffix felt of the intended faucet account ID
+#! - faucet_id_prefix: Prefix felt of the intended faucet account ID
 #!
 #! Public mode (12+ storage items) - creates a public note with variable-length storage:
 #! - SCRIPT_ROOT: Script root of the output note (4 elements)
 #! - SERIAL_NUM: Serial number of the output note (4 elements)
 #! - tag: Note tag for the output note
 #! - amount: The amount to mint
-#! - padding
-#! - padding
+#! - faucet_id_suffix: Suffix felt of the intended faucet account ID
+#! - faucet_id_prefix: Prefix felt of the intended faucet account ID
 #! - [STORAGE]: Variable-length storage for the output note (Vec<Felt>)
 #!              The number of output note storage items = num_mint_note_storage_items - 12
 #!
-#! The padding is necessary since note::compute_and_store_recipient expects a word-aligned storage_ptr.
+#! The faucet_id slot at indices 10-11 of public storage also acts as the word-alignment padding
+#! that note::compute_and_store_recipient expects for the output note storage_ptr at index 12.
+#!
+#! The script binds consumption to the recorded faucet by asserting that the active account ID
+#! equals (faucet_id_prefix, faucet_id_suffix) before invoking mint_and_send. This prevents a
+#! different fungible faucet from consuming the note and minting its own asset to the recipient.
 #!
 #! Panics if:
 #! - account does not expose mint_and_send procedure.
-#! - the number of storage items is not exactly 6 for private or less than 12 for public output notes.
+#! - the number of storage items is not exactly 8 for private or less than 12 for public output notes.
+#! - the active account ID is not equal to the faucet ID recorded in note storage.
 @note_script
 pub proc main
     dropw
@@ -79,6 +94,18 @@ pub proc main
 
     if.true
         # public output note creation
+        # => [num_storage_items, pad(16)]
+
+        mem_load.PUBLIC_FAUCET_ID_PREFIX_PTR mem_load.PUBLIC_FAUCET_ID_SUFFIX_PTR
+        # => [exp_faucet_id_suffix, exp_faucet_id_prefix, num_storage_items, pad(16)]
+
+        exec.active_account::get_id
+        # => [account_id_suffix, account_id_prefix, exp_faucet_id_suffix, exp_faucet_id_prefix, num_storage_items, pad(16)]
+
+        exec.account_id::is_equal
+        # => [is_id_equal, num_storage_items, pad(16)]
+        
+        assert.err=ERR_MINT_WRONG_FAUCET
         # => [num_storage_items, pad(16)]
 
         movdn.8
@@ -108,6 +135,18 @@ pub proc main
         # private output note creation
 
         eq.MINT_NOTE_NUM_STORAGE_ITEMS_PRIVATE assert.err=ERR_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
+        # => [pad(16)]
+
+        mem_load.PRIVATE_FAUCET_ID_PREFIX_PTR mem_load.PRIVATE_FAUCET_ID_SUFFIX_PTR
+        # => [exp_faucet_id_suffix, exp_faucet_id_prefix, pad(16)]
+
+        exec.active_account::get_id
+        # => [account_id_suffix, account_id_prefix, exp_faucet_id_suffix, exp_faucet_id_prefix, pad(16)]
+
+        exec.account_id::is_equal
+        # => [is_id_equal, pad(16)]
+
+        assert.err=ERR_MINT_WRONG_FAUCET
         # => [pad(16)]
 
         mem_loadw_le.PRIVATE_RECIPIENT_PTR

--- a/crates/miden-standards/src/note/mint.rs
+++ b/crates/miden-standards/src/note/mint.rs
@@ -87,7 +87,7 @@ impl MintNote {
     /// is automatically set to the faucet's account ID for proper routing.
     ///
     /// # Parameters
-    /// - `faucet_id`: The account ID of the network faucet that will mint the assets.
+    /// - `faucet_id`: The account ID of the network faucet that will mint the assets
     /// - `sender`: The account ID of the note creator (must be the faucet owner)
     /// - `mint_storage`: The storage configuration specifying private or public output mode
     /// - `attachment`: The [`NoteAttachments`] of the MINT note

--- a/crates/miden-standards/src/note/mint.rs
+++ b/crates/miden-standards/src/note/mint.rs
@@ -76,9 +76,9 @@ impl MintNote {
     ///
     /// This script enables the creation of a PUBLIC note that, when consumed by a network faucet,
     /// will mint the specified amount of fungible assets and create either a PRIVATE or PUBLIC
-    /// output note depending on the input configuration. Consumption is bound to `faucet_id`:
-    /// the script panics if the consuming account does not match the recorded faucet, so a
-    /// different fungible faucet cannot race to consume the note and mint its own asset.
+    /// output note depending on the input configuration. The MINT note uses note-based
+    /// authentication, checking if the note sender equals the faucet owner to authorize
+    /// minting.
     ///
     /// MINT notes are always PUBLIC (for network execution). Output notes can be either PRIVATE
     /// or PUBLIC depending on the MintNoteStorage variant used.
@@ -87,8 +87,7 @@ impl MintNote {
     /// is automatically set to the faucet's account ID for proper routing.
     ///
     /// # Parameters
-    /// - `faucet_id`: The account ID of the network faucet that will mint the assets. Embedded into
-    ///   the note storage and enforced at consumption time.
+    /// - `faucet_id`: The account ID of the network faucet that will mint the assets.
     /// - `sender`: The account ID of the note creator (must be the faucet owner)
     /// - `mint_storage`: The storage configuration specifying private or public output mode
     /// - `attachment`: The [`NoteAttachments`] of the MINT note
@@ -109,8 +108,7 @@ impl MintNote {
         // MINT notes are always public for network execution
         let note_type = NoteType::Public;
 
-        // Convert MintNoteStorage to NoteStorage, embedding the intended faucet ID so the script
-        // can refuse consumption by any other account.
+        // Convert MintNoteStorage to NoteStorage
         let storage = mint_storage.into_note_storage(faucet_id);
 
         let tag = NoteTag::with_account_target(faucet_id);
@@ -169,8 +167,6 @@ impl MintNoteStorage {
         Ok(Self::Public { recipient, amount, tag })
     }
 
-    /// Serializes the storage to a [`NoteStorage`], embedding the intended `faucet_id` so the
-    /// MINT script can verify the consuming account at execution time.
     pub(crate) fn into_note_storage(self, faucet_id: AccountId) -> NoteStorage {
         let faucet_id_suffix = Felt::new_unchecked(faucet_id.suffix().as_canonical_u64());
         let faucet_id_prefix = faucet_id.prefix().as_felt();

--- a/crates/miden-standards/src/note/mint.rs
+++ b/crates/miden-standards/src/note/mint.rs
@@ -46,7 +46,15 @@ impl MintNote {
     // --------------------------------------------------------------------------------------------
 
     /// Expected number of storage items of the MINT note (private mode).
-    pub const NUM_STORAGE_ITEMS_PRIVATE: usize = 6;
+    ///
+    /// Layout: 4 felts RECIPIENT, 1 felt tag, 1 felt amount, 2 felts intended faucet ID.
+    pub const NUM_STORAGE_ITEMS_PRIVATE: usize = 8;
+
+    /// Minimum number of fixed storage items of the MINT note (public mode).
+    ///
+    /// Layout: 4 felts SCRIPT_ROOT, 4 felts SERIAL_NUM, 1 felt tag, 1 felt amount, 2 felts
+    /// intended faucet ID. Variable-length output note storage follows from index 12 onward.
+    pub const FIXED_NUM_STORAGE_ITEMS_PUBLIC: usize = 12;
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
@@ -68,9 +76,9 @@ impl MintNote {
     ///
     /// This script enables the creation of a PUBLIC note that, when consumed by a network faucet,
     /// will mint the specified amount of fungible assets and create either a PRIVATE or PUBLIC
-    /// output note depending on the input configuration. The MINT note uses note-based
-    /// authentication, checking if the note sender equals the faucet owner to authorize
-    /// minting.
+    /// output note depending on the input configuration. Consumption is bound to `faucet_id`:
+    /// the script panics if the consuming account does not match the recorded faucet, so a
+    /// different fungible faucet cannot race to consume the note and mint its own asset.
     ///
     /// MINT notes are always PUBLIC (for network execution). Output notes can be either PRIVATE
     /// or PUBLIC depending on the MintNoteStorage variant used.
@@ -79,7 +87,8 @@ impl MintNote {
     /// is automatically set to the faucet's account ID for proper routing.
     ///
     /// # Parameters
-    /// - `faucet_id`: The account ID of the network faucet that will mint the assets
+    /// - `faucet_id`: The account ID of the network faucet that will mint the assets. Embedded into
+    ///   the note storage and enforced at consumption time.
     /// - `sender`: The account ID of the note creator (must be the faucet owner)
     /// - `mint_storage`: The storage configuration specifying private or public output mode
     /// - `attachment`: The [`NoteAttachments`] of the MINT note
@@ -100,8 +109,9 @@ impl MintNote {
         // MINT notes are always public for network execution
         let note_type = NoteType::Public;
 
-        // Convert MintNoteStorage to NoteStorage
-        let storage = NoteStorage::from(mint_storage);
+        // Convert MintNoteStorage to NoteStorage, embedding the intended faucet ID so the script
+        // can refuse consumption by any other account.
+        let storage = mint_storage.into_note_storage(faucet_id);
 
         let tag = NoteTag::with_account_target(faucet_id);
 
@@ -147,11 +157,10 @@ impl MintNoteStorage {
         tag: Felt,
     ) -> Result<Self, NoteError> {
         // Calculate total number of storage items that will be created:
-        // 12 fixed items (SCRIPT_ROOT, SERIAL_NUM, tag, amount, 2 padding) + variable recipient
-        // number of storage items
-        const FIXED_PUBLIC_STORAGE_ITEMS: usize = 12;
+        // FIXED_NUM_STORAGE_ITEMS_PUBLIC fixed items (SCRIPT_ROOT, SERIAL_NUM, tag, amount,
+        // intended faucet ID) + variable output-note storage items.
         let total_storage_items =
-            FIXED_PUBLIC_STORAGE_ITEMS + recipient.storage().num_items() as usize;
+            MintNote::FIXED_NUM_STORAGE_ITEMS_PUBLIC + recipient.storage().num_items() as usize;
 
         if total_storage_items > MAX_NOTE_STORAGE_ITEMS {
             return Err(NoteError::TooManyStorageItems(total_storage_items));
@@ -159,15 +168,22 @@ impl MintNoteStorage {
 
         Ok(Self::Public { recipient, amount, tag })
     }
-}
 
-impl From<MintNoteStorage> for NoteStorage {
-    fn from(mint_storage: MintNoteStorage) -> Self {
-        match mint_storage {
+    /// Serializes the storage to a [`NoteStorage`], embedding the intended `faucet_id` so the
+    /// MINT script can verify the consuming account at execution time.
+    pub(crate) fn into_note_storage(self, faucet_id: AccountId) -> NoteStorage {
+        let faucet_id_suffix = Felt::new_unchecked(faucet_id.suffix().as_canonical_u64());
+        let faucet_id_prefix = faucet_id.prefix().as_felt();
+        match self {
             MintNoteStorage::Private { recipient_digest, amount, tag } => {
                 let mut storage_values = Vec::with_capacity(MintNote::NUM_STORAGE_ITEMS_PRIVATE);
                 storage_values.extend_from_slice(recipient_digest.as_elements());
-                storage_values.extend_from_slice(&[tag, amount]);
+                storage_values.extend_from_slice(&[
+                    tag,
+                    amount,
+                    faucet_id_suffix,
+                    faucet_id_prefix,
+                ]);
                 NoteStorage::new(storage_values)
                     .expect("number of storage items should not exceed max storage items")
             },
@@ -175,7 +191,12 @@ impl From<MintNoteStorage> for NoteStorage {
                 let mut storage_values = Vec::new();
                 storage_values.extend_from_slice(recipient.script().root().as_elements());
                 storage_values.extend_from_slice(recipient.serial_num().as_elements());
-                storage_values.extend_from_slice(&[tag, amount, Felt::ZERO, Felt::ZERO]);
+                storage_values.extend_from_slice(&[
+                    tag,
+                    amount,
+                    faucet_id_suffix,
+                    faucet_id_prefix,
+                ]);
                 storage_values.extend_from_slice(recipient.storage().items());
                 NoteStorage::new(storage_values)
                     .expect("number of storage items should not exceed max storage items")

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -1848,11 +1848,8 @@ async fn network_faucet_mint_with_blocklist() -> anyhow::Result<()> {
 /// permissive mint policy can race to consume the note and mint its OWN asset to the recipient,
 /// nullifying the MINT note (request DoS) and delivering a wrong-asset to the recipient.
 ///
-/// Both `MintNoteStorage` variants (private and public output) are exercised because each takes
+/// Both `MintNoteStorage` variants (private and public output) are tested because each takes
 /// a separate `if` branch in the MINT script with its own faucet_id offset.
-///
-/// Happy-path consumption (intended faucet, both variants) is already covered by
-/// `test_mint_note_output_note_types`.
 #[rstest::rstest]
 #[case::private_output(NoteType::Private)]
 #[case::public_output(NoteType::Public)]

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -1842,16 +1842,24 @@ async fn network_faucet_mint_with_blocklist() -> anyhow::Result<()> {
 // TESTS FOR MINT NOTE FAUCET BINDING
 // ================================================================================================
 
-/// Regression test: a MINT note must only be consumable by the faucet recorded in its storage.
+/// A MINT note must only be consumable by the faucet recorded in its storage.
 ///
 /// Without the binding, a different fungible faucet that exposes `mint_and_send` and has a
 /// permissive mint policy can race to consume the note and mint its OWN asset to the recipient,
 /// nullifying the MINT note (request DoS) and delivering a wrong-asset to the recipient.
 ///
-/// The MINT script now embeds `faucet_id` into note storage and asserts that the consuming
-/// account ID matches it (see `ERR_MINT_WRONG_FAUCET`).
+/// Both `MintNoteStorage` variants (private and public output) are exercised because each takes
+/// a separate `if` branch in the MINT script with its own faucet_id offset.
+///
+/// Happy-path consumption (intended faucet, both variants) is already covered by
+/// `test_mint_note_output_note_types`.
+#[rstest::rstest]
+#[case::private_output(NoteType::Private)]
+#[case::public_output(NoteType::Public)]
 #[tokio::test]
-async fn mint_note_consumption_is_bound_to_intended_faucet() -> anyhow::Result<()> {
+async fn mint_note_rejects_unintended_faucet(
+    #[case] output_note_type: NoteType,
+) -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
 
     let faucet_a_owner =
@@ -1879,22 +1887,34 @@ async fn mint_note_consumption_is_bound_to_intended_faucet() -> anyhow::Result<(
 
     let recipient_account = builder.add_existing_wallet(Auth::IncrNonce)?;
 
-    // Construct a MINT note that records Faucet A as the intended faucet.
     let amount = Felt::new_unchecked(75);
     let intended_asset: Asset =
         FungibleAsset::new(faucet_a.id(), amount.as_canonical_u64())?.into();
-    let serial_num = Word::default();
+    let serial_num = Word::from([1, 2, 3, 4u32]);
     let output_note_tag = NoteTag::with_account_target(recipient_account.id());
 
     let p2id_note = create_p2id_note_exact(
         faucet_a.id(),
         recipient_account.id(),
         vec![intended_asset],
-        NoteType::Private,
+        output_note_type,
         serial_num,
     )?;
-    let mint_recipient = p2id_note.recipient().digest();
-    let mint_storage = MintNoteStorage::new_private(mint_recipient, amount, output_note_tag.into());
+
+    let mint_storage = match output_note_type {
+        NoteType::Private => {
+            let mint_recipient = p2id_note.recipient().digest();
+            MintNoteStorage::new_private(mint_recipient, amount, output_note_tag.into())
+        },
+        NoteType::Public => {
+            let p2id_script = StandardNote::P2ID.script();
+            let p2id_storage =
+                vec![recipient_account.id().suffix(), recipient_account.id().prefix().as_felt()];
+            let note_storage = NoteStorage::new(p2id_storage)?;
+            let recipient = NoteRecipient::new(serial_num, p2id_script, note_storage);
+            MintNoteStorage::new_public(recipient, amount, output_note_tag.into())?
+        },
+    };
 
     let mut rng = RandomCoin::new([Felt::from(7u32); 4].into());
     let mint_note = MintNote::create(
@@ -1916,117 +1936,5 @@ async fn mint_note_consumption_is_bound_to_intended_faucet() -> anyhow::Result<(
 
     assert_transaction_executor_error!(result, ERR_MINT_WRONG_FAUCET);
 
-    Ok(())
-}
-
-/// Same as [`mint_note_consumption_is_bound_to_intended_faucet`] but exercises the public
-/// output variant, which has a different storage layout and a separate `if` branch in the
-/// MINT script.
-#[tokio::test]
-async fn mint_note_consumption_is_bound_to_intended_faucet_public() -> anyhow::Result<()> {
-    let mut builder = MockChain::builder();
-
-    let faucet_a_owner =
-        AccountId::dummy([4; 15], AccountIdVersion::Version1, AccountType::Private);
-    let faucet_b_owner =
-        AccountId::dummy([5; 15], AccountIdVersion::Version1, AccountType::Private);
-
-    let faucet_a = builder.add_existing_network_faucet(
-        "CCC",
-        1000,
-        faucet_a_owner,
-        Some(0),
-        MintPolicyConfig::AllowAll,
-        [],
-    )?;
-    let faucet_b = builder.add_existing_network_faucet(
-        "DDD",
-        1000,
-        faucet_b_owner,
-        Some(0),
-        MintPolicyConfig::AllowAll,
-        [],
-    )?;
-
-    let recipient_account = builder.add_existing_wallet(Auth::IncrNonce)?;
-
-    let amount = Felt::new_unchecked(50);
-    let serial_num = Word::from([1, 2, 3, 4u32]);
-    let output_note_tag = NoteTag::with_account_target(recipient_account.id());
-
-    let p2id_script = StandardNote::P2ID.script();
-    let p2id_storage =
-        vec![recipient_account.id().suffix(), recipient_account.id().prefix().as_felt()];
-    let note_storage = NoteStorage::new(p2id_storage)?;
-    let recipient = NoteRecipient::new(serial_num, p2id_script, note_storage);
-    let mint_storage = MintNoteStorage::new_public(recipient, amount, output_note_tag.into())?;
-
-    let mut rng = RandomCoin::new([Felt::from(11u32); 4].into());
-    let mint_note = MintNote::create(
-        faucet_a.id(),
-        faucet_a_owner,
-        mint_storage,
-        NoteAttachments::default(),
-        &mut rng,
-    )?;
-
-    let mock_chain = builder.build()?;
-
-    // Attack: try to consume Faucet A's MINT note with Faucet B.
-    let result = mock_chain
-        .build_tx_context(faucet_b.id(), &[], &[mint_note])?
-        .build()?
-        .execute()
-        .await;
-
-    assert_transaction_executor_error!(result, ERR_MINT_WRONG_FAUCET);
-
-    Ok(())
-}
-
-/// Sanity test: a MINT note must remain consumable by its intended faucet after the binding
-/// is in place (private output variant).
-#[tokio::test]
-async fn mint_note_consumed_by_intended_faucet_still_succeeds_private() -> anyhow::Result<()> {
-    let mut builder = MockChain::builder();
-
-    let owner = AccountId::dummy([3; 15], AccountIdVersion::Version1, AccountType::Private);
-    let faucet = builder.add_existing_network_faucet(
-        "OKK",
-        1000,
-        owner,
-        Some(0),
-        MintPolicyConfig::AllowAll,
-        [],
-    )?;
-    let recipient_account = builder.add_existing_wallet(Auth::IncrNonce)?;
-
-    let amount = Felt::new_unchecked(50);
-    let mint_asset: Asset = FungibleAsset::new(faucet.id(), amount.as_canonical_u64())?.into();
-    let output_note_tag = NoteTag::with_account_target(recipient_account.id());
-
-    let p2id_note = create_p2id_note_exact(
-        faucet.id(),
-        recipient_account.id(),
-        vec![mint_asset],
-        NoteType::Private,
-        Word::default(),
-    )?;
-    let mint_recipient = p2id_note.recipient().digest();
-    let mint_storage = MintNoteStorage::new_private(mint_recipient, amount, output_note_tag.into());
-
-    let mut rng = RandomCoin::new([Felt::from(9u32); 4].into());
-    let mint_note =
-        MintNote::create(faucet.id(), owner, mint_storage, NoteAttachments::default(), &mut rng)?;
-
-    let mock_chain = builder.build()?;
-
-    let executed = mock_chain
-        .build_tx_context(faucet.id(), &[], &[mint_note])?
-        .build()?
-        .execute()
-        .await?;
-
-    assert_eq!(executed.output_notes().num_notes(), 1);
     Ok(())
 }

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -43,6 +43,7 @@ use miden_standards::errors::standards::{
     ERR_FAUCET_BURN_AMOUNT_EXCEEDS_TOKEN_SUPPLY,
     ERR_FUNGIBLE_ASSET_DISTRIBUTE_AMOUNT_EXCEEDS_MAX_SUPPLY,
     ERR_MINT_POLICY_ROOT_NOT_ALLOWED,
+    ERR_MINT_WRONG_FAUCET,
     ERR_SENDER_NOT_OWNER,
 };
 use miden_standards::note::{BurnNote, MintNote, MintNoteStorage, StandardNote};
@@ -1830,6 +1831,198 @@ async fn network_faucet_mint_with_blocklist() -> anyhow::Result<()> {
 
     let executed = mock_chain
         .build_tx_context(faucet.id(), &[mint_note.id()], &[])?
+        .build()?
+        .execute()
+        .await?;
+
+    assert_eq!(executed.output_notes().num_notes(), 1);
+    Ok(())
+}
+
+// TESTS FOR MINT NOTE FAUCET BINDING
+// ================================================================================================
+
+/// Regression test: a MINT note must only be consumable by the faucet recorded in its storage.
+///
+/// Without the binding, a different fungible faucet that exposes `mint_and_send` and has a
+/// permissive mint policy can race to consume the note and mint its OWN asset to the recipient,
+/// nullifying the MINT note (request DoS) and delivering a wrong-asset to the recipient.
+///
+/// The MINT script now embeds `faucet_id` into note storage and asserts that the consuming
+/// account ID matches it (see `ERR_MINT_WRONG_FAUCET`).
+#[tokio::test]
+async fn mint_note_consumption_is_bound_to_intended_faucet() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let faucet_a_owner =
+        AccountId::dummy([1; 15], AccountIdVersion::Version1, AccountType::Private);
+    let faucet_b_owner =
+        AccountId::dummy([2; 15], AccountIdVersion::Version1, AccountType::Private);
+
+    let faucet_a = builder.add_existing_network_faucet(
+        "AAA",
+        1000,
+        faucet_a_owner,
+        Some(0),
+        MintPolicyConfig::AllowAll,
+        [],
+    )?;
+    let faucet_b = builder.add_existing_network_faucet(
+        "BBB",
+        1000,
+        faucet_b_owner,
+        Some(0),
+        MintPolicyConfig::AllowAll,
+        [],
+    )?;
+    assert_ne!(faucet_a.id(), faucet_b.id(), "the two faucets must have distinct ids");
+
+    let recipient_account = builder.add_existing_wallet(Auth::IncrNonce)?;
+
+    // Construct a MINT note that records Faucet A as the intended faucet.
+    let amount = Felt::new_unchecked(75);
+    let intended_asset: Asset =
+        FungibleAsset::new(faucet_a.id(), amount.as_canonical_u64())?.into();
+    let serial_num = Word::default();
+    let output_note_tag = NoteTag::with_account_target(recipient_account.id());
+
+    let p2id_note = create_p2id_note_exact(
+        faucet_a.id(),
+        recipient_account.id(),
+        vec![intended_asset],
+        NoteType::Private,
+        serial_num,
+    )?;
+    let mint_recipient = p2id_note.recipient().digest();
+    let mint_storage = MintNoteStorage::new_private(mint_recipient, amount, output_note_tag.into());
+
+    let mut rng = RandomCoin::new([Felt::from(7u32); 4].into());
+    let mint_note = MintNote::create(
+        faucet_a.id(),
+        faucet_a_owner,
+        mint_storage,
+        NoteAttachments::default(),
+        &mut rng,
+    )?;
+
+    let mock_chain = builder.build()?;
+
+    // Attack: try to consume Faucet A's MINT note with Faucet B.
+    let result = mock_chain
+        .build_tx_context(faucet_b.id(), &[], &[mint_note])?
+        .build()?
+        .execute()
+        .await;
+
+    assert_transaction_executor_error!(result, ERR_MINT_WRONG_FAUCET);
+
+    Ok(())
+}
+
+/// Same as [`mint_note_consumption_is_bound_to_intended_faucet`] but exercises the public
+/// output variant, which has a different storage layout and a separate `if` branch in the
+/// MINT script.
+#[tokio::test]
+async fn mint_note_consumption_is_bound_to_intended_faucet_public() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let faucet_a_owner =
+        AccountId::dummy([4; 15], AccountIdVersion::Version1, AccountType::Private);
+    let faucet_b_owner =
+        AccountId::dummy([5; 15], AccountIdVersion::Version1, AccountType::Private);
+
+    let faucet_a = builder.add_existing_network_faucet(
+        "CCC",
+        1000,
+        faucet_a_owner,
+        Some(0),
+        MintPolicyConfig::AllowAll,
+        [],
+    )?;
+    let faucet_b = builder.add_existing_network_faucet(
+        "DDD",
+        1000,
+        faucet_b_owner,
+        Some(0),
+        MintPolicyConfig::AllowAll,
+        [],
+    )?;
+
+    let recipient_account = builder.add_existing_wallet(Auth::IncrNonce)?;
+
+    let amount = Felt::new_unchecked(50);
+    let serial_num = Word::from([1, 2, 3, 4u32]);
+    let output_note_tag = NoteTag::with_account_target(recipient_account.id());
+
+    let p2id_script = StandardNote::P2ID.script();
+    let p2id_storage =
+        vec![recipient_account.id().suffix(), recipient_account.id().prefix().as_felt()];
+    let note_storage = NoteStorage::new(p2id_storage)?;
+    let recipient = NoteRecipient::new(serial_num, p2id_script, note_storage);
+    let mint_storage = MintNoteStorage::new_public(recipient, amount, output_note_tag.into())?;
+
+    let mut rng = RandomCoin::new([Felt::from(11u32); 4].into());
+    let mint_note = MintNote::create(
+        faucet_a.id(),
+        faucet_a_owner,
+        mint_storage,
+        NoteAttachments::default(),
+        &mut rng,
+    )?;
+
+    let mock_chain = builder.build()?;
+
+    // Attack: try to consume Faucet A's MINT note with Faucet B.
+    let result = mock_chain
+        .build_tx_context(faucet_b.id(), &[], &[mint_note])?
+        .build()?
+        .execute()
+        .await;
+
+    assert_transaction_executor_error!(result, ERR_MINT_WRONG_FAUCET);
+
+    Ok(())
+}
+
+/// Sanity test: a MINT note must remain consumable by its intended faucet after the binding
+/// is in place (private output variant).
+#[tokio::test]
+async fn mint_note_consumed_by_intended_faucet_still_succeeds_private() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let owner = AccountId::dummy([3; 15], AccountIdVersion::Version1, AccountType::Private);
+    let faucet = builder.add_existing_network_faucet(
+        "OKK",
+        1000,
+        owner,
+        Some(0),
+        MintPolicyConfig::AllowAll,
+        [],
+    )?;
+    let recipient_account = builder.add_existing_wallet(Auth::IncrNonce)?;
+
+    let amount = Felt::new_unchecked(50);
+    let mint_asset: Asset = FungibleAsset::new(faucet.id(), amount.as_canonical_u64())?.into();
+    let output_note_tag = NoteTag::with_account_target(recipient_account.id());
+
+    let p2id_note = create_p2id_note_exact(
+        faucet.id(),
+        recipient_account.id(),
+        vec![mint_asset],
+        NoteType::Private,
+        Word::default(),
+    )?;
+    let mint_recipient = p2id_note.recipient().digest();
+    let mint_storage = MintNoteStorage::new_private(mint_recipient, amount, output_note_tag.into());
+
+    let mut rng = RandomCoin::new([Felt::from(9u32); 4].into());
+    let mint_note =
+        MintNote::create(faucet.id(), owner, mint_storage, NoteAttachments::default(), &mut rng)?;
+
+    let mock_chain = builder.build()?;
+
+    let executed = mock_chain
+        .build_tx_context(faucet.id(), &[], &[mint_note])?
         .build()?
         .execute()
         .await?;


### PR DESCRIPTION
Closes the issue: https://github.com/0xMiden/protocol/issues/2965