### PR TITLE
fix(agglayer): enforce NoteType::Public for B2AGG bridge-out notes (#2988)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).
+- AggLayer `bridge_out` now rejects B2AGG notes whose `NoteType` is not `Public`, preventing a recipient-identical private note from desyncing the Local Exit Tree from AggLayer's off-chain mirror ([#2988](https://github.com/0xMiden/protocol/pull/2988)).
 
 ## v0.15.1 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - [BREAKING] Renamed `AccountStorageDelta` to `AccountStoragePatch` ([#3002](https://github.com/0xMiden/protocol/pull/3002)).
+- Added `active_note::is_public` and `active_note::is_private` MASM procedures for checking whether the active note is public or private ([#2988](https://github.com/0xMiden/protocol/pull/2988)).
 
 ### Fixes
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -22,6 +22,7 @@ use agglayer::common::eth_address::EthereumAddressFormat
 # =================================================================================================
 
 const ERR_B2AGG_DESTINATION_NETWORK_IS_MIDEN = "B2AGG note destination network ID must not be Miden's AggLayer network ID"
+const ERR_B2AGG_NOTE_MUST_BE_PUBLIC = "B2AGG note must be public"
 
 # CONSTANTS
 # =================================================================================================
@@ -106,11 +107,15 @@ const BURN_NOTE_NUM_STORAGE_ITEMS=0
 #! - dest_address(5) are 5 u32 values representing a 20-byte Ethereum address.
 #!
 #! Panics if:
+#! - the B2AGG note calling `bridge_out` is not public.
 #! - destination network ID is Miden's AggLayer network ID.
 #!
 #! Invocation: call
 @locals(15)
 pub proc bridge_out
+    exec.active_note::is_public assert.err=ERR_B2AGG_NOTE_MUST_BE_PUBLIC
+    # => [ASSET_KEY, ASSET_VALUE, dest_network_id, dest_address(5), pad(2)]
+
     # Save ASSET to local memory for later BURN note creation
     locaddr.BRIDGE_OUT_BURN_ASSET_LOC
     exec.asset::store

--- a/crates/miden-agglayer/asm/note_scripts/b2agg.masm
+++ b/crates/miden-agglayer/asm/note_scripts/b2agg.masm
@@ -50,6 +50,7 @@ const ERR_B2AGG_TARGET_ACCOUNT_MISMATCH="B2AGG note attachment target account do
 #! - The note does not contain exactly 6 storage items.
 #! - The note does not contain exactly 1 asset.
 #! - The note attachment does not target the consuming account.
+#! - The note is not public (enforced by `bridge_out`).
 #! - The destination network ID equals Miden's AggLayer network ID.
 @note_script
 pub proc main

--- a/crates/miden-protocol/asm/protocol/active_note.masm
+++ b/crates/miden-protocol/asm/protocol/active_note.masm
@@ -9,6 +9,8 @@ use miden::protocol::kernel_proc_offsets::INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET
 use miden::protocol::kernel_proc_offsets::INPUT_NOTE_GET_SCRIPT_ROOT_OFFSET
 use miden::protocol::note
 use miden::protocol::input_note
+use miden::protocol::util::note::NOTE_TYPE_PUBLIC
+use miden::protocol::util::note::NOTE_TYPE_PRIVATE
 
 # ERRORS
 # =================================================================================================
@@ -172,6 +174,52 @@ pub proc get_metadata
     # clean the stack
     swapdw dropw dropw swapw dropw
     # => [METADATA]
+end
+
+#! Returns whether the active note is public.
+#!
+#! Inputs:  []
+#! Outputs: [is_public]
+#!
+#! Where:
+#! - is_public is 1 if the active note is public, 0 otherwise.
+#!
+#! Panics if:
+#! - no note is currently active.
+#!
+#! Invocation: exec
+pub proc is_public
+    exec.get_metadata
+    # => [METADATA]
+
+    exec.note::metadata_into_note_type
+    # => [note_type]
+
+    eq.NOTE_TYPE_PUBLIC
+    # => [is_public]
+end
+
+#! Returns whether the active note is private.
+#!
+#! Inputs:  []
+#! Outputs: [is_private]
+#!
+#! Where:
+#! - is_private is 1 if the active note is private, 0 otherwise.
+#!
+#! Panics if:
+#! - no note is currently active.
+#!
+#! Invocation: exec
+pub proc is_private
+    exec.get_metadata
+    # => [METADATA]
+
+    exec.note::metadata_into_note_type
+    # => [note_type]
+
+    eq.NOTE_TYPE_PRIVATE
+    # => [is_private]
 end
 
 #! Returns the sender of the active note.

--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -24,7 +24,7 @@ use miden_protocol::testing::account_id::{
 };
 use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::transaction::memory::{ASSET_SIZE, ASSET_VALUE_OFFSET};
-use miden_protocol::{EMPTY_WORD, Felt, ONE, WORD_SIZE, Word};
+use miden_protocol::{EMPTY_WORD, Felt, ONE, WORD_SIZE, Word, ZERO};
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::testing::mock_account::MockAccountExt;
 use miden_standards::testing::note::NoteBuilder;
@@ -32,7 +32,7 @@ use rstest::rstest;
 
 use super::StackInputs;
 use crate::kernel_tests::tx::ExecutionOutputExt;
-use crate::utils::create_public_p2any_note;
+use crate::utils::{create_p2any_note, create_public_p2any_note};
 use crate::{
     Auth,
     MockChain,
@@ -121,6 +121,61 @@ async fn test_active_note_get_metadata() -> anyhow::Result<()> {
         end
         "#,
         METADATA = tx_context.input_notes().get_note(0).note().metadata().to_metadata_word(),
+    );
+
+    tx_context.execute_code(&code).await?;
+
+    Ok(())
+}
+
+/// `is_public` / `is_private` return the correct flag for the active note's type.
+#[rstest::rstest]
+#[case::public(NoteType::Public)]
+#[case::private(NoteType::Private)]
+#[tokio::test]
+async fn test_active_note_is_public_and_is_private(
+    #[case] note_type: NoteType,
+) -> anyhow::Result<()> {
+    let tx_context = {
+        let account =
+            Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, Auth::IncrNonce);
+        let mut rng = RandomCoin::new(Word::default());
+        let input_note = create_p2any_note(
+            ACCOUNT_ID_SENDER.try_into().unwrap(),
+            note_type,
+            [FungibleAsset::mock(100)],
+            &mut rng,
+        );
+        TransactionContextBuilder::new(account)
+            .extend_input_notes(vec![input_note])
+            .build()?
+    };
+
+    let (expected_public, expected_private) = match note_type {
+        NoteType::Public => (ONE, ZERO),
+        NoteType::Private => (ZERO, ONE),
+    };
+
+    let code = format!(
+        r#"
+        use $kernel::prologue
+        use $kernel::note->note_internal
+        use miden::protocol::active_note
+
+        begin
+            exec.prologue::prepare_transaction
+            exec.note_internal::prepare_note
+            dropw dropw dropw dropw
+
+            exec.active_note::is_public
+            push.{expected_public}
+            assert_eq.err="active note public flag did not match expected value"
+
+            exec.active_note::is_private
+            push.{expected_private}
+            assert_eq.err="active note private flag did not match expected value"
+        end
+        "#
     );
 
     tx_context.execute_code(&code).await?;

--- a/crates/miden-testing/tests/agglayer/bridge_out.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_out.rs
@@ -661,9 +661,10 @@ async fn test_bridge_out_rejects_invalid_b2agg_note(
                 builder.rng_mut(),
             )?;
 
-            let attachment = NoteAttachment::from(
-                NetworkAccountTarget::new(bridge_account.id(), NoteExecutionHint::Always)?
-            );
+            let attachment = NoteAttachment::from(NetworkAccountTarget::new(
+                bridge_account.id(),
+                NoteExecutionHint::Always,
+            )?);
             let attachments = NoteAttachments::from(attachment);
             let metadata = PartialNoteMetadata::new(faucet.id(), NoteType::Private);
             Note::with_attachments(

--- a/crates/miden-testing/tests/agglayer/bridge_out.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_out.rs
@@ -662,8 +662,7 @@ async fn test_bridge_out_rejects_invalid_b2agg_note(
             )?;
 
             let attachment = NoteAttachment::from(
-                NetworkAccountTarget::new(bridge_account.id(), NoteExecutionHint::Always)
-                    .map_err(|e| anyhow::anyhow!(e.to_string()))?,
+                NetworkAccountTarget::new(bridge_account.id(), NoteExecutionHint::Always)?
             );
             let attachments = NoteAttachments::from(attachment);
             let metadata = PartialNoteMetadata::new(faucet.id(), NoteType::Private);

--- a/crates/miden-testing/tests/agglayer/bridge_out.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_out.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 
 use miden_agglayer::errors::{
     ERR_B2AGG_DESTINATION_NETWORK_IS_MIDEN,
+    ERR_B2AGG_NOTE_MUST_BE_PUBLIC,
     ERR_B2AGG_TARGET_ACCOUNT_MISMATCH,
     ERR_FAUCET_NOT_REGISTERED,
 };
@@ -22,12 +23,20 @@ use miden_crypto::rand::FeltRng;
 use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::account::{Account, AccountId, AccountIdVersion, AccountType, StorageMapKey};
 use miden_protocol::asset::{Asset, AssetAmount, FungibleAsset};
-use miden_protocol::note::{NoteAssets, NoteType};
+use miden_protocol::errors::MasmError;
+use miden_protocol::note::{
+    Note,
+    NoteAssets,
+    NoteAttachment,
+    NoteAttachments,
+    NoteType,
+    PartialNoteMetadata,
+};
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::{Felt, Word};
 use miden_standards::account::faucets::FungibleFaucet;
 use miden_standards::account::policies::MintPolicyConfig;
-use miden_standards::note::{NetworkAccountTarget, StandardNote};
+use miden_standards::note::{NetworkAccountTarget, NoteExecutionHint, StandardNote};
 use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
 use miden_tx::utils::hex_to_bytes;
 use rand::rngs::StdRng;
@@ -538,10 +547,29 @@ async fn test_bridge_out_fails_with_unregistered_faucet() -> anyhow::Result<()> 
     Ok(())
 }
 
-/// B2AGG / bridge-out must reject a note whose `destination_network` equals the Miden network ID,
-/// even when the faucet is registered and the rest of the bridge-out path would otherwise succeed.
+/// The kind of malformation applied to an otherwise-valid B2AGG note in
+/// [`test_bridge_out_rejects_invalid_b2agg_note`].
+#[derive(Debug, Clone, Copy)]
+enum InvalidB2aggNote {
+    /// `destination_network` equals Miden's AggLayer network ID.
+    DestinationIsMiden,
+    /// Recipient-identical note marked `NoteType::Private` instead of public.
+    PrivateNoteType,
+}
+
+/// B2AGG notes must be public; private notes and bridge-out requests to Miden from Miden are
+/// rejected.
+#[rstest::rstest]
+#[case::destination_is_miden(
+    InvalidB2aggNote::DestinationIsMiden,
+    ERR_B2AGG_DESTINATION_NETWORK_IS_MIDEN
+)]
+#[case::private_note_type(InvalidB2aggNote::PrivateNoteType, ERR_B2AGG_NOTE_MUST_BE_PUBLIC)]
 #[tokio::test]
-async fn test_bridge_out_fails_when_destination_is_miden_network() -> anyhow::Result<()> {
+async fn test_bridge_out_rejects_invalid_b2agg_note(
+    #[case] invalid_note: InvalidB2aggNote,
+    #[case] expected_err: MasmError,
+) -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
 
     // CREATE BRIDGE ADMIN ACCOUNT (sends CONFIG_AGG_BRIDGE notes)
@@ -604,9 +632,7 @@ async fn test_bridge_out_fails_when_destination_is_miden_network() -> anyhow::Re
     )?;
     builder.add_output_note(RawOutputNote::Full(config_note.clone()));
 
-    // CREATE B2AGG NOTE (targets the bridge)
-    // Set destination_network to exactly `AggLayerBridge::MIDEN_NETWORK_ID` so `bridge_out`
-    // fails immediately.
+    // CREATE THE INVALID B2AGG NOTE (targets the bridge)
     // --------------------------------------------------------------------------------------------
     let amount = Felt::new_unchecked(100);
     let bridge_asset: Asset =
@@ -614,14 +640,41 @@ async fn test_bridge_out_fails_when_destination_is_miden_network() -> anyhow::Re
     let eth_address =
         EthAddress::from_hex(&vectors.destination_addresses[0]).expect("valid destination address");
 
-    let b2agg_note = B2AggNote::create(
-        AggLayerBridge::MIDEN_NETWORK_ID,
-        eth_address,
-        NoteAssets::new(vec![bridge_asset])?,
-        bridge_account.id(),
-        faucet.id(),
-        builder.rng_mut(),
-    )?;
+    let b2agg_note = match invalid_note {
+        // Destination network equals Miden's own network ID, which `bridge_out` rejects.
+        InvalidB2aggNote::DestinationIsMiden => B2AggNote::create(
+            AggLayerBridge::MIDEN_NETWORK_ID,
+            eth_address,
+            NoteAssets::new(vec![bridge_asset])?,
+            bridge_account.id(),
+            faucet.id(),
+            builder.rng_mut(),
+        )?,
+        // Build a public B2AGG note, then reuse its recipient and assets in a private note.
+        InvalidB2aggNote::PrivateNoteType => {
+            let public_note = B2AggNote::create(
+                origin_network,
+                eth_address,
+                NoteAssets::new(vec![bridge_asset])?,
+                bridge_account.id(),
+                faucet.id(),
+                builder.rng_mut(),
+            )?;
+
+            let attachment = NoteAttachment::from(
+                NetworkAccountTarget::new(bridge_account.id(), NoteExecutionHint::Always)
+                    .map_err(|e| anyhow::anyhow!(e.to_string()))?,
+            );
+            let attachments = NoteAttachments::from(attachment);
+            let metadata = PartialNoteMetadata::new(faucet.id(), NoteType::Private);
+            Note::with_attachments(
+                public_note.assets().clone(),
+                metadata,
+                public_note.recipient().clone(),
+                attachments,
+            )
+        },
+    };
 
     builder.add_output_note(RawOutputNote::Full(b2agg_note.clone()));
 
@@ -641,7 +694,7 @@ async fn test_bridge_out_fails_when_destination_is_miden_network() -> anyhow::Re
     mock_chain.add_pending_executed_transaction(&config_executed)?;
     mock_chain.prove_next_block()?;
 
-    // TX1: EXECUTE B2AGG NOTE AGAINST BRIDGE (must fail: destination_network is Miden's ID)
+    // TX1: EXECUTE THE INVALID B2AGG NOTE AGAINST BRIDGE (must fail)
     // --------------------------------------------------------------------------------------------
     let foreign_account_inputs = mock_chain.get_foreign_account_inputs(faucet.id())?;
 
@@ -652,7 +705,7 @@ async fn test_bridge_out_fails_when_destination_is_miden_network() -> anyhow::Re
         .execute()
         .await;
 
-    assert_transaction_executor_error!(result, ERR_B2AGG_DESTINATION_NETWORK_IS_MIDEN);
+    assert_transaction_executor_error!(result, expected_err);
 
     Ok(())
 }


### PR DESCRIPTION
Cherry-picks [#2988](https://github.com/0xMiden/protocol/pull/2988) (merged to `agglayer`) back to `next`.

The B2AGG note type lives in `NoteMetadata`, not in the recipient commitment, so an attacker could submit a B2AGG note with an identical recipient/attachment/asset but `NoteType::Private`. The bridge would accept it, fold the leaf into the on-chain Local Exit Tree, but aggkit could never recover the pre-image off-chain — the LET mirror would permanently desync and the bridge-out path would brick for everyone.

This PR:

- Adds `active_note::is_public` and `active_note::is_private` to the protocol (built on `note::metadata_into_note_type` from [#2738](https://github.com/0xMiden/protocol/pull/2738)).
- Asserts `active_note::is_public` at the top of `bridge::bridge_out::bridge_out` with `ERR_B2AGG_NOTE_MUST_BE_PUBLIC`.
- Parameterises the bridge-out integration test into `test_bridge_out_rejects_invalid_b2agg_note` covering both the `DestinationIsMiden` and `PrivateNoteType` cases.

`note::metadata_into_note_type` (from #2738) is reused instead of porting `note::extract_note_type_from_metadata` from #2988 — the two procs decode different bit positions because `next` and `agglayer` lay out the metadata header differently, and `metadata_into_note_type` is the correct primitive for `next`.
