### PR TITLE
feat(agglayer): reject duplicate GER insertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.16.0 (TBD)
 
+### Fixes
+- Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).
+
 ## v0.15.0 (2026-05-22)
 
 ### Features

--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -113,18 +113,23 @@ on Miden. The bridge consumes these notes:
 1. Asserts the note sender is the designated GER manager.
 2. Computes `KEY = poseidon2::merge(GER_LOWER, GER_UPPER)`.
 3. Stores `KEY -> [1, 0, 0, 0]` in the `ger_map`, marking the GER as known.
+4. Reverts if the GER was already present in the map (duplicate insertions are rejected).
 
 Subsequent CLAIM notes reference a GER that must be present in this map for the claim
 to be valid.
+
+> **Note on Solidity divergence:** The Solidity `GlobalExitRootManager` contract treats a
+> duplicate GER insertion as an idempotent no-op. Miden intentionally diverges: a duplicate
+> `UPDATE_GER` note causes the consuming transaction to revert. Because `UPDATE_GER` is a
+> network note (consumed by the note nullifier mechanism), a duplicate would become
+> permanently unconsumable rather than silently accepted. Rejecting duplicates makes the
+> failure explicit and prevents the GER manager from accidentally creating unconsumed notes.
 
 TODO: GERs cannot be removed once inserted
 ([#2702](https://github.com/0xMiden/protocol/issues/2702)).
 
 TODO: No hash chain tracks GER insertions for proof generation
 ([#2707](https://github.com/0xMiden/protocol/issues/2707)).
-
-TODO: Duplicate GER insertions are silently accepted
-([#2708](https://github.com/0xMiden/protocol/issues/2708)).
 
 ### 2.4 Faucet Registration
 
@@ -237,12 +242,14 @@ Asserts the note sender matches the bridge admin stored in
 | **Inputs** | `[GER_LOWER(4), GER_UPPER(4), pad(8)]` |
 | **Outputs** | `[pad(16)]` |
 | **Context** | Consuming an `UPDATE_GER` note on the bridge account |
-| **Panics** | Note sender is not the GER manager |
+| **Panics** | Note sender is not the GER manager; GER has already been registered in storage |
 
 Asserts the note sender matches the GER manager stored in
 `agglayer::bridge::ger_manager_account_id`, then computes
 `KEY = poseidon2::merge(GER_LOWER, GER_UPPER)` and stores
 `KEY -> [1, 0, 0, 0]` in the `ger_map` map slot. This marks the GER as "known".
+Duplicate insertions (same GER value) are explicitly rejected: if the key already exists
+in the map the procedure panics with `ERR_GER_ALREADY_REGISTERED`.
 
 #### `bridge_in::claim`
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -1,4 +1,5 @@
 use miden::core::crypto::hashes::poseidon2
+use miden::core::word
 use miden::protocol::account_id
 use miden::protocol::active_account
 use miden::protocol::active_note
@@ -87,7 +88,7 @@ pub proc update_ger
     # => [OLD_VALUE, pad(12)]
 
     # assert OLD_VALUE is EMPTY_WORD, i.e. the GER was not previously registered
-    padw assert_eqw.err=ERR_GER_ALREADY_REGISTERED
+    exec.word::eqz assert.err=ERR_GER_ALREADY_REGISTERED
     # => [pad(16)]
 end
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -87,10 +87,7 @@ pub proc update_ger
     # => [OLD_VALUE, pad(12)]
 
     # assert OLD_VALUE is EMPTY_WORD, i.e. the GER was not previously registered
-    padw
-    # => [ZERO_WORD, OLD_VALUE, pad(12)]
-
-    assert_eqw.err=ERR_GER_ALREADY_REGISTERED
+    padw assert_eqw.err=ERR_GER_ALREADY_REGISTERED
     # => [pad(16)]
 end
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -9,6 +9,7 @@ use agglayer::common::utils
 # =================================================================================================
 
 const ERR_GER_NOT_FOUND = "GER not found in storage"
+const ERR_GER_ALREADY_REGISTERED = "GER is already registered in storage"
 const ERR_FAUCET_NOT_REGISTERED = "faucet is not registered in the bridge's faucet registry"
 const ERR_TOKEN_NOT_REGISTERED = "(origin token address, origin network) pair is not registered in the bridge's token registry"
 const ERR_SENDER_NOT_BRIDGE_ADMIN = "note sender is not the bridge admin"
@@ -60,6 +61,7 @@ const FAUCET_METADATA_SUBKEY_HASH_HI = 3  # METADATA_HASH_HI[4]
 #!
 #! Panics if:
 #! - the note sender is not the global exit root manager.
+#! - the GER has already been registered in storage.
 #!
 #! Invocation: call
 pub proc update_ger
@@ -83,8 +85,12 @@ pub proc update_ger
 
     exec.native_account::set_map_item
     # => [OLD_VALUE, pad(12)]
-    
-    dropw
+
+    # assert OLD_VALUE is EMPTY_WORD, i.e. the GER was not previously registered
+    padw
+    # => [ZERO_WORD, OLD_VALUE, pad(12)]
+
+    assert_eqw.err=ERR_GER_ALREADY_REGISTERED
     # => [pad(16)]
 end
 

--- a/crates/miden-agglayer/asm/note_scripts/update_ger.masm
+++ b/crates/miden-agglayer/asm/note_scripts/update_ger.masm
@@ -39,6 +39,7 @@ const ERR_UPDATE_GER_TARGET_ACCOUNT_MISMATCH = "UPDATE_GER note attachment targe
 #! - account does not expose update_ger procedure.
 #! - target account ID does not match the consuming account ID.
 #! - number of note storage items is not exactly 8.
+#! - the GER has already been registered in storage.
 @note_script
 pub proc main
     dropw

--- a/crates/miden-testing/tests/agglayer/update_ger.rs
+++ b/crates/miden-testing/tests/agglayer/update_ger.rs
@@ -4,6 +4,7 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+use miden_agglayer::errors::ERR_GER_ALREADY_REGISTERED;
 use miden_agglayer::{
     AggLayerBridge,
     ExitRoot,
@@ -262,6 +263,71 @@ async fn test_compute_ger_basic() -> anyhow::Result<()> {
     let result_digest: Vec<Felt> = exec_output.stack[0..8].to_vec();
 
     assert_eq!(result_digest, expected_ger_felts);
+
+    Ok(())
+}
+
+/// Tests that consuming a second UPDATE_GER note with the same GER is rejected.
+#[tokio::test]
+async fn update_ger_rejects_duplicate() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    // CREATE BRIDGE ADMIN ACCOUNT
+    let bridge_admin = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    // CREATE GER MANAGER ACCOUNT
+    let ger_manager = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+
+    // CREATE BRIDGE ACCOUNT
+    let bridge_seed = builder.rng_mut().draw_word();
+    let bridge_account =
+        create_existing_bridge_account(bridge_seed, bridge_admin.id(), ger_manager.id());
+    builder.add_account(bridge_account.clone())?;
+
+    let ger_bytes: [u8; 32] = [
+        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+        0x77, 0x88,
+    ];
+    let ger = ExitRoot::from(ger_bytes);
+
+    // CREATE TWO UPDATE_GER NOTES WITH THE SAME GER
+    let update_ger_note_1 =
+        UpdateGerNote::create(ger, ger_manager.id(), bridge_account.id(), builder.rng_mut())?;
+    builder.add_output_note(RawOutputNote::Full(update_ger_note_1.clone()));
+
+    let update_ger_note_2 =
+        UpdateGerNote::create(ger, ger_manager.id(), bridge_account.id(), builder.rng_mut())?;
+    builder.add_output_note(RawOutputNote::Full(update_ger_note_2.clone()));
+
+    let mut mock_chain = builder.build()?;
+
+    // TX1: Consume first UPDATE_GER note (should succeed)
+    let tx_context_1 = mock_chain
+        .build_tx_context(bridge_account.id(), &[update_ger_note_1.id()], &[])?
+        .build()?;
+    let executed_tx_1 = tx_context_1.execute().await?;
+    mock_chain.add_pending_executed_transaction(&executed_tx_1)?;
+    mock_chain.prove_next_block()?;
+
+    // TX2: Consume second UPDATE_GER note with same GER (should fail)
+    let result = mock_chain
+        .build_tx_context(bridge_account.id(), &[], &[update_ger_note_2])?
+        .build()?
+        .execute()
+        .await;
+
+    assert!(result.is_err(), "Second UPDATE_GER note with duplicate GER should fail");
+    let error_msg = result.unwrap_err().to_string();
+    let expected_err_code = ERR_GER_ALREADY_REGISTERED.code().to_string();
+    assert!(
+        error_msg.contains(&expected_err_code),
+        "expected error code {expected_err_code} for 'GER already registered', got: {error_msg}"
+    );
 
     Ok(())
 }

--- a/crates/miden-testing/tests/agglayer/update_ger.rs
+++ b/crates/miden-testing/tests/agglayer/update_ger.rs
@@ -21,7 +21,7 @@ use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::utils::sync::LazyLock;
-use miden_testing::{Auth, MockChain};
+use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
 use miden_tx::utils::hex_to_bytes;
 use serde::Deserialize;
 
@@ -321,13 +321,7 @@ async fn update_ger_rejects_duplicate() -> anyhow::Result<()> {
         .execute()
         .await;
 
-    assert!(result.is_err(), "Second UPDATE_GER note with duplicate GER should fail");
-    let error_msg = result.unwrap_err().to_string();
-    let expected_err_code = ERR_GER_ALREADY_REGISTERED.code().to_string();
-    assert!(
-        error_msg.contains(&expected_err_code),
-        "expected error code {expected_err_code} for 'GER already registered', got: {error_msg}"
-    );
+    assert_transaction_executor_error!(result, ERR_GER_ALREADY_REGISTERED);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #2708.

Adds a duplicate-detection guard to `bridge_config::update_ger`. After calling `set_map_item`, the `OLD_VALUE` returned by the map write is compared against `EMPTY_WORD`; if it is not empty the GER was already registered and the transaction reverts with `ERR_GER_ALREADY_REGISTERED`.

## Why reject instead of silently overwriting?

The Solidity `GlobalExitRootManager` treats a duplicate GER insertion as an idempotent no-op (`if (globalExitRootMap[ger] == 0) { ... }`). On Miden we intentionally diverge:

`UPDATE_GER` is a network note, consumed via the nullifier mechanism. If the bridge silently accepted a duplicate, the note would still consume its nullifier and become permanently unconsumable, but the GER manager would have no signal that anything went wrong. Reverting makes the failure explicit at submission time and prevents accidental orphaned notes.

This divergence is now documented in `SPEC.md` Section 2.3.

## Changes

- `crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm`
  - New error constant `ERR_GER_ALREADY_REGISTERED`.
  - After `set_map_item`, push `padw` and `assert_eqw.err=ERR_GER_ALREADY_REGISTERED` to verify the previous map value was empty. Net stack delta is unchanged from the previous `dropw`.
  - Doc comment on `update_ger` updated with the new panic condition.
- `crates/miden-agglayer/asm/note_scripts/update_ger.masm`
  - Doc comment on `main` updated with the new panic condition (`update_ger` is invoked via `call` from the note script).
- `crates/miden-agglayer/SPEC.md`
  - Section 2.3 (GER Injection) now lists the duplicate-rejection behavior and explains the Solidity divergence.
  - `bridge_config::update_ger` reference table updated with the new panic row.
  - Stale TODO referencing #2708 removed.
- `crates/miden-testing/tests/agglayer/update_ger.rs`
  - New `update_ger_rejects_duplicate` integration test: consumes two `UPDATE_GER` notes carrying the same GER value across two blocks and asserts the second fails with `ERR_GER_ALREADY_REGISTERED.code()`.

## Testing

`cargo test -p miden-testing update_ger -- --nocapture` passes locally, including the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)