### PR TITLE
fix(hooks): scope pre-push review to the commits being pushed

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -13,18 +13,22 @@ You are an experienced Staff Engineer conducting a thorough code review with fre
 
 ## Step 1: Gather Context
 
-Diff against the integration branch (the remote's default branch), not the
-branch's own upstream:
+Review only the commits being pushed — the delta over this branch's already-pushed
+state — not the entire branch. Resolve the base and diff against it:
 
 ```
-git diff "$(git symbolic-ref --short refs/remotes/origin/HEAD)...HEAD"
+BASE="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null \
+  || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null \
+  || echo origin/next)"
+git diff "$BASE...HEAD"
 ```
 
-If `origin/HEAD` is not set, resolve the default branch with
-`gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'` and run
-`git diff origin/<branch>...HEAD`.
+`@{upstream}` is the branch's remote-tracking ref, so on a branch that has been pushed
+before you review only the new commits — code from earlier, already-reviewed commits is
+out of scope. (On a never-pushed branch this falls back to the integration branch and
+reviews the whole branch, which is correct for a first review.)
 
-For every file in the diff, read the **full file** - not just the changed lines. Bugs hide in how new code interacts with existing code.
+For every file in the diff, read the **full file** - not just the changed lines. Bugs hide in how new code interacts with existing code. Confirm every finding against the current file contents before reporting it — never raise an issue the code already addresses.
 
 ## Step 2: Review Tests First
 
@@ -121,6 +125,7 @@ then the incompleteness itself is NOT a Critical or Important finding - the chan
 5. If uncertain about something, say so and suggest investigation rather than guessing
 6. Be direct. "This will panic when the vec is empty" not "this might possibly be a concern"
 7. New code without tests is always a finding
+8. Review only the changes in this diff. Do not raise findings about pre-existing code outside the diff range — it was reviewed when it was first pushed. Only flag unchanged code when the changes under review newly depend on it.
 
 **All findings (Critical, Important, and Nit) block the merge.** Every issue must be addressed before pushing.
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -13,18 +13,22 @@ You are a hostile reviewer. Your job is to break this code before an attacker do
 
 ## Step 1: Gather the Changes
 
-Diff against the integration branch (the remote's default branch), not the
-branch's own upstream:
+Review only the commits being pushed — the delta over this branch's already-pushed
+state — not the entire branch. Resolve the base and diff against it:
 
 ```
-git diff "$(git symbolic-ref --short refs/remotes/origin/HEAD)...HEAD"
+BASE="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null \
+  || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null \
+  || echo origin/next)"
+git diff "$BASE...HEAD"
 ```
 
-If `origin/HEAD` is not set, resolve the default branch with
-`gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'` and run
-`git diff origin/<branch>...HEAD`.
+`@{upstream}` is the branch's remote-tracking ref, so on a branch that has been pushed
+before you review only the new commits — code from earlier, already-reviewed commits is
+out of scope. (On a never-pushed branch this falls back to the integration branch and
+reviews the whole branch, which is correct for a first review.)
 
-For every file in the diff, read the **full file**. Vulnerabilities hide in how new code interacts with existing code, not just in the diff itself.
+For every file in the diff, read the **full file**. Vulnerabilities hide in how new code interacts with existing code, not just in the diff itself. Confirm every finding against the current file contents before reporting it — never raise an issue the code already addresses.
 
 ## Step 2: Run Both Personas
 
@@ -128,6 +132,7 @@ then classify it as a NOTE, not CRITICAL or WARNING. Surfacing it keeps it visib
 - **Restating the diff** - "This function was added" is not a finding. What's WRONG with it?
 - **Cosmetic-only findings** - Reporting style issues while missing a panic is worse than no review.
 - **Reviewing only changed lines** - Read the full file. The bug is in the interaction.
+- **Re-reviewing already-pushed code** - Only the commits being pushed are in scope. Don't resurrect findings about code outside this diff range; it was reviewed when it was first pushed.
 
 ## Breaking the Self-Review Trap
 

--- a/.claude/hooks/pre_push_review.py
+++ b/.claude/hooks/pre_push_review.py
@@ -96,16 +96,29 @@ def main() -> None:
 
 
 def _diff_base() -> str:
-    """Return the integration branch to review against — the remote's
-    default branch (e.g. `origin/next`).
+    """Return the ref to review against — the current branch's upstream (its
+    already-pushed state), so only the commits being pushed are reviewed rather
+    than the entire branch. This avoids re-reviewing earlier, already-reviewed
+    commits on every push.
+
+    Falls back to the remote's default branch (e.g. `origin/next`) for a branch
+    that has never been pushed, so a first push reviews the whole branch.
     """
-    result = subprocess.run(
+    upstream = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        capture_output=True,
+        text=True,
+    )
+    if upstream.returncode == 0 and upstream.stdout.strip():
+        return upstream.stdout.strip()
+
+    default = subprocess.run(
         ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
         capture_output=True,
         text=True,
     )
-    if result.returncode == 0 and result.stdout.strip():
-        return result.stdout.strip()
+    if default.returncode == 0 and default.stdout.strip():
+        return default.stdout.strip()
     return "origin/next"
 
 

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -9,6 +9,7 @@ so a regression points directly at the responsible script.
 from __future__ import annotations
 
 import importlib
+from types import SimpleNamespace
 
 import pytest
 
@@ -139,3 +140,37 @@ def test_paired_hooks_share_target(
         f"Either re-align or remove the entry from PAIRED_TARGETS and add "
         f"explicit per-hook routing cases for both."
     )
+
+
+# pre_push_review review base selection. The review must cover only the commits
+# being pushed (the branch's upstream), not the whole branch vs the integration
+# branch — otherwise every push re-reviews earlier, already-reviewed commits.
+def _fake_proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> SimpleNamespace:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_diff_base_prefers_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the branch has an upstream, review against it (only the pushed commits)."""
+    import pre_push_review
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        assert "@{upstream}" in cmd, "upstream must be queried first"
+        return _fake_proc(stdout="origin/some-feature-branch\n")
+
+    monkeypatch.setattr(pre_push_review.subprocess, "run", fake_run)
+    assert pre_push_review._diff_base() == "origin/some-feature-branch"
+
+
+def test_diff_base_falls_back_to_default_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A never-pushed branch (no upstream) falls back to the remote default branch."""
+    import pre_push_review
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        if "@{upstream}" in cmd:
+            return _fake_proc(returncode=128, stderr="no upstream configured")
+        if "symbolic-ref" in cmd:
+            return _fake_proc(stdout="origin/next\n")
+        return _fake_proc(returncode=1)
+
+    monkeypatch.setattr(pre_push_review.subprocess, "run", fake_run)
+    assert pre_push_review._diff_base() == "origin/next"


### PR DESCRIPTION
## Problem

The pre-push reviewer agents (`code-reviewer`, `security-reviewer`, orchestrated by `.claude/hooks/pre_push_review.py`) diffed against the integration branch — `merge-base(HEAD, origin/next)..HEAD` — so every push re-reviewed the **entire PR from its branch point**. On a long-running PR this re-examined earlier, already-reviewed commits on each push and resurfaced stale findings about code the push never touched (e.g. a kernel-refactor push getting blocked on findings about a verifier added many commits earlier and already addressed).

## Fix

Review only the commits actually being pushed — the delta over the branch's upstream (its already-pushed state):

- `pre_push_review.py` `_diff_base()` now prefers `@{upstream}`, falling back to the remote default branch for a never-pushed branch (so a first push still reviews the whole branch).
- Both reviewer agents' "Step 1" diff against the same range (`@{upstream}...HEAD` with the same fallback), and gain a rule to not raise findings about pre-existing code outside the diff and to confirm findings against the current file contents.
- Added unit tests covering the base selection (upstream preferred; fallback when no upstream).

## Verification

- `make hooks-test` — 161 passed (including the two new base-selection tests).
- `make typos-check` — clean.