### PR TITLE
refactor: rename network-account note allowlist API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - [BREAKING] `AuthNetworkAccount` now gates transaction scripts with a root allowlist instead of banning them outright, enabling network accounts to run approved tx scripts such as setting the expiration delta ([#3028](https://github.com/0xMiden/protocol/pull/3028)).
 - [BREAKING] `TransactionScript::root()` now returns `TransactionScriptRoot` instead of `Word` ([#3028](https://github.com/0xMiden/protocol/pull/3028)).
+- Renamed `AuthNetworkAccount::with_allowlist` to `with_allowed_notes` and aligned the component's internal allowlist field names, for consistency with `with_allowed_tx_scripts` ([#3049](https://github.com/0xMiden/protocol/pull/3049)).
 
 ## v0.15.1 (TBD)
 

--- a/crates/miden-agglayer/build.rs
+++ b/crates/miden-agglayer/build.rs
@@ -327,7 +327,7 @@ fn generate_agglayer_constants(
         // The allowlist lives in storage, not code, and here we only care about the code commitment
         // of the accounts, so we can init the allowlists with dummy values.
         let placeholder_allowlist = BTreeSet::from([NoteScriptRoot::from_raw(Word::default())]);
-        let auth_component = AuthNetworkAccount::with_allowlist(placeholder_allowlist)
+        let auth_component = AuthNetworkAccount::with_allowed_notes(placeholder_allowlist)
             .expect("placeholder allowlist is non-empty");
         let mut components: Vec<AccountComponent> =
             vec![AccountComponent::from(auth_component), agglayer_component];

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -139,7 +139,7 @@ fn create_bridge_account_builder(
         .account_type(AccountType::Public)
         .with_component(AggLayerBridge::new(bridge_admin_id, ger_manager_id))
         .with_auth_component(
-            AuthNetworkAccount::with_allowlist(AggLayerBridge::allowed_notes())
+            AuthNetworkAccount::with_allowed_notes(AggLayerBridge::allowed_notes())
                 .expect("bridge note allowlist is non-empty"),
         )
 }
@@ -217,7 +217,7 @@ fn create_agglayer_faucet_builder(
         .with_components(token_policy_manager)
         .with_component(BurnAllowAll)
         .with_auth_component(
-            AuthNetworkAccount::with_allowlist(AggLayerFaucet::allowed_notes())
+            AuthNetworkAccount::with_allowed_notes(AggLayerFaucet::allowed_notes())
                 .expect("faucet note allowlist is non-empty"),
         )
 }

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -60,8 +60,8 @@ account_component_code!(NETWORK_ACCOUNT_AUTH_CODE, "auth/network_account.masl");
 /// that the node would likely not yet respect updates made to the list after deployment, but there
 /// is in principle nothing preventing us from supporting mutation in the future.
 pub struct AuthNetworkAccount {
-    allowlist: NetworkAccountNoteAllowlist,
-    tx_script_allowlist: NetworkAccountTxScriptAllowlist,
+    allowed_notes: NetworkAccountNoteAllowlist,
+    allowed_tx_scripts: NetworkAccountTxScriptAllowlist,
 }
 
 impl AuthNetworkAccount {
@@ -85,12 +85,12 @@ impl AuthNetworkAccount {
     ///
     /// Returns an error if `allowed_script_roots` is empty since the account could not consume any
     /// notes.
-    pub fn with_allowlist(
+    pub fn with_allowed_notes(
         allowed_script_roots: BTreeSet<NoteScriptRoot>,
     ) -> Result<Self, NetworkAccountNoteAllowlistError> {
         Ok(Self {
-            allowlist: NetworkAccountNoteAllowlist::new(allowed_script_roots)?,
-            tx_script_allowlist: NetworkAccountTxScriptAllowlist::default(),
+            allowed_notes: NetworkAccountNoteAllowlist::new(allowed_script_roots)?,
+            allowed_tx_scripts: NetworkAccountTxScriptAllowlist::default(),
         })
     }
 
@@ -107,7 +107,7 @@ impl AuthNetworkAccount {
         mut self,
         allowed_tx_script_roots: BTreeSet<TransactionScriptRoot>,
     ) -> Self {
-        self.tx_script_allowlist = NetworkAccountTxScriptAllowlist::new(allowed_tx_script_roots);
+        self.allowed_tx_scripts = NetworkAccountTxScriptAllowlist::new(allowed_tx_script_roots);
         self
     }
 
@@ -151,8 +151,8 @@ impl AuthNetworkAccount {
 impl From<AuthNetworkAccount> for AccountComponent {
     fn from(component: AuthNetworkAccount) -> Self {
         let storage_slots = vec![
-            component.allowlist.into_storage_slot(),
-            component.tx_script_allowlist.into_storage_slot(),
+            component.allowed_notes.into_storage_slot(),
+            component.allowed_tx_scripts.into_storage_slot(),
         ];
         let metadata = AuthNetworkAccount::component_metadata();
 
@@ -180,7 +180,7 @@ mod tests {
 
         let _account = AccountBuilder::new([0; 32])
             .with_auth_component(
-                AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([root_a, root_b]))
+                AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([root_a, root_b]))
                     .expect("non-empty allowlist should construct"),
             )
             .with_component(BasicWallet)
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn auth_network_account_with_empty_allowlist_is_rejected() {
-        let result = AuthNetworkAccount::with_allowlist(BTreeSet::new());
+        let result = AuthNetworkAccount::with_allowed_notes(BTreeSet::new());
         assert!(matches!(result, Err(NetworkAccountNoteAllowlistError::EmptyAllowlist)));
     }
 
@@ -198,7 +198,7 @@ mod tests {
     fn auth_network_account_uses_standardized_allowlist_slot() {
         let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let component: AccountComponent =
-            AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([root_a]))
+            AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([root_a]))
                 .expect("non-empty allowlist should construct")
                 .into();
 

--- a/crates/miden-standards/src/account/auth/network_account/network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/network_account.rs
@@ -101,7 +101,7 @@ mod tests {
         AccountBuilder::new([0; 32])
             .account_type(account_type)
             .with_auth_component(
-                AuthNetworkAccount::with_allowlist(roots).expect("non-empty allowlist"),
+                AuthNetworkAccount::with_allowed_notes(roots).expect("non-empty allowlist"),
             )
             .with_component(BasicWallet)
             .build()

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -217,7 +217,7 @@ mod tests {
 
         let account = AccountBuilder::new([0; 32])
             .with_auth_component(
-                AuthNetworkAccount::with_allowlist(original_roots.clone())
+                AuthNetworkAccount::with_allowed_notes(original_roots.clone())
                     .expect("non-empty allowlist should construct"),
             )
             .with_component(BasicWallet)

--- a/crates/miden-standards/src/account/auth/network_account/tx_script_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/tx_script_allowlist.rs
@@ -206,7 +206,7 @@ mod tests {
 
         let account = AccountBuilder::new([0; 32])
             .with_auth_component(
-                AuthNetworkAccount::with_allowlist(BTreeSet::from_iter([
+                AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([
                     miden_protocol::note::NoteScriptRoot::from_array([9, 9, 9, 9]),
                 ]))
                 .expect("non-empty note allowlist should construct")

--- a/crates/miden-standards/src/account/faucets/fungible/mod.rs
+++ b/crates/miden-standards/src/account/faucets/fungible/mod.rs
@@ -673,7 +673,7 @@ fn build_auth_component(
                 allowed_script_roots,
                 allowed_tx_script_roots,
             },
-        ) => Ok(AuthNetworkAccount::with_allowlist(allowed_script_roots)
+        ) => Ok(AuthNetworkAccount::with_allowed_notes(allowed_script_roots)
             .map_err(|err| {
                 FungibleFaucetError::UnsupportedAuthMethod(alloc::format!(
                     "invalid network account allowlist: {err}"

--- a/crates/miden-testing/src/mock_chain/auth.rs
+++ b/crates/miden-testing/src/mock_chain/auth.rs
@@ -177,7 +177,7 @@ impl Auth {
                 allowed_script_roots,
                 allowed_tx_script_roots,
             } => {
-                let component = AuthNetworkAccount::with_allowlist(allowed_script_roots.clone())
+                let component = AuthNetworkAccount::with_allowed_notes(allowed_script_roots.clone())
                     .expect("network account allowlist must be non-empty")
                     .with_allowed_tx_scripts(allowed_tx_script_roots.clone())
                     .into();

--- a/crates/miden-testing/src/mock_chain/auth.rs
+++ b/crates/miden-testing/src/mock_chain/auth.rs
@@ -177,10 +177,11 @@ impl Auth {
                 allowed_script_roots,
                 allowed_tx_script_roots,
             } => {
-                let component = AuthNetworkAccount::with_allowed_notes(allowed_script_roots.clone())
-                    .expect("network account allowlist must be non-empty")
-                    .with_allowed_tx_scripts(allowed_tx_script_roots.clone())
-                    .into();
+                let component =
+                    AuthNetworkAccount::with_allowed_notes(allowed_script_roots.clone())
+                        .expect("network account allowlist must be non-empty")
+                        .with_allowed_tx_scripts(allowed_tx_script_roots.clone())
+                        .into();
                 (component, None)
             },
         }

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -39,7 +39,7 @@ fn build_account_with_allowlists(
     allowed_note_script_roots: Vec<Word>,
     allowed_tx_script_roots: Vec<TransactionScriptRoot>,
 ) -> anyhow::Result<Account> {
-    let auth_component = AuthNetworkAccount::with_allowlist(
+    let auth_component = AuthNetworkAccount::with_allowed_notes(
         allowed_note_script_roots.into_iter().map(NoteScriptRoot::from_raw).collect(),
     )?
     .with_allowed_tx_scripts(allowed_tx_script_roots.into_iter().collect::<BTreeSet<_>>());


### PR DESCRIPTION
Follow-up to #3028 addressing @bobbinth's post-merge review nits.

## Changes

- Rename `AuthNetworkAccount::with_allowlist` -> `with_allowed_notes`, so the note constructor reads consistently with the new `with_allowed_tx_scripts` builder.
- Rename the component's internal allowlist fields `allowlist` / `tx_script_allowlist` -> `allowed_notes` / `allowed_tx_scripts`.

Pure rename, no behavior change. All in-repo call sites updated (`miden-standards`, `miden-agglayer`, `miden-testing`).

## Why `main` (and not `next`)

#3028 was rebased onto `main` to ship as the v0.15.2 hotfix, and this API is brand new in #3028 (never released). Landing the rename on `main` means v0.15.2 ships the final names on first release, avoiding a rename churning into 0.16. `main` will be forward-merged into `next` separately.

## Verification

- `cargo build -p miden-standards -p miden-agglayer`
- `cargo test -p miden-standards` (121 passed)
- `cargo test -p miden-testing network_account` (auth + agglayer regression: 15 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)