### PR TITLE
fix: add missing transaction reference block commitment check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Fixed `TokenPolicyManager::manager_storage_slots` to register the protocol-reserved asset-callback storage slots whenever any transfer policy is configured (including `TransferAllowAll`), so every minted asset carries `AssetCallbackFlag::Enabled` and future `set_send_policy` / `set_receive_policy` switches apply uniformly to the entire circulating supply ([#2946](https://github.com/0xMiden/protocol/pull/2946)).
 - [BREAKING] Keyed the AggLayer faucet token registry by `(origin_token_address, origin_network)` instead of `origin_token_address` alone, preventing same-address cross-network mint collisions on CLAIM ([#2860](https://github.com/0xMiden/protocol/pull/2860)).
 - Fixed `set_procedure_threshold` in the multisig auth component validating per-procedure overrides against initial `num_approvers`.
+- [BREAKING] Added missing transaction `ref_block_commitment` validation in `ProposedBatch::new` ([#2971](https://github.com/0xMiden/protocol/pull/2971)).
 
 ## 0.14.6 (2026-05-09)
 

--- a/crates/miden-protocol/src/batch/proposed_batch.rs
+++ b/crates/miden-protocol/src/batch/proposed_batch.rs
@@ -165,30 +165,53 @@ impl ProposedBatch {
         //
         // Note that some block X is only added to the blockchain by block X + 1. This
         // is because block X cannot compute its own block commitment and thus cannot add
-        // itself to the chain. So, more generally, a previous block is added to the
-        // blockchain by its child block.
+        // itself to the chain. So, more generally, a block is added to the blockchain by its child
+        // block.
         //
         // The reference block of a batch may be the latest block in the chain and, as mentioned,
-        // block is not yet part of the blockchain, so its inclusion cannot be proven.
-        // Since the inclusion cannot be proven in all cases, the batch kernel instead
-        // commits to this reference block's commitment as a public input, which means the
-        // block kernel will prove this block's inclusion when including this batch and
-        // verifying its ZK proof.
+        // the block is not yet part of the blockchain, so its inclusion cannot be proven.
+        // Since the inclusion cannot be proven, the batch kernel instead commits to this reference
+        // block's commitment as a public input, which means the block kernel will prove
+        // this block's inclusion when including this batch and verifying its ZK proof.
         //
         // Finally, note that we don't verify anything cryptographically here. We have previously
-        // verified that the batch reference block's chain commitment matches the hashed peaks of
-        // the `PartialBlockchain`, and so we only have to check if the partial blockchain contains
-        // the block here.
+        // verified that the chain commitment of the batch's reference block matches the hashed
+        // peaks of the `PartialBlockchain`. This means the provided blockchain is consistent with
+        // the batch's reference block and that all blocks contained in the blockchain are
+        // consistent, too. So, as long as each transaction's reference block (number and
+        // commitment) is contained in the partial blockchain, we know the transaction's
+        // block header is consistent with the batch's reference block, too.
         // --------------------------------------------------------------------------------------------
 
         for tx in transactions.iter() {
-            if reference_block_header.block_num() != tx.ref_block_num()
-                && !partial_blockchain.contains_block(tx.ref_block_num())
-            {
-                return Err(ProposedBatchError::MissingTransactionBlockReference {
-                    block_reference: tx.ref_block_commitment(),
-                    transaction_id: tx.id(),
-                });
+            // Differentiate between validation against the batch's reference block or a block from
+            // the chain (see above).
+            if reference_block_header.block_num() == tx.ref_block_num() {
+                if reference_block_header.commitment() != tx.ref_block_commitment() {
+                    return Err(ProposedBatchError::TransactionReferenceBlockCommitmentMismatch {
+                        transaction_id: tx.id(),
+                        block_num: tx.ref_block_num(),
+                        actual_block_commitment: tx.ref_block_commitment(),
+                        expected_block_commitment: reference_block_header.commitment(),
+                    });
+                }
+            } else {
+                let block_header =
+                    partial_blockchain.get_block(tx.ref_block_num()).ok_or_else(|| {
+                        ProposedBatchError::MissingTransactionReferenceBlock {
+                            transaction_id: tx.id(),
+                            block_num: tx.ref_block_num(),
+                        }
+                    })?;
+
+                if block_header.commitment() != tx.ref_block_commitment() {
+                    return Err(ProposedBatchError::TransactionReferenceBlockCommitmentMismatch {
+                        transaction_id: tx.id(),
+                        block_num: tx.ref_block_num(),
+                        actual_block_commitment: tx.ref_block_commitment(),
+                        expected_block_commitment: block_header.commitment(),
+                    });
+                }
             }
         }
 

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -1050,11 +1050,21 @@ pub enum ProposedBatchError {
     InconsistentChainRoot { expected: Word, actual: Word },
 
     #[error(
-        "block {block_reference} referenced by transaction {transaction_id} is not in the partial blockchain"
+        "block {block_num} referenced by transaction {transaction_id} is not in the partial blockchain"
     )]
-    MissingTransactionBlockReference {
-        block_reference: Word,
+    MissingTransactionReferenceBlock {
         transaction_id: TransactionId,
+        block_num: BlockNumber,
+    },
+
+    #[error(
+        "transaction {transaction_id} references block {block_num} with commitment {actual_block_commitment}, but the block in the chain with the same number has commitment {expected_block_commitment}"
+    )]
+    TransactionReferenceBlockCommitmentMismatch {
+        transaction_id: TransactionId,
+        block_num: BlockNumber,
+        expected_block_commitment: Word,
+        actual_block_commitment: Word,
     },
 }
 

--- a/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
@@ -104,12 +104,12 @@ fn note_created_and_consumed_in_same_batch() -> anyhow::Result<()> {
     let note = mock_note(40);
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .output_notes(vec![RawOutputNote::Full(note.clone()).into_output_note().unwrap()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![note.clone()])
             .build()?;
 
@@ -154,12 +154,12 @@ fn same_details_different_metadata_not_erased_from_batch() -> anyhow::Result<()>
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .output_notes(vec![output_note_proven.clone()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![input_note.clone()])
             .build()?;
 
@@ -211,7 +211,7 @@ fn two_p2id_inputs_same_details_different_metadata_in_same_batch() -> anyhow::Re
 
     let tx =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .authenticated_notes(vec![note_300.clone(), note_301.clone()])
             .build()?;
 
@@ -237,12 +237,12 @@ fn duplicate_unauthenticated_input_notes() -> anyhow::Result<()> {
     let note = mock_note(50);
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![note.clone()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![note.clone()])
             .build()?;
 
@@ -276,12 +276,12 @@ fn duplicate_authenticated_input_notes() -> anyhow::Result<()> {
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .authenticated_notes(vec![note1.clone()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .authenticated_notes(vec![note1.clone()])
             .build()?;
 
@@ -315,12 +315,12 @@ fn duplicate_mixed_input_notes() -> anyhow::Result<()> {
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![note1.clone()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .authenticated_notes(vec![note1.clone()])
             .build()?;
 
@@ -354,12 +354,12 @@ fn duplicate_output_notes() -> anyhow::Result<()> {
     let note0 = mock_output_note(50);
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .output_notes(vec![note0.clone()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .output_notes(vec![note0.clone()])
             .build()?;
 
@@ -426,7 +426,7 @@ async fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()>
     // Consume the authenticated note as an unauthenticated one in the transaction.
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block2.header().commitment())
+            .reference_block(block2.header())
             .unauthenticated_notes(vec![note2.clone()])
             .build()?;
 
@@ -535,12 +535,12 @@ fn authenticated_note_created_in_same_batch() -> anyhow::Result<()> {
     let note0 = mock_note(50);
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .output_notes(vec![RawOutputNote::Full(note0.clone()).into_output_note().unwrap()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .authenticated_notes(vec![note1.clone()])
             .build()?;
 
@@ -572,7 +572,7 @@ fn multiple_transactions_against_same_account() -> anyhow::Result<()> {
         initial_state_commitment,
         account1.to_commitment(),
     )
-    .ref_block_commitment(block1.commitment())
+    .reference_block(&block1)
     .output_notes(vec![mock_output_note(0)])
     .build()?;
 
@@ -583,7 +583,7 @@ fn multiple_transactions_against_same_account() -> anyhow::Result<()> {
         account1.to_commitment(),
         final_state_commitment,
     )
-    .ref_block_commitment(block1.commitment())
+    .reference_block(&block1)
     .build()?;
 
     // Success: Transactions are correctly ordered.
@@ -651,13 +651,13 @@ fn input_and_output_notes_commitment() -> anyhow::Result<()> {
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![note1.clone(), note5.clone()])
             .output_notes(vec![note0.clone()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![note4.clone(), note6.clone()])
             .output_notes(vec![
                 RawOutputNote::Full(note1.clone()).into_output_note().unwrap(),
@@ -705,14 +705,14 @@ fn batch_expiration() -> anyhow::Result<()> {
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .expiration_block_num(BlockNumber::from(35))
             .build()?;
     // This transaction has the smallest valid expiration block num that allows it to still be
     // included in the batch.
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .expiration_block_num(block1.block_num() + 1)
             .build()?;
 
@@ -736,7 +736,7 @@ fn duplicate_transaction() -> anyhow::Result<()> {
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .expiration_block_num(BlockNumber::from(35))
             .build()?;
 
@@ -766,13 +766,13 @@ fn circular_note_dependency() -> anyhow::Result<()> {
 
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![note_x.clone()])
             .output_notes(vec![RawOutputNote::Full(note_y.clone()).into_output_note().unwrap()])
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .unauthenticated_notes(vec![note_y.clone()])
             .output_notes(vec![RawOutputNote::Full(note_x.clone()).into_output_note().unwrap()])
             .build()?;
@@ -799,12 +799,12 @@ fn expired_transaction() -> anyhow::Result<()> {
     // This transaction expired at the batch's reference block.
     let tx1 =
         MockProvenTxBuilder::with_account(account1.id(), Word::empty(), account1.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .expiration_block_num(block1.block_num())
             .build()?;
     let tx2 =
         MockProvenTxBuilder::with_account(account2.id(), Word::empty(), account2.to_commitment())
-            .ref_block_commitment(block1.commitment())
+            .reference_block(&block1)
             .expiration_block_num(block1.block_num() + 3)
             .build()?;
 
@@ -847,7 +847,7 @@ fn noop_tx_before_state_updating_tx_against_same_account() -> anyhow::Result<()>
         account1.to_commitment(),
         account1.to_commitment(),
     )
-    .ref_block_commitment(block1.commitment())
+    .reference_block(&block1)
     .authenticated_notes(vec![note1])
     .output_notes(vec![RawOutputNote::Full(note.clone()).into_output_note().unwrap()])
     .build()?;
@@ -863,7 +863,7 @@ fn noop_tx_before_state_updating_tx_against_same_account() -> anyhow::Result<()>
         account1.to_commitment(),
         random_final_state_commitment,
     )
-    .ref_block_commitment(block1.commitment())
+    .reference_block(&block1)
     .unauthenticated_notes(vec![note.clone()])
     .build()?;
 
@@ -877,6 +877,116 @@ fn noop_tx_before_state_updating_tx_against_same_account() -> anyhow::Result<()>
     let update = batch.account_updates().get(&account1.id()).unwrap();
     assert_eq!(update.initial_state_commitment(), account1.to_commitment());
     assert_eq!(update.final_state_commitment(), random_final_state_commitment);
+
+    Ok(())
+}
+
+/// Tests that a transaction with a ref_block_commitment that does not match the commitment of the
+/// block at the declared ref_block_num in the partial blockchain is rejected.
+///
+/// The test uses two independent MockChain instances so that the same block 1 has different block
+/// commitments on each chain. A transaction built against chain_a's block 1 is then included in a
+/// batch whose partial blockchain comes from chain_b, which has a different commitment for block 1.
+#[test]
+fn mismatched_ref_block_commitment_rejected() -> anyhow::Result<()> {
+    let account_builder = Account::builder([42; 32])
+        .account_type(AccountType::Private)
+        .with_component(MockAccountComponent::with_empty_slots());
+
+    // Build chain_a with the account.
+    let mut builder1 = MockChain::builder();
+    let account_a = builder1.add_account_from_builder(
+        Auth::IncrNonce,
+        account_builder.clone(),
+        AccountState::Exists,
+    )?;
+    let mut chain_a = builder1.build()?;
+    let chain_a_block1 = chain_a.prove_next_block()?;
+
+    // Build chain_b with the exact same account.
+    let mut builder2 = MockChain::builder();
+    let account_b = builder2.add_account_from_builder(
+        Auth::IncrNonce,
+        account_builder,
+        AccountState::Exists,
+    )?;
+    let mut chain_b = builder2.build()?;
+    let chain_b_block1 = chain_b.prove_next_block()?;
+    let chain_b_block2 = chain_b.prove_next_block()?;
+
+    // Sanity checks: same account, different block commitments at block 1.
+    assert_eq!(
+        account_a.to_commitment(),
+        account_b.to_commitment(),
+        "accounts should have the same commitment"
+    );
+    assert_ne!(
+        chain_a_block1.header().commitment(),
+        chain_b_block1.header().commitment(),
+        "block 1 should have different commitments on the two chains"
+    );
+
+    // Build a transaction that references chain_a's block 1. This means the transaction was
+    // executed against a chain state that is incompatible with chain_b.
+    let tx =
+        MockProvenTxBuilder::with_account(account_a.id(), Word::empty(), account_a.to_commitment())
+            .reference_block(chain_a_block1.header())
+            .build()?;
+
+    // chain_b's partial blockchain contains block 1, but with chain_b's commitment - not chain_a's.
+    // ProposedBatch::new should reject this transaction because its ref_block_commitment doesn't
+    // match the commitment of block 1 in the partial blockchain.
+    let result = ProposedBatch::new(
+        vec![Arc::new(tx.clone())],
+        chain_b_block2.header().clone(),
+        chain_b.latest_partial_blockchain(),
+        BTreeMap::default(),
+    )
+    .unwrap_err();
+
+    assert_matches!(
+        result,
+        ProposedBatchError::TransactionReferenceBlockCommitmentMismatch {
+              transaction_id, block_num, expected_block_commitment, actual_block_commitment
+          } => {
+            assert_eq!(transaction_id, tx.id());
+            assert_eq!(block_num, tx.ref_block_num());
+            assert_eq!(actual_block_commitment, tx.ref_block_commitment());
+            assert_eq!(expected_block_commitment, chain_b_block1.header().commitment());
+        }
+    );
+
+    // Make sure the same error occurs when the block referenced by the transaction is the same as
+    // the batch reference block.
+    let (ref_block, partial_blockchain) = chain_b.selective_partial_blockchain(
+        chain_b_block1.header().block_num(),
+        [BlockNumber::GENESIS],
+    )?;
+    assert_eq!(
+        ref_block.block_num(),
+        tx.ref_block_num(),
+        "tx and batch ref block num should match"
+    );
+
+    let result = ProposedBatch::new(
+        vec![Arc::new(tx.clone())],
+        ref_block.clone(),
+        partial_blockchain,
+        BTreeMap::default(),
+    )
+    .unwrap_err();
+
+    assert_matches!(
+        result,
+        ProposedBatchError::TransactionReferenceBlockCommitmentMismatch {
+            transaction_id, block_num, expected_block_commitment, actual_block_commitment
+          } => {
+            assert_eq!(transaction_id, tx.id());
+            assert_eq!(block_num, tx.ref_block_num());
+            assert_eq!(actual_block_commitment, tx.ref_block_commitment());
+            assert_eq!(expected_block_commitment, ref_block.commitment());
+        }
+    );
 
     Ok(())
 }
@@ -898,7 +1008,7 @@ fn noop_tx_after_state_updating_tx_against_same_account() -> anyhow::Result<()> 
         account1.to_commitment(),
         random_final_state_commitment,
     )
-    .ref_block_commitment(block1.commitment())
+    .reference_block(&block1)
     .unauthenticated_notes(vec![note.clone()])
     .build()?;
 
@@ -908,7 +1018,7 @@ fn noop_tx_after_state_updating_tx_against_same_account() -> anyhow::Result<()> 
         random_final_state_commitment,
         random_final_state_commitment,
     )
-    .ref_block_commitment(block1.commitment())
+    .reference_block(&block1)
     .authenticated_notes(vec![note1])
     .output_notes(vec![RawOutputNote::Full(note.clone()).into_output_note().unwrap()])
     .build()?;

--- a/crates/miden-testing/src/kernel_tests/batch/proven_tx_builder.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/proven_tx_builder.rs
@@ -5,7 +5,7 @@ use miden_protocol::Word;
 use miden_protocol::account::AccountId;
 use miden_protocol::account::delta::AccountUpdateDetails;
 use miden_protocol::asset::FungibleAsset;
-use miden_protocol::block::BlockNumber;
+use miden_protocol::block::{BlockHeader, BlockNumber};
 use miden_protocol::crypto::merkle::SparseMerklePath;
 use miden_protocol::note::{Note, NoteInclusionProof, Nullifier};
 use miden_protocol::transaction::{
@@ -22,7 +22,7 @@ pub struct MockProvenTxBuilder {
     account_id: AccountId,
     initial_account_commitment: Word,
     final_account_commitment: Word,
-    ref_block_commitment: Option<Word>,
+    reference_block: Option<(BlockNumber, Word)>,
     fee: FungibleAsset,
     expiration_block_num: BlockNumber,
     output_notes: Option<Vec<OutputNote>>,
@@ -42,7 +42,7 @@ impl MockProvenTxBuilder {
             account_id,
             initial_account_commitment,
             final_account_commitment,
-            ref_block_commitment: None,
+            reference_block: None,
             fee: FungibleAsset::mock(50).unwrap_fungible(),
             expiration_block_num: BlockNumber::from(u32::MAX),
             output_notes: None,
@@ -96,8 +96,8 @@ impl MockProvenTxBuilder {
 
     /// Sets the transaction's block reference.
     #[must_use]
-    pub fn ref_block_commitment(mut self, ref_block_commitment: Word) -> Self {
-        self.ref_block_commitment = Some(ref_block_commitment);
+    pub fn reference_block(mut self, ref_block: &BlockHeader) -> Self {
+        self.reference_block = Some((ref_block.block_num(), ref_block.commitment()));
 
         self
     }
@@ -124,12 +124,15 @@ impl MockProvenTxBuilder {
         )
         .context("failed to build account update")?;
 
+        let (ref_block_num, ref_block_commitment) =
+            self.reference_block.unwrap_or((BlockNumber::GENESIS, Word::empty()));
+
         ProvenTransaction::new(
             account_update,
             input_note_commitments,
             self.output_notes.unwrap_or_default(),
-            BlockNumber::from(0),
-            self.ref_block_commitment.unwrap_or_default(),
+            ref_block_num,
+            ref_block_commitment,
             self.fee,
             self.expiration_block_num,
             ExecutionProof::new_dummy(),


### PR DESCRIPTION
## Summary

- Newly added test `mismatched_ref_block_commitment_rejected` failed on current `next`. No longer does now.
- `ProposedBatch::new` previously only checked that a transaction's `ref_block_num` *existed* in the `PartialBlockchain` (via `contains_block`), without verifying that the transaction's `ref_block_commitment` matched the actual block header's `commitment()` at that number. A transaction referencing block N from a different chain (with a different commitment) would be silently accepted as long as block N was present.
- The fix retrieves the full `BlockHeader` via `get_block()` and compares commitments, returning a new `TransactionReferenceBlockCommitmentMismatch` error on mismatch. Both code paths are covered: when the transaction references the batch's own reference block, and when it references a historical block in the partial blockchain.
- I also tried to improve the docs above that check, which it took me a while to understand. Let me know if it is clearer or worse.