### PR TITLE
Refactor ownable2step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
-- Consolidated the Ownable2Step owner check into a single `assert_sender_is_owner` (`exec`) procedure, removing the redundant `assert_sender_is_owner_internal` helper, and updated `rbac::set_role_admin` to call it for consistency with `authority` and the faucet policies ([#XXXX](https://github.com/0xMiden/protocol/pull/XXXX)).
+- Cleaned up the Ownable2Step owner-check API so the `_internal` suffix consistently marks private same-module helpers: consolidated the owner assertion into a single `exec` `assert_sender_is_owner` (removing the redundant `assert_sender_is_owner_internal` wrapper), and renamed the cross-module predicate `is_sender_owner_internal` to `is_sender_owner`. Updated `rbac` to call both, matching `authority` and the faucet policies ([#XXXX](https://github.com/0xMiden/protocol/pull/XXXX)).
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
-- Cleaned up the Ownable2Step owner-check API so the `_internal` suffix consistently marks private same-module helpers: consolidated the owner assertion into a single `exec` `assert_sender_is_owner` (removing the redundant `assert_sender_is_owner_internal` wrapper), and renamed the cross-module predicate `is_sender_owner_internal` to `is_sender_owner`. Updated `rbac` to call both, matching `authority` and the faucet policies ([#XXXX](https://github.com/0xMiden/protocol/pull/XXXX)).
+- Simplified the Ownable2Step owner-check API: merged the owner assertion into a single `exec` `assert_sender_is_owner` and renamed `is_sender_owner_internal` to `is_sender_owner` ([#3088](https://github.com/0xMiden/protocol/pull/3088)).
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
+- Consolidated the Ownable2Step owner check into a single `assert_sender_is_owner` (`exec`) procedure, removing the redundant `assert_sender_is_owner_internal` helper, and updated `rbac::set_role_admin` to call it for consistency with `authority` and the faucet policies ([#XXXX](https://github.com/0xMiden/protocol/pull/XXXX)).
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -147,7 +147,7 @@ end
 #! - is_sender_owner is 1 if the note sender is the current owner, otherwise 0.
 #!
 #! Invocation: exec
-pub proc is_sender_owner_internal
+pub proc is_sender_owner
     exec.active_note::get_sender
     # => [sender_suffix, sender_prefix]
 
@@ -165,7 +165,7 @@ end
 #!
 #! Invocation: exec
 pub proc assert_sender_is_owner
-    exec.is_sender_owner_internal
+    exec.is_sender_owner
     # => [is_sender_owner]
 
     assert.err=ERR_SENDER_NOT_OWNER

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -164,7 +164,7 @@ end
 #! - the note sender is not the owner.
 #!
 #! Invocation: exec
-pub proc assert_sender_is_owner_internal
+pub proc assert_sender_is_owner
     exec.is_sender_owner_internal
     # => [is_sender_owner]
 
@@ -174,20 +174,6 @@ end
 
 # PUBLIC INTERFACE
 # ================================================================================================
-
-#! Checks if the note sender is the owner and panics if not.
-#!
-#! Inputs:  [pad(16)]
-#! Outputs: [pad(16)]
-#!
-#! Panics if:
-#! - the note sender is not the owner.
-#!
-#! Invocation: call
-pub proc assert_sender_is_owner
-    exec.assert_sender_is_owner_internal
-    # => [pad(16)]
-end
 
 #! Returns the owner account ID.
 #!
@@ -245,7 +231,7 @@ end
 #!
 #! Invocation: call
 pub proc transfer_ownership
-    exec.assert_sender_is_owner_internal
+    exec.assert_sender_is_owner
     # => [new_owner_suffix, new_owner_prefix, pad(14)]
 
     # Detect explicit cancel via the zero address. The zero address is not a valid
@@ -332,7 +318,7 @@ end
 #!
 #! Invocation: call
 pub proc renounce_ownership
-    exec.assert_sender_is_owner_internal
+    exec.assert_sender_is_owner
     # => [pad(16)]
 
     exec.get_nominated_owner_internal

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -253,24 +253,14 @@ pub proc transfer_ownership
     dup.1 eq.0 dup.1 eq.0 and
     # => [is_zero_address, new_owner_suffix, new_owner_prefix, pad(14)]
 
-    if.true
-        # Cancel via zero address: drop the (0, 0) inputs and write [owner, 0, 0].
-        drop drop
-        # => [pad(14)]
-
-        exec.get_owner_internal
-        # => [owner_suffix, owner_prefix, pad(14)]
-
-        push.0.0 movup.3 movup.3
-        # => [owner_suffix, owner_prefix, 0, 0, pad(14)]
-    else
-        # Non-zero new owner: validate and store as the nominated owner.
+    if.false
+        # Non-zero new owner: validate before storing as the nominated owner.
         dup.1 dup.1 exec.account_id::validate
-        # => [new_owner_suffix, new_owner_prefix, pad(14)]
-
-        exec.get_owner_internal
-        # => [owner_suffix, owner_prefix, new_owner_suffix, new_owner_prefix, pad(14)]
     end
+    # => [new_owner_suffix, new_owner_prefix, pad(14)]
+
+    exec.get_owner_internal
+    # => [owner_suffix, owner_prefix, new_owner_suffix, new_owner_prefix, pad(14)]
 
     exec.save_ownership_info
     # => [pad(14)]

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -409,7 +409,7 @@ end
 #!
 #! Invocation: exec
 proc assert_sender_is_owner_or_role_admin
-    exec.ownable2step::is_sender_owner_internal
+    exec.ownable2step::is_sender_owner
     # => [is_owner, role_symbol]
 
     if.true

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -161,7 +161,7 @@ end
 #!
 #! Invocation: call
 pub proc set_role_admin
-    exec.ownable2step::assert_sender_is_owner_internal
+    exec.ownable2step::assert_sender_is_owner
     exec.assert_role_symbol_non_zero
     # => [role_symbol, new_admin_role_symbol, pad(14)]
 


### PR DESCRIPTION
This PR improves the `Ownable2Step` module by the following:
- Simplifying branch under `transfer_ownership`.
- Consolidated the owner assertion into a single `exec` procedure `ownable2step::assert_sender_is_owner`, removing the redundant `assert_sender_is_owner_internal` wrapper (the public proc was a no-op passthrough that was never `call`-invoked or exported). Updated `rbac::set_role_admin` to call it instead of the internal helper, so it now matches `authority` and the faucet policies which already `exec` `assert_sender_is_owner`.
- Renamed the cross-module predicate `ownable2step::is_sender_owner_internal` to `is_sender_owner`, removing the `_internal` suffix from a proc that is intentionally `pub` for cross-module `exec` use. Updated `rbac::assert_sender_is_owner_or_role_admin` accordingly. 
