### PR TITLE
refactor: Optimize `grant_role_internal` and `revoke_role_internal` in rbac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [BREAKING] Refactored `TransferPolicy`, `MintPolicyConfig`, and `BurnPolicyConfig` from enums into structs ([#2974](https://github.com/0xMiden/protocol/pull/2974)).
 - Added `AccountComponent::has_procedure(root)` helper ([#2974](https://github.com/0xMiden/protocol/pull/2974)).
 - Optimized protocol MASM stack-cleaning sequences, saving 1 cycle per occurrence across 9 single-element-extraction procedures ([#3041](https://github.com/0xMiden/protocol/pull/3041)).
+- Optimized `rbac::grant_role_internal` and `rbac::revoke_role_internal` by removing the redundant membership read and rearranging the stack ([#3090](https://github.com/0xMiden/protocol/pull/3090)).
 - [BREAKING] Refactored `TokenPolicyManager` by adding `invoke_send_policy` / `invoke_receive_policy` wrappers (stored in the protocol reserved asset callback slots) that read the active policy root from the new `active_send_policy_proc_root` / `active_receive_policy_proc_root` storage slots ([#3047](https://github.com/0xMiden/protocol/pull/3047)).
 - Added a definition of the Miden operator on the architecture overview page and linked it from the note lifecycle ([#3017](https://github.com/0xMiden/protocol/pull/3017)).
 - Clarified Miden's operational roles on the architecture overview page and linked them from the note lifecycle ([#3017](https://github.com/0xMiden/protocol/pull/3017)).

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -434,8 +434,8 @@ end
 
 #! Internal helper used by `grant_role` to assign a role to an account.
 #!
-#! Validates the account ID, then no-ops if the account is already a member.
-#! Otherwise, sets the membership flag and increments the role's member count.
+#! Validates the account ID, sets the membership flag, and increments the role's
+#! member count only when the account did not already hold the role.
 #!
 #! Inputs:  [role_symbol, account_suffix, account_prefix]
 #! Outputs: []
@@ -445,41 +445,37 @@ proc grant_role_internal
     dup.2 dup.2 exec.account_id::validate
     # => [role_symbol, account_suffix, account_prefix]
 
-    dup.2 dup.2 dup.2 exec.has_role_internal
-    # => [has_role, role_symbol, account_suffix, account_prefix]
+    # Save a copy of role_symbol at the bottom of the stack so it survives the
+    # membership map write and is available for the role-config update.
+    dup movdn.3
+    # => [role_symbol, account_suffix, account_prefix, role_symbol]
+
+    push.0
+    # => [0, role_symbol, account_suffix, account_prefix, role_symbol]
+
+    push.SET_MEMBERSHIP
+    # => [1, 0, 0, 0, 0, role_symbol, account_suffix, account_prefix, role_symbol]
+
+    swapw
+    # => [0, role_symbol, account_suffix, account_prefix, 1, 0, 0, 0, role_symbol]
+
+    push.ROLE_MEMBERSHIP_SLOT[0..2]
+    # => [slot_suffix, slot_prefix, 0, role_symbol, account_suffix, account_prefix,
+    #     1, 0, 0, 0, role_symbol]
+
+    exec.native_account::set_map_item
+    # => [OLD_MEMBERSHIP_WORD, role_symbol]
+
+    # Reduce OLD_MEMBERSHIP_WORD to its first element, the previous membership flag.
+    movdn.3 drop drop drop
+    # => [old_is_member, role_symbol]
 
     if.true
-        # Already a member — no-op.
-        drop drop drop
+        # Role was already held — the write above was idempotent, count unchanged.
+        drop
         # => []
     else
-        # Save a copy of role_symbol at the bottom of the stack so it survives the
-        # membership map write and is available for the role-config update.
-        dup movdn.3
-        # => [role_symbol, account_suffix, account_prefix, role_symbol]
-
-        # Write membership[role, account] = [1, 0, 0, 0].
-        push.SET_MEMBERSHIP
-        # => [1, 0, 0, 0, role_symbol, account_suffix, account_prefix, role_symbol]
-
-        # Bring role/suffix/prefix back in order.
-        movup.6 movup.6 movup.6
-        # => [role_symbol, account_suffix, account_prefix, 1, 0, 0, 0, role_symbol]
-
-        push.0
-        # => [0, role_symbol, account_suffix, account_prefix, 1, 0, 0, 0, role_symbol]
-
-        push.ROLE_MEMBERSHIP_SLOT[0..2]
-        # => [slot_suffix, slot_prefix, 0, role_symbol, account_suffix, account_prefix,
-        #     1, 0, 0, 0, role_symbol]
-
-        exec.native_account::set_map_item
-        # => [OLD_MEMBERSHIP_WORD, role_symbol]
-
-        dropw
-        # => [role_symbol]
-
-        # Increment the role's member count.
+        # New grant — increment the role's member count.
         dup exec.get_role_config
         # => [member_count, admin_role_symbol, role_symbol]
 
@@ -497,8 +493,8 @@ end
 #! Internal helper used by `revoke_role` and `renounce_role` to remove a role from
 #! an account.
 #!
-#! Validates the account ID, asserts that the account currently holds the role,
-#! clears the membership flag, and decrements the role's member count.
+#! Validates the account ID, clears the membership flag, asserts that the account
+#! previously held the role, and decrements the role's member count.
 #!
 #! Inputs:  [role_symbol, account_suffix, account_prefix]
 #! Outputs: []
@@ -512,27 +508,18 @@ proc revoke_role_internal
     dup.2 dup.2 exec.account_id::validate
     # => [role_symbol, account_suffix, account_prefix]
 
-    # Assert the account currently holds the role, preserving the inputs.
-    dup.2 dup.2 dup.2 exec.has_role_internal
-    # => [has_role, role_symbol, account_suffix, account_prefix]
-
-    assert.err=ERR_ACCOUNT_NOT_IN_ROLE
-    # => [role_symbol, account_suffix, account_prefix]
-
     # Save a copy of role_symbol at the bottom of the stack so it survives the
     # membership map write and is available for the role-config update.
     dup movdn.3
     # => [role_symbol, account_suffix, account_prefix, role_symbol]
 
-    # Clear membership[role, account] = [0, 0, 0, 0].
-    push.CLEAR_MEMBERSHIP
-    # => [0, 0, 0, 0, role_symbol, account_suffix, account_prefix, role_symbol]
-
-    # Bring role/suffix/prefix back above the value word, in order.
-    movup.6 movup.6 movup.6
-    # => [role_symbol, account_suffix, account_prefix, 0, 0, 0, 0, role_symbol]
-
     push.0
+    # => [0, role_symbol, account_suffix, account_prefix, role_symbol]
+
+    push.CLEAR_MEMBERSHIP
+    # => [0, 0, 0, 0, 0, role_symbol, account_suffix, account_prefix, role_symbol]
+
+    swapw
     # => [0, role_symbol, account_suffix, account_prefix, 0, 0, 0, 0, role_symbol]
 
     push.ROLE_MEMBERSHIP_SLOT[0..2]
@@ -542,7 +529,10 @@ proc revoke_role_internal
     exec.native_account::set_map_item
     # => [OLD_MEMBERSHIP_WORD, role_symbol]
 
-    dropw
+    movdn.3 drop drop drop
+    # => [old_is_member, role_symbol]
+
+    assert.err=ERR_ACCOUNT_NOT_IN_ROLE
     # => [role_symbol]
 
     # Decrement the role's member count.

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -70,7 +70,7 @@ const ERR_MEMBER_COUNT_OVERFLOW = "role member count overflowed u32"
 #!
 #! Invocation: call
 pub proc assert_sender_has_role
-    exec.assert_role_symbol_non_zero
+    dup exec.assert_role_symbol_non_zero
     # => [role_symbol, pad(15)]
 
     exec.is_sender_in_role
@@ -162,7 +162,7 @@ end
 #! Invocation: call
 pub proc set_role_admin
     exec.ownable2step::assert_sender_is_owner_internal
-    exec.assert_role_symbol_non_zero
+    dup exec.assert_role_symbol_non_zero
     # => [role_symbol, new_admin_role_symbol, pad(14)]
 
     dup exec.get_role_member_count_internal
@@ -195,7 +195,7 @@ end
 #!
 #! Invocation: call
 pub proc grant_role
-    exec.assert_role_symbol_non_zero
+    dup exec.assert_role_symbol_non_zero
     # => [role_symbol, account_suffix, account_prefix, pad(13)]
 
     dup exec.assert_sender_is_owner_or_role_admin
@@ -226,7 +226,7 @@ end
 #!
 #! Invocation: call
 pub proc revoke_role
-    exec.assert_role_symbol_non_zero
+    dup exec.assert_role_symbol_non_zero
     # => [role_symbol, account_suffix, account_prefix, pad(13)]
 
     dup exec.assert_sender_is_owner_or_role_admin
@@ -251,7 +251,7 @@ end
 #!
 #! Invocation: call
 pub proc renounce_role
-    exec.assert_role_symbol_non_zero
+    dup exec.assert_role_symbol_non_zero
     # => [role_symbol, pad(15)]
 
     exec.active_note::get_sender
@@ -270,16 +270,15 @@ end
 #! Asserts that a role symbol is non-zero.
 #!
 #! Inputs:  [role_symbol]
-#! Outputs: [role_symbol]
+#! Outputs: []
 #!
 #! Panics if:
 #! - role_symbol is zero.
 #!
 #! Invocation: exec
 proc assert_role_symbol_non_zero
-    dup eq.0
-    assertz.err=ERR_ROLE_SYMBOL_ZERO
-    # => [role_symbol]
+    eq.0 assertz.err=ERR_ROLE_SYMBOL_ZERO
+    # => []
 end
 
 #! Returns the config for a role.


### PR DESCRIPTION
This PR works on following improvement items:
- Moves `dup` in `assert_role_symbol_non_zero` to each call site.
- Optimizes `rbac::grant_role_internal` and `rbac::revoke_role_internal` by removing the redundant membership read and rearranging the stack.