### PR TITLE
feat(batch-prover): verify batch kernel execution proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,8 @@ dependencies = [
  "miden-processor",
  "miden-protocol",
  "miden-prover",
+ "miden-verifier",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/miden-protocol/src/batch/kernel.rs
+++ b/crates/miden-protocol/src/batch/kernel.rs
@@ -3,10 +3,9 @@ use alloc::vec::Vec;
 use miden_core::program::Kernel;
 
 use crate::batch::{BatchId, ProposedBatch};
-use crate::block::BlockNumber;
 use crate::utils::serde::Deserializable;
 use crate::utils::sync::LazyLock;
-use crate::vm::{AdviceInputs, Program, ProgramInfo, StackInputs, StackOutputs};
+use crate::vm::{AdviceInputs, Program, ProgramInfo, StackInputs};
 use crate::{Felt, Word};
 
 // CONSTANTS
@@ -75,26 +74,6 @@ impl BatchKernel {
         inputs.extend_from_slice(batch_id.as_word().as_elements());
 
         StackInputs::new(&inputs).expect("number of stack inputs should be <= 16")
-    }
-
-    /// Builds the stack with the expected batch kernel outputs.
-    ///
-    /// The output stack is defined as:
-    ///
-    /// ```text
-    /// [INPUT_NOTES_COMMITMENT, BATCH_NOTE_TREE_ROOT, batch_expiration_block_num]
-    /// ```
-    pub fn build_output_stack(
-        input_notes_commitment: Word,
-        batch_note_tree_root: Word,
-        batch_expiration_block_num: BlockNumber,
-    ) -> StackOutputs {
-        let mut outputs: Vec<Felt> = Vec::with_capacity(9);
-        outputs.extend_from_slice(input_notes_commitment.as_elements());
-        outputs.extend_from_slice(batch_note_tree_root.as_elements());
-        outputs.push(Felt::from(batch_expiration_block_num));
-
-        StackOutputs::new(&outputs).expect("number of stack outputs should be <= 16")
     }
 
     // ADVICE BUILDER

--- a/crates/miden-protocol/src/batch/output.rs
+++ b/crates/miden-protocol/src/batch/output.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::block::BlockNumber;
 use crate::errors::BatchOutputError;
 use crate::vm::StackOutputs;
@@ -118,6 +120,25 @@ impl BatchOutputs {
     /// Returns the block number at which the batch expires.
     pub fn batch_expiration_block_num(&self) -> BlockNumber {
         self.batch_expiration_block_num
+    }
+
+    // CONVERSIONS
+    // --------------------------------------------------------------------------------------------
+
+    /// Encodes these [`BatchOutputs`] into the batch kernel's output stack.
+    ///
+    /// This is the inverse of [`BatchOutputs::parse`]; the resulting stack is laid out as:
+    ///
+    /// ```text
+    /// [INPUT_NOTES_COMMITMENT, BATCH_NOTE_TREE_ROOT, batch_expiration_block_num]
+    /// ```
+    pub fn into_stack_outputs(self) -> StackOutputs {
+        let mut outputs: Vec<Felt> = Vec::with_capacity(9);
+        outputs.extend_from_slice(self.input_notes_commitment.as_elements());
+        outputs.extend_from_slice(self.batch_note_tree_root.as_elements());
+        outputs.push(Felt::from(self.batch_expiration_block_num));
+
+        StackOutputs::new(&outputs).expect("number of stack outputs should be <= 16")
     }
 }
 

--- a/crates/miden-testing/src/kernel_tests/batch/batch_verifier.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/batch_verifier.rs
@@ -18,12 +18,15 @@ fn batch_verifier_accepts_freshly_proven_batch() -> anyhow::Result<()> {
     let executed = BatchExecutor::new().execute(batch).context("batch execution failed")?;
     let proven = LocalBatchProver::new().prove(executed).context("batch proving failed")?;
 
-    BatchVerifier::new(0)
+    let security_level = proven.proof_security_level();
+
+    // Requiring exactly the security level the proof provides must succeed.
+    BatchVerifier::new(security_level)
         .verify(&proven)
         .context("verifying the proven batch should succeed")?;
 
-    // Requiring more security than the proof actually provides must fail.
-    let err = BatchVerifier::new(u32::MAX).verify(&proven).unwrap_err();
+    // Requiring even one more bit than the proof provides must fail.
+    let err = BatchVerifier::new(security_level + 1).verify(&proven).unwrap_err();
     assert_matches!(err, BatchVerifierError::InsufficientProofSecurityLevel { .. });
 
     Ok(())

--- a/crates/miden-testing/src/kernel_tests/batch/batch_verifier.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/batch_verifier.rs
@@ -1,0 +1,44 @@
+use anyhow::Context;
+use assert_matches::assert_matches;
+use miden_tx_batch_prover::{BatchExecutor, BatchVerifier, BatchVerifierError, LocalBatchProver};
+
+use super::proposed_batch::setup_chain;
+use super::test_batch_kernel::two_tx_batch;
+
+// BATCH VERIFIER TESTS
+// ================================================================================================
+
+/// A batch proven by the batch kernel verifies against the kernel program, and requiring a higher
+/// security level than the proof provides is rejected.
+#[test]
+fn batch_verifier_accepts_freshly_proven_batch() -> anyhow::Result<()> {
+    let mut setup = setup_chain();
+    let batch = two_tx_batch(&mut setup)?;
+
+    let executed = BatchExecutor::new().execute(batch).context("batch execution failed")?;
+    let proven = LocalBatchProver::new().prove(executed).context("batch proving failed")?;
+
+    BatchVerifier::new(0)
+        .verify(&proven)
+        .context("verifying the proven batch should succeed")?;
+
+    // Requiring more security than the proof actually provides must fail.
+    let err = BatchVerifier::new(u32::MAX).verify(&proven).unwrap_err();
+    assert_matches!(err, BatchVerifierError::InsufficientProofSecurityLevel { .. });
+
+    Ok(())
+}
+
+/// The dummy proof carried by `prove_dummy` is not a valid batch-kernel proof and must be rejected.
+#[test]
+fn batch_verifier_rejects_dummy_proof() -> anyhow::Result<()> {
+    let mut setup = setup_chain();
+    let batch = two_tx_batch(&mut setup)?;
+
+    let proven = LocalBatchProver::new().prove_dummy(batch)?;
+
+    let err = BatchVerifier::new(0).verify(&proven).unwrap_err();
+    assert_matches!(err, BatchVerifierError::BatchVerificationFailed(_));
+
+    Ok(())
+}

--- a/crates/miden-testing/src/kernel_tests/batch/mod.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/mod.rs
@@ -1,3 +1,4 @@
+mod batch_verifier;
 pub(super) mod proposed_batch;
 mod proven_tx_builder;
 mod test_batch_kernel;

--- a/crates/miden-testing/src/kernel_tests/batch/test_batch_kernel.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/test_batch_kernel.rs
@@ -16,7 +16,7 @@ use super::proven_tx_builder::MockProvenTxBuilder;
 /// Builds a two-transaction batch with realistic inputs and outputs. The skeleton kernel does not
 /// inspect any of this data, but the batch is built end-to-end so the smoke test exercises the
 /// real `prepare_inputs` path that the verification PR will eventually consume.
-fn two_tx_batch(setup: &mut TestSetup) -> anyhow::Result<ProposedBatch> {
+pub(super) fn two_tx_batch(setup: &mut TestSetup) -> anyhow::Result<ProposedBatch> {
     let block1 = setup.chain.block_header(1);
     let block2 = setup.chain.prove_next_block()?;
 

--- a/crates/miden-tx-batch-prover/Cargo.toml
+++ b/crates/miden-tx-batch-prover/Cargo.toml
@@ -18,13 +18,15 @@ doctest = false
 
 [features]
 default = ["std"]
-std     = ["miden-processor/std", "miden-protocol/std", "miden-prover/std"]
+std     = ["miden-processor/std", "miden-protocol/std", "miden-prover/std", "miden-verifier/std"]
 testing = ["miden-processor/testing", "miden-protocol/testing"]
 
 [dependencies]
 miden-processor = { workspace = true }
 miden-protocol  = { workspace = true }
 miden-prover    = { workspace = true }
+miden-verifier  = { workspace = true }
+thiserror       = { workspace = true }
 
 [dev-dependencies]
 miden-protocol = { features = ["testing"], workspace = true }

--- a/crates/miden-tx-batch-prover/src/errors.rs
+++ b/crates/miden-tx-batch-prover/src/errors.rs
@@ -1,0 +1,14 @@
+use miden_verifier::VerificationError;
+use thiserror::Error;
+
+// BATCH VERIFIER ERROR
+// ================================================================================================
+
+/// Errors returned when verifying a [`ProvenBatch`](miden_protocol::batch::ProvenBatch)'s proof.
+#[derive(Debug, Error)]
+pub enum BatchVerifierError {
+    #[error("failed to verify batch")]
+    BatchVerificationFailed(#[source] VerificationError),
+    #[error("batch proof security level is {actual} but must be at least {expected_minimum}")]
+    InsufficientProofSecurityLevel { actual: u32, expected_minimum: u32 },
+}

--- a/crates/miden-tx-batch-prover/src/lib.rs
+++ b/crates/miden-tx-batch-prover/src/lib.rs
@@ -8,8 +8,14 @@ extern crate std;
 mod batch_executor;
 pub use batch_executor::BatchExecutor;
 
+mod errors;
+pub use errors::BatchVerifierError;
+
 mod executed_batch;
 pub use executed_batch::ExecutedBatch;
 
 mod local_batch_prover;
 pub use local_batch_prover::LocalBatchProver;
+
+mod verifier;
+pub use verifier::BatchVerifier;

--- a/crates/miden-tx-batch-prover/src/verifier.rs
+++ b/crates/miden-tx-batch-prover/src/verifier.rs
@@ -43,17 +43,16 @@ impl BatchVerifier {
     /// - Batch proof verification fails.
     /// - The security level of the verified proof is insufficient.
     pub fn verify(&self, batch: &ProvenBatch) -> Result<(), BatchVerifierError> {
-        let stack_inputs = BatchKernel::build_input_stack(
-            batch.reference_block_commitment(),
-            batch.id().as_word(),
-        );
+        let stack_inputs =
+            BatchKernel::build_input_stack(batch.reference_block_commitment(), batch.id());
 
         // The skeleton kernel drops its inputs and emits the all-zero output region, so the proof
         // attests to empty outputs. Once the kernel computes the real commitments, these empty
         // values become `batch.input_notes().commitment()`, the batch note tree root and
         // `batch.batch_expiration_block_num()`.
-        let stack_outputs = BatchOutputs::new(Word::empty(), Word::empty(), BlockNumber::from(0u32))
-            .into_stack_outputs();
+        let stack_outputs =
+            BatchOutputs::new(Word::empty(), Word::empty(), BlockNumber::from(0u32))
+                .into_stack_outputs();
 
         let proof_security_level = verify(
             self.batch_program_info.clone(),

--- a/crates/miden-tx-batch-prover/src/verifier.rs
+++ b/crates/miden-tx-batch-prover/src/verifier.rs
@@ -19,7 +19,7 @@ use crate::BatchVerifierError;
 ///
 /// The current batch kernel is a skeleton that drops its inputs and emits an all-zero output
 /// region, so a successful [`verify`](BatchVerifier::verify) attests only that the kernel program
-/// ran over the batch's `[BATCH_ID, BLOCK_COMMITMENT]` public inputs. It does **not** yet bind the
+/// ran over the batch's `[BLOCK_COMMITMENT, BATCH_ID]` public inputs. It does **not** yet bind the
 /// batch's notes, account updates, or expiration: those values are not part of what the proof
 /// commits to, so a `ProvenBatch` whose contents were mutated would still verify. This verifier
 /// must therefore not be relied on at a trust boundary until the kernel verification logic that
@@ -44,13 +44,13 @@ impl BatchVerifier {
     /// - The security level of the verified proof is insufficient.
     pub fn verify(&self, batch: &ProvenBatch) -> Result<(), BatchVerifierError> {
         let stack_inputs = BatchKernel::build_input_stack(
-            batch.id().as_word(),
             batch.reference_block_commitment(),
+            batch.id().as_word(),
         );
 
         // The skeleton kernel drops its inputs and emits the all-zero output region, so the proof
         // attests to empty outputs. Once the kernel computes the real commitments, these empty
-        // values become `batch.input_notes().commitment()`, the output notes commitment and
+        // values become `batch.input_notes().commitment()`, the batch note tree root and
         // `batch.batch_expiration_block_num()`.
         let stack_outputs =
             BatchKernel::build_output_stack(Word::empty(), Word::empty(), BlockNumber::from(0u32));

--- a/crates/miden-tx-batch-prover/src/verifier.rs
+++ b/crates/miden-tx-batch-prover/src/verifier.rs
@@ -1,0 +1,75 @@
+use miden_protocol::Word;
+use miden_protocol::batch::{BatchKernel, ProvenBatch};
+use miden_protocol::block::BlockNumber;
+use miden_protocol::vm::ProgramInfo;
+use miden_verifier::verify;
+
+use crate::BatchVerifierError;
+
+// BATCH VERIFIER
+// ================================================================================================
+
+/// The [`BatchVerifier`] verifies the execution proof attached to a [`ProvenBatch`] against the
+/// batch kernel program.
+///
+/// The `proof_security_level` specifies the minimum security level (in bits) the batch proof must
+/// have to be considered valid.
+///
+/// # Warning
+///
+/// The current batch kernel is a skeleton that drops its inputs and emits an all-zero output
+/// region, so a successful [`verify`](BatchVerifier::verify) attests only that the kernel program
+/// ran over the batch's `[BATCH_ID, BLOCK_COMMITMENT]` public inputs. It does **not** yet bind the
+/// batch's notes, account updates, or expiration: those values are not part of what the proof
+/// commits to, so a `ProvenBatch` whose contents were mutated would still verify. This verifier
+/// must therefore not be relied on at a trust boundary until the kernel verification logic that
+/// emits and binds the real commitments lands.
+pub struct BatchVerifier {
+    batch_program_info: ProgramInfo,
+    proof_security_level: u32,
+}
+
+impl BatchVerifier {
+    /// Returns a new [`BatchVerifier`] instantiated with the specified minimum security level.
+    pub fn new(proof_security_level: u32) -> Self {
+        let batch_program_info = BatchKernel::program_info();
+        Self { batch_program_info, proof_security_level }
+    }
+
+    /// Verifies the provided [`ProvenBatch`]'s execution proof against the batch kernel.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - Batch proof verification fails.
+    /// - The security level of the verified proof is insufficient.
+    pub fn verify(&self, batch: &ProvenBatch) -> Result<(), BatchVerifierError> {
+        let stack_inputs = BatchKernel::build_input_stack(
+            batch.id().as_word(),
+            batch.reference_block_commitment(),
+        );
+
+        // The skeleton kernel drops its inputs and emits the all-zero output region, so the proof
+        // attests to empty outputs. Once the kernel computes the real commitments, these empty
+        // values become `batch.input_notes().commitment()`, the output notes commitment and
+        // `batch.batch_expiration_block_num()`.
+        let stack_outputs =
+            BatchKernel::build_output_stack(Word::empty(), Word::empty(), BlockNumber::from(0u32));
+
+        let proof_security_level = verify(
+            self.batch_program_info.clone(),
+            stack_inputs,
+            stack_outputs,
+            batch.proof().clone(),
+        )
+        .map_err(BatchVerifierError::BatchVerificationFailed)?;
+
+        if proof_security_level < self.proof_security_level {
+            return Err(BatchVerifierError::InsufficientProofSecurityLevel {
+                actual: proof_security_level,
+                expected_minimum: self.proof_security_level,
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/crates/miden-tx-batch-prover/src/verifier.rs
+++ b/crates/miden-tx-batch-prover/src/verifier.rs
@@ -1,5 +1,5 @@
 use miden_protocol::Word;
-use miden_protocol::batch::{BatchKernel, ProvenBatch};
+use miden_protocol::batch::{BatchKernel, BatchOutputs, ProvenBatch};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::vm::ProgramInfo;
 use miden_verifier::verify;
@@ -52,8 +52,8 @@ impl BatchVerifier {
         // attests to empty outputs. Once the kernel computes the real commitments, these empty
         // values become `batch.input_notes().commitment()`, the batch note tree root and
         // `batch.batch_expiration_block_num()`.
-        let stack_outputs =
-            BatchKernel::build_output_stack(Word::empty(), Word::empty(), BlockNumber::from(0u32));
+        let stack_outputs = BatchOutputs::new(Word::empty(), Word::empty(), BlockNumber::from(0u32))
+            .into_stack_outputs();
 
         let proof_security_level = verify(
             self.batch_program_info.clone(),


### PR DESCRIPTION
Adds `BatchVerifier`

Depends on:
- https://github.com/0xMiden/protocol/pull/3001
- https://github.com/0xMiden/protocol/pull/3002
- https://github.com/0xMiden/protocol/pull/2904

## Summary

Follow-up to the skeleton batch kernel ([#2904](https://github.com/0xMiden/protocol/pull/2904)). Adds `BatchVerifier`:

- `BatchVerifier::new(proof_security_level)` / `verify(&ProvenBatch)` reconstructs the batch kernel's public input stack from the batch (`id().as_word()`, `reference_block_commitment()`) and verifies the attached `ExecutionProof` against the batch kernel program via `miden_verifier::verify`.
- uses the simple `verify` (no precompiles for now, since we don't do recursive verification)
- `LocalBatchProver`: extracted the kernel-prove body into a private `prove_kernel`; added a testing-gated `prove_without_tx_verification` so tests can obtain a real batch proof from mock transactions (whose dummy tx-proofs `TransactionVerifier` would reject — the reason the smoke test uses `FastProcessor`).


The batch kernel is still a skeleton: it drops its inputs and emits an all-zero output region. So `BatchVerifier::verify` checks the proof against these - temporarily meaningless - empty public inputs.