### PR TITLE
perf(batch kernel): absorb input-note entries in runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 - The batch kernel verifies the transaction list against `BATCH_ID` and computes the nullifier-sorted `INPUT_NOTES_COMMITMENT` matching `ProposedBatch::input_notes().commitment()` ([#2905](https://github.com/0xMiden/protocol/pull/2905)).
+- Optimized the batch kernel's input-note commitment hashing to absorb contiguous non-erased entries in runs, and removed the unreachable pending-erasure epilogue assertion ([#3095](https://github.com/0xMiden/protocol/pull/3095)).
 
 - [BREAKING] Renamed `AccountStorageDelta` to `AccountStoragePatch` ([#3002](https://github.com/0xMiden/protocol/pull/3002)).
 - [BREAKING] Replaced the per-tree account and nullifier backend traits with shared `SmtBackend` and `SmtBackendReader` traits, split into read-only and read-write capabilities, enabling read-only `LargeSmt`-backed tree views via `reader()` ([#2755](https://github.com/0xMiden/protocol/pull/2755), [#3009](https://github.com/0xMiden/protocol/pull/3009)).

--- a/crates/miden-protocol/asm/kernels/batch/lib/epilogue.masm
+++ b/crates/miden-protocol/asm/kernels/batch/lib/epilogue.masm
@@ -1,7 +1,6 @@
 use miden::core::crypto::hashes::poseidon2
 
 use miden::batch_kernel::memory
-use miden::batch_kernel::memory::NOTE_ENTRY_FELT_LEN
 use miden::batch_kernel::memory::INPUT_NOTE_CONSUMPTION_OFFSET
 use miden::batch_kernel::memory::OUTPUT_NOTE_IS_CREATED_OFFSET
 
@@ -12,8 +11,6 @@ const ERR_BATCH_INPUT_NOTE_NOT_CONSUMED="a nullifier-sorted input-note list entr
 
 const ERR_BATCH_OUTPUT_NOTE_NOT_CREATED="a note-id-sorted output-note list entry was not created by any transaction"
 
-const ERR_BATCH_NOTE_CONSUMED_BEFORE_CREATED="an erased input note was consumed before the transaction that creates it (incorrect ordering or circular dependency)"
-
 # ASSERTIONS
 # =================================================================================================
 
@@ -21,8 +18,8 @@ const ERR_BATCH_NOTE_CONSUMED_BEFORE_CREATED="an erased input note was consumed 
 #! binding, this proves the list is exactly the union of the per-transaction output notes, so a host
 #! cannot fabricate an erasure with a note no transaction creates).
 #!
-#! The matching input-note checks (every entry consumed exactly once, none left pending-erasure) are
-#! folded into the single pass in [`compute_input_notes_commitment`].
+#! The matching input-note check (every entry consumed exactly once) is folded into the single pass
+#! in [`compute_input_notes_commitment`].
 #!
 #! Inputs:  []
 #! Outputs: []
@@ -42,19 +39,19 @@ end
 # INPUT NOTES COMMITMENT
 # =================================================================================================
 
-#! Absorbs input-note list entry `idx`'s 8-felt `(NULLIFIER, NOTE_ID_OR_EMPTY)` tuple into the batch
-#! hasher state held in memory (overwrite-mode poseidon2, matching `Hasher::hash_elements`).
+#! Absorbs input-note list entries `[run_start, run_end)` — their 8-felt
+#! `(NULLIFIER, NOTE_ID_OR_EMPTY)` tuples — into the batch hasher state held in memory
+#! (overwrite-mode poseidon2, matching `Hasher::hash_elements`). A no-op for an empty run.
 #!
-#! Inputs:  [idx]
+#! Inputs:  [run_start, run_end]
 #! Outputs: []
-proc absorb_input_entry
-    # The entry occupies one double word [entry_ptr, entry_ptr + NOTE_ENTRY_FELT_LEN).
-    exec.memory::input_note_entry_ptr
-    # => [entry_ptr]
-    dup add.NOTE_ENTRY_FELT_LEN swap
-    # => [entry_ptr, end_ptr]
+proc absorb_input_run
+    exec.memory::input_note_entry_ptr swap
+    # => [run_end, start_ptr]
+    exec.memory::input_note_entry_ptr swap
+    # => [start_ptr, end_ptr]
     exec.memory::load_batch_hasher_state
-    # => [RATE0, RATE1, CAPACITY, entry_ptr, end_ptr]
+    # => [RATE0, RATE1, CAPACITY, start_ptr, end_ptr]
     exec.poseidon2::absorb_double_words_from_memory
     # => [RATE0', RATE1', CAPACITY', end_ptr, end_ptr]
     exec.memory::save_batch_hasher_state
@@ -66,9 +63,13 @@ end
 #! `(NULLIFIER, NOTE_ID_OR_EMPTY)` entries of the nullifier-sorted input-note list (entries with
 #! erasure flag == 2 are skipped).
 #!
-#! The single pass over the input entries also enforces the epilogue invariants on each entry: it
-#! was consumed exactly once (consumption == 1) and is not left expected-to-be-erased (erasure != 1,
-#! i.e. any created-and-consumed note had its creator processed).
+#! The single pass over the input entries also asserts each entry was consumed exactly once
+#! (consumption == 1). No pending-erasure (erasure == 1) check is needed: such an entry either was
+#! consumed — tripping the ordering gate in the note tracker at consume time (erasure never
+#! transitions back to 1) — or was not, tripping the consumption assert here.
+#!
+#! Entries are absorbed in contiguous non-erased runs, so the hasher state round-trips through
+#! memory once per run (once in total for a batch with no erasures) instead of once per entry.
 #!
 #! Inputs:  []
 #! Outputs: [INPUT_NOTES_COMMITMENT]
@@ -78,38 +79,48 @@ proc compute_input_notes_commitment
     exec.memory::save_batch_hasher_state
 
     exec.memory::get_num_input_notes
-    push.0 push.0
-    # => [idx, absorbed_count, num]
-    dup dup.3 neq
-    # => [should_loop, idx, absorbed_count, num]
+    push.0 push.0 push.0
+    # => [run_start, idx, absorbed_count, num]
+    dup.1 dup.4 neq
+    # => [should_loop, run_start, idx, absorbed_count, num]
     while.true
-        # Assert this entry was consumed exactly once and is not left expected-to-be-erased.
-        dup exec.memory::input_note_flags_ptr
-        # => [flags_ptr, idx, absorbed_count, num]
+        # Assert this entry was consumed exactly once.
+        dup.1 exec.memory::input_note_flags_ptr
+        # => [flags_ptr, run_start, idx, absorbed_count, num]
         dup add.INPUT_NOTE_CONSUMPTION_OFFSET mem_load
-        # => [consumption, flags_ptr, idx, absorbed_count, num]
+        # => [consumption, flags_ptr, run_start, idx, absorbed_count, num]
         assert.err=ERR_BATCH_INPUT_NOTE_NOT_CONSUMED
-        # => [flags_ptr, idx, absorbed_count, num]
-        mem_load
-        # => [erasure, idx, absorbed_count, num]
-        dup neq.1 assert.err=ERR_BATCH_NOTE_CONSUMED_BEFORE_CREATED
-        # => [erasure, idx, absorbed_count, num]
-
-        # Absorb the entry unless it was erased (created-and-consumed in this batch).
-        neq.2
-        # => [not_erased, idx, absorbed_count, num]
+        # => [flags_ptr, run_start, idx, absorbed_count, num]
+        mem_load eq.2
+        # => [is_erased, run_start, idx, absorbed_count, num]
         if.true
-            dup exec.absorb_input_entry
-            swap add.1 swap
-            # => [idx, absorbed_count+1, num]
+            # Erased (created-and-consumed in this batch): absorb the pending run [run_start, idx),
+            # account for its length, and start the next run after this entry.
+            dup.1 dup.1 sub
+            # => [run_len, run_start, idx, absorbed_count, num]
+            movup.3 add movdn.2
+            # => [run_start, idx, absorbed_count', num]
+            dup.1 dup.1 exec.absorb_input_run
+            # => [run_start, idx, absorbed_count', num]
+            drop dup add.1
+            # => [run_start', idx, absorbed_count', num]   (run_start' = idx + 1)
         end
-        add.1
-        dup dup.3 neq
-        # => [should_loop, idx, absorbed_count, num]
+        swap add.1 swap
+        # => [run_start, idx+1, absorbed_count, num]
+        dup.1 dup.4 neq
+        # => [should_loop, run_start, idx, absorbed_count, num]
     end
-    # => [idx, absorbed_count, num]
-    drop swap drop
-    # => [absorbed_count]
+    # => [run_start, num, absorbed_count, num]
+
+    # Absorb the final run [run_start, num).
+    dup.1 dup.1 sub
+    # => [run_len, run_start, num, absorbed_count, num]
+    movup.3 add movdn.2
+    # => [run_start, num, absorbed_count', num]
+    dup.1 dup.1 exec.absorb_input_run
+    # => [run_start, num, absorbed_count', num]
+    drop drop swap drop
+    # => [absorbed_count']
 
     # With no non-erased entries the commitment is the empty word, matching the early return in
     # `build_input_note_commitment` (this is not the hash of zero elements). Otherwise squeeze the
@@ -146,8 +157,8 @@ end
 #! Verifies the note-tracking results and computes the batch's note commitments.
 #!
 #! Asserts every output-note list entry was created, then computes the input- and output-notes
-#! commitments. The per-input-entry invariants (consumed exactly once, no pending erasure) are
-#! enforced inside the input-commitment pass.
+#! commitments. The per-input-entry invariant (consumed exactly once) is enforced inside the
+#! input-commitment pass.
 #!
 #! Inputs:  []
 #! Outputs: [INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT]


### PR DESCRIPTION
Follow-up to #2905, split out per review so the optimization can be evaluated independently of the main verification logic.

# What this does

## Run-based absorption

`compute_input_notes_commitment` previously absorbed each non-erased input-note entry with its own `absorb_double_words_from_memory` call, loading and saving the 12-felt hasher state through memory for every entry (~12 ops per entry, dominating the ~2 cycles of actual hashing).

This PR absorbs *contiguous runs* of non-erased entries instead: the loop tracks `run_start`, flushes the pending run whenever it hits an erased entry, and flushes the final run after the loop. The hasher state now round-trips memory once per run - once in total for a batch with no erasures (the common case), instead of once per entry (up to 1024).

The absorbed felt sequence is unchanged (same `mem_stream`/`hperm` schedule), so the commitment is identical.

## Removal of the unreachable pending-erasure assert

The epilogue asserted `erasure != 1` (expected-to-be-erased but creator never processed) for each entry. This is unreachable:

- the epilogue first asserts `consumption == 1`, so an unconsumed entry trips that assert;
- a consumed entry passed the note tracker's ordering gate (`assert_input_not_consumed_before_created`) at consume time, and the erasure flag never transitions back to 1 (only `0 -> 1` during cross-referencing, before binding, and `1 -> 2` when the creator is processed).

Removing it also removes the `ERR_BATCH_NOTE_CONSUMED_BEFORE_CREATED` constant that was duplicated between `epilogue.masm` and `note_tracker.masm`.

Note for the parent PR description: its epilogue bullet says the epilogue asserts "no erasure is left pending" - if this lands, that becomes "impossible by construction" rather than asserted.
