### PR TITLE
chore: add `AccountCode::interface` and use `StorageMapKey` in `Account::get_map_item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Added a definition of the Miden operator on the architecture overview page and linked it from the note lifecycle ([#3017](https://github.com/0xMiden/protocol/pull/3017)).
 - Clarified Miden's operational roles on the architecture overview page and linked them from the note lifecycle ([#3017](https://github.com/0xMiden/protocol/pull/3017)).
 - [BREAKING] Replaced `AccountInterface::build_send_notes_script` with a standalone `SendNotesTransactionScript` built against `AccountCodeInterface` ([#3055](https://github.com/0xMiden/protocol/pull/3055)).
+- Added an `AccountCode::interface` helper that returns the public `AccountCodeInterface` ([#3080](https://github.com/0xMiden/protocol/pull/3080)).
+- [BREAKING] Tightened `AccountStorage::get_map_item` to take a `StorageMapKey` instead of a raw `Word` ([#3080](https://github.com/0xMiden/protocol/pull/3080)).
+- [BREAKING] Renamed the `TransactionEvent::AuthRequest` field from `pub_key_hash: Word` to `pub_key_commitment: PublicKeyCommitment` ([#3080](https://github.com/0xMiden/protocol/pull/3080)).
 
 ### Fixes
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).

--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -6,7 +6,14 @@ use alloc::vec::Vec;
 
 use miden_core::{Felt, ONE, Word, ZERO};
 use miden_protocol::account::component::AccountComponentMetadata;
-use miden_protocol::account::{Account, AccountComponent, AccountId, StorageSlot, StorageSlotName};
+use miden_protocol::account::{
+    Account,
+    AccountComponent,
+    AccountId,
+    StorageMapKey,
+    StorageSlot,
+    StorageSlotName,
+};
 use miden_protocol::block::account_tree::AccountIdKey;
 use miden_protocol::crypto::hash::poseidon2::Poseidon2;
 use miden_protocol::note::NoteScriptRoot;
@@ -286,7 +293,7 @@ impl AggLayerBridge {
         // equal to [1, 0, 0, 0]
         let stored_value = bridge_account
             .storage()
-            .get_map_item(AggLayerBridge::ger_map_slot_name(), ger_hash)
+            .get_map_item(AggLayerBridge::ger_map_slot_name(), StorageMapKey::from_raw(ger_hash))
             .expect("provided account should have AggLayer Bridge specific storage slots");
 
         if stored_value == Self::REGISTERED_GER_MAP_VALUE {

--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -15,7 +15,7 @@ use super::{
     Serializable,
 };
 use crate::Word;
-use crate::account::AccountComponent;
+use crate::account::{AccountCodeInterface, AccountComponent, AccountId};
 
 pub mod procedure;
 use procedure::{AccountProcedureRoot, PrintableProcedure};
@@ -178,6 +178,13 @@ impl AccountCode {
     /// And then concatenating the resulting elements into a single vector.
     pub fn to_elements(&self) -> Vec<Felt> {
         procedures_as_elements(self.procedures())
+    }
+
+    /// Returns the public interface of this account code: the given account ID and the set of
+    /// procedure roots exposed by this code.
+    pub fn interface(&self, account_id: AccountId) -> AccountCodeInterface {
+        AccountCodeInterface::new(account_id, self.procedures.iter().copied().collect())
+            .expect("account code procedure count is enforced by AccountCode invariants")
     }
 
     /// Returns an iterator of printable representations for all procedures in this account code.

--- a/crates/miden-protocol/src/account/mod.rs
+++ b/crates/miden-protocol/src/account/mod.rs
@@ -251,8 +251,7 @@ impl Account {
     /// Returns the public interface of this account: its ID and the set of procedure roots it
     /// exposes.
     pub fn code_interface(&self) -> AccountCodeInterface {
-        AccountCodeInterface::new(self.id(), self.code.procedures().iter().copied().collect())
-            .expect("account code procedure count is enforced by AccountCode invariants")
+        self.code.interface(self.id())
     }
 
     /// Returns nonce for this account.

--- a/crates/miden-protocol/src/account/partial.rs
+++ b/crates/miden-protocol/src/account/partial.rs
@@ -98,8 +98,7 @@ impl PartialAccount {
     /// Returns the public interface of this account: its ID and the set of procedure roots it
     /// exposes.
     pub fn code_interface(&self) -> AccountCodeInterface {
-        AccountCodeInterface::new(self.id, self.code.procedures().iter().copied().collect())
-            .expect("account code procedure count is enforced by AccountCode invariants")
+        self.code.interface(self.id)
     }
 
     /// Returns a reference to the partial storage representation of the account.

--- a/crates/miden-protocol/src/account/storage/mod.rs
+++ b/crates/miden-protocol/src/account/storage/mod.rs
@@ -186,12 +186,12 @@ impl AccountStorage {
     pub fn get_map_item(
         &self,
         slot_name: &StorageSlotName,
-        key: Word,
+        key: StorageMapKey,
     ) -> Result<Word, AccountError> {
         self.get(slot_name)
             .ok_or_else(|| AccountError::StorageSlotNameNotFound { slot_name: slot_name.clone() })
             .and_then(|slot| match slot.content() {
-                StorageSlotContent::Map(map) => Ok(map.get(&StorageMapKey::from_raw(key))),
+                StorageSlotContent::Map(map) => Ok(map.get(&key)),
                 _ => Err(AccountError::StorageSlotNotMap(slot_name.clone())),
             })
     }

--- a/crates/miden-standards/src/account/auth/guarded_multisig.rs
+++ b/crates/miden-standards/src/account/auth/guarded_multisig.rs
@@ -406,7 +406,7 @@ mod tests {
                 .storage()
                 .get_map_item(
                     AuthGuardedMultisig::approver_public_keys_slot(),
-                    Word::from([i as u32, 0, 0, 0]),
+                    StorageMapKey::from_index(i as u32),
                 )
                 .expect("approver public key storage map access failed");
             assert_eq!(stored_pub_key, Word::from(*expected_pub_key));
@@ -418,7 +418,7 @@ mod tests {
                 .storage()
                 .get_map_item(
                     AuthGuardedMultisig::approver_scheme_ids_slot(),
-                    Word::from([i as u32, 0, 0, 0]),
+                    StorageMapKey::from_index(i as u32),
                 )
                 .expect("approver scheme ID storage map access failed");
             assert_eq!(stored_scheme_id, Word::from([*expected_auth_scheme as u32, 0, 0, 0]));
@@ -429,7 +429,7 @@ mod tests {
             .storage()
             .get_map_item(
                 AuthGuardedMultisig::guardian_public_key_slot(),
-                Word::from([0u32, 0, 0, 0]),
+                StorageMapKey::from_index(0),
             )
             .expect("guardian public key storage map access failed");
         assert_eq!(guardian_public_key, Word::from(guardian_key.public_key().to_commitment()));
@@ -438,7 +438,7 @@ mod tests {
             .storage()
             .get_map_item(
                 AuthGuardedMultisig::guardian_scheme_id_slot(),
-                Word::from([0u32, 0, 0, 0]),
+                StorageMapKey::from_index(0),
             )
             .expect("guardian scheme ID storage map access failed");
         assert_eq!(guardian_scheme_id, Word::from([guardian_key.auth_scheme() as u32, 0, 0, 0]));
@@ -482,7 +482,7 @@ mod tests {
             .storage()
             .get_map_item(
                 AuthGuardedMultisig::approver_public_keys_slot(),
-                Word::from([0u32, 0, 0, 0]),
+                StorageMapKey::from_index(0),
             )
             .expect("approver pub keys storage map access failed");
         assert_eq!(stored_pub_key, Word::from(pub_key));
@@ -491,7 +491,7 @@ mod tests {
             .storage()
             .get_map_item(
                 AuthGuardedMultisig::approver_scheme_ids_slot(),
-                Word::from([0u32, 0, 0, 0]),
+                StorageMapKey::from_index(0),
             )
             .expect("approver scheme IDs storage map access failed");
         assert_eq!(stored_scheme_id, Word::from([AuthScheme::EcdsaK256Keccak as u32, 0, 0, 0]));
@@ -532,7 +532,7 @@ mod tests {
             .storage()
             .get_map_item(
                 AuthGuardedMultisig::guardian_public_key_slot(),
-                Word::from([0u32, 0, 0, 0]),
+                StorageMapKey::from_index(0),
             )
             .expect("guardian public key storage map access failed");
         assert_eq!(guardian_public_key, Word::from(guardian_key.public_key().to_commitment()));
@@ -541,7 +541,7 @@ mod tests {
             .storage()
             .get_map_item(
                 AuthGuardedMultisig::guardian_scheme_id_slot(),
-                Word::from([0u32, 0, 0, 0]),
+                StorageMapKey::from_index(0),
             )
             .expect("guardian scheme ID storage map access failed");
         assert_eq!(guardian_scheme_id, Word::from([guardian_key.auth_scheme() as u32, 0, 0, 0]));

--- a/crates/miden-standards/src/account/auth/multisig.rs
+++ b/crates/miden-standards/src/account/auth/multisig.rs
@@ -386,7 +386,7 @@ mod tests {
                 .storage()
                 .get_map_item(
                     AuthMultisig::approver_public_keys_slot(),
-                    Word::from([i as u32, 0, 0, 0]),
+                    StorageMapKey::from_index(i as u32),
                 )
                 .expect("approver public key storage map access failed");
             assert_eq!(stored_pub_key, Word::from(*expected_pub_key));
@@ -398,7 +398,7 @@ mod tests {
                 .storage()
                 .get_map_item(
                     AuthMultisig::approver_scheme_ids_slot(),
-                    Word::from([i as u32, 0, 0, 0]),
+                    StorageMapKey::from_index(i as u32),
                 )
                 .expect("approver scheme ID storage map access failed");
             assert_eq!(stored_scheme_id, Word::from([*expected_auth_scheme as u32, 0, 0, 0]));
@@ -432,13 +432,13 @@ mod tests {
 
         let stored_pub_key = account
             .storage()
-            .get_map_item(AuthMultisig::approver_public_keys_slot(), Word::from([0u32, 0, 0, 0]))
+            .get_map_item(AuthMultisig::approver_public_keys_slot(), StorageMapKey::from_index(0))
             .expect("approver pub keys storage map access failed");
         assert_eq!(stored_pub_key, Word::from(pub_key));
 
         let stored_scheme_id = account
             .storage()
-            .get_map_item(AuthMultisig::approver_scheme_ids_slot(), Word::from([0u32, 0, 0, 0]))
+            .get_map_item(AuthMultisig::approver_scheme_ids_slot(), StorageMapKey::from_index(0))
             .expect("approver scheme IDs storage map access failed");
         assert_eq!(
             stored_scheme_id,

--- a/crates/miden-standards/src/account/auth/multisig_smart/component.rs
+++ b/crates/miden-standards/src/account/auth/multisig_smart/component.rs
@@ -330,7 +330,7 @@ mod tests {
             .storage()
             .get_map_item(
                 AuthMultisigSmart::procedure_policies_slot(),
-                BasicWallet::receive_asset_root().as_word(),
+                StorageMapKey::from_raw(BasicWallet::receive_asset_root().as_word()),
             )
             .expect("receive_asset policy should be present");
         assert_eq!(

--- a/crates/miden-standards/src/account/auth/singlesig_acl.rs
+++ b/crates/miden-standards/src/account/auth/singlesig_acl.rs
@@ -408,7 +408,7 @@ mod tests {
                     .storage()
                     .get_map_item(
                         AuthSingleSigAcl::trigger_procedure_roots_slot(),
-                        Word::from([i as u32, 0, 0, 0]),
+                        StorageMapKey::from_index(i as u32),
                     )
                     .expect("storage map access failed");
                 assert_eq!(proc_root, expected_proc_root.as_word());
@@ -417,7 +417,10 @@ mod tests {
             // When no procedures, the map should return empty for key [0,0,0,0]
             let proc_root = account
                 .storage()
-                .get_map_item(AuthSingleSigAcl::trigger_procedure_roots_slot(), Word::empty())
+                .get_map_item(
+                    AuthSingleSigAcl::trigger_procedure_roots_slot(),
+                    StorageMapKey::empty(),
+                )
                 .expect("storage map access failed");
             assert_eq!(proc_root, Word::empty());
         }

--- a/crates/miden-standards/src/account/faucets/fungible/tests.rs
+++ b/crates/miden-standards/src/account/faucets/fungible/tests.rs
@@ -2,7 +2,7 @@ use alloc::collections::BTreeSet;
 
 use assert_matches::assert_matches;
 use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
-use miden_protocol::account::{AccountBuilder, AccountType};
+use miden_protocol::account::{AccountBuilder, AccountType, StorageMapKey};
 use miden_protocol::asset::{AssetAmount, TokenSymbol};
 use miden_protocol::{Felt, Word};
 
@@ -47,7 +47,7 @@ fn read_trigger_procedure_roots(
                 .storage()
                 .get_map_item(
                     AuthSingleSigAcl::trigger_procedure_roots_slot(),
-                    [Felt::from(i), Felt::ZERO, Felt::ZERO, Felt::ZERO].into(),
+                    StorageMapKey::from_index(i),
                 )
                 .unwrap()
         })

--- a/crates/miden-standards/src/account/interface/component.rs
+++ b/crates/miden-standards/src/account/interface/component.rs
@@ -1,9 +1,13 @@
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use miden_protocol::Word;
 use miden_protocol::account::auth::{AuthScheme, PublicKeyCommitment};
-use miden_protocol::account::{AccountProcedureRoot, AccountStorage, StorageSlotName};
+use miden_protocol::account::{
+    AccountProcedureRoot,
+    AccountStorage,
+    StorageMapKey,
+    StorageSlotName,
+};
 
 use crate::AuthMethod;
 use crate::account::auth::{
@@ -213,7 +217,7 @@ fn extract_multisig_auth_method(
     // Read each public key from the map
     for key_index in 0..num_approvers {
         // The multisig component stores keys and scheme IDs using pattern [index, 0, 0, 0]
-        let map_key = Word::from([key_index as u32, 0, 0, 0]);
+        let map_key = StorageMapKey::from_index(key_index as u32);
 
         let pub_key_word =
             storage.get_map_item(approver_public_keys_slot, map_key).unwrap_or_else(|_| {

--- a/crates/miden-testing/tests/agglayer/config_bridge.rs
+++ b/crates/miden-testing/tests/agglayer/config_bridge.rs
@@ -11,7 +11,7 @@ use miden_agglayer::{
     create_existing_bridge_account,
 };
 use miden_protocol::account::auth::AuthScheme;
-use miden_protocol::account::{AccountId, AccountIdVersion, AccountType};
+use miden_protocol::account::{AccountId, AccountIdVersion, AccountType, StorageMapKey};
 use miden_protocol::block::account_tree::AccountIdKey;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::transaction::RawOutputNote;
@@ -22,11 +22,11 @@ use miden_testing::{Auth, MockChain};
 ///
 /// Mirrors `bridge_config::hash_token_address` in `bridge_config.masm`: hashes the 5-felt token
 /// address concatenated with the origin network felt (LE-packed u32), using Poseidon2.
-fn token_registry_key(origin_token_address: &EthAddress, origin_network: u32) -> Word {
+fn token_registry_key(origin_token_address: &EthAddress, origin_network: u32) -> StorageMapKey {
     let mut elements: Vec<Felt> = origin_token_address.to_elements();
     let origin_network_packed = u32::from_le_bytes(origin_network.to_be_bytes());
     elements.push(Felt::from(origin_network_packed));
-    Hasher::hash_elements(&elements)
+    StorageMapKey::from_raw(Hasher::hash_elements(&elements))
 }
 
 /// Tests that a CONFIG_AGG_BRIDGE note registers a faucet in the bridge's faucet registry.
@@ -65,7 +65,7 @@ async fn test_config_agg_bridge_registers_faucet() -> anyhow::Result<()> {
 
     // Verify the faucet is NOT in the registry before registration
     let registry_slot_name = AggLayerBridge::faucet_registry_map_slot_name();
-    let key = AccountIdKey::new(faucet_to_register).as_word();
+    let key = StorageMapKey::from_raw(AccountIdKey::new(faucet_to_register).as_word());
     let value_before = bridge_account.storage().get_map_item(registry_slot_name, key)?;
     assert_eq!(
         value_before,

--- a/crates/miden-testing/tests/auth/guarded_multisig.rs
+++ b/crates/miden-testing/tests/auth/guarded_multisig.rs
@@ -1,5 +1,11 @@
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey, PublicKey};
-use miden_protocol::account::{Account, AccountBuilder, AccountProcedureRoot, AccountType};
+use miden_protocol::account::{
+    Account,
+    AccountBuilder,
+    AccountProcedureRoot,
+    AccountType,
+    StorageMapKey,
+};
 use miden_protocol::asset::FungibleAsset;
 use miden_protocol::note::{
     Note,
@@ -343,11 +349,11 @@ async fn test_guarded_multisig_update_guardian_public_key(
     updated_multisig_account.apply_delta(update_guardian_tx.account_delta())?;
     let updated_guardian_public_key = updated_multisig_account
         .storage()
-        .get_map_item(AuthGuardedMultisig::guardian_public_key_slot(), Word::empty())?;
+        .get_map_item(AuthGuardedMultisig::guardian_public_key_slot(), StorageMapKey::empty())?;
     assert_eq!(updated_guardian_public_key, Word::from(new_guardian_public_key.to_commitment()));
     let updated_guardian_scheme_id = updated_multisig_account.storage().get_map_item(
         AuthGuardedMultisig::guardian_scheme_id_slot(),
-        Word::from([0u32, 0, 0, 0]),
+        StorageMapKey::from_index(0),
     )?;
     assert_eq!(
         updated_guardian_scheme_id,

--- a/crates/miden-testing/tests/auth/hybrid_multisig.rs
+++ b/crates/miden-testing/tests/auth/hybrid_multisig.rs
@@ -1,7 +1,13 @@
 use miden_processor::advice::AdviceInputs;
 use miden_processor::crypto::random::RandomCoin;
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey, PublicKey};
-use miden_protocol::account::{Account, AccountBuilder, AccountProcedureRoot, AccountType};
+use miden_protocol::account::{
+    Account,
+    AccountBuilder,
+    AccountProcedureRoot,
+    AccountType,
+    StorageMapKey,
+};
 use miden_protocol::asset::FungibleAsset;
 use miden_protocol::note::NoteType;
 use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE;
@@ -414,8 +420,7 @@ async fn test_multisig_update_signers() -> anyhow::Result<()> {
 
     // Verify that the public keys were actually updated in storage
     for (i, expected_key) in new_public_keys.iter().enumerate() {
-        let storage_key =
-            [Felt::new_unchecked(i as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+        let storage_key = StorageMapKey::from_index(i as u32);
         let storage_item = updated_multisig_account
             .storage()
             .get_map_item(AuthMultisig::approver_public_keys_slot(), storage_key)
@@ -677,8 +682,7 @@ async fn test_multisig_update_signers_remove_owner() -> anyhow::Result<()> {
 
     // Verify public keys were updated
     for (i, expected_key) in new_public_keys.iter().enumerate() {
-        let storage_key =
-            [Felt::new_unchecked(i as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+        let storage_key = StorageMapKey::from_index(i as u32);
         let storage_item = updated_multisig_account
             .storage()
             .get_map_item(AuthMultisig::approver_public_keys_slot(), storage_key)
@@ -713,8 +717,7 @@ async fn test_multisig_update_signers_remove_owner() -> anyhow::Result<()> {
 
     // Verify removed owners' slots are empty (indices 2, 3, and 4 should be cleared)
     for removed_idx in 2..5 {
-        let removed_owner_key =
-            [Felt::new_unchecked(removed_idx), Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+        let removed_owner_key = StorageMapKey::from_index(removed_idx as u32);
         let removed_owner_slot = updated_multisig_account
             .storage()
             .get_map_item(AuthMultisig::approver_public_keys_slot(), removed_owner_key)
@@ -730,8 +733,7 @@ async fn test_multisig_update_signers_remove_owner() -> anyhow::Result<()> {
     // Verify only 2 non-empty keys remain (at indices 0 and 1)
     let mut non_empty_count = 0;
     for i in 0..5 {
-        let storage_key =
-            [Felt::new_unchecked(i as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+        let storage_key = StorageMapKey::from_index(i as u32);
         let storage_item = updated_multisig_account
             .storage()
             .get_map_item(AuthMultisig::approver_public_keys_slot(), storage_key)

--- a/crates/miden-testing/tests/auth/multisig.rs
+++ b/crates/miden-testing/tests/auth/multisig.rs
@@ -7,6 +7,7 @@ use miden_protocol::account::{
     AccountId,
     AccountProcedureRoot,
     AccountType,
+    StorageMapKey,
 };
 use miden_protocol::asset::{AssetCallbackFlag, AssetVaultKey, FungibleAsset};
 use miden_protocol::note::NoteType;
@@ -542,8 +543,7 @@ async fn test_multisig_update_signers(#[case] auth_scheme: AuthScheme) -> anyhow
 
     // Verify that the public keys were actually updated in storage
     for (i, expected_key) in new_public_keys.iter().enumerate() {
-        let storage_key =
-            [Felt::new_unchecked(i as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+        let storage_key = StorageMapKey::from_index(i as u32);
         let storage_item = updated_multisig_account
             .storage()
             .get_map_item(AuthMultisig::approver_public_keys_slot(), storage_key)
@@ -792,8 +792,7 @@ async fn test_multisig_update_signers_remove_owner(
 
     // Verify public keys were updated
     for (i, expected_key) in new_public_keys.iter().enumerate() {
-        let storage_key =
-            [Felt::new_unchecked(i as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+        let storage_key = StorageMapKey::from_index(i as u32);
         let storage_item = updated_multisig_account
             .storage()
             .get_map_item(AuthMultisig::approver_public_keys_slot(), storage_key)
@@ -828,8 +827,7 @@ async fn test_multisig_update_signers_remove_owner(
 
     // Verify removed owners' slots are empty (indices 2, 3, and 4 should be cleared)
     for removed_idx in 2..5 {
-        let removed_owner_key =
-            [Felt::new_unchecked(removed_idx), Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+        let removed_owner_key = StorageMapKey::from_index(removed_idx as u32);
         let removed_owner_slot = updated_multisig_account
             .storage()
             .get_map_item(AuthMultisig::approver_public_keys_slot(), removed_owner_key)
@@ -845,8 +843,7 @@ async fn test_multisig_update_signers_remove_owner(
     // Verify only 2 non-empty keys remain (at indices 0 and 1)
     let mut non_empty_count = 0;
     for i in 0..5 {
-        let storage_key =
-            [Felt::new_unchecked(i as u64), Felt::ZERO, Felt::ZERO, Felt::ZERO].into();
+        let storage_key = StorageMapKey::from_index(i as u32);
         let storage_item = updated_multisig_account
             .storage()
             .get_map_item(AuthMultisig::approver_public_keys_slot(), storage_key)

--- a/crates/miden-testing/tests/auth/multisig_smart.rs
+++ b/crates/miden-testing/tests/auth/multisig_smart.rs
@@ -1,6 +1,6 @@
 use miden_processor::advice::AdviceInputs;
 use miden_protocol::account::auth::{AuthScheme, PublicKey};
-use miden_protocol::account::{Account, AccountBuilder, AccountId, AccountType};
+use miden_protocol::account::{Account, AccountBuilder, AccountId, AccountType, StorageMapKey};
 use miden_protocol::asset::FungibleAsset;
 use miden_protocol::note::NoteType;
 use miden_protocol::testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET;
@@ -370,7 +370,7 @@ async fn test_multisig_smart_update_signers_and_thresholds(
 
     // Verify each new public key is stored at its expected map index.
     for (i, expected_key) in new_public_keys.iter().enumerate() {
-        let storage_key = Word::from([i as u32, 0, 0, 0]);
+        let storage_key = StorageMapKey::from_index(i as u32);
         let stored_pub_key = multisig_account
             .storage()
             .get_map_item(AuthMultisigSmart::approver_public_keys_slot(), storage_key)
@@ -401,7 +401,7 @@ async fn test_multisig_smart_set_procedure_policy(
     let mock_chain =
         MockChainBuilder::with_accounts([multisig_account.clone()]).unwrap().build()?;
 
-    let receive_asset_root = BasicWallet::receive_asset_root().as_word();
+    let receive_asset_root = StorageMapKey::from_raw(BasicWallet::receive_asset_root().as_word());
     let immediate_threshold = 1u32;
     let delayed_threshold = 0u32;
     let note_restrictions = ProcedurePolicyNoteRestriction::NoInputNotes;

--- a/crates/miden-testing/tests/scripts/rbac.rs
+++ b/crates/miden-testing/tests/scripts/rbac.rs
@@ -11,6 +11,7 @@ use miden_protocol::account::{
     AccountIdVersion,
     AccountType,
     RoleSymbol,
+    StorageMapKey,
 };
 use miden_protocol::errors::AccountIdError;
 use miden_protocol::note::{Note, NoteType};
@@ -54,12 +55,17 @@ fn role(name: &str) -> RoleSymbol {
     RoleSymbol::new(name).expect("role symbol should be valid")
 }
 
-fn role_config_key(role: &RoleSymbol) -> Word {
-    Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::from(role)])
+fn role_config_key(role: &RoleSymbol) -> StorageMapKey {
+    StorageMapKey::from_raw(Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::from(role)]))
 }
 
-fn role_membership_key(role: &RoleSymbol, account_id: AccountId) -> Word {
-    Word::from([Felt::ZERO, Felt::from(role), account_id.suffix(), account_id.prefix().as_felt()])
+fn role_membership_key(role: &RoleSymbol, account_id: AccountId) -> StorageMapKey {
+    StorageMapKey::from_raw(Word::from([
+        Felt::ZERO,
+        Felt::from(role),
+        account_id.suffix(),
+        account_id.prefix().as_felt(),
+    ]))
 }
 
 fn account_id_from_felt_pair(

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -200,7 +200,7 @@ where
     /// The signature is requested from the host's authenticator.
     pub async fn on_auth_requested(
         &mut self,
-        pub_key_hash: Word,
+        pub_key_commitment: PublicKeyCommitment,
         tx_summary: TransactionSummary,
     ) -> Result<Vec<AdviceMutation>, TransactionKernelError> {
         let signing_inputs = SigningInputs::TransactionSummary(Box::new(tx_summary));
@@ -212,12 +212,12 @@ where
         let message = signing_inputs.to_commitment();
 
         let signature: Vec<Felt> = authenticator
-            .get_signature(PublicKeyCommitment::from(pub_key_hash), &signing_inputs)
+            .get_signature(pub_key_commitment, &signing_inputs)
             .await
             .map_err(TransactionKernelError::SignatureGenerationFailed)?
             .to_prepared_signature(message);
 
-        let signature_key = Hasher::merge(&[pub_key_hash, message]);
+        let signature_key = Hasher::merge(&[pub_key_commitment.into(), message]);
         self.generated_signatures.insert(signature_key, signature.clone());
 
         Ok(vec![AdviceMutation::extend_stack(signature)])
@@ -632,11 +632,15 @@ where
                     .on_note_before_add_attachment(note_idx, attachment)
                     .map(|_| Vec::new()),
 
-                TransactionEvent::AuthRequest { pub_key_hash, tx_summary, signature } => {
+                TransactionEvent::AuthRequest {
+                    pub_key_commitment,
+                    tx_summary,
+                    signature,
+                } => {
                     if let Some(signature) = signature {
                         Ok(self.base_host.on_auth_requested(signature))
                     } else {
-                        self.on_auth_requested(pub_key_hash, tx_summary).await
+                        self.on_auth_requested(pub_key_commitment, tx_summary).await
                     }
                 },
 

--- a/crates/miden-tx/src/host/tx_event.rs
+++ b/crates/miden-tx/src/host/tx_event.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use miden_processor::ProcessorState;
 use miden_processor::advice::{AdviceMutation, AdviceProvider};
 use miden_processor::trace::RowIndex;
+use miden_protocol::account::auth::PublicKeyCommitment;
 use miden_protocol::account::{
     AccountId,
     StorageMap,
@@ -142,7 +143,7 @@ pub(crate) enum TransactionEvent {
 
     /// The data necessary to handle an auth request.
     AuthRequest {
-        pub_key_hash: Word,
+        pub_key_commitment: PublicKeyCommitment,
         tx_summary: TransactionSummary,
         signature: Option<Vec<Felt>>,
     },
@@ -487,8 +488,8 @@ impl TransactionEvent {
             TransactionEventId::AuthRequest => {
                 // Expected stack state: [event, MESSAGE, PUB_KEY]
                 let message = process.get_stack_word(1);
-                let pub_key_hash = process.get_stack_word(5);
-                let signature_key = Hasher::merge(&[pub_key_hash, message]);
+                let pub_key_commitment = PublicKeyCommitment::from(process.get_stack_word(5));
+                let signature_key = Hasher::merge(&[pub_key_commitment.into(), message]);
 
                 let signature = process
                     .advice_provider()
@@ -497,7 +498,11 @@ impl TransactionEvent {
 
                 let tx_summary = extract_tx_summary(base_host, process, message)?;
 
-                Some(TransactionEvent::AuthRequest { pub_key_hash, tx_summary, signature })
+                Some(TransactionEvent::AuthRequest {
+                    pub_key_commitment,
+                    tx_summary,
+                    signature,
+                })
             },
 
             TransactionEventId::Unauthorized => {


### PR DESCRIPTION
Implements a few small quality of life improvements:
- Introduce `AccountCode::interface(AccountId)` so Account / PartialAccount code_interface() no longer duplicate construction (addresses https://github.com/0xMiden/protocol/pull/2924#discussion_r3392175548).
- Type `AccountStorage::get_map_item`'s key as `StorageMapKey`. This was an oversight in an earlier refactor.
- Renames the `TransactionEvent::AuthRequest` field to `pub_key_commitment: PublicKeyCommitment`.
