### PR TITLE
refactor: verify transaction proofs in `ProposedBatch::new` instead of `LocalBatchProver`

### DIFF
--- a/crates/miden-protocol/src/batch/proposed_batch.rs
+++ b/crates/miden-protocol/src/batch/proposed_batch.rs
@@ -16,6 +16,7 @@ use crate::transaction::{
     PartialBlockchain,
     ProvenTransaction,
     TransactionHeader,
+    TransactionVerifier,
 };
 use crate::utils::serde::{
     ByteReader,
@@ -122,7 +123,7 @@ impl ProposedBatch {
     /// - There are duplicate transactions.
     /// - If any transaction's expiration block number is less than or equal to the batch's
     ///   reference block.
-    pub fn new(
+    fn new_batch_inner(
         transactions: Vec<Arc<ProvenTransaction>>,
         reference_block_header: BlockHeader,
         partial_blockchain: PartialBlockchain,
@@ -326,6 +327,63 @@ impl ProposedBatch {
         })
     }
 
+    /// Creates a new [`ProposedBatch`] from the provided parts, verifying every transaction's
+    /// execution proof against the transaction kernel.
+    ///
+    /// This runs the same batch validation as `new_batch_inner` and additionally verifies that
+    /// each transaction's proof is valid and meets `proof_security_level`. Note that this verifies
+    /// `N` transaction proofs and is therefore relatively expensive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for any of the batch-validation conditions documented on `new_batch_inner`,
+    /// or if a transaction's proof fails to verify or does not meet `proof_security_level`.
+    pub fn new(
+        transactions: Vec<Arc<ProvenTransaction>>,
+        reference_block_header: BlockHeader,
+        partial_blockchain: PartialBlockchain,
+        unauthenticated_note_proofs: BTreeMap<NoteId, NoteInclusionProof>,
+        proof_security_level: u32,
+    ) -> Result<Self, ProposedBatchError> {
+        let batch = Self::new_batch_inner(
+            transactions,
+            reference_block_header,
+            partial_blockchain,
+            unauthenticated_note_proofs,
+        )?;
+
+        let verifier = TransactionVerifier::new(proof_security_level);
+        for tx in batch.transactions() {
+            verifier.verify(tx).map_err(|source| {
+                ProposedBatchError::TransactionVerificationFailed {
+                    transaction_id: tx.id(),
+                    source,
+                }
+            })?;
+        }
+
+        Ok(batch)
+    }
+
+    /// Creates a new [`ProposedBatch`] **without verifying the transactions' execution proofs**.
+    ///
+    /// Runs the same batch validation as [`Self::new`] but skips proof verification. Exposed for
+    /// tests that build batches from mock transactions carrying dummy proofs.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new_unverified(
+        transactions: Vec<Arc<ProvenTransaction>>,
+        reference_block_header: BlockHeader,
+        partial_blockchain: PartialBlockchain,
+        unauthenticated_note_proofs: BTreeMap<NoteId, NoteInclusionProof>,
+    ) -> Result<Self, ProposedBatchError> {
+        Self::new_batch_inner(
+            transactions,
+            reference_block_header,
+            partial_blockchain,
+            unauthenticated_note_proofs,
+        )
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -440,7 +498,11 @@ impl Deserializable for ProposedBatch {
         let unauthenticated_note_proofs =
             BTreeMap::<NoteId, NoteInclusionProof>::read_from(source)?;
 
-        ProposedBatch::new(
+        // Reconstruct structurally via `new_batch_inner` rather than `new`: deserialization must
+        // not re-run STARK verification of the transactions' proofs (they were verified when the
+        // batch was originally constructed via `new`), keeping deserialization cheap and not
+        // requiring valid proofs to be present.
+        ProposedBatch::new_batch_inner(
             transactions,
             block_header,
             partial_blockchain,
@@ -523,7 +585,7 @@ mod tests {
         )
         .context("failed to build proven transaction")?;
 
-        let batch = ProposedBatch::new(
+        let batch = ProposedBatch::new_unverified(
             vec![Arc::new(tx)],
             reference_block_header,
             partial_blockchain,

--- a/crates/miden-protocol/src/batch/proposed_batch.rs
+++ b/crates/miden-protocol/src/batch/proposed_batch.rs
@@ -330,10 +330,6 @@ impl ProposedBatch {
     /// Creates a new [`ProposedBatch`] from the provided parts, verifying every transaction's
     /// execution proof against the transaction kernel.
     ///
-    /// This runs the same batch validation as `new_batch_inner` and additionally verifies that
-    /// each transaction's proof is valid and meets `proof_security_level`. Note that this verifies
-    /// `N` transaction proofs and is therefore relatively expensive.
-    ///
     /// # Errors
     ///
     /// Returns an error for any of the batch-validation conditions documented on `new_batch_inner`,
@@ -498,10 +494,7 @@ impl Deserializable for ProposedBatch {
         let unauthenticated_note_proofs =
             BTreeMap::<NoteId, NoteInclusionProof>::read_from(source)?;
 
-        // Reconstruct structurally via `new_batch_inner` rather than `new`: deserialization must
-        // not re-run STARK verification of the transactions' proofs (they were verified when the
-        // batch was originally constructed via `new`), keeping deserialization cheap and not
-        // requiring valid proofs to be present.
+        // Reconstruct structurally without verifying the transactions' proofs.
         ProposedBatch::new_batch_inner(
             transactions,
             block_header,

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -959,6 +959,12 @@ pub enum ProvenTransactionError {
 
 #[derive(Debug, Error)]
 pub enum ProposedBatchError {
+    #[error("failed to verify transaction {transaction_id} in transaction batch")]
+    TransactionVerificationFailed {
+        transaction_id: TransactionId,
+        source: TransactionVerifierError,
+    },
+
     #[error(
         "transaction batch has {0} input notes but at most {MAX_INPUT_NOTES_PER_BATCH} are allowed"
     )]
@@ -1074,11 +1080,6 @@ pub enum ProposedBatchError {
 
 #[derive(Debug, Error)]
 pub enum ProvenBatchError {
-    #[error("failed to verify transaction {transaction_id} in transaction batch")]
-    TransactionVerificationFailed {
-        transaction_id: TransactionId,
-        source: Box<dyn Error + Send + Sync + 'static>,
-    },
     #[error(
         "batch expiration block number {batch_expiration_block_num} is not greater than the reference block number {reference_block_num}"
     )]

--- a/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/proposed_batch.rs
@@ -84,9 +84,13 @@ fn empty_transaction_batch() -> anyhow::Result<()> {
     let TestSetup { chain, .. } = setup_chain();
     let block1 = chain.block_header(1);
 
-    let error =
-        ProposedBatch::new(vec![], block1, chain.latest_partial_blockchain(), BTreeMap::default())
-            .unwrap_err();
+    let error = ProposedBatch::new_unverified(
+        vec![],
+        block1,
+        chain.latest_partial_blockchain(),
+        BTreeMap::default(),
+    )
+    .unwrap_err();
 
     assert_matches!(error, ProposedBatchError::EmptyTransactionBatch);
 
@@ -113,7 +117,7 @@ fn note_created_and_consumed_in_same_batch() -> anyhow::Result<()> {
             .unauthenticated_notes(vec![note.clone()])
             .build()?;
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1, tx2].into_iter().map(Arc::new).collect(),
         block2.header().clone(),
         chain.latest_partial_blockchain(),
@@ -163,7 +167,7 @@ fn same_details_different_metadata_not_erased_from_batch() -> anyhow::Result<()>
             .unauthenticated_notes(vec![input_note.clone()])
             .build()?;
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1, tx2].into_iter().map(Arc::new).collect(),
         block2.header().clone(),
         chain.latest_partial_blockchain(),
@@ -215,7 +219,7 @@ fn two_p2id_inputs_same_details_different_metadata_in_same_batch() -> anyhow::Re
             .authenticated_notes(vec![note_300.clone(), note_301.clone()])
             .build()?;
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         vec![Arc::new(tx)],
         block2.header().clone(),
         chain.latest_partial_blockchain(),
@@ -246,7 +250,7 @@ fn duplicate_unauthenticated_input_notes() -> anyhow::Result<()> {
             .unauthenticated_notes(vec![note.clone()])
             .build()?;
 
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
         block1,
         chain.latest_partial_blockchain(),
@@ -285,7 +289,7 @@ fn duplicate_authenticated_input_notes() -> anyhow::Result<()> {
             .authenticated_notes(vec![note1.clone()])
             .build()?;
 
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
         block2.header().clone(),
         chain.latest_partial_blockchain(),
@@ -324,7 +328,7 @@ fn duplicate_mixed_input_notes() -> anyhow::Result<()> {
             .authenticated_notes(vec![note1.clone()])
             .build()?;
 
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
         block2.header().clone(),
         chain.latest_partial_blockchain(),
@@ -363,7 +367,7 @@ fn duplicate_output_notes() -> anyhow::Result<()> {
             .output_notes(vec![note0.clone()])
             .build()?;
 
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
         block1,
         chain.latest_partial_blockchain(),
@@ -443,7 +447,7 @@ async fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()>
     // Case 1: Error: A wrong proof is passed.
     // --------------------------------------------------------------------------------------------
 
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx1.clone()].into_iter().map(Arc::new).collect(),
         block3.header().clone(),
         partial_blockchain.clone(),
@@ -472,7 +476,7 @@ async fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()>
         .filter(|header| header.block_num() != block1.header().block_num())
         .cloned();
 
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx1.clone()].into_iter().map(Arc::new).collect(),
         block3.header().clone(),
         PartialBlockchain::new(mmr, blocks)
@@ -495,7 +499,7 @@ async fn unauthenticated_note_converted_to_authenticated() -> anyhow::Result<()>
     // Case 3: Success: The correct proof is passed.
     // --------------------------------------------------------------------------------------------
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1].into_iter().map(Arc::new).collect(),
         block3.header().clone(),
         partial_blockchain,
@@ -544,7 +548,7 @@ fn authenticated_note_created_in_same_batch() -> anyhow::Result<()> {
             .authenticated_notes(vec![note1.clone()])
             .build()?;
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1, tx2].into_iter().map(Arc::new).collect(),
         block2.header().clone(),
         chain.latest_partial_blockchain(),
@@ -587,7 +591,7 @@ fn multiple_transactions_against_same_account() -> anyhow::Result<()> {
     .build()?;
 
     // Success: Transactions are correctly ordered.
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
         block1.clone(),
         chain.latest_partial_blockchain(),
@@ -607,7 +611,7 @@ fn multiple_transactions_against_same_account() -> anyhow::Result<()> {
     );
 
     // Error: Transactions are incorrectly ordered.
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx2.clone(), tx1.clone()].into_iter().map(Arc::new).collect(),
         block1,
         chain.latest_partial_blockchain(),
@@ -666,7 +670,7 @@ fn input_and_output_notes_commitment() -> anyhow::Result<()> {
             ])
             .build()?;
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1.clone(), tx2.clone()].into_iter().map(Arc::new).collect(),
         block1,
         chain.latest_partial_blockchain(),
@@ -716,7 +720,7 @@ fn batch_expiration() -> anyhow::Result<()> {
             .expiration_block_num(block1.block_num() + 1)
             .build()?;
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1, tx2].into_iter().map(Arc::new).collect(),
         block1.clone(),
         chain.latest_partial_blockchain(),
@@ -740,7 +744,7 @@ fn duplicate_transaction() -> anyhow::Result<()> {
             .expiration_block_num(BlockNumber::from(35))
             .build()?;
 
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx1.clone(), tx1.clone()].into_iter().map(Arc::new).collect(),
         block1,
         chain.latest_partial_blockchain(),
@@ -777,7 +781,7 @@ fn circular_note_dependency() -> anyhow::Result<()> {
             .output_notes(vec![RawOutputNote::Full(note_x.clone()).into_output_note().unwrap()])
             .build()?;
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1, tx2].into_iter().map(Arc::new).collect(),
         block1,
         chain.latest_partial_blockchain(),
@@ -808,7 +812,7 @@ fn expired_transaction() -> anyhow::Result<()> {
             .expiration_block_num(block1.block_num() + 3)
             .build()?;
 
-    let error = ProposedBatch::new(
+    let error = ProposedBatch::new_unverified(
         [tx1.clone(), tx2].into_iter().map(Arc::new).collect(),
         block1.clone(),
         chain.latest_partial_blockchain(),
@@ -867,7 +871,7 @@ fn noop_tx_before_state_updating_tx_against_same_account() -> anyhow::Result<()>
     .unauthenticated_notes(vec![note.clone()])
     .build()?;
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [noop_tx1, tx2].into_iter().map(Arc::new).collect(),
         block2.header().clone(),
         chain.latest_partial_blockchain(),
@@ -936,7 +940,7 @@ fn mismatched_ref_block_commitment_rejected() -> anyhow::Result<()> {
     // chain_b's partial blockchain contains block 1, but with chain_b's commitment - not chain_a's.
     // ProposedBatch::new should reject this transaction because its ref_block_commitment doesn't
     // match the commitment of block 1 in the partial blockchain.
-    let result = ProposedBatch::new(
+    let result = ProposedBatch::new_unverified(
         vec![Arc::new(tx.clone())],
         chain_b_block2.header().clone(),
         chain_b.latest_partial_blockchain(),
@@ -968,7 +972,7 @@ fn mismatched_ref_block_commitment_rejected() -> anyhow::Result<()> {
         "tx and batch ref block num should match"
     );
 
-    let result = ProposedBatch::new(
+    let result = ProposedBatch::new_unverified(
         vec![Arc::new(tx.clone())],
         ref_block.clone(),
         partial_blockchain,
@@ -1029,7 +1033,7 @@ fn noop_tx_after_state_updating_tx_against_same_account() -> anyhow::Result<()> 
         noop_tx2.account_update().final_state_commitment()
     );
 
-    let batch = ProposedBatch::new(
+    let batch = ProposedBatch::new_unverified(
         [tx1, noop_tx2].into_iter().map(Arc::new).collect(),
         block2.header().clone(),
         chain.latest_partial_blockchain(),

--- a/crates/miden-testing/src/mock_chain/chain.rs
+++ b/crates/miden-testing/src/mock_chain/chain.rs
@@ -516,7 +516,7 @@ impl MockChain {
                     .flat_map(|tx| tx.unauthenticated_notes().map(NoteHeader::id)),
             )?;
 
-        Ok(ProposedBatch::new(
+        Ok(ProposedBatch::new_unverified(
             transactions,
             batch_reference_block,
             partial_blockchain,
@@ -531,8 +531,8 @@ impl MockChain {
         &self,
         proposed_batch: ProposedBatch,
     ) -> anyhow::Result<ProvenBatch> {
-        let batch_prover = LocalBatchProver::new(0);
-        Ok(batch_prover.prove_dummy(proposed_batch)?)
+        let batch_prover = LocalBatchProver::new();
+        Ok(batch_prover.prove(proposed_batch)?)
     }
 
     // BLOCK APIS

--- a/crates/miden-tx-batch-prover/Cargo.toml
+++ b/crates/miden-tx-batch-prover/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace      = true
 [lib]
 bench   = false
 doctest = false
+test    = false
 
 [features]
 default = ["std"]

--- a/crates/miden-tx-batch-prover/src/local_batch_prover.rs
+++ b/crates/miden-tx-batch-prover/src/local_batch_prover.rs
@@ -1,66 +1,25 @@
-use alloc::boxed::Box;
-
 use miden_protocol::batch::{ProposedBatch, ProvenBatch};
 use miden_protocol::errors::ProvenBatchError;
-use miden_protocol::transaction::TransactionVerifier;
 
 // LOCAL BATCH PROVER
 // ================================================================================================
 
 /// A local prover for transaction batches, proving the transactions in a [`ProposedBatch`] and
 /// returning a [`ProvenBatch`].
-#[derive(Clone)]
-pub struct LocalBatchProver {
-    proof_security_level: u32,
-}
+#[derive(Clone, Default)]
+pub struct LocalBatchProver;
 
 impl LocalBatchProver {
     /// Creates a new [`LocalBatchProver`] instance.
-    pub fn new(proof_security_level: u32) -> Self {
-        Self { proof_security_level }
+    pub fn new() -> Self {
+        Self
     }
 
-    /// Attempts to prove the [`ProposedBatch`] into a [`ProvenBatch`].
+    /// Converts the provided [`ProposedBatch`] into a [`ProvenBatch`].
     ///
-    /// Currently we don't perform any recursive proving. For now, this function runs a native
-    /// verifier for each transaction separately, and outputs a `ProvenBatch` object if all of the
-    /// individual proofs verify.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - a proof of any transaction in the batch fails to verify.
+    /// The batch's transactions are verified when the [`ProposedBatch`] is constructed, so this
+    /// currently only repackages the batch. Recursive proving is not yet implemented.
     pub fn prove(&self, proposed_batch: ProposedBatch) -> Result<ProvenBatch, ProvenBatchError> {
-        let verifier = TransactionVerifier::new(self.proof_security_level);
-
-        for tx in proposed_batch.transactions() {
-            verifier.verify(tx).map_err(|source| {
-                ProvenBatchError::TransactionVerificationFailed {
-                    transaction_id: tx.id(),
-                    source: Box::new(source),
-                }
-            })?;
-        }
-
-        self.prove_inner(proposed_batch)
-    }
-
-    /// Proves the provided [`ProposedBatch`] into a [`ProvenBatch`], **without verifying batches
-    /// and proving the block**.
-    ///
-    /// This is exposed for testing purposes.
-    #[cfg(any(feature = "testing", test))]
-    pub fn prove_dummy(
-        &self,
-        proposed_batch: ProposedBatch,
-    ) -> Result<ProvenBatch, ProvenBatchError> {
-        self.prove_inner(proposed_batch)
-    }
-
-    /// Converts a proposed batch into a proven batch.
-    ///
-    /// For now, this doesn't do anything interesting.
-    fn prove_inner(&self, proposed_batch: ProposedBatch) -> Result<ProvenBatch, ProvenBatchError> {
         let tx_headers = proposed_batch.transaction_headers();
         let (
             _transactions,


### PR DESCRIPTION
Depends on #3001

Currently, the verification of each tx's proof is done upon converting `ProposedBatch` into `ProvenBatch`. But the tx verification should be part of all the other checks that are done when constructing a batch (e.g. note erasure, etc.) so it should happen within `ProposedBatch::new`

towards https://github.com/0xMiden/protocol/issues/1122