### PR TITLE
feat: Rename `AccountStorageDelta` to `AccountStoragePatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.16.0 (TBD)
 
+### Changes
+
+- [BREAKING] Renamed `AccountStorageDelta` to `AccountStoragePatch` ([#3002](https://github.com/0xMiden/protocol/pull/3002)).
+
 ### Fixes
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).
 

--- a/crates/miden-protocol/asm/kernels/transaction/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/api.masm
@@ -153,7 +153,7 @@ end
 #! - DELTA_COMMITMENT is the commitment to the account delta.
 #!
 #! Panics if:
-#! - the vault or storage delta is not empty but the nonce increment is zero.
+#! - the vault delta or storage patch is not empty but the nonce increment is zero.
 #!
 #! Invocation: dynexec
 pub proc account_compute_delta_commitment

--- a/crates/miden-protocol/asm/kernels/transaction/lib/account_delta.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/account_delta.masm
@@ -45,7 +45,7 @@ const FELT_MAX = 0xffffffff00000000
 #! - DELTA_COMMITMENT is the commitment to the account delta.
 #!
 #! Panics if:
-#! - the vault or storage delta is not empty but the nonce increment is zero.
+#! - the vault delta or storage patch is not empty but the nonce increment is zero.
 pub proc compute_commitment
     # pad capacity and RATE1 of the hasher with empty words
     padw padw
@@ -72,7 +72,7 @@ pub proc compute_commitment
     exec.update_non_fungible_asset_delta
     # => [RATE0, RATE1, CAPACITY, ID_AND_NONCE_DIGEST]
 
-    exec.update_storage_delta
+    exec.update_storage_patch
     # => [RATE0, RATE1, CAPACITY, ID_AND_NONCE_DIGEST]
 
     exec.poseidon2::squeeze_digest
@@ -102,7 +102,7 @@ end
 #!
 #! Inputs:  [RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc update_storage_delta
+proc update_storage_patch
     exec.memory::get_native_num_storage_slots movdn.12
     # => [RATE0, RATE1, CAPACITY, num_storage_slots]
 
@@ -117,7 +117,7 @@ proc update_storage_delta
         dup.12
         # => [slot_idx, RATE0, RATE1, CAPACITY, slot_idx, num_storage_slots]
 
-        exec.update_slot_delta
+        exec.update_slot_patch
         # => [RATE0, RATE1, CAPACITY, slot_idx, num_storage_slots]
 
         # increment slot index
@@ -143,7 +143,7 @@ end
 #!
 #! Inputs:  [slot_idx, RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc update_slot_delta
+proc update_slot_patch
     dup exec.account::get_native_storage_slot_type
     # => [storage_slot_type, slot_idx, RATE0, RATE1, CAPACITY]
 
@@ -152,9 +152,9 @@ proc update_slot_delta
     # => [is_value_slot_type, slot_idx, RATE0, RATE1, CAPACITY]
 
     if.true
-        exec.update_value_slot_delta
+        exec.update_value_slot_patch
     else
-        exec.update_map_slot_delta
+        exec.update_map_slot_patch
     end
     # => [RATE0, RATE1, CAPACITY]
 end
@@ -163,7 +163,7 @@ end
 #!
 #! Inputs:  [slot_idx, RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc update_value_slot_delta
+proc update_value_slot_patch
     exec.account::get_item_delta
     # => [INIT_VALUE, CURRENT_VALUE, slot_id_suffix, slot_id_prefix, RATE0, RATE1, CAPACITY]
 
@@ -216,7 +216,7 @@ end
 #! - 3: iter
 #! - 4: num_changed_entries
 @locals(5)
-proc update_map_slot_delta
+proc update_map_slot_patch
     # initialize num_changed_entries = 0
     # this is necessary because this procedure can be called multiple times and the second
     # invocation shouldn't reuse the first invocation's value
@@ -229,8 +229,8 @@ proc update_map_slot_delta
     loc_store.0 loc_store.1
     # => [slot_idx, RATE0, RATE1, CAPACITY]
 
-    exec.memory::get_account_delta_storage_map_ptr
-    # => [account_delta_storage_map_ptr, RATE0, RATE1, CAPACITY]
+    exec.memory::get_account_patch_storage_map_ptr
+    # => [account_patch_storage_map_ptr, RATE0, RATE1, CAPACITY]
 
     exec.link_map::iter
     # => [has_next, iter, RATE0, RATE1, CAPACITY]
@@ -746,7 +746,7 @@ pub proc remove_non_fungible_asset
     # => []
 end
 
-#! Updates the storage map delta of the given slot index with the given key-value pair and its
+#! Updates the storage map patch of the given slot index with the given key-value pair and its
 #! previous value.
 #!
 #! The layout of a link map entry for a given KEY is: [KEY, INIT_VALUE, NEW_VALUE] where INIT_VALUE
@@ -763,9 +763,9 @@ end
 #! - NEW_VALUE is the new value of the key in the storage map that is being updated.
 @locals(8)
 pub proc set_map_item
-    # retrieve the link map ptr to the storage map delta for the provided index
-    exec.memory::get_account_delta_storage_map_ptr
-    # => [account_delta_storage_map_ptr, KEY, PREV_VALUE, NEW_VALUE]
+    # retrieve the link map ptr to the storage map patch for the provided index
+    exec.memory::get_account_patch_storage_map_ptr
+    # => [account_patch_storage_map_ptr, KEY, PREV_VALUE, NEW_VALUE]
 
     # store map ptr in local
     loc_store.0
@@ -776,9 +776,9 @@ pub proc set_map_item
     # => [KEY, PREV_VALUE, NEW_VALUE]
 
     loc_load.0
-    # => [account_delta_storage_map_ptr, KEY, PREV_VALUE, NEW_VALUE]
+    # => [account_patch_storage_map_ptr, KEY, PREV_VALUE, NEW_VALUE]
 
-    # retrieve the current delta
+    # retrieve the current patch
     exec.link_map::get
     # => [contains_key, VALUE0, VALUE1, PREV_VALUE, NEW_VALUE]
 
@@ -804,7 +804,7 @@ pub proc set_map_item
 
     # load key and index from locals
     padw loc_loadw_le.4 loc_load.0
-    # => [account_delta_storage_map_ptr, KEY, INITIAL_VALUE, NEW_VALUE]
+    # => [account_patch_storage_map_ptr, KEY, INITIAL_VALUE, NEW_VALUE]
 
     exec.link_map::set drop
     # => []

--- a/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/memory.masm
@@ -226,7 +226,7 @@ pub const ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR=532480
 # The link map pointer at which the delta of the non-fungible asset vault is stored.
 pub const ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_PTR=ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR+4
 
-# The section of link map pointers where storage map deltas are stored.
+# The section of link map pointers where storage map patches are stored.
 # This section is offset by `slot index` to get the link map ptr for the storage map
 # delta at that slot index. Slot indices that are not map slots are simply unused.
 const ACCOUNT_DELTA_STORAGE_MAP_SECTION=ACCOUNT_DELTA_FUNGIBLE_ASSET_PTR+8
@@ -1427,15 +1427,15 @@ end
 
 ### ACCOUNT DELTA #################################################
 
-#! Returns the link map pointer to the storage map delta of the storage map in the given slot index.
+#! Returns the link map pointer to the storage map patch of the storage map in the given slot index.
 #!
 #! Inputs:  [slot_idx]
-#! Outputs: [account_delta_storage_map_ptr]
+#! Outputs: [account_patch_storage_map_ptr]
 #!
 #! Where:
-#! - account_delta_storage_map_ptr is the link map pointer to the storage map delta for the
+#! - account_patch_storage_map_ptr is the link map pointer to the storage map patch for the
 #!   requested slot index.
-pub proc get_account_delta_storage_map_ptr
+pub proc get_account_patch_storage_map_ptr
     add.ACCOUNT_DELTA_STORAGE_MAP_SECTION
 end
 

--- a/crates/miden-protocol/asm/protocol/native_account.masm
+++ b/crates/miden-protocol/asm/protocol/native_account.masm
@@ -99,7 +99,7 @@ end
 #! - DELTA_COMMITMENT is the commitment to the account delta.
 #!
 #! Panics if:
-#! - the vault or storage delta is not empty but the nonce increment is zero.
+#! - the vault or storage patch is not empty but the nonce increment is zero.
 pub proc compute_delta_commitment
     # pad the stack
     padw padw padw push.0.0.0

--- a/crates/miden-protocol/src/account/delta/mod.rs
+++ b/crates/miden-protocol/src/account/delta/mod.rs
@@ -22,7 +22,7 @@ use crate::utils::serde::{
 use crate::{Felt, Word, ZERO};
 
 mod storage;
-pub use storage::{AccountStorageDelta, StorageMapDelta, StorageSlotDelta};
+pub use storage::{AccountStoragePatch, StorageMapPatch, StorageSlotPatch};
 
 mod vault;
 pub use vault::{
@@ -39,7 +39,7 @@ pub use vault::{
 /// one or more transaction.
 ///
 /// The differences are represented as follows:
-/// - storage: an [`AccountStorageDelta`] that contains the changes to the account storage.
+/// - storage: an [`AccountStoragePatch`] that contains the changes to the account storage.
 /// - vault: an [`AccountVaultDelta`] object that contains the changes to the account vault.
 /// - nonce: if the nonce of the account has changed, the _delta_ of the nonce is stored, i.e. the
 ///   value by which the nonce increased.
@@ -57,8 +57,8 @@ pub struct AccountDelta {
     /// The ID of the account to which this delta applies. If the delta is created during
     /// transaction execution, that is the native account of the transaction.
     account_id: AccountId,
-    /// The delta of the account's storage.
-    storage: AccountStorageDelta,
+    /// The patch of the account's storage.
+    storage: AccountStoragePatch,
     /// The delta of the account's asset vault.
     vault: AccountVaultDelta,
     /// The code of a new account (`Some`) or `None` for existing accounts.
@@ -79,7 +79,7 @@ impl AccountDelta {
     /// - Returns an error if storage or vault were updated, but the nonce_delta is 0.
     pub fn new(
         account_id: AccountId,
-        storage: AccountStorageDelta,
+        storage: AccountStoragePatch,
         vault: AccountVaultDelta,
         nonce_delta: Felt,
     ) -> Result<Self, AccountDeltaError> {
@@ -158,7 +158,7 @@ impl AccountDelta {
     }
 
     /// Returns storage updates for this account delta.
-    pub fn storage(&self) -> &AccountStorageDelta {
+    pub fn storage(&self) -> &AccountStoragePatch {
         &self.storage
     }
 
@@ -182,8 +182,8 @@ impl AccountDelta {
         self.code.as_ref()
     }
 
-    /// Converts this storage delta into individual delta components.
-    pub fn into_parts(self) -> (AccountStorageDelta, AccountVaultDelta, Option<AccountCode>, Felt) {
+    /// Converts this delta into its individual components.
+    pub fn into_parts(self) -> (AccountStoragePatch, AccountVaultDelta, Option<AccountCode>, Felt) {
         (self.storage, self.vault, self.code, self.nonce_delta)
     }
 
@@ -278,7 +278,7 @@ impl AccountDelta {
     ///   ID_AND_NONCE, EMPTY_WORD,
     ///   [/* no fungible asset delta */],
     ///   [[domain = 1, was_added = 0, faucet_id_suffix, faucet_id_prefix], NON_FUNGIBLE_ASSET],
-    ///   [/* no storage delta */]
+    ///   [/* no storage patch */]
     /// ]
     /// ```
     ///
@@ -352,7 +352,7 @@ impl TryFrom<&AccountDelta> for Account {
     /// - If any vault delta operation removes an asset.
     /// - If any vault delta operation adds an asset that would overflow the maximum representable
     ///   amount.
-    /// - If any storage delta update violates account storage constraints.
+    /// - If any storage patch update violates account storage constraints.
     fn try_from(delta: &AccountDelta) -> Result<Self, Self::Error> {
         if !delta.is_full_state() {
             return Err(AccountError::PartialStateDeltaToAccount);
@@ -369,16 +369,16 @@ impl TryFrom<&AccountDelta> for Account {
         // this to create an empty account and use `Account::apply_delta` instead.
         // For now, we need to create the initial storage of the account with the same slot types.
         let mut empty_storage_slots = Vec::new();
-        for (slot_name, slot_delta) in delta.storage().slots() {
-            let slot = match slot_delta.slot_type() {
+        for (slot_name, slot_patch) in delta.storage().slots() {
+            let slot = match slot_patch.slot_type() {
                 StorageSlotType::Value => StorageSlot::with_empty_value(slot_name.clone()),
                 StorageSlotType::Map => StorageSlot::with_empty_map(slot_name.clone()),
             };
             empty_storage_slots.push(slot);
         }
         let mut storage = AccountStorage::new(empty_storage_slots)
-            .expect("storage delta should contain a valid number of slots");
-        storage.apply_delta(delta.storage())?;
+            .expect("storage patch should contain a valid number of slots");
+        storage.apply_patch(delta.storage())?;
 
         // The nonce of the account is the initial nonce of 0 plus the nonce_delta, so the
         // nonce_delta itself.
@@ -415,7 +415,7 @@ impl SequentialCommit for AccountDelta {
         // Vault Delta
         self.vault.append_delta_elements(&mut elements);
 
-        // Storage Delta
+        // Storage Patch
         self.storage.append_delta_elements(&mut elements);
 
         debug_assert!(
@@ -514,7 +514,7 @@ impl Serializable for AccountDelta {
 impl Deserializable for AccountDelta {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let account_id = AccountId::read_from(source)?;
-        let storage = AccountStorageDelta::read_from(source)?;
+        let storage = AccountStoragePatch::read_from(source)?;
         let vault = AccountVaultDelta::read_from(source)?;
         let code = <Option<AccountCode>>::read_from(source)?;
         let nonce_delta = Felt::read_from(source)?;
@@ -579,7 +579,7 @@ impl Deserializable for AccountUpdateDetails {
 /// - storage or vault were updated, but the nonce_delta was set to 0.
 fn validate_nonce(
     nonce_delta: Felt,
-    storage: &AccountStorageDelta,
+    storage: &AccountStoragePatch,
     vault: &AccountVaultDelta,
 ) -> Result<(), AccountDeltaError> {
     if (!storage.is_empty() || !vault.is_empty()) && nonce_delta == ZERO {
@@ -598,7 +598,7 @@ mod tests {
     use assert_matches::assert_matches;
     use miden_core::Felt;
 
-    use super::{AccountDelta, AccountStorageDelta, AccountVaultDelta};
+    use super::{AccountDelta, AccountStoragePatch, AccountVaultDelta};
     use crate::account::delta::AccountUpdateDetails;
     use crate::account::{
         Account,
@@ -606,8 +606,8 @@ mod tests {
         AccountId,
         AccountStorage,
         AccountType,
-        StorageMapDelta,
         StorageMapKey,
+        StorageMapPatch,
         StorageSlotName,
     };
     use crate::asset::{
@@ -630,37 +630,37 @@ mod tests {
     fn account_delta_nonce_validation() {
         let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
         // empty delta
-        let storage_delta = AccountStorageDelta::new();
+        let storage_patch = AccountStoragePatch::new();
         let vault_delta = AccountVaultDelta::default();
 
-        AccountDelta::new(account_id, storage_delta.clone(), vault_delta.clone(), ZERO).unwrap();
-        AccountDelta::new(account_id, storage_delta.clone(), vault_delta.clone(), ONE).unwrap();
+        AccountDelta::new(account_id, storage_patch.clone(), vault_delta.clone(), ZERO).unwrap();
+        AccountDelta::new(account_id, storage_patch.clone(), vault_delta.clone(), ONE).unwrap();
 
         // non-empty delta
-        let storage_delta = AccountStorageDelta::from_iters([StorageSlotName::mock(1)], [], []);
+        let storage_patch = AccountStoragePatch::from_iters([StorageSlotName::mock(1)], [], []);
 
         assert_matches!(
-            AccountDelta::new(account_id, storage_delta.clone(), vault_delta.clone(), ZERO)
+            AccountDelta::new(account_id, storage_patch.clone(), vault_delta.clone(), ZERO)
                 .unwrap_err(),
             AccountDeltaError::NonEmptyStorageOrVaultDeltaWithZeroNonceDelta
         );
-        AccountDelta::new(account_id, storage_delta.clone(), vault_delta.clone(), ONE).unwrap();
+        AccountDelta::new(account_id, storage_patch.clone(), vault_delta.clone(), ONE).unwrap();
     }
 
     #[test]
     fn account_delta_nonce_overflow() {
         let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
-        let storage_delta = AccountStorageDelta::new();
+        let storage_patch = AccountStoragePatch::new();
         let vault_delta = AccountVaultDelta::default();
 
         let nonce_delta0 = ONE;
         let nonce_delta1 = Felt::try_from(0xffff_ffff_0000_0000u64).unwrap();
 
         let mut delta0 =
-            AccountDelta::new(account_id, storage_delta.clone(), vault_delta.clone(), nonce_delta0)
+            AccountDelta::new(account_id, storage_patch.clone(), vault_delta.clone(), nonce_delta0)
                 .unwrap();
         let delta1 =
-            AccountDelta::new(account_id, storage_delta, vault_delta, nonce_delta1).unwrap();
+            AccountDelta::new(account_id, storage_patch, vault_delta, nonce_delta1).unwrap();
 
         assert_matches!(delta0.merge(delta1).unwrap_err(), AccountDeltaError::NonceIncrementOverflow {
           current, increment, new
@@ -675,16 +675,16 @@ mod tests {
     fn account_update_details_size_hint() {
         // AccountDelta
         let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER).unwrap();
-        let storage_delta = AccountStorageDelta::new();
+        let storage_patch = AccountStoragePatch::new();
         let vault_delta = AccountVaultDelta::default();
-        assert_eq!(storage_delta.to_bytes().len(), storage_delta.get_size_hint());
+        assert_eq!(storage_patch.to_bytes().len(), storage_patch.get_size_hint());
         assert_eq!(vault_delta.to_bytes().len(), vault_delta.get_size_hint());
 
         let account_delta =
-            AccountDelta::new(account_id, storage_delta, vault_delta, ZERO).unwrap();
+            AccountDelta::new(account_id, storage_patch, vault_delta, ZERO).unwrap();
         assert_eq!(account_delta.to_bytes().len(), account_delta.get_size_hint());
 
-        let storage_delta = AccountStorageDelta::from_iters(
+        let storage_patch = AccountStoragePatch::from_iters(
             [StorageSlotName::mock(1)],
             [
                 (StorageSlotName::mock(2), Word::from([1, 1, 1, 1u32])),
@@ -692,7 +692,7 @@ mod tests {
             ],
             [(
                 StorageSlotName::mock(4),
-                StorageMapDelta::from_iters(
+                StorageMapPatch::from_iters(
                     [
                         StorageMapKey::from_array([1, 1, 1, 0]),
                         StorageMapKey::from_array([0, 1, 1, 1]),
@@ -719,10 +719,10 @@ mod tests {
         .into();
         let vault_delta = AccountVaultDelta::from_iters([non_fungible], [fungible_2]);
 
-        assert_eq!(storage_delta.to_bytes().len(), storage_delta.get_size_hint());
+        assert_eq!(storage_patch.to_bytes().len(), storage_patch.get_size_hint());
         assert_eq!(vault_delta.to_bytes().len(), vault_delta.get_size_hint());
 
-        let account_delta = AccountDelta::new(account_id, storage_delta, vault_delta, ONE).unwrap();
+        let account_delta = AccountDelta::new(account_id, storage_patch, vault_delta, ONE).unwrap();
         assert_eq!(account_delta.to_bytes().len(), account_delta.get_size_hint());
 
         // Account

--- a/crates/miden-protocol/src/account/delta/storage.rs
+++ b/crates/miden-protocol/src/account/delta/storage.rs
@@ -20,58 +20,58 @@ use crate::account::{
 };
 use crate::{EMPTY_WORD, Felt, ZERO};
 
-// ACCOUNT STORAGE DELTA
+// ACCOUNT STORAGE PATCH
 // ================================================================================================
 
-/// The [`AccountStorageDelta`] stores the differences between two states of account storage.
+/// The [`AccountStoragePatch`] stores the differences between two states of account storage.
 ///
-/// The delta consists of a map from [`StorageSlotName`] to [`StorageSlotDelta`].
+/// The patch consists of a map from [`StorageSlotName`] to [`StorageSlotPatch`].
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AccountStorageDelta {
+pub struct AccountStoragePatch {
     /// The updates to the slots of the account.
-    deltas: BTreeMap<StorageSlotName, StorageSlotDelta>,
+    patches: BTreeMap<StorageSlotName, StorageSlotPatch>,
 }
 
-impl AccountStorageDelta {
-    /// Creates a new, empty storage delta.
+impl AccountStoragePatch {
+    /// Creates a new, empty storage patch.
     pub fn new() -> Self {
-        Self { deltas: BTreeMap::new() }
+        Self { patches: BTreeMap::new() }
     }
 
-    /// Creates a new storage delta from the provided slot deltas.
-    pub fn from_raw(deltas: BTreeMap<StorageSlotName, StorageSlotDelta>) -> Self {
-        Self { deltas }
+    /// Creates a new storage patch from the provided slot patches.
+    pub fn from_raw(patches: BTreeMap<StorageSlotName, StorageSlotPatch>) -> Self {
+        Self { patches }
     }
 
-    /// Returns the delta for the provided slot name, or `None` if no delta exists.
-    pub fn get(&self, slot_name: &StorageSlotName) -> Option<&StorageSlotDelta> {
-        self.deltas.get(slot_name)
+    /// Returns the patch for the provided slot name, or `None` if no patch exists.
+    pub fn get(&self, slot_name: &StorageSlotName) -> Option<&StorageSlotPatch> {
+        self.patches.get(slot_name)
     }
 
-    /// Returns an iterator over the slot deltas.
-    pub(crate) fn slots(&self) -> impl Iterator<Item = (&StorageSlotName, &StorageSlotDelta)> {
-        self.deltas.iter()
+    /// Returns an iterator over the slot patches.
+    pub(crate) fn slots(&self) -> impl Iterator<Item = (&StorageSlotName, &StorageSlotPatch)> {
+        self.patches.iter()
     }
 
-    /// Returns an iterator over the updated values in this storage delta.
+    /// Returns an iterator over the updated values in this storage patch.
     pub fn values(&self) -> impl Iterator<Item = (&StorageSlotName, &Word)> {
-        self.deltas.iter().filter_map(|(slot_name, slot_delta)| match slot_delta {
-            StorageSlotDelta::Value(word) => Some((slot_name, word)),
-            StorageSlotDelta::Map(_) => None,
+        self.patches.iter().filter_map(|(slot_name, slot_patch)| match slot_patch {
+            StorageSlotPatch::Value(word) => Some((slot_name, word)),
+            StorageSlotPatch::Map(_) => None,
         })
     }
 
-    /// Returns an iterator over the updated maps in this storage delta.
-    pub fn maps(&self) -> impl Iterator<Item = (&StorageSlotName, &StorageMapDelta)> {
-        self.deltas.iter().filter_map(|(slot_name, slot_delta)| match slot_delta {
-            StorageSlotDelta::Value(_) => None,
-            StorageSlotDelta::Map(map_delta) => Some((slot_name, map_delta)),
+    /// Returns an iterator over the updated maps in this storage patch.
+    pub fn maps(&self) -> impl Iterator<Item = (&StorageSlotName, &StorageMapPatch)> {
+        self.patches.iter().filter_map(|(slot_name, slot_patch)| match slot_patch {
+            StorageSlotPatch::Value(_) => None,
+            StorageSlotPatch::Map(map_patch) => Some((slot_name, map_patch)),
         })
     }
 
-    /// Returns true if storage delta contains no updates.
+    /// Returns true if storage patch contains no updates.
     pub fn is_empty(&self) -> bool {
-        self.deltas.is_empty()
+        self.patches.is_empty()
     }
 
     /// Tracks a slot change.
@@ -88,11 +88,11 @@ impl AccountStorageDelta {
         slot_name: StorageSlotName,
         new_slot_value: Word,
     ) -> Result<(), AccountDeltaError> {
-        if !self.deltas.get(&slot_name).map(StorageSlotDelta::is_value).unwrap_or(true) {
+        if !self.patches.get(&slot_name).map(StorageSlotPatch::is_value).unwrap_or(true) {
             return Err(AccountDeltaError::StorageSlotUsedAsDifferentTypes(slot_name));
         }
 
-        self.deltas.insert(slot_name, StorageSlotDelta::Value(new_slot_value));
+        self.patches.insert(slot_name, StorageSlotPatch::Value(new_slot_value));
 
         Ok(())
     }
@@ -113,39 +113,39 @@ impl AccountStorageDelta {
         new_value: Word,
     ) -> Result<(), AccountDeltaError> {
         match self
-            .deltas
+            .patches
             .entry(slot_name.clone())
-            .or_insert(StorageSlotDelta::Map(StorageMapDelta::default()))
+            .or_insert(StorageSlotPatch::Map(StorageMapPatch::default()))
         {
-            StorageSlotDelta::Value(_) => {
+            StorageSlotPatch::Value(_) => {
                 return Err(AccountDeltaError::StorageSlotUsedAsDifferentTypes(slot_name));
             },
-            StorageSlotDelta::Map(storage_map_delta) => {
-                storage_map_delta.insert(key, new_value);
+            StorageSlotPatch::Map(storage_map_patch) => {
+                storage_map_patch.insert(key, new_value);
             },
         };
 
         Ok(())
     }
 
-    /// Inserts an empty storage map delta for the provided slot name.
+    /// Inserts an empty storage map patch for the provided slot name.
     ///
-    /// This is useful for full state deltas to represent an empty map in the delta.
+    /// This is useful for full state patches to represent an empty map in the patch.
     ///
-    /// This overwrites the existing slot delta, if any.
-    pub fn insert_empty_map_delta(&mut self, slot_name: StorageSlotName) {
-        self.deltas.insert(slot_name, StorageSlotDelta::with_empty_map());
+    /// This overwrites the existing slot patch, if any.
+    pub fn insert_empty_map_patch(&mut self, slot_name: StorageSlotName) {
+        self.patches.insert(slot_name, StorageSlotPatch::with_empty_map());
     }
 
-    /// Merges another delta into this one, overwriting any existing values.
+    /// Merges another patch into this one, overwriting any existing values.
     pub fn merge(&mut self, other: Self) -> Result<(), AccountDeltaError> {
-        for (slot_name, slot_delta) in other.deltas {
-            match self.deltas.entry(slot_name.clone()) {
+        for (slot_name, slot_patch) in other.patches {
+            match self.patches.entry(slot_name.clone()) {
                 Entry::Vacant(vacant_entry) => {
-                    vacant_entry.insert(slot_delta);
+                    vacant_entry.insert(slot_patch);
                 },
                 Entry::Occupied(mut occupied_entry) => {
-                    occupied_entry.get_mut().merge(slot_delta).ok_or_else(|| {
+                    occupied_entry.get_mut().merge(slot_patch).ok_or_else(|| {
                         AccountDeltaError::StorageSlotUsedAsDifferentTypes(slot_name)
                     })?;
                 },
@@ -175,17 +175,17 @@ impl AccountStorageDelta {
         })
     }
 
-    /// Appends the storage slots delta to the given `elements` from which the delta commitment will
+    /// Appends the storage slots patch to the given `elements` from which the delta commitment will
     /// be computed.
     pub(super) fn append_delta_elements(&self, elements: &mut Vec<Felt>) {
         let domain_value = Felt::from_u8(2);
         let domain_map = Felt::from_u8(3);
 
-        for (slot_name, slot_delta) in self.deltas.iter() {
+        for (slot_name, slot_patch) in self.patches.iter() {
             let slot_id = slot_name.id();
 
-            match slot_delta {
-                StorageSlotDelta::Value(new_value) => {
+            match slot_patch {
+                StorageSlotPatch::Value(new_value) => {
                     elements.extend_from_slice(&[
                         domain_value,
                         ZERO,
@@ -194,13 +194,13 @@ impl AccountStorageDelta {
                     ]);
                     elements.extend_from_slice(new_value.as_elements());
                 },
-                StorageSlotDelta::Map(map_delta) => {
-                    for (key, value) in map_delta.entries() {
+                StorageSlotPatch::Map(map_patch) => {
+                    for (key, value) in map_patch.entries() {
                         elements.extend_from_slice(key.as_elements());
                         elements.extend_from_slice(value.as_elements());
                     }
 
-                    let num_changed_entries = Felt::try_from(map_delta.num_entries() as u64)
+                    let num_changed_entries = Felt::try_from(map_patch.num_entries() as u64)
                         .expect(
                             "number of changed entries should not exceed max representable felt",
                         );
@@ -217,19 +217,19 @@ impl AccountStorageDelta {
         }
     }
 
-    /// Consumes self and returns the underlying map of the storage delta.
-    pub fn into_map(self) -> BTreeMap<StorageSlotName, StorageSlotDelta> {
-        self.deltas
+    /// Consumes self and returns the underlying map of the storage patch.
+    pub fn into_map(self) -> BTreeMap<StorageSlotName, StorageSlotPatch> {
+        self.patches
     }
 }
 
-impl Default for AccountStorageDelta {
+impl Default for AccountStoragePatch {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Serializable for AccountStorageDelta {
+impl Serializable for AccountStoragePatch {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let num_cleared_values = self.cleared_values().count();
         let num_cleared_values =
@@ -258,11 +258,11 @@ impl Serializable for AccountStorageDelta {
     fn get_size_hint(&self) -> usize {
         let u8_size = 0u8.get_size_hint();
 
-        let mut storage_map_delta_size = 0;
-        for (slot_name, storage_map_delta) in self.maps() {
-            // The serialized size of each entry is the combination of slot (key) and the delta
+        let mut storage_map_patch_size = 0;
+        for (slot_name, storage_map_patch) in self.maps() {
+            // The serialized size of each entry is the combination of slot (key) and the patch
             // (value).
-            storage_map_delta_size += slot_name.get_size_hint() + storage_map_delta.get_size_hint();
+            storage_map_patch_size += slot_name.get_size_hint() + storage_map_patch.get_size_hint();
         }
 
         // Length Prefixes
@@ -273,91 +273,91 @@ impl Serializable for AccountStorageDelta {
         self.updated_values().fold(0, |acc, (slot_name, slot_value)| {
             acc + slot_name.get_size_hint() + slot_value.get_size_hint()
         }) +
-        // Storage Map Delta
-        storage_map_delta_size
+        // Storage Map Patch
+        storage_map_patch_size
     }
 }
 
-impl Deserializable for AccountStorageDelta {
+impl Deserializable for AccountStoragePatch {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let mut deltas = BTreeMap::new();
+        let mut patches = BTreeMap::new();
 
         let num_cleared_values = source.read_u8()?;
         for _ in 0..num_cleared_values {
             let cleared_value: StorageSlotName = source.read()?;
-            deltas.insert(cleared_value, StorageSlotDelta::with_empty_value());
+            patches.insert(cleared_value, StorageSlotPatch::with_empty_value());
         }
 
         let num_updated_values = source.read_u8()?;
         for _ in 0..num_updated_values {
             let (updated_slot, updated_value) = source.read()?;
-            deltas.insert(updated_slot, StorageSlotDelta::Value(updated_value));
+            patches.insert(updated_slot, StorageSlotPatch::Value(updated_value));
         }
 
         let num_maps = source.read_u8()? as usize;
-        for read_result in source.read_many_iter::<(StorageSlotName, StorageMapDelta)>(num_maps)? {
-            let (slot_name, map_delta) = read_result?;
-            deltas.insert(slot_name, StorageSlotDelta::Map(map_delta));
+        for read_result in source.read_many_iter::<(StorageSlotName, StorageMapPatch)>(num_maps)? {
+            let (slot_name, map_patch) = read_result?;
+            patches.insert(slot_name, StorageSlotPatch::Map(map_patch));
         }
 
-        Ok(Self::from_raw(deltas))
+        Ok(Self::from_raw(patches))
     }
 }
 
-// STORAGE SLOT DELTA
+// STORAGE SLOT PATCH
 // ================================================================================================
 
-/// The delta of a single storage slot.
+/// The patch of a single storage slot.
 ///
-/// - [`StorageSlotDelta::Value`] contains the value to which a value slot is updated.
-/// - [`StorageSlotDelta::Map`] contains the [`StorageMapDelta`] which contains the key-value pairs
+/// - [`StorageSlotPatch::Value`] contains the value to which a value slot is updated.
+/// - [`StorageSlotPatch::Map`] contains the [`StorageMapPatch`] which contains the key-value pairs
 ///   that were updated in a map slot.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StorageSlotDelta {
+pub enum StorageSlotPatch {
     Value(Word),
-    Map(StorageMapDelta),
+    Map(StorageMapPatch),
 }
 
-impl StorageSlotDelta {
+impl StorageSlotPatch {
     // CONSTANTS
     // ----------------------------------------------------------------------------------------
 
-    /// The type byte for value slot deltas.
+    /// The type byte for value slot patches.
     const VALUE: u8 = 0;
 
-    /// The type byte for map slot deltas.
+    /// The type byte for map slot patches.
     const MAP: u8 = 1;
 
     // CONSTRUCTORS
     // ----------------------------------------------------------------------------------------
 
-    /// Returns a new [`StorageSlotDelta::Value`] with an empty value.
+    /// Returns a new [`StorageSlotPatch::Value`] with an empty value.
     pub fn with_empty_value() -> Self {
         Self::Value(Word::empty())
     }
 
-    /// Returns a new [`StorageSlotDelta::Map`] with an empty map delta.
+    /// Returns a new [`StorageSlotPatch::Map`] with an empty map patch.
     pub fn with_empty_map() -> Self {
-        Self::Map(StorageMapDelta::default())
+        Self::Map(StorageMapPatch::default())
     }
 
     // ACCESSORS
     // ----------------------------------------------------------------------------------------
 
-    /// Returns the [`StorageSlotType`] of this slot delta.
+    /// Returns the [`StorageSlotType`] of this slot patch.
     pub fn slot_type(&self) -> StorageSlotType {
         match self {
-            StorageSlotDelta::Value(_) => StorageSlotType::Value,
-            StorageSlotDelta::Map(_) => StorageSlotType::Map,
+            StorageSlotPatch::Value(_) => StorageSlotType::Value,
+            StorageSlotPatch::Map(_) => StorageSlotType::Map,
         }
     }
 
-    /// Returns `true` if the slot delta is of type [`StorageSlotDelta::Value`], `false` otherwise.
+    /// Returns `true` if the slot patch is of type [`StorageSlotPatch::Value`], `false` otherwise.
     pub fn is_value(&self) -> bool {
         matches!(self, Self::Value(_))
     }
 
-    /// Returns `true` if the slot delta is of type [`StorageSlotDelta::Map`], `false` otherwise.
+    /// Returns `true` if the slot patch is of type [`StorageSlotPatch::Map`], `false` otherwise.
     pub fn is_map(&self) -> bool {
         matches!(self, Self::Map(_))
     }
@@ -365,29 +365,29 @@ impl StorageSlotDelta {
     // MUTATORS
     // ----------------------------------------------------------------------------------------
 
-    /// Unwraps a value slot delta into a [`Word`].
+    /// Unwraps a value slot patch into a [`Word`].
     ///
     /// # Panics
     ///
     /// Panics if:
-    /// - `self` is not of type [`StorageSlotDelta::Value`].
+    /// - `self` is not of type [`StorageSlotPatch::Value`].
     pub fn unwrap_value(self) -> Word {
         match self {
-            StorageSlotDelta::Value(value) => value,
-            StorageSlotDelta::Map(_) => panic!("called unwrap_value on a map slot delta"),
+            StorageSlotPatch::Value(value) => value,
+            StorageSlotPatch::Map(_) => panic!("called unwrap_value on a map slot patch"),
         }
     }
 
-    /// Unwraps a map slot delta into a [`StorageMapDelta`].
+    /// Unwraps a map slot patch into a [`StorageMapPatch`].
     ///
     /// # Panics
     ///
     /// Panics if:
-    /// - `self` is not of type [`StorageSlotDelta::Map`].
-    pub fn unwrap_map(self) -> StorageMapDelta {
+    /// - `self` is not of type [`StorageSlotPatch::Map`].
+    pub fn unwrap_map(self) -> StorageMapPatch {
         match self {
-            StorageSlotDelta::Value(_) => panic!("called unwrap_map on a value slot delta"),
-            StorageSlotDelta::Map(map_delta) => map_delta,
+            StorageSlotPatch::Value(_) => panic!("called unwrap_map on a value slot patch"),
+            StorageSlotPatch::Map(map_patch) => map_patch,
         }
     }
 
@@ -400,11 +400,11 @@ impl StorageSlotDelta {
     #[must_use]
     fn merge(&mut self, other: Self) -> Option<()> {
         match (self, other) {
-            (StorageSlotDelta::Value(current_value), StorageSlotDelta::Value(new_value)) => {
+            (StorageSlotPatch::Value(current_value), StorageSlotPatch::Value(new_value)) => {
                 *current_value = new_value;
             },
-            (StorageSlotDelta::Map(current_map_delta), StorageSlotDelta::Map(new_map_delta)) => {
-                current_map_delta.merge(new_map_delta);
+            (StorageSlotPatch::Map(current_map_patch), StorageSlotPatch::Map(new_map_patch)) => {
+                current_map_patch.merge(new_map_patch);
             },
             (..) => {
                 return None;
@@ -415,33 +415,33 @@ impl StorageSlotDelta {
     }
 }
 
-impl From<StorageSlotContent> for StorageSlotDelta {
+impl From<StorageSlotContent> for StorageSlotPatch {
     fn from(content: StorageSlotContent) -> Self {
         match content {
-            StorageSlotContent::Value(word) => StorageSlotDelta::Value(word),
+            StorageSlotContent::Value(word) => StorageSlotPatch::Value(word),
             StorageSlotContent::Map(storage_map) => {
-                StorageSlotDelta::Map(StorageMapDelta::from(storage_map))
+                StorageSlotPatch::Map(StorageMapPatch::from(storage_map))
             },
         }
     }
 }
 
-impl Serializable for StorageSlotDelta {
+impl Serializable for StorageSlotPatch {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         match self {
-            StorageSlotDelta::Value(value) => {
+            StorageSlotPatch::Value(value) => {
                 target.write_u8(Self::VALUE);
                 target.write(value);
             },
-            StorageSlotDelta::Map(storage_map_delta) => {
+            StorageSlotPatch::Map(storage_map_patch) => {
                 target.write_u8(Self::MAP);
-                target.write(storage_map_delta);
+                target.write(storage_map_patch);
             },
         }
     }
 }
 
-impl Deserializable for StorageSlotDelta {
+impl Deserializable for StorageSlotPatch {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         match source.read_u8()? {
             Self::VALUE => {
@@ -449,55 +449,55 @@ impl Deserializable for StorageSlotDelta {
                 Ok(Self::Value(value))
             },
             Self::MAP => {
-                let map_delta = source.read()?;
-                Ok(Self::Map(map_delta))
+                let map_patch = source.read()?;
+                Ok(Self::Map(map_patch))
             },
             other => Err(DeserializationError::InvalidValue(format!(
-                "unknown storage slot delta variant {other}"
+                "unknown storage slot patch variant {other}"
             ))),
         }
     }
 }
 
-// STORAGE MAP DELTA
+// STORAGE MAP PATCH
 // ================================================================================================
 
-/// [StorageMapDelta] stores the differences between two states of account storage maps.
+/// [StorageMapPatch] stores the differences between two states of account storage maps.
 ///
 /// The differences are represented as leaf updates: a map of updated item key ([Word]) to
 /// value ([Word]). For cleared items the value is [EMPTY_WORD].
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct StorageMapDelta(BTreeMap<StorageMapKey, Word>);
+pub struct StorageMapPatch(BTreeMap<StorageMapKey, Word>);
 
-impl StorageMapDelta {
-    /// Creates a new storage map delta from the provided leaves.
+impl StorageMapPatch {
+    /// Creates a new storage map patch from the provided leaves.
     pub fn new(map: BTreeMap<StorageMapKey, Word>) -> Self {
         Self(map)
     }
 
-    /// Returns the number of changed entries in this map delta.
+    /// Returns the number of changed entries in this map patch.
     pub fn num_entries(&self) -> usize {
         self.0.len()
     }
 
-    /// Returns a reference to the updated entries in this storage map delta.
+    /// Returns a reference to the updated entries in this storage map patch.
     ///
     /// Note that the returned key is the [`StorageMapKey`].
     pub fn entries(&self) -> &BTreeMap<StorageMapKey, Word> {
         &self.0
     }
 
-    /// Inserts an item into the storage map delta.
+    /// Inserts an item into the storage map patch.
     pub fn insert(&mut self, key: StorageMapKey, value: Word) {
         self.0.insert(key, value);
     }
 
-    /// Returns true if storage map delta contains no updates.
+    /// Returns true if storage map patch contains no updates.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
-    /// Merge `other` into this delta, giving precedence to `other`.
+    /// Merge `other` into this patch, giving precedence to `other`.
     pub fn merge(&mut self, other: Self) {
         // Aggregate the changes into a map such that `other` overwrites self.
         self.0.extend(other.0);
@@ -524,8 +524,8 @@ impl StorageMapDelta {
 }
 
 #[cfg(any(feature = "testing", test))]
-impl StorageMapDelta {
-    /// Creates a new [StorageMapDelta] from the provided iterators.
+impl StorageMapPatch {
+    /// Creates a new [StorageMapPatch] from the provided iterators.
     pub fn from_iters(
         cleared_leaves: impl IntoIterator<Item = StorageMapKey>,
         updated_leaves: impl IntoIterator<Item = (StorageMapKey, Word)>,
@@ -541,14 +541,14 @@ impl StorageMapDelta {
     }
 }
 
-/// Converts a [StorageMap] into a [StorageMapDelta] for initial delta construction.
-impl From<StorageMap> for StorageMapDelta {
+/// Converts a [StorageMap] into a [StorageMapPatch] for initial patch construction.
+impl From<StorageMap> for StorageMapPatch {
     fn from(map: StorageMap) -> Self {
-        StorageMapDelta::new(map.into_entries().into_iter().collect())
+        StorageMapPatch::new(map.into_entries().into_iter().collect())
     }
 }
 
-impl Serializable for StorageMapDelta {
+impl Serializable for StorageMapPatch {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let cleared: Vec<&StorageMapKey> = self.cleared_keys().collect();
         let updated: Vec<(&StorageMapKey, &Word)> = self.updated_entries().collect();
@@ -574,7 +574,7 @@ impl Serializable for StorageMapDelta {
     }
 }
 
-impl Deserializable for StorageMapDelta {
+impl Deserializable for StorageMapPatch {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let mut map = BTreeMap::new();
 
@@ -602,30 +602,30 @@ mod tests {
     use anyhow::Context;
     use assert_matches::assert_matches;
 
-    use super::{AccountStorageDelta, Deserializable, Serializable};
-    use crate::account::{StorageMapDelta, StorageMapKey, StorageSlotDelta, StorageSlotName};
+    use super::{AccountStoragePatch, Deserializable, Serializable};
+    use crate::account::{StorageMapKey, StorageMapPatch, StorageSlotName, StorageSlotPatch};
     use crate::errors::AccountDeltaError;
     use crate::{ONE, Word};
 
     #[test]
-    fn account_storage_delta_returns_err_on_slot_type_mismatch() {
+    fn account_storage_patch_returns_err_on_slot_type_mismatch() {
         let value_slot_name = StorageSlotName::mock(1);
         let map_slot_name = StorageSlotName::mock(2);
 
-        let mut delta = AccountStorageDelta::from_iters(
+        let mut patch = AccountStoragePatch::from_iters(
             [value_slot_name.clone()],
             [],
-            [(map_slot_name.clone(), StorageMapDelta::default())],
+            [(map_slot_name.clone(), StorageMapPatch::default())],
         );
 
-        let err = delta
+        let err = patch
             .set_map_item(value_slot_name.clone(), StorageMapKey::empty(), Word::empty())
             .unwrap_err();
         assert_matches!(err, AccountDeltaError::StorageSlotUsedAsDifferentTypes(slot_name) => {
             assert_eq!(value_slot_name, slot_name)
         });
 
-        let err = delta.set_item(map_slot_name.clone(), Word::empty()).unwrap_err();
+        let err = patch.set_item(map_slot_name.clone(), Word::empty()).unwrap_err();
         assert_matches!(err, AccountDeltaError::StorageSlotUsedAsDifferentTypes(slot_name) => {
             assert_eq!(map_slot_name, slot_name)
         });
@@ -633,112 +633,112 @@ mod tests {
 
     #[test]
     fn test_is_empty() {
-        let storage_delta = AccountStorageDelta::new();
-        assert!(storage_delta.is_empty());
+        let storage_patch = AccountStoragePatch::new();
+        assert!(storage_patch.is_empty());
 
-        let storage_delta = AccountStorageDelta::from_iters([StorageSlotName::mock(1)], [], []);
-        assert!(!storage_delta.is_empty());
+        let storage_patch = AccountStoragePatch::from_iters([StorageSlotName::mock(1)], [], []);
+        assert!(!storage_patch.is_empty());
 
-        let storage_delta = AccountStorageDelta::from_iters(
+        let storage_patch = AccountStoragePatch::from_iters(
             [],
             [(StorageSlotName::mock(2), Word::from([ONE, ONE, ONE, ONE]))],
             [],
         );
-        assert!(!storage_delta.is_empty());
+        assert!(!storage_patch.is_empty());
 
-        let storage_delta = AccountStorageDelta::from_iters(
+        let storage_patch = AccountStoragePatch::from_iters(
             [],
             [],
-            [(StorageSlotName::mock(3), StorageMapDelta::default())],
+            [(StorageSlotName::mock(3), StorageMapPatch::default())],
         );
-        assert!(!storage_delta.is_empty());
+        assert!(!storage_patch.is_empty());
     }
 
     #[test]
-    fn test_serde_account_storage_delta() {
-        let storage_delta = AccountStorageDelta::new();
-        let serialized = storage_delta.to_bytes();
-        let deserialized = AccountStorageDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, storage_delta);
-        assert_eq!(storage_delta.get_size_hint(), serialized.len());
+    fn test_serde_account_storage_patch() {
+        let storage_patch = AccountStoragePatch::new();
+        let serialized = storage_patch.to_bytes();
+        let deserialized = AccountStoragePatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, storage_patch);
+        assert_eq!(storage_patch.get_size_hint(), serialized.len());
 
-        let storage_delta = AccountStorageDelta::from_iters([StorageSlotName::mock(1)], [], []);
-        let serialized = storage_delta.to_bytes();
-        let deserialized = AccountStorageDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, storage_delta);
-        assert_eq!(storage_delta.get_size_hint(), serialized.len());
+        let storage_patch = AccountStoragePatch::from_iters([StorageSlotName::mock(1)], [], []);
+        let serialized = storage_patch.to_bytes();
+        let deserialized = AccountStoragePatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, storage_patch);
+        assert_eq!(storage_patch.get_size_hint(), serialized.len());
 
-        let storage_delta = AccountStorageDelta::from_iters(
+        let storage_patch = AccountStoragePatch::from_iters(
             [],
             [(StorageSlotName::mock(2), Word::from([ONE, ONE, ONE, ONE]))],
             [],
         );
-        let serialized = storage_delta.to_bytes();
-        let deserialized = AccountStorageDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, storage_delta);
-        assert_eq!(storage_delta.get_size_hint(), serialized.len());
+        let serialized = storage_patch.to_bytes();
+        let deserialized = AccountStoragePatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, storage_patch);
+        assert_eq!(storage_patch.get_size_hint(), serialized.len());
 
-        let storage_delta = AccountStorageDelta::from_iters(
+        let storage_patch = AccountStoragePatch::from_iters(
             [],
             [],
-            [(StorageSlotName::mock(3), StorageMapDelta::default())],
+            [(StorageSlotName::mock(3), StorageMapPatch::default())],
         );
-        let serialized = storage_delta.to_bytes();
-        let deserialized = AccountStorageDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, storage_delta);
-        assert_eq!(storage_delta.get_size_hint(), serialized.len());
+        let serialized = storage_patch.to_bytes();
+        let deserialized = AccountStoragePatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, storage_patch);
+        assert_eq!(storage_patch.get_size_hint(), serialized.len());
     }
 
     #[test]
-    fn test_serde_storage_map_delta() {
-        let storage_map_delta = StorageMapDelta::default();
-        let serialized = storage_map_delta.to_bytes();
-        let deserialized = StorageMapDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, storage_map_delta);
+    fn test_serde_storage_map_patch() {
+        let storage_map_patch = StorageMapPatch::default();
+        let serialized = storage_map_patch.to_bytes();
+        let deserialized = StorageMapPatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, storage_map_patch);
 
-        let storage_map_delta =
-            StorageMapDelta::from_iters([StorageMapKey::from_array([1, 1, 1, 1])], []);
-        let serialized = storage_map_delta.to_bytes();
-        let deserialized = StorageMapDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, storage_map_delta);
+        let storage_map_patch =
+            StorageMapPatch::from_iters([StorageMapKey::from_array([1, 1, 1, 1])], []);
+        let serialized = storage_map_patch.to_bytes();
+        let deserialized = StorageMapPatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, storage_map_patch);
 
-        let storage_map_delta = StorageMapDelta::from_iters(
+        let storage_map_patch = StorageMapPatch::from_iters(
             [],
             [(StorageMapKey::empty(), Word::from([ONE, ONE, ONE, ONE]))],
         );
-        let serialized = storage_map_delta.to_bytes();
-        let deserialized = StorageMapDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, storage_map_delta);
+        let serialized = storage_map_patch.to_bytes();
+        let deserialized = StorageMapPatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, storage_map_patch);
     }
 
     #[test]
-    fn test_serde_storage_slot_value_delta() {
-        let slot_delta = StorageSlotDelta::with_empty_value();
-        let serialized = slot_delta.to_bytes();
-        let deserialized = StorageSlotDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, slot_delta);
+    fn test_serde_storage_slot_value_patch() {
+        let slot_patch = StorageSlotPatch::with_empty_value();
+        let serialized = slot_patch.to_bytes();
+        let deserialized = StorageSlotPatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, slot_patch);
 
-        let slot_delta = StorageSlotDelta::Value(Word::from([1, 2, 3, 4u32]));
-        let serialized = slot_delta.to_bytes();
-        let deserialized = StorageSlotDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, slot_delta);
+        let slot_patch = StorageSlotPatch::Value(Word::from([1, 2, 3, 4u32]));
+        let serialized = slot_patch.to_bytes();
+        let deserialized = StorageSlotPatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, slot_patch);
     }
 
     #[test]
-    fn test_serde_storage_slot_map_delta() {
-        let slot_delta = StorageSlotDelta::with_empty_map();
-        let serialized = slot_delta.to_bytes();
-        let deserialized = StorageSlotDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, slot_delta);
+    fn test_serde_storage_slot_map_patch() {
+        let slot_patch = StorageSlotPatch::with_empty_map();
+        let serialized = slot_patch.to_bytes();
+        let deserialized = StorageSlotPatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, slot_patch);
 
-        let map_delta = StorageMapDelta::from_iters(
+        let map_patch = StorageMapPatch::from_iters(
             [StorageMapKey::from_array([1, 2, 3, 4])],
             [(StorageMapKey::from_array([5, 6, 7, 8]), Word::from([3, 4, 5, 6u32]))],
         );
-        let slot_delta = StorageSlotDelta::Map(map_delta);
-        let serialized = slot_delta.to_bytes();
-        let deserialized = StorageSlotDelta::read_from_bytes(&serialized).unwrap();
-        assert_eq!(deserialized, slot_delta);
+        let slot_patch = StorageSlotPatch::Map(map_patch);
+        let serialized = slot_patch.to_bytes();
+        let deserialized = StorageSlotPatch::read_from_bytes(&serialized).unwrap();
+        assert_eq!(deserialized, slot_patch);
     }
 
     #[rstest::rstest]
@@ -751,23 +751,23 @@ mod tests {
         #[case] y: Option<u32>,
         #[case] expected: Option<u32>,
     ) -> anyhow::Result<()> {
-        /// Creates a delta containing the item as an update if Some, else with the item cleared.
-        fn create_delta(item: Option<u32>) -> AccountStorageDelta {
+        /// Creates a patch containing the item as an update if Some, else with the item cleared.
+        fn create_patch(item: Option<u32>) -> AccountStoragePatch {
             let slot_name = StorageSlotName::mock(123);
             let item = item.map(|x| (slot_name.clone(), Word::from([x, 0, 0, 0])));
 
-            AccountStorageDelta::new()
+            AccountStoragePatch::new()
                 .add_cleared_items(item.is_none().then_some(slot_name.clone()))
                 .add_updated_values(item)
         }
 
-        let mut delta_x = create_delta(x);
-        let delta_y = create_delta(y);
-        let expected = create_delta(expected);
+        let mut patch_x = create_patch(x);
+        let patch_y = create_patch(y);
+        let expected = create_patch(expected);
 
-        delta_x.merge(delta_y).context("failed to merge deltas")?;
+        patch_x.merge(patch_y).context("failed to merge patches")?;
 
-        assert_eq!(delta_x, expected);
+        assert_eq!(patch_x, expected);
 
         Ok(())
     }
@@ -778,22 +778,22 @@ mod tests {
     #[case::some_none(Some(1), None, None)]
     #[test]
     fn merge_maps(#[case] x: Option<u32>, #[case] y: Option<u32>, #[case] expected: Option<u32>) {
-        fn create_delta(value: Option<u32>) -> StorageMapDelta {
+        fn create_patch(value: Option<u32>) -> StorageMapPatch {
             let key = StorageMapKey::from_array([10, 0, 0, 0]);
             match value {
                 Some(value) => {
-                    StorageMapDelta::from_iters([], [(key, Word::from([value, 0, 0, 0]))])
+                    StorageMapPatch::from_iters([], [(key, Word::from([value, 0, 0, 0]))])
                 },
-                None => StorageMapDelta::from_iters([key], []),
+                None => StorageMapPatch::from_iters([key], []),
             }
         }
 
-        let mut delta_x = create_delta(x);
-        let delta_y = create_delta(y);
-        let expected = create_delta(expected);
+        let mut patch_x = create_patch(x);
+        let patch_y = create_patch(y);
+        let expected = create_patch(expected);
 
-        delta_x.merge(delta_y);
+        patch_x.merge(patch_y);
 
-        assert_eq!(delta_x, expected);
+        assert_eq!(patch_x, expected);
     }
 }

--- a/crates/miden-protocol/src/account/mod.rs
+++ b/crates/miden-protocol/src/account/mod.rs
@@ -46,13 +46,13 @@ pub use interface::AccountComponentName;
 pub mod delta;
 pub use delta::{
     AccountDelta,
-    AccountStorageDelta,
+    AccountStoragePatch,
     AccountVaultDelta,
     FungibleAssetDelta,
     NonFungibleAssetDelta,
     NonFungibleDeltaAction,
-    StorageMapDelta,
-    StorageSlotDelta,
+    StorageMapPatch,
+    StorageSlotPatch,
 };
 
 pub mod storage;
@@ -306,7 +306,7 @@ impl Account {
             .map_err(AccountError::AssetVaultUpdateError)?;
 
         // update storage
-        self.storage.apply_delta(delta.storage())?;
+        self.storage.apply_patch(delta.storage())?;
 
         // update nonce
         self.increment_nonce(delta.nonce_delta())?;
@@ -382,9 +382,9 @@ impl TryFrom<Account> for AccountDelta {
             .into_slots()
             .into_iter()
             .map(StorageSlot::into_parts)
-            .map(|(slot_name, slot_content)| (slot_name, StorageSlotDelta::from(slot_content)))
+            .map(|(slot_name, slot_content)| (slot_name, StorageSlotPatch::from(slot_content)))
             .collect();
-        let storage_delta = AccountStorageDelta::from_raw(slot_deltas);
+        let storage_patch = AccountStoragePatch::from_raw(slot_deltas);
 
         let mut fungible_delta = FungibleAssetDelta::default();
         let mut non_fungible_delta = NonFungibleAssetDelta::default();
@@ -411,7 +411,7 @@ impl TryFrom<Account> for AccountDelta {
 
         // SAFETY: As checked earlier, the nonce delta should be greater than 0 allowing for
         // non-empty state changes.
-        let delta = AccountDelta::new(id, storage_delta, vault_delta, nonce_delta)
+        let delta = AccountDelta::new(id, storage_patch, vault_delta, nonce_delta)
             .expect("nonce_delta should be greater than 0")
             .with_code(Some(code));
 
@@ -520,7 +520,7 @@ mod tests {
         AccountDelta,
         AccountId,
         AccountStorage,
-        AccountStorageDelta,
+        AccountStoragePatch,
         AccountVaultDelta,
     };
     use crate::account::{
@@ -530,8 +530,8 @@ mod tests {
         AccountType,
         PartialAccount,
         StorageMap,
-        StorageMapDelta,
         StorageMapKey,
+        StorageMapPatch,
         StorageSlot,
         StorageSlotContent,
         StorageSlotName,
@@ -564,7 +564,7 @@ mod tests {
         let nonce_delta = Felt::from(2_u32);
         let asset_0 = FungibleAsset::mock(15);
         let asset_1 = NonFungibleAsset::mock(&[5, 5, 5]);
-        let storage_delta = AccountStorageDelta::new()
+        let storage_patch = AccountStoragePatch::new()
             .add_cleared_items([StorageSlotName::mock(0)])
             .add_updated_values([(StorageSlotName::mock(1), Word::from([1, 2, 3, 4u32]))]);
         let account_delta = build_account_delta(
@@ -572,7 +572,7 @@ mod tests {
             vec![asset_1],
             vec![asset_0],
             nonce_delta,
-            storage_delta,
+            storage_patch,
         );
 
         let serialized = account_delta.to_bytes();
@@ -614,12 +614,12 @@ mod tests {
         let key = StorageMapKey::from_array([101, 102, 103, 104]);
         let value = Word::from([9, 10, 11, 12u32]);
 
-        let updated_map = StorageMapDelta::from_iters([], [(key, value)]);
+        let updated_map = StorageMapPatch::from_iters([], [(key, value)]);
         storage_map.insert(key, value).unwrap();
 
         // build account delta
         let final_nonce = Felt::from(2_u32);
-        let storage_delta = AccountStorageDelta::new()
+        let storage_patch = AccountStoragePatch::new()
             .add_cleared_items([StorageSlotName::mock(0)])
             .add_updated_values([(StorageSlotName::mock(1), Word::from([1, 2, 3, 4u32]))])
             .add_updated_maps([(StorageSlotName::mock(2), updated_map)]);
@@ -628,7 +628,7 @@ mod tests {
             vec![asset_1],
             vec![asset_0],
             final_nonce - init_nonce,
-            storage_delta,
+            storage_patch,
         );
 
         // apply delta and create final_account
@@ -659,11 +659,11 @@ mod tests {
             build_account(vec![asset], init_nonce, vec![StorageSlotContent::Value(Word::empty())]);
 
         // build account delta
-        let storage_delta = AccountStorageDelta::new()
+        let storage_patch = AccountStoragePatch::new()
             .add_cleared_items([StorageSlotName::mock(0)])
             .add_updated_values([(StorageSlotName::mock(1), Word::from([1, 2, 3, 4u32]))]);
         let account_delta =
-            build_account_delta(account_id, vec![], vec![asset], init_nonce, storage_delta);
+            build_account_delta(account_id, vec![], vec![asset], init_nonce, storage_patch);
 
         // apply delta
         account.apply_delta(&account_delta).unwrap()
@@ -681,11 +681,11 @@ mod tests {
 
         // build account delta
         let final_nonce = Felt::from(1_u32);
-        let storage_delta = AccountStorageDelta::new()
+        let storage_patch = AccountStoragePatch::new()
             .add_cleared_items([StorageSlotName::mock(0)])
             .add_updated_values([(StorageSlotName::mock(1), Word::from([1, 2, 3, 4u32]))]);
         let account_delta =
-            build_account_delta(account_id, vec![], vec![asset], final_nonce, storage_delta);
+            build_account_delta(account_id, vec![], vec![asset], final_nonce, storage_patch);
 
         // apply delta
         account.apply_delta(&account_delta).unwrap()
@@ -704,7 +704,7 @@ mod tests {
         let nonce_delta = Felt::from(1_u32);
         let account_delta = AccountDelta::new(
             account_id,
-            AccountStorageDelta::new(),
+            AccountStoragePatch::new(),
             AccountVaultDelta::default(),
             nonce_delta,
         )
@@ -719,10 +719,10 @@ mod tests {
         added_assets: Vec<Asset>,
         removed_assets: Vec<Asset>,
         nonce_delta: Felt,
-        storage_delta: AccountStorageDelta,
+        storage_patch: AccountStoragePatch,
     ) -> AccountDelta {
         let vault_delta = AccountVaultDelta::from_iters(added_assets, removed_assets);
-        AccountDelta::new(account_id, storage_delta, vault_delta, nonce_delta).unwrap()
+        AccountDelta::new(account_id, storage_patch, vault_delta, nonce_delta).unwrap()
     }
 
     pub fn build_account(

--- a/crates/miden-protocol/src/account/storage/map/mod.rs
+++ b/crates/miden-protocol/src/account/storage/map/mod.rs
@@ -4,7 +4,7 @@ use miden_core::EMPTY_WORD;
 use miden_crypto::merkle::EmptySubtreeRoots;
 
 use super::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, Word};
-use crate::account::StorageMapDelta;
+use crate::account::StorageMapPatch;
 use crate::crypto::merkle::InnerNodeInfo;
 use crate::crypto::merkle::smt::{LeafIndex, SMT_DEPTH, Smt, SmtLeaf};
 use crate::errors::{AccountError, StorageMapError};
@@ -189,7 +189,7 @@ impl StorageMap {
     }
 
     /// Applies the provided delta to this account storage.
-    pub fn apply_delta(&mut self, delta: &StorageMapDelta) -> Result<Word, AccountError> {
+    pub fn apply_patch(&mut self, delta: &StorageMapPatch) -> Result<Word, AccountError> {
         // apply the updated and cleared leaves to the storage map
         for (&key, &value) in delta.entries().iter() {
             self.insert(key, value)?;

--- a/crates/miden-protocol/src/account/storage/mod.rs
+++ b/crates/miden-protocol/src/account/storage/mod.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use super::{
     AccountError,
-    AccountStorageDelta,
+    AccountStoragePatch,
     ByteReader,
     ByteWriter,
     Deserializable,
@@ -44,7 +44,7 @@ pub use partial::PartialStorage;
 /// necessary to:
 /// - Simplify lookups of slots in the transaction kernel (using `std::collections::sorted_array`
 ///   from the miden core library)
-/// - Allow the [`AccountStorageDelta`] to work only with slot names instead of slot indices.
+/// - Allow the [`AccountStoragePatch`] to work only with slot names instead of slot indices.
 /// - Make it simple to check for duplicates by iterating the slots and checking that no two
 ///   adjacent items have the same slot name.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -205,14 +205,14 @@ impl AccountStorage {
     ///
     /// Returns an error if:
     /// - The updates violate storage constraints.
-    pub(super) fn apply_delta(&mut self, delta: &AccountStorageDelta) -> Result<(), AccountError> {
+    pub(super) fn apply_patch(&mut self, delta: &AccountStoragePatch) -> Result<(), AccountError> {
         // Update storage values
         for (slot_name, &value) in delta.values() {
             self.set_item(slot_name, value)?;
         }
 
         // Update storage maps
-        for (slot_name, map_delta) in delta.maps() {
+        for (slot_name, map_patch) in delta.maps() {
             let slot = self
                 .get_mut(slot_name)
                 .ok_or(AccountError::StorageSlotNameNotFound { slot_name: slot_name.clone() })?;
@@ -222,7 +222,7 @@ impl AccountStorage {
                 _ => return Err(AccountError::StorageSlotNotMap(slot_name.clone())),
             };
 
-            storage_map.apply_delta(map_delta)?;
+            storage_map.apply_patch(map_patch)?;
         }
 
         Ok(())

--- a/crates/miden-protocol/src/testing/storage.rs
+++ b/crates/miden-protocol/src/testing/storage.rs
@@ -4,39 +4,39 @@ use miden_core::{Felt, Word};
 
 use crate::account::{
     AccountStorage,
-    AccountStorageDelta,
+    AccountStoragePatch,
     StorageMap,
-    StorageMapDelta,
     StorageMapKey,
+    StorageMapPatch,
     StorageSlot,
-    StorageSlotDelta,
     StorageSlotName,
+    StorageSlotPatch,
 };
 use crate::utils::sync::LazyLock;
 
-// ACCOUNT STORAGE DELTA
+// ACCOUNT STORAGE PATCH
 // ================================================================================================
 
-impl AccountStorageDelta {
+impl AccountStoragePatch {
     // CONSTRUCTORS
     // ----------------------------------------------------------------------------------------
 
-    /// Creates an [`AccountStorageDelta`] from the given iterators.
+    /// Creates an [`AccountStoragePatch`] from the given iterators.
     pub fn from_iters(
         cleared_values: impl IntoIterator<Item = StorageSlotName>,
         updated_values: impl IntoIterator<Item = (StorageSlotName, Word)>,
-        updated_maps: impl IntoIterator<Item = (StorageSlotName, StorageMapDelta)>,
+        updated_maps: impl IntoIterator<Item = (StorageSlotName, StorageMapPatch)>,
     ) -> Self {
         let deltas =
             cleared_values
                 .into_iter()
-                .map(|slot_name| (slot_name, StorageSlotDelta::with_empty_value()))
+                .map(|slot_name| (slot_name, StorageSlotPatch::with_empty_value()))
                 .chain(updated_values.into_iter().map(|(slot_name, slot_value)| {
-                    (slot_name, StorageSlotDelta::Value(slot_value))
+                    (slot_name, StorageSlotPatch::Value(slot_value))
                 }))
                 .chain(
-                    updated_maps.into_iter().map(|(slot_name, map_delta)| {
-                        (slot_name, StorageSlotDelta::Map(map_delta))
+                    updated_maps.into_iter().map(|(slot_name, map_patch)| {
+                        (slot_name, StorageSlotPatch::Map(map_patch))
                     }),
                 )
                 .collect();
@@ -68,10 +68,10 @@ impl AccountStorageDelta {
 
     pub fn add_updated_maps(
         mut self,
-        items: impl IntoIterator<Item = (StorageSlotName, StorageMapDelta)>,
+        items: impl IntoIterator<Item = (StorageSlotName, StorageMapPatch)>,
     ) -> Self {
-        items.into_iter().for_each(|(slot_name, map_delta)| {
-            for (key, value) in map_delta.entries() {
+        items.into_iter().for_each(|(slot_name, map_patch)| {
+            for (key, value) in map_patch.entries() {
                 self.set_map_item(slot_name.clone(), *key, *value).expect("TODO")
             }
         });

--- a/crates/miden-protocol/src/transaction/kernel/memory.rs
+++ b/crates/miden-protocol/src/transaction/kernel/memory.rs
@@ -54,7 +54,7 @@ pub type StorageSlot = u8;
 // | ---------------------------- | ------------- | ---------------- | ----------------------------------- |
 // | Fungible Asset Delta Ptr     | 0             | 4                |                                     |
 // | Non-Fungible Asset Delta Ptr | 4             | 4                |                                     |
-// | Storage Map Delta Ptrs       | 8             | 256              | Max 255 storage map deltas          |
+// | Storage Map Patch Ptrs       | 8             | 256              | Max 255 storage map patches         |
 
 // BOOKKEEPING
 // ------------------------------------------------------------------------------------------------

--- a/crates/miden-protocol/src/transaction/proven_tx.rs
+++ b/crates/miden-protocol/src/transaction/proven_tx.rs
@@ -617,11 +617,11 @@ mod tests {
         AccountDelta,
         AccountId,
         AccountIdVersion,
-        AccountStorageDelta,
+        AccountStoragePatch,
         AccountType,
         AccountVaultDelta,
-        StorageMapDelta,
         StorageMapKey,
+        StorageMapPatch,
         StorageSlotName,
     };
     use crate::asset::FungibleAsset;
@@ -688,12 +688,12 @@ mod tests {
         for _ in 0..required_entries {
             map.insert(StorageMapKey::from_raw(rand_value()), rand_value::<Word>());
         }
-        let storage_delta = StorageMapDelta::new(map);
+        let storage_patch = StorageMapPatch::new(map);
 
         // A delta that exceeds the limit returns an error.
-        let storage_delta =
-            AccountStorageDelta::from_iters([], [], [(StorageSlotName::mock(4), storage_delta)]);
-        let delta = AccountDelta::new(account_id, storage_delta, AccountVaultDelta::default(), ONE)
+        let storage_patch =
+            AccountStoragePatch::from_iters([], [], [(StorageSlotName::mock(4), storage_patch)]);
+        let delta = AccountDelta::new(account_id, storage_patch, AccountVaultDelta::default(), ONE)
             .unwrap();
         let details = AccountUpdateDetails::Delta(delta);
         let details_size = details.get_size_hint();

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -22,9 +22,9 @@ use miden_protocol::account::{
     StorageMapKey,
     StorageSlot,
     StorageSlotContent,
-    StorageSlotDelta,
     StorageSlotId,
     StorageSlotName,
+    StorageSlotPatch,
     StorageSlotType,
 };
 use miden_protocol::assembly::diagnostics::NamedSource;
@@ -829,21 +829,21 @@ async fn prove_account_creation_with_non_empty_storage() -> anyhow::Result<()> {
 
     assert_matches!(
         tx.account_delta().storage().get(&slot_name0).unwrap(),
-        StorageSlotDelta::Value(value) => {
+        StorageSlotPatch::Value(value) => {
             assert_eq!(*value, slot0.value())
         }
     );
     assert_matches!(
         tx.account_delta().storage().get(&slot_name1).unwrap(),
-        StorageSlotDelta::Value(value) => {
+        StorageSlotPatch::Value(value) => {
             assert_eq!(*value, slot1.value())
         }
     );
     assert_matches!(
         tx.account_delta().storage().get(&slot_name2).unwrap(),
-        StorageSlotDelta::Map(map_delta) => {
+        StorageSlotPatch::Map(map_patch) => {
             let expected = &BTreeMap::from_iter(map_entries);
-            assert_eq!(expected, map_delta.entries())
+            assert_eq!(expected, map_patch.entries())
         }
     );
 
@@ -1471,7 +1471,7 @@ async fn transaction_executor_account_code_using_custom_library() -> anyhow::Res
     assert_eq!(executed_tx.account_delta().storage().values().count(), 1);
     assert_eq!(
         executed_tx.account_delta().storage().get(&MOCK_VALUE_SLOT0).unwrap(),
-        &StorageSlotDelta::Value(slot_value),
+        &StorageSlotPatch::Value(slot_value),
     );
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_delta.rs
@@ -15,8 +15,8 @@ use miden_protocol::account::{
     StorageMap,
     StorageMapKey,
     StorageSlot,
-    StorageSlotDelta,
     StorageSlotName,
+    StorageSlotPatch,
 };
 use miden_protocol::asset::{
     Asset,
@@ -112,7 +112,7 @@ async fn delta_nonce() -> anyhow::Result<()> {
 /// - Slot 2: [1,3,5,7]  -> [1,3,5,7]               -> Delta: None
 /// - Slot 3: [1,3,5,7]  -> [2,3,4,5] -> [1,3,5,7]  -> Delta: None
 #[tokio::test]
-async fn storage_delta_for_value_slots() -> anyhow::Result<()> {
+async fn storage_patch_for_value_slots() -> anyhow::Result<()> {
     let slot_0_name = StorageSlotName::mock(0);
     let slot_0_init_value = Word::from([2, 4, 6, 8u32]);
     let slot_0_tmp_value = Word::from([3, 4, 5, 6u32]);
@@ -225,7 +225,7 @@ async fn storage_delta_for_value_slots() -> anyhow::Result<()> {
 ///   - key5 and key4 are the same scenario, but in different slots. In particular, slot 2's delta
 ///     map will be empty after normalization and so it shouldn't be present in the delta at all.
 #[tokio::test]
-async fn storage_delta_for_map_slots() -> anyhow::Result<()> {
+async fn storage_patch_for_map_slots() -> anyhow::Result<()> {
     // Test with random keys to make sure the ordering in the MASM and Rust implementations
     // matches.
     let key0 = StorageMapKey::from_raw(rand_value::<Word>());
@@ -361,13 +361,13 @@ async fn storage_delta_for_map_slots() -> anyhow::Result<()> {
 
     let mut map0_delta = maps_delta
         .get(&slot_0_name)
-        .map(|map_delta| (*map_delta).clone())
+        .map(|map_patch| (*map_patch).clone())
         .expect("delta for map 0 should exist")
         .into_map();
 
     let mut map1_delta = maps_delta
         .get(&slot_1_name)
-        .map(|map_delta| (*map_delta).clone())
+        .map(|map_patch| (*map_patch).clone())
         .expect("delta for map 1 should exist")
         .clone()
         .into_map();
@@ -608,7 +608,7 @@ async fn non_fungible_asset_delta() -> anyhow::Result<()> {
 /// Tests that adding and removing assets and updating value and map storage slots results in the
 /// correct delta.
 #[tokio::test]
-async fn asset_and_storage_delta() -> anyhow::Result<()> {
+async fn asset_and_storage_patch() -> anyhow::Result<()> {
     let account_assets = AssetVault::mock().assets().collect::<Vec<Asset>>();
 
     let account = AccountBuilder::new(ChaCha20Rng::from_os_rng().random())
@@ -766,7 +766,7 @@ async fn asset_and_storage_delta() -> anyhow::Result<()> {
 
     assert_eq!(executed_transaction.account_delta().nonce_delta(), Felt::ONE);
 
-    // storage delta
+    // storage patch
     // --------------------------------------------------------------------------------------------
     // We expect one updated item and one updated map
     assert_eq!(executed_transaction.account_delta().storage().values().count(), 1);
@@ -776,19 +776,19 @@ async fn asset_and_storage_delta() -> anyhow::Result<()> {
             .storage()
             .get(&MOCK_VALUE_SLOT0)
             .cloned()
-            .map(StorageSlotDelta::unwrap_value),
+            .map(StorageSlotPatch::unwrap_value),
         Some(updated_slot_value)
     );
 
     assert_eq!(executed_transaction.account_delta().storage().maps().count(), 1);
-    let map_delta = executed_transaction
+    let map_patch = executed_transaction
         .account_delta()
         .storage()
         .get(&MOCK_MAP_SLOT)
         .cloned()
-        .map(StorageSlotDelta::unwrap_map)
+        .map(StorageSlotPatch::unwrap_map)
         .unwrap();
-    assert_eq!(*map_delta.entries().get(&updated_map_key).unwrap(), updated_map_value);
+    assert_eq!(*map_patch.entries().get(&updated_map_key).unwrap(), updated_map_value);
 
     // vault delta
     // --------------------------------------------------------------------------------------------
@@ -897,15 +897,15 @@ async fn proven_tx_storage_maps_matches_executed_tx_for_new_account() -> anyhow:
     for (slot_name, expected_map) in
         [(map0_slot_name, map0), (map1_slot_name, map1), (map2_slot_name, map2)]
     {
-        let map_delta = tx
+        let map_patch = tx
             .account_delta()
             .storage()
             .get(&slot_name)
             .cloned()
-            .map(StorageSlotDelta::unwrap_map)
+            .map(StorageSlotPatch::unwrap_map)
             .unwrap();
         assert_eq!(
-            map_delta.entries().iter().collect::<BTreeMap<_, _>>(),
+            map_patch.entries().iter().collect::<BTreeMap<_, _>>(),
             expected_map.entries().collect(),
             "map delta does not match for slot {slot_name}",
         );
@@ -971,7 +971,7 @@ async fn delta_for_new_account_retains_empty_value_storage_slots() -> anyhow::Re
             .storage()
             .get(&slot_name0)
             .cloned()
-            .map(StorageSlotDelta::unwrap_value)
+            .map(StorageSlotPatch::unwrap_value)
             .unwrap(),
         Word::empty()
     );
@@ -980,7 +980,7 @@ async fn delta_for_new_account_retains_empty_value_storage_slots() -> anyhow::Re
             .storage()
             .get(&slot_name1)
             .cloned()
-            .map(StorageSlotDelta::unwrap_value)
+            .map(StorageSlotPatch::unwrap_value)
             .unwrap(),
         slot_value2
     );
@@ -1022,7 +1022,7 @@ async fn delta_for_new_account_retains_empty_map_storage_slots() -> anyhow::Resu
             .storage()
             .get(&slot_name0)
             .cloned()
-            .map(StorageSlotDelta::unwrap_map)
+            .map(StorageSlotPatch::unwrap_map)
             .unwrap()
             .is_empty()
     );

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -3,7 +3,7 @@ use std::borrow::ToOwned;
 
 use miden_processor::crypto::random::RandomCoin;
 use miden_processor::{Felt, ONE};
-use miden_protocol::account::{Account, AccountDelta, AccountStorageDelta, AccountVaultDelta};
+use miden_protocol::account::{Account, AccountDelta, AccountStoragePatch, AccountVaultDelta};
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::errors::tx_kernel::{
     ERR_ACCOUNT_DELTA_NONCE_MUST_BE_INCREMENTED_IF_VAULT_OR_STORAGE_CHANGED,
@@ -107,7 +107,7 @@ async fn test_transaction_epilogue() -> anyhow::Result<()> {
 
     let account_delta_commitment = AccountDelta::new(
         tx_context.account().id(),
-        AccountStorageDelta::default(),
+        AccountStoragePatch::default(),
         AccountVaultDelta::default(),
         ONE,
     )?

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -39,7 +39,7 @@ async fn create_account_with_fees() -> anyhow::Result<()> {
     let added_asset = FungibleAsset::new(chain.fee_faucet_id(), note_amount)?.sub(tx.fee())?;
 
     assert_eq!(tx.account_delta().nonce_delta(), Felt::ONE);
-    // except for the nonce, the storage delta should be empty
+    // except for the nonce, the storage patch should be empty
     assert!(tx.account_delta().storage().is_empty());
     assert_eq!(tx.account_delta().vault().added_assets().count(), 1);
     assert_eq!(tx.account_delta().vault().removed_assets().count(), 0);

--- a/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
@@ -2,7 +2,7 @@
 //!
 //! Once lazy loading is enabled generally, it can be removed and/or integrated into other tests.
 
-use miden_protocol::account::{AccountId, AccountStorage, StorageMapKey, StorageSlotDelta};
+use miden_protocol::account::{AccountId, AccountStorage, StorageMapKey, StorageSlotPatch};
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::testing::account_id::{
     ACCOUNT_ID_FEE_FAUCET,
@@ -234,15 +234,15 @@ async fn setting_map_item_with_lazy_loading_succeeds() -> anyhow::Result<()> {
         .execute()
         .await?;
 
-    let map_delta = tx
+    let map_patch = tx
         .account_delta()
         .storage()
         .get(mock_map_slot)
         .cloned()
-        .map(StorageSlotDelta::unwrap_map)
+        .map(StorageSlotPatch::unwrap_map)
         .unwrap();
-    assert_eq!(map_delta.entries().get(&existing_key).unwrap(), &value0);
-    assert_eq!(map_delta.entries().get(&non_existent_key).unwrap(), &value1);
+    assert_eq!(map_patch.entries().get(&existing_key).unwrap(), &value0);
+    assert_eq!(map_patch.entries().get(&non_existent_key).unwrap(), &value1);
 
     Ok(())
 }

--- a/crates/miden-testing/tests/scripts/fee.rs
+++ b/crates/miden-testing/tests/scripts/fee.rs
@@ -36,7 +36,7 @@ async fn prove_account_creation_with_fees() -> anyhow::Result<()> {
     let added_asset = FungibleAsset::new(chain.fee_faucet_id(), amount)?.sub(tx.fee())?;
 
     assert_eq!(tx.account_delta().nonce_delta(), Felt::ONE);
-    // except for the nonce, the storage delta should be empty
+    // except for the nonce, the storage patch should be empty
     assert!(tx.account_delta().storage().is_empty());
     assert_eq!(tx.account_delta().vault().added_assets().count(), 1);
     assert_eq!(tx.account_delta().vault().removed_assets().count(), 0);

--- a/crates/miden-tx/src/host/account_delta_tracker.rs
+++ b/crates/miden-tx/src/host/account_delta_tracker.rs
@@ -7,7 +7,7 @@ use miden_protocol::account::{
     PartialAccount,
 };
 
-use crate::host::storage_delta_tracker::StorageDeltaTracker;
+use crate::host::storage_patch_tracker::StoragePatchTracker;
 
 // ACCOUNT DELTA TRACKER
 // ================================================================================================
@@ -24,7 +24,7 @@ use crate::host::storage_delta_tracker::StorageDeltaTracker;
 #[derive(Debug, Clone)]
 pub struct AccountDeltaTracker {
     account_id: AccountId,
-    storage: StorageDeltaTracker,
+    storage: StoragePatchTracker,
     vault: AccountVaultDelta,
     code: Option<AccountCode>,
     nonce_delta: Felt,
@@ -41,7 +41,7 @@ impl AccountDeltaTracker {
 
         Self {
             account_id: account.id(),
-            storage: StorageDeltaTracker::new(account),
+            storage: StoragePatchTracker::new(account),
             vault: AccountVaultDelta::default(),
             code,
             nonce_delta: Felt::ZERO,
@@ -68,8 +68,8 @@ impl AccountDeltaTracker {
         &mut self.vault
     }
 
-    /// Returns a mutable reference to the current storage delta tracker.
-    pub fn storage(&mut self) -> &mut StorageDeltaTracker {
+    /// Returns a mutable reference to the current storage patch tracker.
+    pub fn storage(&mut self) -> &mut StoragePatchTracker {
         &mut self.storage
     }
 
@@ -81,10 +81,10 @@ impl AccountDeltaTracker {
         let account_id = self.account_id;
         let nonce_delta = self.nonce_delta;
 
-        let storage_delta = self.storage.into_delta();
+        let storage_patch = self.storage.into_patch();
         let vault_delta = self.vault;
 
-        AccountDelta::new(account_id, storage_delta, vault_delta, nonce_delta)
+        AccountDelta::new(account_id, storage_patch, vault_delta, nonce_delta)
             .expect("account delta created in delta tracker should be valid")
             .with_code(self.code)
     }

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -1,7 +1,7 @@
 mod account_delta_tracker;
 
 use account_delta_tracker::AccountDeltaTracker;
-mod storage_delta_tracker;
+mod storage_patch_tracker;
 
 mod link_map;
 pub use link_map::{LinkMap, MemoryViewer};

--- a/crates/miden-tx/src/host/storage_patch_tracker.rs
+++ b/crates/miden-tx/src/host/storage_patch_tracker.rs
@@ -3,13 +3,13 @@ use alloc::vec::Vec;
 
 use miden_protocol::Word;
 use miden_protocol::account::{
-    AccountStorageDelta,
     AccountStorageHeader,
+    AccountStoragePatch,
     PartialAccount,
     StorageMapKey,
-    StorageSlotDelta,
     StorageSlotHeader,
     StorageSlotName,
+    StorageSlotPatch,
     StorageSlotType,
 };
 
@@ -24,8 +24,8 @@ use miden_protocol::account::{
 /// first time the key is written to, then the previous value is the initial value of that key in
 /// that slot.
 #[derive(Debug, Clone)]
-pub struct StorageDeltaTracker {
-    /// Flag indicating whether this delta is for a new account.
+pub struct StoragePatchTracker {
+    /// Flag indicating whether this patch is for a new account.
     is_account_new: bool,
     /// The _initial_ storage header of the native account against which the transaction is
     /// executed. This is only used to look up the initial values of storage _value_ slots, while
@@ -34,18 +34,18 @@ pub struct StorageDeltaTracker {
     /// A map from slot name to a map of key-value pairs where the key is a storage map key and
     /// the value represents the value of that key at the beginning of transaction execution.
     init_maps: BTreeMap<StorageSlotName, BTreeMap<StorageMapKey, Word>>,
-    /// The account storage delta.
-    delta: AccountStorageDelta,
+    /// The account storage patch.
+    patch: AccountStoragePatch,
 }
 
-impl StorageDeltaTracker {
+impl StoragePatchTracker {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Constructs a new initial storage delta from the provided account.
+    /// Constructs a new initial storage patch from the provided account.
     ///
-    /// If the account is new, inserts the storage entries into the delta analogously to the
-    /// transaction kernel delta.
+    /// If the account is new, inserts the storage entries into the patch analogously to the
+    /// transaction kernel patch.
     pub fn new(account: &PartialAccount) -> Self {
         let initial_storage_header = if account.is_new() {
             empty_storage_header_from_account(account)
@@ -53,21 +53,21 @@ impl StorageDeltaTracker {
             account.storage().header().clone()
         };
 
-        let mut storage_delta_tracker = Self {
+        let mut storage_patch_tracker = Self {
             is_account_new: account.is_new(),
             storage_header: initial_storage_header,
             init_maps: BTreeMap::new(),
-            delta: AccountStorageDelta::new(),
+            patch: AccountStoragePatch::new(),
         };
 
-        // Insert account storage into delta if it is new to match the kernel behavior.
+        // Insert account storage into patch if it is new to match the kernel behavior.
         if account.is_new() {
             account.storage().header().slots().for_each(|slot_header| {
                 match slot_header.slot_type() {
                     StorageSlotType::Value => {
-                        // For new accounts, all values should be added to the delta, even empty
-                        // words, so that the final delta includes the storage slot.
-                        storage_delta_tracker
+                        // For new accounts, all values should be added to the patch, even empty
+                        // words, so that the final patch includes the storage slot.
+                        storage_patch_tracker
                             .set_item(slot_header.name().clone(), slot_header.value());
                     },
                     StorageSlotType::Map => {
@@ -77,13 +77,13 @@ impl StorageDeltaTracker {
                             .find(|map| map.root() == slot_header.value())
                             .expect("storage map should be present in partial storage");
 
-                        // Make sure each map is represented by at least an empty storage map delta.
-                        storage_delta_tracker
-                            .delta
-                            .insert_empty_map_delta(slot_header.name().clone());
+                        // Make sure each map is represented by at least an empty storage map patch.
+                        storage_patch_tracker
+                            .patch
+                            .insert_empty_map_patch(slot_header.name().clone());
 
                         storage_map.entries().for_each(|(key, value)| {
-                            storage_delta_tracker.set_map_item(
+                            storage_patch_tracker.set_map_item(
                                 slot_header.name().clone(),
                                 *key,
                                 Word::empty(),
@@ -95,7 +95,7 @@ impl StorageDeltaTracker {
             });
         }
 
-        storage_delta_tracker
+        storage_patch_tracker
     }
 
     // PUBLIC MUTATORS
@@ -103,7 +103,7 @@ impl StorageDeltaTracker {
 
     /// Updates a value slot.
     pub fn set_item(&mut self, slot_name: StorageSlotName, new_value: Word) {
-        self.delta
+        self.patch
             .set_item(slot_name, new_value)
             .expect("transaction kernel should not change slot types");
     }
@@ -116,17 +116,17 @@ impl StorageDeltaTracker {
         prev_value: Word,
         new_value: Word,
     ) {
-        // Don't update the delta if the new value matches the old one.
+        // Don't update the patch if the new value matches the old one.
         if prev_value != new_value {
             self.set_init_map_item(slot_name.clone(), key, prev_value);
-            self.delta
+            self.patch
                 .set_map_item(slot_name, key, new_value)
                 .expect("transaction kernel should not change slot types");
         }
     }
 
-    /// Consumes `self` and returns the resulting, normalized [`AccountStorageDelta`].
-    pub fn into_delta(self) -> AccountStorageDelta {
+    /// Consumes `self` and returns the resulting, normalized [`AccountStoragePatch`].
+    pub fn into_patch(self) -> AccountStoragePatch {
         self.normalize()
     }
 
@@ -145,24 +145,24 @@ impl StorageDeltaTracker {
         slot_map.entry(key).or_insert(prev_value);
     }
 
-    /// Normalizes the storage delta by:
+    /// Normalizes the storage patch by:
     ///
     /// - removing entries for value slot updates whose new value is equal to the initial value at
     ///   the beginning of transaction execution.
     /// - removing entries for map slot updates where for a given key, the new value is equal to the
     ///   initial value at the beginning of transaction execution.
-    fn normalize(self) -> AccountStorageDelta {
+    fn normalize(self) -> AccountStoragePatch {
         let Self {
             is_account_new,
             storage_header,
             init_maps,
-            delta,
+            patch,
         } = self;
-        let mut deltas = delta.into_map();
+        let mut patches = patch.into_map();
 
-        deltas.retain(|slot_name, slot_delta| {
-            match slot_delta {
-                StorageSlotDelta::Value(new_value) => {
+        patches.retain(|slot_name, slot_patch| {
+            match slot_patch {
+                StorageSlotPatch::Value(new_value) => {
                     // SAFETY: The header in the initial storage is the one from the account
                     // against which the transaction is executed, so accessing that slot name
                     // should be fine.
@@ -180,11 +180,11 @@ impl StorageDeltaTracker {
                 // different from the initial value.
                 // On the map level: Keep only the maps that are non-empty after its key-value
                 // pairs have been normalized, or if the account is new.
-                StorageSlotDelta::Map(map_delta) => {
+                StorageSlotPatch::Map(map_patch) => {
                     let init_map = init_maps.get(slot_name);
 
                     if let Some(init_map) = init_map {
-                        map_delta.as_map_mut().retain(|key, new_value| {
+                        map_patch.as_map_mut().retain(|key, new_value| {
                             let initial_value = init_map.get(key).expect(
                               "the initial value should be present for every value that was updated",
                             );
@@ -192,14 +192,14 @@ impl StorageDeltaTracker {
                         });
                     }
 
-                    // Only retain the map delta if the account is new or if it still contains
+                    // Only retain the map patch if the account is new or if it still contains
                     // values after normalization.
-                    is_account_new || !map_delta.is_empty()
+                    is_account_new || !map_patch.is_empty()
                 },
             }
         });
 
-        AccountStorageDelta::from_raw(deltas)
+        AccountStoragePatch::from_raw(patches)
     }
 }
 


### PR DESCRIPTION
Renames `AccountStorageDelta` to `AccountStoragePatch` since this "delta" is already an absolute state today and this will make more sense when introducing `AccountPatch` in a subsequent PR (see proposal in https://github.com/0xMiden/protocol/issues/2078#issuecomment-4119875529).

preparation for https://github.com/0xMiden/protocol/issues/2078