### PR TITLE
docs(claude): require new commits (not force-push) when addressing PR review

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,6 +40,7 @@
 - **Worktree visibility:** Always tell the user which worktree (full path) you will work in as part of the plan. When finished, state where the changes live (worktree path and branch name).
 - **Commit authorship:** Always commit as Claude, not as the user. Use: `git -c user.name="Claude (Opus)" -c user.email="noreply@anthropic.com" -c commit.gpgsign=false commit -m "message"`
 - **Commit frequency:** Always commit at the end of each task. Avoid single commits that span multiple unrelated changes.
+- **Responding to PR review:** When addressing review feedback on a pushed PR, add new commits on top of the branch (e.g. `fix: address review comments`). NEVER amend, squash, or otherwise rewrite already-pushed commits to incorporate review changes, and NEVER force-push the branch to do so - this destroys the diff reviewers rely on to see what changed since their review. The only time a force-push is acceptable is when the branch must be rebased onto an updated base (or a PR lower in a stack changed); that is a base update, not a review response, and should be called out explicitly.
 
 ## Output Formatting
 


### PR DESCRIPTION
Adds a Git Conventions rule to `.claude/CLAUDE.md`: review feedback on a pushed PR must be addressed with new commits on top, never by amending/squashing/force-pushing already-pushed commits (which destroys the since-review diff). Force-push stays acceptable only for rebasing onto an updated base / stacked-PR updates, which is a base change rather than a review response.

Motivation: while addressing review comments on a recent PR, the fixes were folded into the original commit and force-pushed, which erased the incremental diff reviewers rely on.