### PR TITLE
fix(agglayer): enforce canonical zero padding on leaf data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).
+- Fixed `pack_leaf_data` to explicitly reject leaf data with non-zero trailing padding felts, replacing an implicit precompile failure with a clear `ERR_LEAF_PADDING_NOT_ZERO` error ([#3003](https://github.com/0xMiden/protocol/pull/3003)).
 
 ## v0.15.1 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).
-- Fixed `pack_leaf_data` to explicitly reject leaf data with non-zero trailing padding felts, replacing an implicit precompile failure with a clear `ERR_LEAF_PADDING_NOT_ZERO` error ([#3003](https://github.com/0xMiden/protocol/pull/3003)).
+- Fixed `pack_leaf_data` to explicitly reject leaf data with non-zero trailing padding felts ([#3003](https://github.com/0xMiden/protocol/pull/3003)).
 
 ## v0.15.1 (TBD)
 

--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -259,7 +259,7 @@ in the map the procedure panics with `ERR_GER_ALREADY_REGISTERED`.
 | **Inputs** | `[PROOF_DATA_KEY, LEAF_DATA_KEY, faucet_mint_amount, pad(7)]` on the operand stack; proof data and leaf data in the advice map keyed by `PROOF_DATA_KEY` and `LEAF_DATA_KEY` respectively |
 | **Outputs** | `[pad(16)]` |
 | **Context** | Consuming a `CLAIM` note on the bridge account |
-| **Panics** | Leaf `destination_network` does not match `agglayer::common::constants::MIDEN_NETWORK_ID`; invalid leaf type; GER not known; global index invalid; Merkle proof verification failed; (origin token address, origin network) pair not in token registry; claim already spent; amount conversion mismatch |
+| **Panics** | Leaf `destination_network` does not match `agglayer::common::constants::MIDEN_NETWORK_ID`; invalid leaf type; leaf padding felts are non-zero; GER not known; global index invalid; Merkle proof verification failed; (origin token address, origin network) pair not in token registry; claim already spent; amount conversion mismatch |
 
 Validates a bridge-in claim and creates a MINT note targeting the faucet:
 
@@ -528,7 +528,7 @@ The storage is divided into three logical regions: proof data (felts 0-535), lea
 | 544-548 | `destination_address` | 5 | 5 x u32 felts |
 | 549-556 | `amount` | 8 | U256 as 8 x u32 felts |
 | 557-564 | `metadata_hash` | 8 | Keccak-256 hash as 8 x u32 felts |
-| 565-567 | padding | 3 | zeros |
+| 565-567 | padding | 3 | zeros (enforced: non-zero padding rejects the claim) |
 | 568 | `miden_claim_amount` | 1 | Scaled-down Miden token amount (Felt). Computed as `floor(amount / 10^scale)` |
 
 **Consumption:**

--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -528,7 +528,7 @@ The storage is divided into three logical regions: proof data (felts 0-535), lea
 | 544-548 | `destination_address` | 5 | 5 x u32 felts |
 | 549-556 | `amount` | 8 | U256 as 8 x u32 felts |
 | 557-564 | `metadata_hash` | 8 | Keccak-256 hash as 8 x u32 felts |
-| 565-567 | padding | 3 | zeros (enforced: non-zero padding rejects the claim) |
+| 565-567 | padding | 3 | zeros |
 | 568 | `miden_claim_amount` | 1 | Scaled-down Miden token amount (Felt). Computed as `floor(amount / 10^scale)` |
 
 **Consumption:**

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -489,10 +489,18 @@ end
 #!       destinationAddress[5],           // Destination address (5 felts, address as 5 u32 felts)
 #!       amount[8],                       // Amount of tokens (8 felts, uint256 as 8 u32 felts)
 #!       metadata_hash[8],                // Metadata hash (8 felts, bytes32 as 8 u32 felts)
-#!       padding[3],                      // padding (3 felts) - not used in the hash
+#!       padding[3],                      // padding (3 felts) - must be zero (see below)
 #!     ],
 #!   }
 #! Outputs: [LEAF_VALUE[8]]
+#!
+#! The 3 trailing padding felts must be zero. They are not part of any leaf field and do not affect
+#! LEAF_VALUE (the keccak hash covers only the 113 real bytes); pack_leaf_data nonetheless asserts
+#! all 3 are zero as defense-in-depth - see leaf_utils::assert_padding_is_zero. A claim whose
+#! prover-supplied leaf data carries non-zero padding is therefore rejected.
+#!
+#! Panics if:
+#! - any of the 3 trailing padding felts is non-zero.
 #!
 #! Invocation: exec
 pub proc get_leaf_value(leaf_data_key: word) -> DoubleWord

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -489,18 +489,13 @@ end
 #!       destinationAddress[5],           // Destination address (5 felts, address as 5 u32 felts)
 #!       amount[8],                       // Amount of tokens (8 felts, uint256 as 8 u32 felts)
 #!       metadata_hash[8],                // Metadata hash (8 felts, bytes32 as 8 u32 felts)
-#!       padding[3],                      // padding (3 felts) - must be zero (see below)
+#!       padding[3],                      // padding (3 felts) - must be zero
 #!     ],
 #!   }
 #! Outputs: [LEAF_VALUE[8]]
 #!
-#! The 3 trailing padding felts must be zero. They are not part of any leaf field and do not affect
-#! LEAF_VALUE (the keccak hash covers only the 113 real bytes); pack_leaf_data nonetheless asserts
-#! all 3 are zero as defense-in-depth - see leaf_utils::assert_padding_is_zero. A claim whose
-#! prover-supplied leaf data carries non-zero padding is therefore rejected.
-#!
 #! Panics if:
-#! - any of the 3 trailing padding felts is non-zero.
+#! - any of the 3 trailing padding felts in the leaf data is non-zero.
 #!
 #! Invocation: exec
 pub proc get_leaf_value(leaf_data_key: word) -> DoubleWord

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -57,8 +57,7 @@ const DESTINATION_NETWORK_OFFSET=7
 const DESTINATION_ADDRESS_OFFSET=8
 const AMOUNT_OFFSET=13
 const METADATA_HASH_OFFSET=21
-# padding sits immediately after the 8-felt metadata hash; derive it so it tracks the layout above
-const PADDING_OFFSET=METADATA_HASH_OFFSET + 8
+const PADDING_OFFSET=29
 
 # Local memory offsets
 # -------------------------------------------------------------------------------------------------
@@ -202,20 +201,9 @@ pub proc bridge_out
     exec.utils::mem_store_double_word_unaligned
     # => [pad(16)]
 
-    # Explicitly zero the 3 padding felts after METADATA_HASH. leaf_utils::pack_leaf_data requires a
-    # canonical leaf preimage and asserts these are zero, so this zeroing is what keeps the
-    # bridge-out leaf within that enforced contract.
-    push.0
-    push.LEAF_DATA_START_PTR push.PADDING_OFFSET add
-    mem_store
-
-    push.0
-    push.LEAF_DATA_START_PTR push.PADDING_OFFSET add.1 add
-    mem_store
-
-    push.0
-    push.LEAF_DATA_START_PTR push.PADDING_OFFSET add.2 add
-    mem_store
+    # Explicitly zero the 3 padding felts after METADATA_HASH for
+    # leaf_utils::pack_leaf_data
+    exec.zero_padding_felts
     # => [pad(16)]
 
     # --- 4. Compute leaf value and append it to the Local Exit Tree ---
@@ -242,6 +230,19 @@ end
 
 # HELPER PROCEDURES
 # =================================================================================================
+
+#! Zeroes the 3 trailing padding felts of the leaf data so it satisfies the zero-padding contract
+#! enforced by leaf_utils::pack_leaf_data.
+#!
+#! Inputs:  []
+#! Outputs: []
+#!
+#! Invocation: exec
+proc zero_padding_felts
+    push.0 push.LEAF_DATA_START_PTR push.PADDING_OFFSET add mem_store
+    push.0 push.LEAF_DATA_START_PTR push.PADDING_OFFSET add.1 add mem_store
+    push.0 push.LEAF_DATA_START_PTR push.PADDING_OFFSET add.2 add mem_store
+end
 
 #! Asserts that the bridge-out destination network ID is not equal to the Miden's AggLayer network
 #! ID.
@@ -328,11 +329,11 @@ end
 #!   destinationAddress[5],
 #!   amount[8],
 #!   metadataHash[8],
-#!   padding[3],          // must be zero; asserted by leaf_utils::pack_leaf_data
+#!   padding[3],
 #! ]
 #!
 #! Panics if:
-#! - any of the 3 trailing padding felts is non-zero.
+#! - any of the 3 trailing padding felts in the leaf data is non-zero.
 #!
 #! Invocation: exec
 proc add_leaf_bridge(leaf_data_start_ptr: MemoryAddress)

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -239,9 +239,18 @@ end
 #!
 #! Invocation: exec
 proc zero_padding_felts
-    push.0 push.LEAF_DATA_START_PTR push.PADDING_OFFSET add mem_store
-    push.0 push.LEAF_DATA_START_PTR push.PADDING_OFFSET add.1 add mem_store
-    push.0 push.LEAF_DATA_START_PTR push.PADDING_OFFSET add.2 add mem_store
+    # prepare the padding pointer
+    push.LEAF_DATA_START_PTR add.PADDING_OFFSET
+    # => [padding_ptr]
+
+    push.0 dup.1 mem_store
+    # => [padding_ptr]
+
+    push.0 dup.1 add.1 mem_store
+    # => [padding_ptr]
+
+    push.0 swap add.2 mem_store
+    # => []
 end
 
 #! Asserts that the bridge-out destination network ID is not equal to the Miden's AggLayer network

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -57,7 +57,8 @@ const DESTINATION_NETWORK_OFFSET=7
 const DESTINATION_ADDRESS_OFFSET=8
 const AMOUNT_OFFSET=13
 const METADATA_HASH_OFFSET=21
-const PADDING_OFFSET=29
+# padding sits immediately after the 8-felt metadata hash; derive it so it tracks the layout above
+const PADDING_OFFSET=METADATA_HASH_OFFSET + 8
 
 # Local memory offsets
 # -------------------------------------------------------------------------------------------------
@@ -201,8 +202,9 @@ pub proc bridge_out
     exec.utils::mem_store_double_word_unaligned
     # => [pad(16)]
 
-    # Explicitly zero the 3 padding felts after METADATA_HASH for
-    # leaf_utils::pack_leaf_data
+    # Explicitly zero the 3 padding felts after METADATA_HASH. leaf_utils::pack_leaf_data requires a
+    # canonical leaf preimage and asserts these are zero, so this zeroing is what keeps the
+    # bridge-out leaf within that enforced contract.
     push.0
     push.LEAF_DATA_START_PTR push.PADDING_OFFSET add
     mem_store
@@ -326,8 +328,11 @@ end
 #!   destinationAddress[5],
 #!   amount[8],
 #!   metadataHash[8],
-#!   padding[3],
+#!   padding[3],          // must be zero; asserted by leaf_utils::pack_leaf_data
 #! ]
+#!
+#! Panics if:
+#! - any of the 3 trailing padding felts is non-zero.
 #!
 #! Invocation: exec
 proc add_leaf_bridge(leaf_data_start_ptr: MemoryAddress)

--- a/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
@@ -2,6 +2,11 @@ use miden::core::crypto::hashes::keccak256
 use miden::protocol::types::DoubleWord
 use miden::protocol::types::MemoryAddress
 
+# ERRORS
+# =================================================================================================
+
+const ERR_LEAF_PADDING_NOT_ZERO = "leaf data padding felts must be zero"
+
 # CONSTANTS
 # =================================================================================================
 
@@ -14,6 +19,12 @@ const PACKING_START_PTR_LOCAL= 0
 # the number of elements to pack (113 bytes = 29 elements, rounding up from 28.25)
 const PACKED_DATA_NUM_ELEMENTS = 29
 
+# the felt offset (relative to the leaf data start pointer) of the 3 trailing padding felts. They
+# sit immediately after the packed data - i.e. at the felt right after the last element the packing
+# loop writes - so derive it from PACKED_DATA_NUM_ELEMENTS to keep it coupled to the loop bound.
+# (bridge_out.masm defines the same relative offset for the leaf it builds.)
+const PADDING_OFFSET = PACKED_DATA_NUM_ELEMENTS
+
 # PUBLIC INTERFACE
 # =================================================================================================
 
@@ -22,6 +33,9 @@ const PACKED_DATA_NUM_ELEMENTS = 29
 #!
 #! Inputs:  [leaf_data_start_ptr]
 #! Outputs: [LEAF_VALUE[8]]
+#!
+#! Panics if:
+#! - any of the 3 trailing padding felts is non-zero (see pack_leaf_data).
 #!
 #! Invocation: exec
 pub proc compute_leaf_value(leaf_data_start_ptr: MemoryAddress) -> DoubleWord
@@ -72,10 +86,17 @@ end
 #! Inputs:  [leaf_data_start_ptr]
 #! Outputs: []
 #!
+#! Panics if:
+#! - any of the 3 trailing padding felts is non-zero.
+#!
 #! Invocation: exec
 @locals(1) # start_ptr
 pub proc pack_leaf_data(leaf_data_start_ptr: MemoryAddress)
     loc_store.PACKING_START_PTR_LOCAL
+    # => []
+
+    # reject non-canonical leaf data: the trailing padding felts must be zero
+    loc_load.PACKING_START_PTR_LOCAL exec.assert_padding_is_zero
     # => []
 
     # initialize loop counter to 0
@@ -147,5 +168,43 @@ pub proc pack_leaf_data(leaf_data_start_ptr: MemoryAddress)
     # => [counter]
 
     drop
+    # => []
+end
+
+# HELPER PROCEDURES
+# =================================================================================================
+
+#! Asserts that the 3 trailing padding felts of the leaf data are all zero.
+#!
+#! The leaf is a 113-byte keccak preimage. pack_leaf_data folds padding[0]'s low 3 bytes into the
+#! high 3 bytes of the final packed u32 (packed[28]), at byte positions 113..115 - the unused tail
+#! of the final limb. The keccak precompile hashes only the first 113 bytes, so padding never
+#! changes the leaf value, but it requires that tail to be zero. padding[1] and padding[2] are never
+#! read by the packer or the hash at all.
+#!
+#! Asserting all 3 are zero turns the precompile's implicit tail-must-be-zero contract into an
+#! explicit and total check - it also covers padding[1] and padding[2], which the precompile never
+#! sees - and produces a clear bridge-specific error instead of a generic precompile padding
+#! failure. This is defense-in-depth only: it does not change LEAF_VALUE or the claim nullifier
+#! (which is derived from the leaf index and source network, not the leaf preimage).
+#!
+#! Inputs:  [leaf_data_start_ptr]
+#! Outputs: []
+#!
+#! Panics if:
+#! - any of the 3 trailing padding felts is non-zero.
+#!
+#! Invocation: exec
+proc assert_padding_is_zero(leaf_data_start_ptr: MemoryAddress)
+    push.PADDING_OFFSET add
+    # => [padding_ptr]
+
+    dup mem_load assertz.err=ERR_LEAF_PADDING_NOT_ZERO
+    # => [padding_ptr]
+
+    dup add.1 mem_load assertz.err=ERR_LEAF_PADDING_NOT_ZERO
+    # => [padding_ptr]
+
+    add.2 mem_load assertz.err=ERR_LEAF_PADDING_NOT_ZERO
     # => []
 end

--- a/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
@@ -19,11 +19,8 @@ const PACKING_START_PTR_LOCAL= 0
 # the number of elements to pack (113 bytes = 29 elements, rounding up from 28.25)
 const PACKED_DATA_NUM_ELEMENTS = 29
 
-# the felt offset (relative to the leaf data start pointer) of the 3 trailing padding felts. They
-# sit immediately after the packed data - i.e. at the felt right after the last element the packing
-# loop writes - so derive it from PACKED_DATA_NUM_ELEMENTS to keep it coupled to the loop bound.
-# (bridge_out.masm defines the same relative offset for the leaf it builds.)
-const PADDING_OFFSET = PACKED_DATA_NUM_ELEMENTS
+# the offset of the 3 trailing padding felts in the leaf data
+const LEAF_DATA_PADDING_OFFSET = PACKED_DATA_NUM_ELEMENTS
 
 # PUBLIC INTERFACE
 # =================================================================================================
@@ -35,7 +32,7 @@ const PADDING_OFFSET = PACKED_DATA_NUM_ELEMENTS
 #! Outputs: [LEAF_VALUE[8]]
 #!
 #! Panics if:
-#! - any of the 3 trailing padding felts is non-zero (see pack_leaf_data).
+#! - any of the 3 trailing padding felts in the leaf data is non-zero.
 #!
 #! Invocation: exec
 pub proc compute_leaf_value(leaf_data_start_ptr: MemoryAddress) -> DoubleWord
@@ -87,7 +84,7 @@ end
 #! Outputs: []
 #!
 #! Panics if:
-#! - any of the 3 trailing padding felts is non-zero.
+#! - any of the 3 trailing padding felts in the leaf data is non-zero.
 #!
 #! Invocation: exec
 @locals(1) # start_ptr
@@ -176,27 +173,20 @@ end
 
 #! Asserts that the 3 trailing padding felts of the leaf data are all zero.
 #!
-#! The leaf is a 113-byte keccak preimage. pack_leaf_data folds padding[0]'s low 3 bytes into the
-#! high 3 bytes of the final packed u32 (packed[28]), at byte positions 113..115 - the unused tail
-#! of the final limb. The keccak precompile hashes only the first 113 bytes, so padding never
-#! changes the leaf value, but it requires that tail to be zero. padding[1] and padding[2] are never
-#! read by the packer or the hash at all.
-#!
-#! Asserting all 3 are zero turns the precompile's implicit tail-must-be-zero contract into an
-#! explicit and total check - it also covers padding[1] and padding[2], which the precompile never
-#! sees - and produces a clear bridge-specific error instead of a generic precompile padding
-#! failure. This is defense-in-depth only: it does not change LEAF_VALUE or the claim nullifier
-#! (which is derived from the leaf index and source network, not the leaf preimage).
+#! `pack_leaf_data` folds `padding[0]`'s low 3 bytes into the high 3 bytes of the final `packed[28]`
+#! value - the unused tail of the final limb. The keccak precompile requires that tail to be zero.
+#! padding[1] and padding[2] are never read by the packer or the hash at all, but are still checked
+#! defensively for potential future use.
 #!
 #! Inputs:  [leaf_data_start_ptr]
 #! Outputs: []
 #!
 #! Panics if:
-#! - any of the 3 trailing padding felts is non-zero.
+#! - any of the 3 trailing padding felts in the leaf data is non-zero.
 #!
 #! Invocation: exec
 proc assert_padding_is_zero(leaf_data_start_ptr: MemoryAddress)
-    push.PADDING_OFFSET add
+    push.LEAF_DATA_PADDING_OFFSET add
     # => [padding_ptr]
 
     dup mem_load assertz.err=ERR_LEAF_PADDING_NOT_ZERO

--- a/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
@@ -89,11 +89,11 @@ end
 #! Invocation: exec
 @locals(1) # start_ptr
 pub proc pack_leaf_data(leaf_data_start_ptr: MemoryAddress)
-    loc_store.PACKING_START_PTR_LOCAL
-    # => []
-
     # reject non-canonical leaf data: the trailing padding felts must be zero
-    loc_load.PACKING_START_PTR_LOCAL exec.assert_padding_is_zero
+    dup exec.assert_padding_is_zero
+    # => [leaf_data_start_ptr]
+
+    loc_store.PACKING_START_PTR_LOCAL
     # => []
 
     # initialize loop counter to 0

--- a/crates/miden-testing/tests/agglayer/leaf_utils.rs
+++ b/crates/miden-testing/tests/agglayer/leaf_utils.rs
@@ -3,6 +3,7 @@ extern crate alloc;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
+use miden_agglayer::errors::ERR_LEAF_PADDING_NOT_ZERO;
 use miden_agglayer::{LeafValue, agglayer_library};
 use miden_assembly::{Assembler, DefaultSourceManager};
 use miden_core_lib::CoreLibrary;
@@ -10,6 +11,7 @@ use miden_crypto::SequentialCommit;
 use miden_processor::advice::AdviceInputs;
 use miden_processor::utils::packed_u32_elements_to_bytes;
 use miden_protocol::{Felt, Word};
+use miden_testing::{ExecError, assert_execution_error};
 use miden_tx::utils::hex_to_bytes;
 
 use super::test_utils::{
@@ -28,6 +30,19 @@ fn felts_to_le_bytes(limbs: &[Felt]) -> Vec<u8> {
         bytes.extend_from_slice(&u32_value.to_le_bytes());
     }
     bytes
+}
+
+/// Wraps a raw leaf-data felt vector so its Poseidon2 sequential commitment can be computed for
+/// arbitrary (possibly non-canonical) contents. `pipe_preimage_to_memory` checks the piped data
+/// against this commitment, so a test that corrupts the leaf data needs the matching key.
+struct RawLeafData(Vec<Felt>);
+
+impl SequentialCommit for RawLeafData {
+    type Commitment = Word;
+
+    fn to_elements(&self) -> Vec<Felt> {
+        self.0.clone()
+    }
 }
 
 // TESTS
@@ -193,5 +208,69 @@ async fn get_leaf_value() -> anyhow::Result<()> {
     let expected_leaf_value: Vec<Felt> = LeafValue::from(expected_leaf_value_bytes).to_elements();
 
     assert_eq!(computed_leaf_value, expected_leaf_value);
+    Ok(())
+}
+
+/// Tests that `pack_leaf_data` rejects leaf data whose trailing padding felts are non-zero.
+///
+/// padding[0] (offset 29) lands in the unused tail of the final packed u32, which the keccak
+/// precompile requires to be zero; padding[1]/[2] (offsets 30, 31) never reach the packer or hash.
+/// `pack_leaf_data` asserts all three are zero, so a non-zero value in any of them must be
+/// rejected.
+#[tokio::test]
+async fn pack_leaf_data_rejects_non_zero_padding() -> anyhow::Result<()> {
+    let vector: LeafValueVector =
+        serde_json::from_str(LEAF_VALUE_VECTORS_JSON).expect("failed to parse leaf value vector");
+    let leaf_data = vector.to_leaf_data();
+    let agglayer_lib = agglayer_library();
+
+    // The 3 trailing padding felts sit at offsets 29, 30, 31 of the 32-felt leaf data.
+    for padding_offset in 29..32usize {
+        let mut leaf_data_elements = leaf_data.to_elements();
+        // Sanity: this felt is part of the (initially zero) padding region.
+        assert_eq!(leaf_data_elements[padding_offset], Felt::ZERO);
+        // Corrupt a single padding felt with a non-zero value.
+        leaf_data_elements[padding_offset] = Felt::from(1u32);
+
+        // pipe_preimage_to_memory checks the piped data against this key, so it must be the
+        // commitment of the corrupted elements.
+        let key: Word = RawLeafData(leaf_data_elements.clone()).to_commitment();
+        let advice_inputs =
+            AdviceInputs::default().with_map(vec![(key, leaf_data_elements.clone())]);
+
+        let source = format!(
+            r#"
+                use miden::core::mem
+                use agglayer::bridge::leaf_utils
+
+                const LEAF_DATA_START_PTR = 0
+                const CLAIM_LEAF_DATA_WORD_LEN = 8
+
+                begin
+                    push.{key}
+
+                    adv.push_mapval
+                    push.LEAF_DATA_START_PTR push.CLAIM_LEAF_DATA_WORD_LEN
+                    exec.mem::pipe_preimage_to_memory drop
+
+                    exec.leaf_utils::pack_leaf_data
+                end
+            "#
+        );
+
+        let program = Assembler::new(Arc::new(DefaultSourceManager::default()))
+            .with_dynamic_library(CoreLibrary::default())
+            .unwrap()
+            .with_dynamic_library(agglayer_lib.clone())
+            .unwrap()
+            .assemble_program(&source)
+            .unwrap();
+
+        let err = execute_program_with_default_host(program, Some(advice_inputs))
+            .await
+            .map_err(ExecError::new);
+        assert_execution_error!(err, ERR_LEAF_PADDING_NOT_ZERO);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #2985.

The bridge leaf is a 113-byte keccak preimage stored as 32 felts: 29 data felts followed by 3 trailing padding felts. `pack_leaf_data` folds `padding[0]`'s low 3 bytes into the unused tail (byte positions 113-115) of the final packed u32. The keccak precompile truncates the hash to 113 bytes, so padding never changes `LEAF_VALUE`, but it requires that tail to be zero - and only enforces it implicitly, via a generic `InvalidPadding` failure. `padding[1]` and `padding[2]` are never read by the packer or the hash at all, so nothing checked them.

On the bridge-in/CLAIM path the leaf data is piped verbatim from the prover-supplied advice map, so the padding felts were never explicitly validated.

## Fix

Make the requirement explicit and total in the shared helper. `pack_leaf_data` now calls a new `assert_padding_is_zero` helper (under a `HELPER PROCEDURES` section) that asserts all 3 trailing padding felts are zero before packing, panicking with `ERR_LEAF_PADDING_NOT_ZERO` otherwise. Because the check lives in the shared helper, it also covers bridge-out (which already zeros these felts) and any future caller, and it yields a clear bridge-specific error instead of the generic precompile padding failure.

This is defense-in-depth: it does not change `LEAF_VALUE` or the claim nullifier (the nullifier is derived from the leaf index and source network, not the leaf preimage).

## Changes

- `crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm`
  - New error const `ERR_LEAF_PADDING_NOT_ZERO`.
  - `PADDING_OFFSET` derived from `PACKED_DATA_NUM_ELEMENTS` so it stays coupled to the packing loop bound.
  - New private `assert_padding_is_zero` helper; called from `pack_leaf_data` before the loop. Docs on `pack_leaf_data` / `compute_leaf_value` updated.
- `crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm`
  - `get_leaf_value` advice-map doc updated to state padding must be zero (and why).
- `crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm`
  - No logic change (already zeros padding); `PADDING_OFFSET` now derived from `METADATA_HASH_OFFSET + 8`; comment/doc updated.
- `crates/miden-agglayer/SPEC.md`
  - CLAIM storage padding row and `bridge_in::claim` Panics row updated.
- `crates/miden-testing/tests/agglayer/leaf_utils.rs`
  - New `pack_leaf_data_rejects_non_zero_padding` test exercising all three padding offsets (29/30/31).

## Testing

`cargo test -p miden-testing --test lib agglayer::` - all 61 agglayer tests pass, including the new negative test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)