### PR TITLE
fix(ci): harden changelog validation script

### DIFF
--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-set -uo pipefail
+set -euo pipefail
 
 CHANGELOG_FILE="CHANGELOG.md"
 
-if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
+if [ "${NO_CHANGELOG_LABEL:-false}" = "true" ]; then
     # 'no changelog' set, so finish successfully
     echo "\"no changelog\" label has been set"
     exit 0


### PR DESCRIPTION
This patch improves the reliability of the changelog validation script by enabling errexit (set -euo pipefail) and safely handling unset NO_CHANGELOG_LABEL variables, preventing silent CI failures and `unbound variable` errors in environments where the label is not defined.
