### PR TITLE
test(active-note): pin get_metadata to a single output word (#3031)

### DIFF
--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -128,6 +128,68 @@ async fn test_active_note_get_metadata() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that `get_metadata` returns only a single word (the metadata) on the stack.
+///
+/// We push a marker word before the call, then assert the metadata sits directly on top of it.
+/// This catches a leaked word at either position: a word left above the metadata fails the first
+/// `assert_eqw` (metadata mismatch), and a word left below the metadata pushes the marker one
+/// word deeper and fails the second `assert_eqw`.
+#[tokio::test]
+async fn test_active_note_get_metadata_no_extra_word() -> anyhow::Result<()> {
+    let tx_context = {
+        let account =
+            Account::mock(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE, Auth::IncrNonce);
+        let input_note = create_public_p2any_note(
+            ACCOUNT_ID_SENDER.try_into().unwrap(),
+            [FungibleAsset::mock(100)],
+        );
+        TransactionContextBuilder::new(account)
+            .extend_input_notes(vec![input_note])
+            .build()?
+    };
+
+    let code = format!(
+        r#"
+        use $kernel::prologue
+        use $kernel::note->note_internal
+        use miden::protocol::active_note
+
+        begin
+            exec.prologue::prepare_transaction
+            exec.note_internal::prepare_note
+            dropw dropw dropw dropw
+            # => []
+
+            # marker word to detect any extra word left by get_metadata.
+            # must match the verifying push below.
+            push.1.2.3.4
+            # => [MARKER]
+
+            exec.active_note::get_metadata
+            # => [METADATA, MARKER]   (correct: exactly one word added)
+
+            push.{METADATA}
+            assert_eqw.err="active note metadata mismatch"
+            # => [MARKER]
+
+            # if get_metadata leaked a word, METADATA would be here instead of MARKER.
+            # must match the marker pushed above.
+            push.1.2.3.4
+            assert_eqw.err="get_metadata left an extra word on the stack"
+            # => []
+
+            # truncate the stack
+            swapw dropw
+        end
+        "#,
+        METADATA = tx_context.input_notes().get_note(0).note().metadata().to_metadata_word(),
+    );
+
+    tx_context.execute_code(&code).await?;
+
+    Ok(())
+}
+
 /// `is_public` / `is_private` return the correct flag for the active note's type.
 #[rstest::rstest]
 #[case::public(NoteType::Public)]


### PR DESCRIPTION
Regression test for #3031.