### PR TITLE
fix(ci): exclude std-only bench binaries from no-std build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,12 +143,12 @@ build: ## By default we should build in release mode
 
 .PHONY: build-no-std
 build-no-std: ## Build without the standard library
-	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --lib
+	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --lib --exclude bench-transaction --exclude bench-note-checker
 
 
 .PHONY: build-no-std-testing
 build-no-std-testing: ## Build without the standard library. Includes the `testing` feature
-	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude bench-transaction --features testing
+	$(BUILD_GENERATED_FILES_IN_SRC) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude bench-transaction --exclude bench-note-checker --features testing
 
 # --- test vectors --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The `build for no-std` CI job was killed mid-compile on `next` with exit 143 (SIGTERM) and "the runner has received a shutdown signal" while building `bench-transaction` on `wasm32-unknown-unknown`. This is an OOM/infra kill on the 7GB `ubuntu-latest` runner, not a compile error.

Root cause: `make build-no-std` compiled the std-only bench binaries `bench-transaction` and `bench-note-checker` for the no-std wasm target. Neither is `#![no_std]` (`bench-transaction` pulls in tokio, the `concurrent` feature, and `serde_json`), so they don't belong on the no-std surface and dominate the build's memory/time.

## Fix

Exclude both bench crates from `build-no-std`, and add `bench-note-checker` to `build-no-std-testing` (which already excluded `bench-transaction`) so both targets are consistent. Verified locally: `make build-no-std` and `make build-no-std-testing` both succeed and skip the two bench crates.

## Caveat

The trigger is an infra-level termination that could be transient. This is the correct root-cause hygiene fix and the most likely mitigation. If the no-std job still flakes afterward, the follow-up is capping `CARGO_BUILD_JOBS` on that job.
