### PR TITLE
feat(standards): P2ID/P2IDE notes must carry at least one asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.16.0 (TBD)
 
+### Changes
+
+- [BREAKING] P2ID and P2IDE notes must carry at least one asset. Enforced in `P2idNote::create` / `P2ideNote::create` (new `NoteError::MissingAsset`) and in the `basic_wallet::add_assets_to_account` MASM helper.
+
 ## v0.15.0 (2026-05-22)
 
 ### Features

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -700,6 +700,8 @@ pub enum NoteError {
     NoteAttachmentSchemeExceeded(u32),
     #[error("attachment scheme value 0 is reserved")]
     NoteAttachmentSchemeZeroReserved,
+    #[error("note must contain at least one asset")]
+    MissingAsset,
     #[error("{error_msg}")]
     Other {
         error_msg: Box<str>,

--- a/crates/miden-standards/asm/standards/wallets/basic.masm
+++ b/crates/miden-standards/asm/standards/wallets/basic.masm
@@ -4,6 +4,11 @@ use miden::protocol::native_account
 use miden::protocol::output_note
 use miden::protocol::active_note
 
+# ERRORS
+# =================================================================================================
+
+const ERR_BASIC_WALLET_EMPTY_NOTE_ASSETS="active note must contain at least one asset"
+
 # CONSTANTS
 # =================================================================================================
 
@@ -75,6 +80,10 @@ pub proc add_assets_to_account
     # we have allocated ASSET_SIZE * MAX_ASSETS_PER_NOTE number of locals so all assets should fit
     # since the asset memory will be overwritten, we don't have to initialize the locals to zero
     locaddr.0 exec.active_note::get_assets
+    # => [num_of_assets]
+
+    # ensure the note carries at least one asset
+    dup neq.0 assert.err=ERR_BASIC_WALLET_EMPTY_NOTE_ASSETS
     # => [num_of_assets]
 
     # compute the pointer at which we should stop iterating

--- a/crates/miden-standards/src/note/p2id.rs
+++ b/crates/miden-standards/src/note/p2id.rs
@@ -73,7 +73,8 @@ impl P2idNote {
     /// tag is set to the target's account ID.
     ///
     /// # Errors
-    /// Returns an error if deserialization or compilation of the `P2ID` script fails.
+    /// - Returns [`NoteError::MissingAsset`] if `assets` is empty.
+    /// - Returns an error if deserialization or compilation of the `P2ID` script fails.
     pub fn create<R: FeltRng>(
         sender: AccountId,
         target: AccountId,
@@ -82,6 +83,10 @@ impl P2idNote {
         attachments: NoteAttachments,
         rng: &mut R,
     ) -> Result<Note, NoteError> {
+        if assets.is_empty() {
+            return Err(NoteError::MissingAsset);
+        }
+
         let serial_num = rng.draw_word();
         let recipient = P2idNoteStorage::new(target).into_recipient(serial_num);
 
@@ -164,6 +169,7 @@ impl TryFrom<&[Felt]> for P2idNoteStorage {
 mod tests {
     use miden_protocol::Felt;
     use miden_protocol::account::{AccountId, AccountIdVersion, AccountType};
+    use miden_protocol::crypto::rand::RandomCoin;
     use miden_protocol::errors::NoteError;
 
     use super::*;
@@ -204,5 +210,24 @@ mod tests {
             .expect_err("should fail due to invalid account id encoding");
 
         assert!(matches!(err, NoteError::Other { source: Some(_), .. }));
+    }
+
+    #[test]
+    fn create_rejects_empty_assets() {
+        let sender = AccountId::dummy([4u8; 15], AccountIdVersion::Version1, AccountType::Private);
+        let target = AccountId::dummy([5u8; 15], AccountIdVersion::Version1, AccountType::Private);
+        let mut rng = RandomCoin::new(Word::default());
+
+        let err = P2idNote::create(
+            sender,
+            target,
+            vec![],
+            NoteType::Private,
+            NoteAttachments::default(),
+            &mut rng,
+        )
+        .expect_err("empty assets must be rejected");
+
+        assert!(matches!(err, NoteError::MissingAsset));
     }
 }

--- a/crates/miden-standards/src/note/p2ide.rs
+++ b/crates/miden-standards/src/note/p2ide.rs
@@ -80,7 +80,8 @@ impl P2ideNote {
     /// and the note tag is set to the storage target account.
     ///
     /// # Errors
-    /// Returns an error if construction of the note recipient or asset vault fails.
+    /// - Returns [`NoteError::MissingAsset`] if `assets` is empty.
+    /// - Returns an error if construction of the note recipient or asset vault fails.
     pub fn create<R: FeltRng>(
         sender: AccountId,
         storage: P2ideNoteStorage,
@@ -89,6 +90,10 @@ impl P2ideNote {
         attachments: NoteAttachments,
         rng: &mut R,
     ) -> Result<Note, NoteError> {
+        if assets.is_empty() {
+            return Err(NoteError::MissingAsset);
+        }
+
         let serial_num = rng.draw_word();
         let recipient = storage.into_recipient(serial_num)?;
         let tag = NoteTag::with_account_target(storage.target());
@@ -216,6 +221,7 @@ mod tests {
     use miden_protocol::Felt;
     use miden_protocol::account::{AccountId, AccountIdVersion, AccountType};
     use miden_protocol::block::BlockNumber;
+    use miden_protocol::crypto::rand::RandomCoin;
     use miden_protocol::errors::NoteError;
 
     use super::*;
@@ -308,5 +314,24 @@ mod tests {
             .expect_err("overflow timelock height must fail");
 
         assert!(matches!(err, NoteError::Other { source: Some(_), .. }));
+    }
+
+    #[test]
+    fn create_rejects_empty_assets() {
+        let sender = AccountId::dummy([4u8; 15], AccountIdVersion::Version1, AccountType::Private);
+        let storage = P2ideNoteStorage::new(dummy_account(), None, None);
+        let mut rng = RandomCoin::new(Word::default());
+
+        let err = P2ideNote::create(
+            sender,
+            storage,
+            vec![],
+            NoteType::Private,
+            NoteAttachments::default(),
+            &mut rng,
+        )
+        .expect_err("empty assets must be rejected");
+
+        assert!(matches!(err, NoteError::MissingAsset));
     }
 }

--- a/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
@@ -5,6 +5,7 @@ use anyhow::Context;
 use assert_matches::assert_matches;
 use miden_protocol::Word;
 use miden_protocol::account::{Account, AccountId, AccountType};
+use miden_protocol::asset::FungibleAsset;
 use miden_protocol::batch::ProposedBatch;
 use miden_protocol::block::BlockNumber;
 use miden_protocol::crypto::merkle::MerkleError;
@@ -60,7 +61,7 @@ fn setup_chain() -> TestSetup {
     let account1 = generate_account(&mut builder);
     let account2 = generate_account(&mut builder);
     let note1 = builder
-        .add_p2id_note(account1.id(), account2.id(), &[], NoteType::Public)
+        .add_p2id_note(account1.id(), account2.id(), &[FungibleAsset::mock(1)], NoteType::Public)
         .expect("adding p2id note1 should work");
     let mut chain = builder.build().expect("genesis should be valid");
     chain.prove_next_block().expect("valid setup");

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_errors.rs
@@ -349,12 +349,14 @@ async fn proposed_block_fails_on_duplicate_output_note() -> anyhow::Result<()> {
 async fn proposed_block_fails_on_invalid_proof_or_missing_note_inclusion_reference_block()
 -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
-    let account0 = builder.add_existing_mock_account(Auth::IncrNonce)?;
+    // account0 funds the P2ID note via the spawn-note flow, so it needs a balance to give.
+    let account0 =
+        builder.add_existing_mock_account_with_assets(Auth::IncrNonce, [FungibleAsset::mock(1)])?;
     let account1 = builder.add_existing_mock_account(Auth::IncrNonce)?;
     let p2id_note = P2idNote::create(
         account0.id(),
         account1.id(),
-        vec![],
+        vec![FungibleAsset::mock(1)],
         NoteType::Private,
         NoteAttachments::default(),
         builder.rng_mut(),

--- a/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
+++ b/crates/miden-testing/src/kernel_tests/block/proposed_block_success.rs
@@ -185,8 +185,18 @@ async fn proposed_block_authenticating_unauthenticated_notes() -> anyhow::Result
     let mut builder = MockChain::builder();
     let account0 = builder.add_existing_mock_account(Auth::IncrNonce)?;
     let account1 = builder.add_existing_mock_account(Auth::IncrNonce)?;
-    let note0 = builder.add_p2id_note(sender_id, account0.id(), &[], NoteType::Private)?;
-    let note1 = builder.add_p2id_note(sender_id, account1.id(), &[], NoteType::Public)?;
+    let note0 = builder.add_p2id_note(
+        sender_id,
+        account0.id(),
+        &[FungibleAsset::mock(1)],
+        NoteType::Private,
+    )?;
+    let note1 = builder.add_p2id_note(
+        sender_id,
+        account1.id(),
+        &[FungibleAsset::mock(1)],
+        NoteType::Public,
+    )?;
     let chain = builder.build()?;
 
     // These txs will use block1 as the reference block.

--- a/crates/miden-testing/src/kernel_tests/tx/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/mod.rs
@@ -102,12 +102,11 @@ pub fn input_note_data_ptr(note_idx: u32) -> memory::MemoryAddress {
 struct TestSetup {
     mock_chain: MockChain,
     account: Account,
-    p2id_note_0_assets: Note,
     p2id_note_1_asset: Note,
     p2id_note_2_assets: Note,
 }
 
-/// Return a [`TestSetup`], whose notes contain 0, 1 and 2 assets respectively.
+/// Return a [`TestSetup`], whose notes contain 1 and 2 assets respectively.
 fn setup_test() -> anyhow::Result<TestSetup> {
     let mut builder = MockChain::builder();
 
@@ -145,12 +144,6 @@ fn setup_test() -> anyhow::Result<TestSetup> {
     )?;
 
     // Notes
-    let p2id_note_0_assets = builder.add_p2id_note(
-        ACCOUNT_ID_SENDER.try_into().unwrap(),
-        account.id(),
-        &[],
-        NoteType::Public,
-    )?;
     let p2id_note_1_asset = builder.add_p2id_note(
         ACCOUNT_ID_SENDER.try_into().unwrap(),
         account.id(),
@@ -169,7 +162,6 @@ fn setup_test() -> anyhow::Result<TestSetup> {
     anyhow::Ok(TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets,
         p2id_note_1_asset,
         p2id_note_2_assets,
     })

--- a/crates/miden-testing/src/kernel_tests/tx/test_input_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_input_note.rs
@@ -9,14 +9,13 @@ use super::{TestSetup, setup_test};
 use crate::TxContextInput;
 
 /// Check that the assets number and assets commitment obtained from the
-/// `input_note::get_assets_info` procedure is correct for each note with zero, one and two
+/// `input_note::get_assets_info` procedure is correct for each note with one and two
 /// different assets.
 #[tokio::test]
 async fn test_get_asset_info() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets,
         p2id_note_1_asset,
         p2id_note_2_assets,
     } = setup_test()?;
@@ -51,25 +50,18 @@ async fn test_get_asset_info() -> anyhow::Result<()> {
         use miden::protocol::input_note
 
         begin
-            {check_note_0}
-
             {check_note_1}
 
             {check_note_2}
         end
     ",
-        check_note_0 = check_asset_info_code(
-            0,
-            p2id_note_0_assets.assets().commitment(),
-            p2id_note_0_assets.assets().num_assets()
-        ),
         check_note_1 = check_asset_info_code(
-            1,
+            0,
             p2id_note_1_asset.assets().commitment(),
             p2id_note_1_asset.assets().num_assets()
         ),
         check_note_2 = check_asset_info_code(
-            2,
+            1,
             p2id_note_2_assets.assets().commitment(),
             p2id_note_2_assets.assets().num_assets()
         ),
@@ -81,7 +73,7 @@ async fn test_get_asset_info() -> anyhow::Result<()> {
         .build_tx_context(
             TxContextInput::AccountId(account.id()),
             &[],
-            &[p2id_note_0_assets, p2id_note_1_asset, p2id_note_2_assets],
+            &[p2id_note_1_asset, p2id_note_2_assets],
         )?
         .tx_script(tx_script)
         .build()?;
@@ -98,7 +90,6 @@ async fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets: _,
         p2id_note_1_asset,
         p2id_note_2_assets: _,
     } = setup_test()?;
@@ -151,7 +142,6 @@ async fn test_get_sender() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets: _,
         p2id_note_1_asset,
         p2id_note_2_assets: _,
     } = setup_test()?;
@@ -194,13 +184,12 @@ async fn test_get_sender() -> anyhow::Result<()> {
 }
 
 /// Check that the assets number and assets data obtained from the `input_note::get_assets`
-/// procedure is correct for each note with zero, one and two different assets.
+/// procedure is correct for each note with one and two different assets.
 #[tokio::test]
 async fn test_get_assets() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets,
         p2id_note_1_asset,
         p2id_note_2_assets,
     } = setup_test()?;
@@ -276,16 +265,13 @@ async fn test_get_assets() -> anyhow::Result<()> {
         use miden::protocol::input_note
 
         begin
-            {check_note_0}
-
             {check_note_1}
 
             {check_note_2}
         end
     ",
-        check_note_0 = check_assets_code(0, 0, &p2id_note_0_assets),
-        check_note_1 = check_assets_code(1, 8, &p2id_note_1_asset),
-        check_note_2 = check_assets_code(2, 16, &p2id_note_2_assets),
+        check_note_1 = check_assets_code(0, 0, &p2id_note_1_asset),
+        check_note_2 = check_assets_code(1, 8, &p2id_note_2_assets),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(code)?;
@@ -294,7 +280,7 @@ async fn test_get_assets() -> anyhow::Result<()> {
         .build_tx_context(
             TxContextInput::AccountId(account.id()),
             &[],
-            &[p2id_note_0_assets, p2id_note_1_asset, p2id_note_2_assets],
+            &[p2id_note_1_asset, p2id_note_2_assets],
         )?
         .tx_script(tx_script)
         .build()?;
@@ -311,7 +297,6 @@ async fn test_get_storage_info() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets: _,
         p2id_note_1_asset,
         p2id_note_2_assets: _,
     } = setup_test()?;
@@ -361,7 +346,6 @@ async fn test_get_script_root() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets: _,
         p2id_note_1_asset,
         p2id_note_2_assets: _,
     } = setup_test()?;
@@ -404,7 +388,6 @@ async fn test_get_serial_number() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets: _,
         p2id_note_1_asset,
         p2id_note_2_assets: _,
     } = setup_test()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_output_note.rs
@@ -1077,13 +1077,12 @@ async fn test_get_recipient_and_metadata() -> anyhow::Result<()> {
 }
 
 /// Check that the assets number and assets data obtained from the `output_note::get_assets`
-/// procedure is correct for each note with zero, one and two different assets.
+/// procedure is correct for each note with one and two different assets.
 #[tokio::test]
 async fn test_get_assets() -> anyhow::Result<()> {
     let TestSetup {
         mock_chain,
         account,
-        p2id_note_0_assets,
         p2id_note_1_asset,
         p2id_note_2_assets,
     } = setup_test()?;
@@ -1160,9 +1159,6 @@ async fn test_get_assets() -> anyhow::Result<()> {
         use miden::core::sys
 
         begin
-            {create_note_0}
-            {check_note_0}
-
             {create_note_1}
             {check_note_1}
 
@@ -1173,12 +1169,10 @@ async fn test_get_assets() -> anyhow::Result<()> {
             exec.sys::truncate_stack
         end
         ",
-        create_note_0 = create_output_note(&p2id_note_0_assets),
-        check_note_0 = check_assets_code(0, 0, &p2id_note_0_assets),
         create_note_1 = create_output_note(&p2id_note_1_asset),
-        check_note_1 = check_assets_code(1, 8, &p2id_note_1_asset),
+        check_note_1 = check_assets_code(0, 0, &p2id_note_1_asset),
         create_note_2 = create_output_note(&p2id_note_2_assets),
-        check_note_2 = check_assets_code(2, 16, &p2id_note_2_assets),
+        check_note_2 = check_assets_code(1, 8, &p2id_note_2_assets),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(tx_script_src)?;
@@ -1186,7 +1180,6 @@ async fn test_get_assets() -> anyhow::Result<()> {
     let tx_context = mock_chain
         .build_tx_context(account.id(), &[], &[])?
         .extend_expected_output_notes(vec![
-            RawOutputNote::Full(p2id_note_0_assets),
             RawOutputNote::Full(p2id_note_1_asset),
             RawOutputNote::Full(p2id_note_2_assets),
         ])

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -465,6 +465,7 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
         .account_type(AccountType::Private)
         .with_auth_component(auth_component)
         .with_component(BasicWallet)
+        .with_assets([FungibleAsset::mock(1)])
         .build_existing()
         .context("failed to build account")?;
 
@@ -473,7 +474,7 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let output_note = P2idNote::create(
         account.id(),
         account.id(),
-        vec![],
+        vec![FungibleAsset::mock(1)],
         NoteType::Private,
         NoteAttachments::default(),
         &mut rng,
@@ -493,7 +494,6 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let error = tx_context.execute().await.unwrap_err();
 
     assert_matches!(error, TransactionExecutorError::Unauthorized(tx_summary) => {
-        assert!(tx_summary.account_delta().vault().is_empty());
         assert!(tx_summary.account_delta().storage().is_empty());
         assert_eq!(tx_summary.account_delta().nonce_delta().as_canonical_u64(), 1);
         assert_eq!(tx_summary.input_notes(), &input_notes);
@@ -511,14 +511,17 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
 #[tokio::test]
 async fn tx_summary_commitment_is_signed_by_falcon_auth() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
-    let account = builder.add_existing_mock_account(Auth::BasicAuth {
-        auth_scheme: AuthScheme::Falcon512Poseidon2,
-    })?;
+    let account = builder.add_existing_mock_account_with_assets(
+        Auth::BasicAuth {
+            auth_scheme: AuthScheme::Falcon512Poseidon2,
+        },
+        [FungibleAsset::mock(1)],
+    )?;
     let mut rng = RandomCoin::new(Word::empty());
     let p2id_note = P2idNote::create(
         account.id(),
         account.id(),
-        vec![],
+        vec![FungibleAsset::mock(1)],
         NoteType::Private,
         NoteAttachments::default(),
         &mut rng,
@@ -574,13 +577,15 @@ async fn tx_summary_commitment_is_signed_by_falcon_auth() -> anyhow::Result<()> 
 #[tokio::test]
 async fn tx_summary_commitment_is_signed_by_ecdsa_auth() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
-    let account = builder
-        .add_existing_mock_account(Auth::BasicAuth { auth_scheme: AuthScheme::EcdsaK256Keccak })?;
+    let account = builder.add_existing_mock_account_with_assets(
+        Auth::BasicAuth { auth_scheme: AuthScheme::EcdsaK256Keccak },
+        [FungibleAsset::mock(1)],
+    )?;
     let mut rng = RandomCoin::new(Word::empty());
     let p2id_note = P2idNote::create(
         account.id(),
         account.id(),
-        vec![],
+        vec![FungibleAsset::mock(1)],
         NoteType::Private,
         NoteAttachments::default(),
         &mut rng,


### PR DESCRIPTION
This PR add the assertion check for the case that there should be atleast one asset in the note when  `add_assets_to_account` function is called.

[BREAKING] Enforced at both layers:
- Rust: P2idNote::create / P2ideNote::create return the new NoteError::MissingAsset on empty assets.
- MASM: basic_wallet::add_assets_to_account asserts num_assets > 0 (new ERR_BASIC_WALLET_EMPTY_NOTE_ASSETS).



closes https://github.com/0xMiden/protocol/issues/2978