### PR TITLE
feat(agglayer): use one-step Ownable for the bridge faucet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added lock/unlock path for Miden-native tokens in the AggLayer bridge: `is_native` flag in `faucet_registry_map`, bridge-local `faucet_metadata_map` (replacing FPI to faucets for conversion data), and `lock_asset` / `unlock_and_send` procedures so the bridge holds native assets in its own vault instead of burn/mint via a faucet ([#2771](https://github.com/0xMiden/protocol/pull/2771)).
 ### Changes
+- Switched the AggLayer faucet and network fungible faucet to the one-step `Ownable` access-control component instead of `Ownable2Step` ([#2995](https://github.com/0xMiden/protocol/pull/2995)).
 - Added validation of leaf type on CLAIM note processing to prevent message leaves from being processed as asset claims ([#2730](https://github.com/0xMiden/protocol/pull/2730)).
 
 - Added PSWAP (partial swap) note for decentralized partial-fill asset exchange with remainder note re-creation ([#2636](https://github.com/0xMiden/protocol/pull/2636)).

--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -328,7 +328,7 @@ modules in `asm/agglayer/common/`.
 
 Re-export of `miden::standards::faucets::network_fungible::mint_and_send`. Mints the
 specified amount and creates an output note with the given recipient. Requires the
-faucet's owner (the bridge account) to be the creator of this note (the bridge is stored in `Ownable2Step` storage slot as the owner; the faucet's `mint_and_send` executes the current access policy via `exec.policy_manager::execute_mint_policy`).
+faucet's owner (the bridge account) to be the creator of this note (the bridge is stored in `Ownable` storage slot as the owner; the faucet's `mint_and_send` executes the current access policy via `exec.policy_manager::execute_mint_policy`).
 
 #### `agglayer_faucet::get_metadata_hash`
 
@@ -394,7 +394,7 @@ This is a re-export of `miden::standards::faucets::basic_fungible::burn`. It bur
 **Companion component storage slots:** The faucet account also includes storage from
 companion components required by `network_fungible::mint_and_send`:
 
-- `Ownable2Step` owner config slot: stores the bridge account ID as owner.
+- `Ownable` owner config slot: stores the bridge account ID as owner.
 - `OwnerControlled` slots (3): `active_policy_proc_root`, `allowed_policy_proc_roots`,
   `policy_authority`.
 
@@ -773,9 +773,9 @@ The standard MINT script for public note creation loads the 18 storage items fro
 
 Before minting, `mint_and_send` executes the active mint policy via
 `policy_manager::execute_mint_policy`. For AggLayer faucets, the active policy is
-`owner_controlled::owner_only`, which calls `ownable2step::assert_sender_is_owner`. This
+`owner_controlled::owner_only`, which calls `ownable::assert_sender_is_owner`. This
 asserts that the MINT note's sender matches the faucet's owner (the bridge account, set
-via the `Ownable2Step` companion component at account creation time). This ensures only
+via the `Ownable` companion component at account creation time). This ensures only
 the bridge can trigger minting on the faucet.
 
 After the policy check passes, `mint_and_send` mints the specified amount and creates a
@@ -786,7 +786,7 @@ destination account ID, tag).
 
 | Role | Enforcement |
 |------|------------|
-| **Issuer** | Bridge account only -- **enforced** by faucet's `owner_only` mint policy via `Ownable2Step` (asserts note sender is the faucet's owner, i.e. the bridge) |
+| **Issuer** | Bridge account only -- **enforced** by faucet's `owner_only` mint policy via `Ownable` (asserts note sender is the faucet's owner, i.e. the bridge) |
 | **Consumer** | Target faucet only -- **enforced** via `NetworkAccountTarget` attachment |
 
 ---
@@ -1159,7 +1159,7 @@ behavior on both directions:
 | Bridge-in    | `bridge_in_output::build_mint_output_note` — emits a MINT note consumed by the faucet. | `bridge_in_output::unlock_and_send` — `native_account::remove_asset` unlocks from the vault, then emits a P2ID note directly to the recipient. No MINT note is emitted. |
 
 The LET leaf is constructed identically in both bridge-out branches. The native branch
-does not require the bridge to be the faucet's owner, and `ownable2step::assert_sender_is_owner`
+does not require the bridge to be the faucet's owner, and `ownable::assert_sender_is_owner`
 is not invoked on the native path. The P2ID note emitted by `unlock_and_send` uses the
 `PROOF_DATA_KEY` as its serial number, which makes the note commitment deterministic for
 a given claim and prevents double-spend within the same claim.

--- a/crates/miden-agglayer/build.rs
+++ b/crates/miden-agglayer/build.rs
@@ -319,7 +319,7 @@ fn generate_agglayer_constants(
         let agglayer_component =
             AccountComponent::new(content_library, vec![], dummy_metadata.clone()).unwrap();
 
-        // The faucet account includes Ownable2Step and OwnerControlled components
+        // The faucet account includes Ownable and OwnerControlled components
         // alongside the agglayer faucet component, since network_fungible::mint_and_send
         // requires these for access control.
         //
@@ -337,7 +337,7 @@ fn generate_agglayer_constants(
             )
             .unwrap();
             components.push(AccountComponent::from(
-                miden_standards::account::access::Ownable2Step::new(dummy_owner),
+                miden_standards::account::access::Ownable::new(dummy_owner),
             ));
             components.push(AccountComponent::from(OwnerControlled::owner_only()));
         }

--- a/crates/miden-agglayer/src/faucet.rs
+++ b/crates/miden-agglayer/src/faucet.rs
@@ -17,7 +17,7 @@ use miden_protocol::account::{
 use miden_protocol::asset::TokenSymbol;
 use miden_protocol::errors::AccountIdError;
 use miden_protocol::note::NoteScriptRoot;
-use miden_standards::account::access::Ownable2Step;
+use miden_standards::account::access::Ownable;
 use miden_standards::account::faucets::{FungibleFaucetError, TokenMetadata};
 use miden_standards::account::mint_policies::OwnerControlled;
 use miden_standards::note::{BurnNote, MintNote};
@@ -66,7 +66,7 @@ include!(concat!(env!("OUT_DIR"), "/agglayer_constants.rs"));
 /// ## Required Companion Components
 ///
 /// This component re-exports `network_fungible::mint_and_send`, which requires:
-/// - [`Ownable2Step`]: Provides ownership data (bridge account ID as owner).
+/// - [`Ownable`]: Provides ownership data (bridge account ID as owner).
 /// - [`miden_standards::account::mint_policies::OwnerControlled`]: Provides mint policy management.
 ///
 /// These must be added as separate components when building the faucet account.
@@ -114,9 +114,9 @@ impl AggLayerFaucet {
     }
 
     /// Storage slot name for the owner account ID (bridge), provided by the
-    /// [`Ownable2Step`] companion component.
+    /// [`Ownable`] companion component.
     pub fn owner_config_slot() -> &'static StorageSlotName {
-        Ownable2Step::slot_name()
+        Ownable::slot_name()
     }
 
     // ALLOWED NOTES
@@ -149,7 +149,7 @@ impl AggLayerFaucet {
         TokenMetadata::try_from(metadata_word).map_err(AgglayerFaucetError::FungibleFaucetError)
     }
 
-    /// Extracts the bridge account ID from the [`Ownable2Step`] owner config storage slot
+    /// Extracts the bridge account ID from the [`Ownable`] owner config storage slot
     /// of the provided account.
     ///
     /// # Errors
@@ -160,8 +160,8 @@ impl AggLayerFaucet {
         // check that the provided account is a faucet account
         Self::assert_faucet_account(faucet_account)?;
 
-        let ownership = Ownable2Step::try_from_storage(faucet_account.storage())
-            .map_err(AgglayerFaucetError::Ownable2StepError)?;
+        let ownership = Ownable::try_from_storage(faucet_account.storage())
+            .map_err(AgglayerFaucetError::OwnableError)?;
         ownership.owner().ok_or(AgglayerFaucetError::OwnershipRenounced)
     }
 
@@ -231,7 +231,7 @@ impl AggLayerFaucet {
     fn slot_names() -> Vec<&'static StorageSlotName> {
         vec![
             TokenMetadata::metadata_slot(),
-            Ownable2Step::slot_name(),
+            Ownable::slot_name(),
             OwnerControlled::active_policy_proc_root_slot(),
             OwnerControlled::allowed_policy_proc_roots_slot(),
             OwnerControlled::policy_authority_slot(),
@@ -262,8 +262,8 @@ pub enum AgglayerFaucetError {
     FungibleFaucetError(#[source] FungibleFaucetError),
     #[error("account ID error")]
     AccountIdError(#[source] AccountIdError),
-    #[error("ownable2step error")]
-    Ownable2StepError(#[source] miden_standards::account::access::Ownable2StepError),
+    #[error("ownable error")]
+    OwnableError(#[source] miden_standards::account::access::OwnableError),
     #[error("faucet ownership has been renounced")]
     OwnershipRenounced,
 }

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -16,7 +16,7 @@ use miden_protocol::account::{
 use miden_protocol::asset::TokenSymbol;
 use miden_protocol::note::{NoteScript, NoteScriptRoot};
 use miden_protocol::vm::Program;
-use miden_standards::account::access::Ownable2Step;
+use miden_standards::account::access::Ownable;
 use miden_standards::account::auth::AuthNetworkAccount;
 use miden_standards::account::mint_policies::OwnerControlled;
 use miden_utils_sync::LazyLock;
@@ -197,7 +197,7 @@ pub fn create_existing_bridge_account(
 ///
 /// The builder includes:
 /// - The `AggLayerFaucet` component (token metadata only; conversion metadata lives on the bridge).
-/// - The `Ownable2Step` component (bridge account ID as owner for mint authorization).
+/// - The `Ownable` component (bridge account ID as owner for mint authorization).
 /// - The `OwnerControlled` component (mint policy management required by
 ///   `network_fungible::mint_and_send`).
 /// - The [`AuthNetworkAccount`] auth component, initialized with
@@ -217,7 +217,7 @@ fn create_agglayer_faucet_builder(
         .account_type(AccountType::FungibleFaucet)
         .storage_mode(AccountStorageMode::Network)
         .with_component(agglayer_component)
-        .with_component(Ownable2Step::new(bridge_account_id))
+        .with_component(Ownable::new(bridge_account_id))
         .with_component(OwnerControlled::owner_only())
         .with_auth_component(
             AuthNetworkAccount::with_allowlist(AggLayerFaucet::allowed_notes())

--- a/crates/miden-standards/asm/account_components/access/ownable.masm
+++ b/crates/miden-standards/asm/account_components/access/ownable.masm
@@ -1,0 +1,7 @@
+# The MASM code of the Ownable Account Component.
+#
+# See the `Ownable` Rust type's documentation for more details.
+
+pub use ::miden::standards::access::ownable::get_owner
+pub use ::miden::standards::access::ownable::transfer_ownership
+pub use ::miden::standards::access::ownable::renounce_ownership

--- a/crates/miden-standards/asm/standards/access/ownable.masm
+++ b/crates/miden-standards/asm/standards/access/ownable.masm
@@ -35,9 +35,9 @@ const ERR_SENDER_NOT_OWNER = "note sender is not the owner"
 #! - owner_{suffix, prefix} are the suffix and prefix felts of the owner AccountId.
 proc owner
     push.OWNER_CONFIG_SLOT[0..2] exec.active_account::get_item
-    # => [0, 0, owner_suffix, owner_prefix]
+    # => [owner_suffix, owner_prefix, 0, 0]
 
-    drop drop
+    movup.2 drop movup.2 drop
     # => [owner_suffix, owner_prefix]
 end
 
@@ -67,7 +67,7 @@ end
 #!
 #! Panics if:
 #! - the note sender is not the owner.
-pub proc verify_owner
+pub proc assert_sender_is_owner
     exec.active_note::get_sender
     # => [sender_suffix, sender_prefix]
 
@@ -108,14 +108,20 @@ end
 #! Invocation: call
 pub proc transfer_ownership
     # Check that the caller is the owner
-    exec.verify_owner
+    exec.assert_sender_is_owner
     # => [new_owner_suffix, new_owner_prefix, pad(14)]
 
-    push.0.0
-    # => [0, 0, new_owner_suffix, new_owner_prefix, pad(14)]
+    # Validate that the new owner is a well-formed account ID
+    dup.1 dup.1 exec.account_id::validate
+    # => [new_owner_suffix, new_owner_prefix, pad(14)]
+
+    # Build the owner word [new_owner_suffix, new_owner_prefix, 0, 0] by inserting the two
+    # trailing zeros below the owner felts.
+    push.0 movdn.2 push.0 movdn.3
+    # => [new_owner_suffix, new_owner_prefix, 0, 0, pad(14)]
 
     push.OWNER_CONFIG_SLOT[0..2]
-    # => [slot_suffix, slot_prefix, 0, 0, new_owner_suffix, new_owner_prefix, pad(14)]
+    # => [slot_suffix, slot_prefix, new_owner_suffix, new_owner_prefix, 0, 0, pad(14)]
 
     exec.native_account::set_item
     # => [OLD_OWNER_WORD, pad(14)]
@@ -143,7 +149,7 @@ end
 #! after an initial stage with centralized administration is over. Once ownership is renounced,
 #! the component becomes permanently ownerless and cannot be managed by any account.
 pub proc renounce_ownership
-    exec.verify_owner
+    exec.assert_sender_is_owner
     # => [pad(16)]
     
     # ---- Push ZERO_ADDRESS to storage ----

--- a/crates/miden-standards/asm/standards/mint_policies/owner_controlled.masm
+++ b/crates/miden-standards/asm/standards/mint_policies/owner_controlled.masm
@@ -1,4 +1,4 @@
-use miden::standards::access::ownable2step
+use miden::standards::access::ownable
 
 # POLICY PROCEDURES
 # ================================================================================================
@@ -13,6 +13,6 @@ use miden::standards::access::ownable2step
 #!
 #! Invocation: dynexec
 pub proc owner_only
-    exec.ownable2step::assert_sender_is_owner
+    exec.ownable::assert_sender_is_owner
     # => [amount, tag, note_type, RECIPIENT, pad(9)]
 end

--- a/crates/miden-standards/asm/standards/mint_policies/policy_manager.masm
+++ b/crates/miden-standards/asm/standards/mint_policies/policy_manager.masm
@@ -1,13 +1,13 @@
 use miden::core::word
 use miden::protocol::active_account
 use miden::protocol::native_account
-use miden::standards::access::ownable2step
+use miden::standards::access::ownable
 
 # DEPENDENCY NOTE
 # This manager supports two policy-authority modes:
-# - 0: auth_controlled: no Ownable2Step dependency.
-# - 1: owner_controlled: requires Ownable2Step component
-#   (`ownable2step::assert_sender_is_owner`) for `set_mint_policy`.
+# - 0: auth_controlled: no Ownable dependency.
+# - 1: owner_controlled: requires Ownable component
+#   (`ownable::assert_sender_is_owner`) for `set_mint_policy`.
 
 # CONSTANTS
 # ================================================================================================
@@ -28,7 +28,7 @@ const ALLOWED_POLICY_PROC_ROOTS_SLOT=word("miden::standards::mint_policy_manager
 # Policy authority slot.
 # Layout: [policy_authority, 0, 0, 0]
 # - POLICY_AUTHORITY = 0: policy authority rely on `auth_controlled`.
-# - POLICY_AUTHORITY = 1: `set_mint_policy` requires Ownable2Step owner check.
+# - POLICY_AUTHORITY = 1: `set_mint_policy` requires Ownable owner check.
 const POLICY_AUTHORITY_SLOT=word("miden::standards::mint_policy_manager::policy_authority")
 const POLICY_AUTHORITY_OWNER_CONTROLLED=1
 
@@ -130,7 +130,7 @@ proc assert_can_set_mint_policy
 
     eq.POLICY_AUTHORITY_OWNER_CONTROLLED
     if.true
-        exec.ownable2step::assert_sender_is_owner
+        exec.ownable::assert_sender_is_owner
         # => [NEW_POLICY_ROOT, pad(12)]
     end
 end

--- a/crates/miden-standards/src/account/access/mod.rs
+++ b/crates/miden-standards/src/account/access/mod.rs
@@ -1,10 +1,13 @@
 use miden_protocol::account::{AccountComponent, AccountId};
 
+pub mod ownable;
 pub mod ownable2step;
 
 /// Access control configuration for account components.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessControl {
+    /// Uses one-step ownership transfer with the provided initial owner.
+    Ownable { owner: AccountId },
     /// Uses two-step ownership transfer with the provided initial owner.
     Ownable2Step { owner: AccountId },
 }
@@ -12,9 +15,11 @@ pub enum AccessControl {
 impl From<AccessControl> for AccountComponent {
     fn from(access_control: AccessControl) -> Self {
         match access_control {
+            AccessControl::Ownable { owner } => Ownable::new(owner).into(),
             AccessControl::Ownable2Step { owner } => Ownable2Step::new(owner).into(),
         }
     }
 }
 
+pub use ownable::{Ownable, OwnableError};
 pub use ownable2step::{Ownable2Step, Ownable2StepError};

--- a/crates/miden-standards/src/account/access/ownable.rs
+++ b/crates/miden-standards/src/account/access/ownable.rs
@@ -1,0 +1,168 @@
+use miden_protocol::account::component::{
+    AccountComponentMetadata,
+    FeltSchema,
+    StorageSchema,
+    StorageSlotSchema,
+};
+use miden_protocol::account::{
+    AccountComponent,
+    AccountId,
+    AccountStorage,
+    AccountType,
+    StorageSlot,
+    StorageSlotName,
+};
+use miden_protocol::errors::AccountIdError;
+use miden_protocol::utils::sync::LazyLock;
+use miden_protocol::{Felt, Word};
+
+use crate::account::components::ownable_library;
+
+static OWNER_CONFIG_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
+    StorageSlotName::new("miden::standards::access::ownable::owner_config")
+        .expect("storage slot name should be valid")
+});
+
+/// One-step ownership management for account components.
+///
+/// This struct holds the current owner of the component. Ownership is transferred in a single
+/// step: the current owner directly assigns a new owner (or renounces ownership). Unlike
+/// [`crate::account::access::Ownable2Step`], there is no nominated-owner acceptance step.
+///
+/// ## Storage Layout
+///
+/// The ownership data is stored in a single word, with the upper two felts left zero:
+///
+/// ```text
+/// Word:  [owner_suffix, owner_prefix, 0, 0]
+///         word[0]       word[1]        word[2]  word[3]
+/// ```
+pub struct Ownable {
+    /// The current owner of the component. `None` when ownership has been renounced.
+    owner: Option<AccountId>,
+}
+
+impl Ownable {
+    /// The name of the component.
+    pub const NAME: &'static str = "miden::standards::components::access::ownable";
+
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new [`Ownable`] with the given owner.
+    pub fn new(owner: AccountId) -> Self {
+        Self { owner: Some(owner) }
+    }
+
+    /// Reads ownership data from account storage, validating any non-zero account ID.
+    ///
+    /// Returns an error if the owner contains an invalid (but non-zero) account ID.
+    pub fn try_from_storage(storage: &AccountStorage) -> Result<Self, OwnableError> {
+        let word: Word =
+            storage.get_item(Self::slot_name()).map_err(OwnableError::StorageLookupFailed)?;
+
+        Self::try_from_word(word)
+    }
+
+    /// Reconstructs an [`Ownable`] from a raw storage word.
+    ///
+    /// Format: `[owner_suffix, owner_prefix, 0, 0]`
+    pub fn try_from_word(word: Word) -> Result<Self, OwnableError> {
+        let owner =
+            account_id_from_felt_pair(word[0], word[1]).map_err(OwnableError::InvalidOwnerId)?;
+
+        Ok(Self { owner })
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the [`StorageSlotName`] where ownership data is stored.
+    pub fn slot_name() -> &'static StorageSlotName {
+        &OWNER_CONFIG_SLOT_NAME
+    }
+
+    /// Returns the storage slot schema for the ownership configuration slot.
+    pub fn slot_schema() -> (StorageSlotName, StorageSlotSchema) {
+        (
+            Self::slot_name().clone(),
+            StorageSlotSchema::value(
+                "Ownership data (owner)",
+                [
+                    FeltSchema::felt("owner_suffix"),
+                    FeltSchema::felt("owner_prefix"),
+                    FeltSchema::new_void(),
+                    FeltSchema::new_void(),
+                ],
+            ),
+        )
+    }
+
+    /// Returns the current owner, or `None` if ownership has been renounced.
+    pub fn owner(&self) -> Option<AccountId> {
+        self.owner
+    }
+
+    /// Converts this ownership data into a [`StorageSlot`].
+    pub fn to_storage_slot(&self) -> StorageSlot {
+        StorageSlot::with_value(Self::slot_name().clone(), self.to_word())
+    }
+
+    /// Converts this ownership data into a raw [`Word`].
+    pub fn to_word(&self) -> Word {
+        let (owner_suffix, owner_prefix) = match self.owner {
+            Some(id) => (id.suffix(), id.prefix().as_felt()),
+            None => (Felt::ZERO, Felt::ZERO),
+        };
+        [owner_suffix, owner_prefix, Felt::ZERO, Felt::ZERO].into()
+    }
+
+    /// Returns the [`AccountComponentMetadata`] for this component.
+    pub fn component_metadata() -> AccountComponentMetadata {
+        let storage_schema =
+            StorageSchema::new([Self::slot_schema()]).expect("storage schema should be valid");
+
+        AccountComponentMetadata::new(Self::NAME, AccountType::all())
+            .with_description("One-step ownership management component")
+            .with_storage_schema(storage_schema)
+    }
+}
+
+impl From<Ownable> for AccountComponent {
+    fn from(ownership: Ownable) -> Self {
+        let storage_slot = ownership.to_storage_slot();
+        let metadata = Ownable::component_metadata();
+
+        AccountComponent::new(ownable_library(), vec![storage_slot], metadata).expect(
+            "Ownable component should satisfy the requirements of a valid account component",
+        )
+    }
+}
+
+// OWNABLE ERROR
+// ================================================================================================
+
+/// Errors that can occur when reading [`Ownable`] data from storage.
+#[derive(Debug, thiserror::Error)]
+pub enum OwnableError {
+    #[error("failed to read ownership slot from storage")]
+    StorageLookupFailed(#[source] miden_protocol::errors::AccountError),
+    #[error("invalid owner account ID in storage")]
+    InvalidOwnerId(#[source] AccountIdError),
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Constructs an `Option<AccountId>` from a suffix/prefix felt pair.
+/// Returns `Ok(None)` when both felts are zero (renounced).
+fn account_id_from_felt_pair(
+    suffix: Felt,
+    prefix: Felt,
+) -> Result<Option<AccountId>, AccountIdError> {
+    if suffix == Felt::ZERO && prefix == Felt::ZERO {
+        Ok(None)
+    } else {
+        AccountId::try_from_elements(suffix, prefix).map(Some)
+    }
+}

--- a/crates/miden-standards/src/account/components/mod.rs
+++ b/crates/miden-standards/src/account/components/mod.rs
@@ -25,6 +25,13 @@ static BASIC_WALLET_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
 // ACCESS LIBRARIES
 // ================================================================================================
 
+// Initialize the Ownable library only once.
+static OWNABLE_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
+    let bytes =
+        include_bytes!(concat!(env!("OUT_DIR"), "/assets/account_components/access/ownable.masl"));
+    Library::read_from_bytes(bytes).expect("Shipped Ownable library is well-formed")
+});
+
 // Initialize the Ownable2Step library only once.
 static OWNABLE2STEP_LIBRARY: LazyLock<Library> = LazyLock::new(|| {
     let bytes = include_bytes!(concat!(
@@ -132,6 +139,11 @@ static MINT_POLICY_AUTH_CONTROLLED_LIBRARY: LazyLock<Library> = LazyLock::new(||
 /// Returns the Basic Wallet Library.
 pub fn basic_wallet_library() -> Library {
     BASIC_WALLET_LIBRARY.clone()
+}
+
+/// Returns the Ownable Library.
+pub fn ownable_library() -> Library {
+    OWNABLE_LIBRARY.clone()
 }
 
 /// Returns the Ownable2Step Library.

--- a/crates/miden-standards/src/account/faucets/mod.rs
+++ b/crates/miden-standards/src/account/faucets/mod.rs
@@ -4,7 +4,7 @@ use miden_protocol::account::StorageSlotName;
 use miden_protocol::errors::{AccountError, TokenSymbolError};
 use thiserror::Error;
 
-use crate::account::access::Ownable2StepError;
+use crate::account::access::OwnableError;
 
 mod basic_fungible;
 mod network_fungible;
@@ -55,5 +55,5 @@ pub enum FungibleFaucetError {
     #[error("account is not a fungible faucet account")]
     NotAFungibleFaucetAccount,
     #[error("failed to read ownership data from storage")]
-    OwnershipError(#[source] Ownable2StepError),
+    OwnershipError(#[source] OwnableError),
 }

--- a/crates/miden-standards/src/account/faucets/network_fungible.rs
+++ b/crates/miden-standards/src/account/faucets/network_fungible.rs
@@ -60,9 +60,9 @@ procedure_digest!(
 /// authentication while `burn` does not require authentication and can be called by anyone.
 /// Thus, this component must be combined with a component providing authentication.
 ///
-/// This component relies on [`crate::account::access::Ownable2Step`] for ownership checks in
+/// This component relies on [`crate::account::access::Ownable`] for ownership checks in
 /// `mint_and_send`. When building an account with this component,
-/// [`crate::account::access::Ownable2Step`] must also be included.
+/// [`crate::account::access::Ownable`] must also be included.
 ///
 /// ## Storage Layout
 ///
@@ -284,7 +284,7 @@ impl TryFrom<&Account> for NetworkFungibleFaucet {
 /// - [`NoAuth`] for authentication
 ///
 /// The storage layout of the faucet account is documented on the [`NetworkFungibleFaucet`] and
-/// [`OwnerControlled`] and [`crate::account::access::Ownable2Step`] component types and
+/// [`OwnerControlled`] and [`crate::account::access::Ownable`] component types and
 /// contains no additional storage slots for its auth ([`NoAuth`]).
 pub fn create_network_fungible_faucet(
     init_seed: [u8; 32],
@@ -293,15 +293,15 @@ pub fn create_network_fungible_faucet(
     max_supply: Felt,
     access_control: AccessControl,
 ) -> Result<Account, FungibleFaucetError> {
-    // Validate that access_control is Ownable2Step, as this faucet depends on it.
+    // Validate that access_control is Ownable, as this faucet depends on it.
     // When new variants are added to AccessControl, update this match to either support
     // them or return Err(FungibleFaucetError::UnsupportedAccessControl).
     match access_control {
-        AccessControl::Ownable2Step { .. } => {},
+        AccessControl::Ownable { .. } => {},
         #[allow(unreachable_patterns)]
         _ => {
             return Err(FungibleFaucetError::UnsupportedAccessControl(
-                "network fungible faucets require Ownable2Step access control".into(),
+                "network fungible faucets require Ownable access control".into(),
             ));
         },
     }
@@ -329,7 +329,7 @@ mod tests {
     use miden_protocol::account::{AccountId, AccountIdVersion, AccountStorageMode, AccountType};
 
     use super::*;
-    use crate::account::access::Ownable2Step;
+    use crate::account::access::Ownable;
 
     #[test]
     fn test_create_network_fungible_faucet() {
@@ -350,13 +350,13 @@ mod tests {
             symbol.clone(),
             decimals,
             max_supply,
-            AccessControl::Ownable2Step { owner },
+            AccessControl::Ownable { owner },
         )
         .expect("network faucet creation should succeed");
 
-        let expected_owner_word = Ownable2Step::new(owner).to_word();
+        let expected_owner_word = Ownable::new(owner).to_word();
         assert_eq!(
-            account.storage().get_item(Ownable2Step::slot_name()).unwrap(),
+            account.storage().get_item(Ownable::slot_name()).unwrap(),
             expected_owner_word
         );
 

--- a/crates/miden-standards/src/account/faucets/network_fungible.rs
+++ b/crates/miden-standards/src/account/faucets/network_fungible.rs
@@ -355,10 +355,7 @@ mod tests {
         .expect("network faucet creation should succeed");
 
         let expected_owner_word = Ownable::new(owner).to_word();
-        assert_eq!(
-            account.storage().get_item(Ownable::slot_name()).unwrap(),
-            expected_owner_word
-        );
+        assert_eq!(account.storage().get_item(Ownable::slot_name()).unwrap(), expected_owner_word);
 
         let faucet = NetworkFungibleFaucet::try_from(&account)
             .expect("network fungible faucet should be extractable from account");

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -47,7 +47,7 @@ use miden_protocol::testing::account_id::ACCOUNT_ID_NATIVE_ASSET_FAUCET;
 use miden_protocol::testing::random_secret_key::random_secret_key;
 use miden_protocol::transaction::{OrderedTransactionHeaders, RawOutputNote, TransactionKernel};
 use miden_protocol::{Felt, MAX_OUTPUT_NOTES_PER_BATCH, Word};
-use miden_standards::account::access::Ownable2Step;
+use miden_standards::account::access::Ownable;
 use miden_standards::account::faucets::{BasicFungibleFaucet, NetworkFungibleFaucet};
 use miden_standards::account::mint_policies::{
     AuthControlled,
@@ -398,7 +398,7 @@ impl MockChainBuilder {
         let account_builder = AccountBuilder::new(self.rng.random())
             .storage_mode(AccountStorageMode::Network)
             .with_component(network_faucet)
-            .with_component(Ownable2Step::new(owner_account_id))
+            .with_component(Ownable::new(owner_account_id))
             .with_component(OwnerControlled::new(mint_policy))
             .account_type(AccountType::FungibleFaucet);
 

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -28,7 +28,7 @@ use miden_protocol::note::{
 use miden_protocol::testing::account_id::ACCOUNT_ID_PRIVATE_SENDER;
 use miden_protocol::transaction::{ExecutedTransaction, RawOutputNote};
 use miden_protocol::{Felt, Word};
-use miden_standards::account::access::Ownable2Step;
+use miden_standards::account::access::Ownable;
 use miden_standards::account::faucets::{
     BasicFungibleFaucet,
     NetworkFungibleFaucet,
@@ -590,14 +590,14 @@ async fn network_faucet_mint() -> anyhow::Result<()> {
     assert_eq!(actual_max_supply.as_canonical_u64(), max_supply);
 
     // Check that the creator account ID is stored in the ownership slot.
-    // Word: [owner_suffix, owner_prefix, nominated_suffix, nominated_prefix]
-    let stored_owner_id = faucet.storage().get_item(Ownable2Step::slot_name()).unwrap();
+    // Word: [owner_suffix, owner_prefix, 0, 0]
+    let stored_owner_id = faucet.storage().get_item(Ownable::slot_name()).unwrap();
     assert_eq!(
         stored_owner_id[0],
         Felt::new(faucet_owner_account_id.suffix().as_canonical_u64())
     );
     assert_eq!(stored_owner_id[1], faucet_owner_account_id.prefix().as_felt());
-    assert_eq!(stored_owner_id[2], Felt::new(0)); // no nominated owner
+    assert_eq!(stored_owner_id[2], Felt::new(0));
     assert_eq!(stored_owner_id[3], Felt::new(0));
 
     // Check that the faucet's token supply has been correctly initialized.
@@ -872,20 +872,18 @@ async fn test_network_faucet_owner_storage() -> anyhow::Result<()> {
     let _mock_chain = builder.build()?;
 
     // Verify owner is stored correctly
-    let stored_owner = faucet.storage().get_item(Ownable2Step::slot_name())?;
+    let stored_owner = faucet.storage().get_item(Ownable::slot_name())?;
 
-    // Word: [owner_suffix, owner_prefix, nominated_suffix, nominated_prefix]
+    // Word: [owner_suffix, owner_prefix, 0, 0]
     assert_eq!(stored_owner[0], Felt::new(owner_account_id.suffix().as_canonical_u64()));
     assert_eq!(stored_owner[1], owner_account_id.prefix().as_felt());
-    assert_eq!(stored_owner[2], Felt::new(0)); // no nominated owner
+    assert_eq!(stored_owner[2], Felt::new(0));
     assert_eq!(stored_owner[3], Felt::new(0));
 
     Ok(())
 }
 
-/// Tests that two-step transfer_ownership updates the owner correctly.
-/// Step 1: Owner nominates a new owner via transfer_ownership.
-/// Step 2: Nominated owner accepts via accept_ownership.
+/// Tests that one-step transfer_ownership updates the owner immediately.
 #[tokio::test]
 async fn test_network_faucet_transfer_ownership() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
@@ -939,16 +937,16 @@ async fn test_network_faucet_transfer_ownership() -> anyhow::Result<()> {
         &mut rng,
     )?;
 
-    // Step 1: Create transfer_ownership note script to nominate new owner
+    // Create the one-step transfer_ownership note script
     let transfer_note_script_code = format!(
         r#"
-        use miden::standards::access::ownable2step
+        use miden::standards::access::ownable
 
         begin
             repeat.14 push.0 end
             push.{new_owner_prefix}
             push.{new_owner_suffix}
-            call.ownable2step::transfer_ownership
+            call.ownable::transfer_ownership
             dropw dropw dropw dropw
         end
         "#,
@@ -979,54 +977,22 @@ async fn test_network_faucet_transfer_ownership() -> anyhow::Result<()> {
     let executed_transaction = tx_context.execute().await?;
     assert_eq!(executed_transaction.output_notes().num_notes(), 1);
 
-    // Execute transfer_ownership via note script (nominates new owner)
+    // Execute transfer_ownership via note script (owner changes immediately)
     let tx_context = mock_chain
         .build_tx_context(faucet.id(), &[transfer_note.id()], &[])?
         .with_source_manager(source_manager.clone())
         .build()?;
     let executed_transaction = tx_context.execute().await?;
 
-    // Persistence: Apply the transaction to update the faucet state
-    mock_chain.add_pending_executed_transaction(&executed_transaction)?;
-    mock_chain.prove_next_block()?;
-
-    let mut updated_faucet = faucet.clone();
-    updated_faucet.apply_delta(executed_transaction.account_delta())?;
-
-    // Step 2: Accept ownership as the nominated owner
-    let accept_note_script_code = r#"
-        use miden::standards::access::ownable2step
-
-        begin
-            repeat.16 push.0 end
-            call.ownable2step::accept_ownership
-            dropw dropw dropw dropw
-        end
-        "#;
-
-    let mut rng = RandomCoin::new([Felt::from(400u32); 4].into());
-    let accept_note = NoteBuilder::new(new_owner_account_id, &mut rng)
-        .note_type(NoteType::Private)
-        .tag(NoteTag::default().into())
-        .serial_number(Word::from([55, 66, 77, 88u32]))
-        .code(accept_note_script_code)
-        .build()?;
-
-    let tx_context = mock_chain
-        .build_tx_context(updated_faucet.clone(), &[], slice::from_ref(&accept_note))?
-        .with_source_manager(source_manager.clone())
-        .build()?;
-    let executed_transaction = tx_context.execute().await?;
-
-    let mut final_faucet = updated_faucet.clone();
+    let mut final_faucet = faucet.clone();
     final_faucet.apply_delta(executed_transaction.account_delta())?;
 
-    // Verify that owner changed to new_owner and nominated was cleared
-    // Word: [owner_suffix, owner_prefix, nominated_suffix, nominated_prefix]
-    let stored_owner = final_faucet.storage().get_item(Ownable2Step::slot_name())?;
+    // Verify that owner changed to new_owner immediately (no acceptance step)
+    // Word: [owner_suffix, owner_prefix, 0, 0]
+    let stored_owner = final_faucet.storage().get_item(Ownable::slot_name())?;
     assert_eq!(stored_owner[0], Felt::new(new_owner_account_id.suffix().as_canonical_u64()));
     assert_eq!(stored_owner[1], new_owner_account_id.prefix().as_felt());
-    assert_eq!(stored_owner[2], Felt::new(0)); // nominated cleared
+    assert_eq!(stored_owner[2], Felt::new(0));
     assert_eq!(stored_owner[3], Felt::new(0));
 
     Ok(())
@@ -1070,13 +1036,13 @@ async fn test_network_faucet_only_owner_can_transfer() -> anyhow::Result<()> {
     // Create transfer ownership note script
     let transfer_note_script_code = format!(
         r#"
-        use miden::standards::access::ownable2step
+        use miden::standards::access::ownable
 
         begin
             repeat.14 push.0 end
             push.{new_owner_prefix}
             push.{new_owner_suffix}
-            call.ownable2step::transfer_ownership
+            call.ownable::transfer_ownership
             dropw dropw dropw dropw
         end
         "#,
@@ -1134,17 +1100,17 @@ async fn test_network_faucet_renounce_ownership() -> anyhow::Result<()> {
     )?;
 
     // Check stored value before renouncing
-    let stored_owner_before = faucet.storage().get_item(Ownable2Step::slot_name())?;
+    let stored_owner_before = faucet.storage().get_item(Ownable::slot_name())?;
     assert_eq!(stored_owner_before[0], Felt::new(owner_account_id.suffix().as_canonical_u64()));
     assert_eq!(stored_owner_before[1], owner_account_id.prefix().as_felt());
 
     // Create renounce_ownership note script
     let renounce_note_script_code = r#"
-        use miden::standards::access::ownable2step
+        use miden::standards::access::ownable
 
         begin
             repeat.16 push.0 end
-            call.ownable2step::renounce_ownership
+            call.ownable::renounce_ownership
             dropw dropw dropw dropw
         end
         "#;
@@ -1154,13 +1120,13 @@ async fn test_network_faucet_renounce_ownership() -> anyhow::Result<()> {
     // Create transfer note script (will be used after renounce)
     let transfer_note_script_code = format!(
         r#"
-        use miden::standards::access::ownable2step
+        use miden::standards::access::ownable
 
         begin
             repeat.14 push.0 end
             push.{new_owner_prefix}
             push.{new_owner_suffix}
-            call.ownable2step::transfer_ownership
+            call.ownable::transfer_ownership
             dropw dropw dropw dropw
         end
         "#,
@@ -1203,7 +1169,7 @@ async fn test_network_faucet_renounce_ownership() -> anyhow::Result<()> {
     updated_faucet.apply_delta(executed_transaction.account_delta())?;
 
     // Check stored value after renouncing - should be zero
-    let stored_owner_after = updated_faucet.storage().get_item(Ownable2Step::slot_name())?;
+    let stored_owner_after = updated_faucet.storage().get_item(Ownable::slot_name())?;
     assert_eq!(stored_owner_after[0], Felt::new(0));
     assert_eq!(stored_owner_after[1], Felt::new(0));
     assert_eq!(stored_owner_after[2], Felt::new(0));

--- a/crates/miden-testing/tests/scripts/mod.rs
+++ b/crates/miden-testing/tests/scripts/mod.rs
@@ -1,5 +1,6 @@
 mod faucet;
 mod fee;
+mod ownable;
 mod ownable2step;
 mod p2id;
 mod p2ide;

--- a/crates/miden-testing/tests/scripts/ownable.rs
+++ b/crates/miden-testing/tests/scripts/ownable.rs
@@ -1,0 +1,287 @@
+extern crate alloc;
+
+use alloc::sync::Arc;
+
+use miden_processor::crypto::random::RandomCoin;
+use miden_protocol::Felt;
+use miden_protocol::account::component::AccountComponentMetadata;
+use miden_protocol::account::{
+    Account,
+    AccountBuilder,
+    AccountComponent,
+    AccountId,
+    AccountStorageMode,
+    AccountType,
+    StorageSlot,
+};
+use miden_protocol::assembly::DefaultSourceManager;
+use miden_protocol::assembly::debuginfo::SourceManagerSync;
+use miden_protocol::note::Note;
+use miden_protocol::testing::account_id::AccountIdBuilder;
+use miden_protocol::transaction::RawOutputNote;
+use miden_standards::account::access::Ownable;
+use miden_standards::code_builder::CodeBuilder;
+use miden_standards::errors::standards::ERR_SENDER_NOT_OWNER;
+use miden_standards::testing::note::NoteBuilder;
+use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
+
+// HELPERS
+// ================================================================================================
+
+fn create_ownable_account(
+    owner: AccountId,
+    initial_storage: Vec<StorageSlot>,
+) -> anyhow::Result<Account> {
+    let component_code = r#"
+        use miden::standards::access::ownable
+        pub use ownable::get_owner
+        pub use ownable::transfer_ownership
+        pub use ownable::renounce_ownership
+    "#;
+    let component_code_obj =
+        CodeBuilder::default().compile_component_code("test::ownable", component_code)?;
+
+    let mut storage_slots = initial_storage;
+    storage_slots.push(Ownable::new(owner).to_storage_slot());
+
+    let account = AccountBuilder::new([1; 32])
+        .storage_mode(AccountStorageMode::Public)
+        .with_auth_component(Auth::IncrNonce)
+        .with_component({
+            let metadata = AccountComponentMetadata::new("test::ownable", AccountType::all());
+            AccountComponent::new(component_code_obj, storage_slots, metadata)?
+        })
+        .build_existing()?;
+    Ok(account)
+}
+
+fn get_owner_from_storage(account: &Account) -> anyhow::Result<Option<AccountId>> {
+    let ownable = Ownable::try_from_storage(account.storage())?;
+    Ok(ownable.owner())
+}
+
+fn create_transfer_note(
+    sender: AccountId,
+    new_owner: AccountId,
+    rng: &mut RandomCoin,
+    source_manager: Arc<dyn SourceManagerSync>,
+) -> anyhow::Result<Note> {
+    let script = format!(
+        r#"
+        use miden::standards::access::ownable->test_account
+        begin
+            repeat.14 push.0 end
+            push.{new_owner_prefix}
+            push.{new_owner_suffix}
+            call.test_account::transfer_ownership
+            dropw dropw dropw dropw
+        end
+    "#,
+        new_owner_prefix = new_owner.prefix().as_felt(),
+        new_owner_suffix = Felt::new(new_owner.suffix().as_canonical_u64()),
+    );
+
+    let note = NoteBuilder::new(sender, rng)
+        .source_manager(source_manager)
+        .code(script)
+        .build()?;
+
+    Ok(note)
+}
+
+fn create_renounce_note(
+    sender: AccountId,
+    rng: &mut RandomCoin,
+    source_manager: Arc<dyn SourceManagerSync>,
+) -> anyhow::Result<Note> {
+    let script = r#"
+        use miden::standards::access::ownable->test_account
+        begin
+            repeat.16 push.0 end
+            call.test_account::renounce_ownership
+            dropw dropw dropw dropw
+        end
+    "#;
+
+    let note = NoteBuilder::new(sender, rng)
+        .source_manager(source_manager)
+        .code(script)
+        .build()?;
+
+    Ok(note)
+}
+
+// TESTS
+// ================================================================================================
+
+/// A non-owner cannot transfer ownership.
+#[tokio::test]
+async fn test_transfer_ownership_only_owner() -> anyhow::Result<()> {
+    let owner = AccountIdBuilder::new().build_with_seed([1; 32]);
+    let non_owner = AccountIdBuilder::new().build_with_seed([2; 32]);
+    let new_owner = AccountIdBuilder::new().build_with_seed([3; 32]);
+
+    let account = create_ownable_account(owner, vec![])?;
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+
+    let source_manager: Arc<dyn SourceManagerSync> = Arc::new(DefaultSourceManager::default());
+    let mut rng = RandomCoin::new([Felt::from(100u32); 4].into());
+    let note = create_transfer_note(non_owner, new_owner, &mut rng, Arc::clone(&source_manager))?;
+
+    builder.add_output_note(RawOutputNote::Full(note.clone()));
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    let tx = mock_chain
+        .build_tx_context(account.id(), &[note.id()], &[])?
+        .with_source_manager(source_manager)
+        .build()?;
+    let result = tx.execute().await;
+
+    assert_transaction_executor_error!(result, ERR_SENDER_NOT_OWNER);
+    Ok(())
+}
+
+/// The owner transfers ownership in a single step; the new owner takes effect immediately.
+#[tokio::test]
+async fn test_transfer_ownership_is_immediate() -> anyhow::Result<()> {
+    let owner = AccountIdBuilder::new().build_with_seed([1; 32]);
+    let new_owner = AccountIdBuilder::new().build_with_seed([2; 32]);
+
+    let account = create_ownable_account(owner, vec![])?;
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+
+    let source_manager: Arc<dyn SourceManagerSync> = Arc::new(DefaultSourceManager::default());
+    let mut rng = RandomCoin::new([Felt::from(100u32); 4].into());
+    let transfer_note =
+        create_transfer_note(owner, new_owner, &mut rng, Arc::clone(&source_manager))?;
+
+    builder.add_output_note(RawOutputNote::Full(transfer_note.clone()));
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    let tx = mock_chain
+        .build_tx_context(account.id(), &[transfer_note.id()], &[])?
+        .with_source_manager(source_manager)
+        .build()?;
+    let executed = tx.execute().await?;
+
+    let mut updated = account.clone();
+    updated.apply_delta(executed.account_delta())?;
+
+    // The owner is updated directly, with no nomination/acceptance step.
+    assert_eq!(get_owner_from_storage(&updated)?, Some(new_owner));
+    Ok(())
+}
+
+/// The owner renounces ownership, leaving the account permanently ownerless.
+#[tokio::test]
+async fn test_renounce_ownership() -> anyhow::Result<()> {
+    let owner = AccountIdBuilder::new().build_with_seed([1; 32]);
+
+    let account = create_ownable_account(owner, vec![])?;
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+
+    let source_manager: Arc<dyn SourceManagerSync> = Arc::new(DefaultSourceManager::default());
+    let mut rng = RandomCoin::new([Felt::from(100u32); 4].into());
+    let renounce_note = create_renounce_note(owner, &mut rng, Arc::clone(&source_manager))?;
+
+    builder.add_output_note(RawOutputNote::Full(renounce_note.clone()));
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    let tx = mock_chain
+        .build_tx_context(account.id(), &[renounce_note.id()], &[])?
+        .with_source_manager(source_manager)
+        .build()?;
+    let executed = tx.execute().await?;
+
+    let mut updated = account.clone();
+    updated.apply_delta(executed.account_delta())?;
+
+    assert_eq!(get_owner_from_storage(&updated)?, None);
+    Ok(())
+}
+
+/// A non-owner cannot renounce ownership.
+#[tokio::test]
+async fn test_renounce_ownership_only_owner() -> anyhow::Result<()> {
+    let owner = AccountIdBuilder::new().build_with_seed([1; 32]);
+    let non_owner = AccountIdBuilder::new().build_with_seed([2; 32]);
+
+    let account = create_ownable_account(owner, vec![])?;
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+
+    let source_manager: Arc<dyn SourceManagerSync> = Arc::new(DefaultSourceManager::default());
+    let mut rng = RandomCoin::new([Felt::from(100u32); 4].into());
+    let renounce_note = create_renounce_note(non_owner, &mut rng, Arc::clone(&source_manager))?;
+
+    builder.add_output_note(RawOutputNote::Full(renounce_note.clone()));
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    let tx = mock_chain
+        .build_tx_context(account.id(), &[renounce_note.id()], &[])?
+        .with_source_manager(source_manager)
+        .build()?;
+    let result = tx.execute().await;
+
+    assert_transaction_executor_error!(result, ERR_SENDER_NOT_OWNER);
+    Ok(())
+}
+
+/// `transfer_ownership` fails when the new owner account ID is invalid.
+/// An invalid account ID has its suffix's lower 8 bits set to a non-zero value.
+#[tokio::test]
+async fn test_transfer_ownership_fails_with_invalid_account_id() -> anyhow::Result<()> {
+    use miden_protocol::errors::protocol::ERR_ACCOUNT_ID_SUFFIX_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO;
+
+    let owner = AccountIdBuilder::new().build_with_seed([1; 32]);
+
+    let account = create_ownable_account(owner, vec![])?;
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+
+    let invalid_prefix = owner.prefix().as_felt();
+    let invalid_suffix = Felt::new(1);
+
+    let script = format!(
+        r#"
+        use miden::standards::access::ownable->test_account
+        begin
+            repeat.14 push.0 end
+            push.{invalid_suffix}
+            push.{invalid_prefix}
+            call.test_account::transfer_ownership
+            dropw dropw dropw dropw
+        end
+    "#,
+    );
+
+    let source_manager: Arc<dyn SourceManagerSync> = Arc::new(DefaultSourceManager::default());
+    let mut rng = RandomCoin::new([Felt::from(100u32); 4].into());
+    let note = NoteBuilder::new(owner, &mut rng)
+        .source_manager(Arc::clone(&source_manager))
+        .code(script)
+        .build()?;
+
+    builder.add_output_note(RawOutputNote::Full(note.clone()));
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    let tx = mock_chain
+        .build_tx_context(account.id(), &[note.id()], &[])?
+        .with_source_manager(source_manager)
+        .build()?;
+    let result = tx.execute().await;
+
+    assert_transaction_executor_error!(
+        result,
+        ERR_ACCOUNT_ID_SUFFIX_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Reintroduces the one-step `Ownable` access-control component and switches the network-faucet owner-control path to it. The `AggLayerFaucet` and the standards `NetworkFungibleFaucet` now use `Ownable` instead of `Ownable2Step`. Two-step ownership adds no value for a faucet whose owner is a fixed controller account (the bridge), so the lighter one-step component is used.

Implements #2990 (bring back `Ownable`) and #2991 (switch `AggLayerFaucet` to `Ownable`).

## Changes

- Add the `Ownable` account component (masm + Rust) and register its library in `miden-standards`.
- Point the shared owner-only mint policy and `policy_manager` at `ownable::assert_sender_is_owner`.
- Migrate `NetworkFungibleFaucet` and `AggLayerFaucet` from `Ownable2Step` to `Ownable`.
- Add one-step `Ownable` script tests and update the affected faucet tests and the agglayer SPEC.

`Ownable2Step` is left in place for any future consumer.

## Testing

- `cargo test -p miden-standards`
- `cargo test -p miden-agglayer`
- `cargo test -p miden-testing --test lib scripts::` (includes new `scripts::ownable`)
- `cargo test -p miden-testing --test lib agglayer` (mint path end to end)

## Notes

- Based off the `agglayer` integration branch.
- `make format` (nightly rustfmt) was not run: no nightly toolchain is available in the dev environment. Formatting follows existing conventions but should be confirmed by CI.
- Issues #2990 and #2991 are currently assigned to another contributor; please coordinate before merging.