### PR TITLE
fix: derive batch ID from transaction headers during deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).
 - AggLayer `bridge_out` now rejects B2AGG notes whose `NoteType` is not `Public`, preventing a recipient-identical private note from desyncing the Local Exit Tree from AggLayer's off-chain mirror ([#2988](https://github.com/0xMiden/protocol/pull/2988)).
 - Fixed `pausable::assert_not_paused` to guard its storage read with `active_account::has_storage_slot`, making it a no-op on accounts without the `Pausable` component instead of panicking on the missing `is_paused` slot ([#3047](https://github.com/0xMiden/protocol/pull/3047)).
+- [BREAKING] Fixed batch ID being serialized/deserialized and potentially not matching the serialized transaction headers ([#3061](https://github.com/0xMiden/protocol/pull/3061)).
 
 ## v0.15.1 (TBD)
 

--- a/crates/miden-protocol/src/batch/proven_batch.rs
+++ b/crates/miden-protocol/src/batch/proven_batch.rs
@@ -167,7 +167,6 @@ impl ProvenBatch {
 
 impl Serializable for ProvenBatch {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.id.write_into(target);
         self.reference_block_commitment.write_into(target);
         self.reference_block_num.write_into(target);
         self.account_updates.write_into(target);
@@ -181,7 +180,6 @@ impl Serializable for ProvenBatch {
 
 impl Deserializable for ProvenBatch {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let id = BatchId::read_from(source)?;
         let reference_block_commitment = Word::read_from(source)?;
         let reference_block_num = BlockNumber::read_from(source)?;
         let account_updates = BTreeMap::read_from(source)?;
@@ -190,6 +188,9 @@ impl Deserializable for ProvenBatch {
         let batch_expiration_block_num = BlockNumber::read_from(source)?;
         let transactions = OrderedTransactionHeaders::read_from(source)?;
         let proof = ExecutionProof::read_from(source)?;
+
+        let id =
+            BatchId::from_ids(transactions.as_slice().iter().map(|tx| (tx.id(), tx.account_id())));
 
         Self::new_unchecked(
             id,

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
   "RUSTSEC-2024-0436", # paste is unmaintained but no alternative available
   "RUSTSEC-2025-0141", # bincode is unmaintained, replace with wincode (https://github.com/0xMiden/miden-vm/issues/2550)
+  "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained, ignore until `alloy-sol-macro` has migrated away
 ]
 yanked = "warn"
 


### PR DESCRIPTION
Fixes batch ID potentially not matching the serialized transaction headers by recomputing it instead. Breaking change due to serialization format changes.

Adds RUSTSEC-2026-0173 to deny.toml for which we need to wait on dependencies to upgrade.