### PR TITLE
docs: discourage multiple attachments with the same scheme

### DIFF
--- a/crates/miden-protocol/src/note/attachment/mod.rs
+++ b/crates/miden-protocol/src/note/attachment/mod.rs
@@ -525,6 +525,9 @@ impl NoteAttachments {
     }
 
     /// Returns the first attachment with the provided scheme, if any.
+    ///
+    /// Schemes are not required to be unique within a note. If multiple attachments share the
+    /// provided scheme, the first one is treated as the canonical one and returned.
     pub fn find(&self, scheme: NoteAttachmentScheme) -> Option<&NoteAttachment> {
         self.attachments
             .iter()

--- a/docs/src/note.md
+++ b/docs/src/note.md
@@ -80,6 +80,8 @@ A note can have up to 4 attachments. Each attachment is a variable-size, _public
 
 The note commits to all of its attachments via a sequential hash over the individual attachment commitments (the attachments commitment). The attachment schemes are encoded in the note's metadata. When the note is consumed, the actual attachment content is provided via the advice provider.
 
+Schemes are not required to be unique within a note, but adding multiple attachments with the same scheme is discouraged. It provides no additional benefit and only increases the note's public on-chain data and the fees its creator pays.
+
 Example use cases for attachments are:
 - Communicate the note details of a private note in encrypted form. This means the encrypted note is attached publicly to the otherwise private note.
 - For [network transactions](./transaction.md#network-transaction), encode the ID of the network account that should


### PR DESCRIPTION
## Summary

The protocol intentionally does not prevent adding multiple attachments with the same scheme to a note. With this PR, we adjust the docs to discourage this.

No behavior changes.

Closes #2873

🤖 Generated with [Claude Code](https://claude.com/claude-code)