### PR TITLE
refactor(agglayer): promote GER_KNOWN_FLAG to a const word

### DIFF
--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -26,7 +26,7 @@ const TOKEN_REGISTRY_MAP_SLOT = word("agglayer::bridge::token_registry_map")
 const FAUCET_METADATA_MAP_SLOT = word("agglayer::bridge::faucet_metadata_map")
 
 # Flags
-const GER_KNOWN_FLAG = 1
+const GER_KNOWN_FLAG = [1, 0, 0, 0]
 const FAUCET_REGISTERED_FLAG = 1
 
 # Offset in the local memory of the `hash_token_address` procedure
@@ -53,7 +53,7 @@ const FAUCET_METADATA_SUBKEY_HASH_HI = 3  # METADATA_HASH_HI[4]
 #! Updates the Global Exit Root (GER) in the bridge account storage.
 #!
 #! Computes hash(GER) = poseidon2::merge(GER_LOWER, GER_UPPER) and stores it in a map with value
-#! [GER_KNOWN_FLAG, 0, 0, 0] to indicate the GER is known.
+#! GER_KNOWN_FLAG to indicate the GER is known.
 #!
 #! Inputs: [GER_LOWER[4], GER_UPPER[4], pad(8)]
 #! Outputs: [pad(16)]
@@ -71,9 +71,9 @@ pub proc update_ger
     exec.poseidon2::merge
     # => [GER_HASH, pad(12)]
 
-    # prepare VALUE = [GER_KNOWN_FLAG, 0, 0, 0]
-    push.0.0.0.GER_KNOWN_FLAG
-    # => [GER_KNOWN_FLAG, 0, 0, 0, GER_HASH, pad(12)]
+    # prepare VALUE = GER_KNOWN_FLAG
+    push.GER_KNOWN_FLAG
+    # => [GER_KNOWN_FLAG, GER_HASH, pad(12)]
 
     swapw
     # => [GER_HASH, VALUE, pad(12)]
@@ -111,9 +111,9 @@ pub proc assert_valid_ger
     exec.active_account::get_map_item
     # => [VALUE]
 
-    # assert the GER is known in storage (VALUE = [GER_KNOWN_FLAG, 0, 0, 0])
-    push.0.0.0.GER_KNOWN_FLAG
-    # => [GER_KNOWN_FLAG, 0, 0, 0, VALUE]
+    # assert the GER is known in storage (VALUE = GER_KNOWN_FLAG)
+    push.GER_KNOWN_FLAG
+    # => [GER_KNOWN_FLAG, VALUE]
 
     assert_eqw.err=ERR_GER_NOT_FOUND
     # => []


### PR DESCRIPTION
Promote `GER_KNOWN_FLAG` from a single-felt constant (`= 1`) to a full Word constant (`= [1, 0, 0, 0]`)