### PR TITLE
chore: remove `AccountDelta` from `ExecutedTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Added an `AccountCode::interface` helper that returns the public `AccountCodeInterface` ([#3080](https://github.com/0xMiden/protocol/pull/3080)).
 - [BREAKING] Tightened `AccountStorage::get_map_item` to take a `StorageMapKey` instead of a raw `Word` ([#3080](https://github.com/0xMiden/protocol/pull/3080)).
 - [BREAKING] Renamed the `TransactionEvent::AuthRequest` field from `pub_key_hash: Word` to `pub_key_commitment: PublicKeyCommitment` ([#3080](https://github.com/0xMiden/protocol/pull/3080)).
+- [BREAKING] Removed `AccountDelta` from `ExecutedTransaction` which is replaced by `AccountPatch` ([#3109](https://github.com/0xMiden/protocol/pull/3109)).
 
 ### Fixes
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).

--- a/bin/bench-transaction/src/cycle_counting_benchmarks/trace_capture.rs
+++ b/bin/bench-transaction/src/cycle_counting_benchmarks/trace_capture.rs
@@ -29,8 +29,7 @@ pub async fn capture_measurements_and_trace_summary(
         .execute()
         .await
         .context("pre-execution (to resolve signatures) failed")?;
-    let (tx_inputs, _tx_outputs, _account_delta, _account_patch, measurements) =
-        executed.into_parts();
+    let (tx_inputs, _tx_outputs, _account_patch, measurements) = executed.into_parts();
 
     let trace_summary = build_trace_summary(tx_inputs).await?;
 

--- a/crates/miden-protocol/src/account/patch/vault.rs
+++ b/crates/miden-protocol/src/account/patch/vault.rs
@@ -106,7 +106,7 @@ impl AccountVaultPatch {
 
     /// Returns an iterator over the keys of assets that were removed (i.e. whose value is
     /// [`Word::empty`]).
-    fn removed_asset_keys(&self) -> impl Iterator<Item = &AssetVaultKey> {
+    pub fn removed_asset_keys(&self) -> impl Iterator<Item = &AssetVaultKey> {
         self.entries
             .iter()
             .filter(|(_key, value)| value.is_empty())
@@ -115,7 +115,7 @@ impl AccountVaultPatch {
 
     /// Returns an iterator over the assets that were added or updated (i.e. whose value is not
     /// [`Word::empty`]).
-    fn added_assets(&self) -> impl Iterator<Item = Asset> {
+    pub fn updated_assets(&self) -> impl Iterator<Item = Asset> {
         self.entries
             .iter()
             .filter(|(_key, value)| !value.is_empty())
@@ -130,15 +130,15 @@ impl Serializable for AccountVaultPatch {
         target.write_usize(self.removed_asset_keys().count());
         target.write_many(self.removed_asset_keys());
 
-        target.write_usize(self.added_assets().count());
-        target.write_many(self.added_assets());
+        target.write_usize(self.updated_assets().count());
+        target.write_many(self.updated_assets());
     }
 
     fn get_size_hint(&self) -> usize {
         let removed_size = AssetVaultKey::SERIALIZED_SIZE * self.removed_asset_keys().count();
-        let added_size: usize = self.added_assets().map(|asset| asset.get_size_hint()).sum();
+        let updated_size: usize = self.updated_assets().map(|asset| asset.get_size_hint()).sum();
 
-        2 * 0usize.get_size_hint() + removed_size + added_size
+        2 * 0usize.get_size_hint() + removed_size + updated_size
     }
 }
 

--- a/crates/miden-protocol/src/transaction/executed_tx.rs
+++ b/crates/miden-protocol/src/transaction/executed_tx.rs
@@ -132,11 +132,6 @@ impl ExecutedTransaction {
         self.tx_inputs.block_header()
     }
 
-    /// Returns a description of changes between the initial and final account states.
-    pub fn account_delta(&self) -> &AccountDelta {
-        &self.account_delta
-    }
-
     /// Returns the patch of the transaction that describes the update from the initial to the final
     /// account state.
     pub fn account_patch(&self) -> &AccountPatch {
@@ -166,20 +161,8 @@ impl ExecutedTransaction {
     /// Returns individual components of this transaction.
     pub fn into_parts(
         self,
-    ) -> (
-        TransactionInputs,
-        TransactionOutputs,
-        AccountDelta,
-        AccountPatch,
-        TransactionMeasurements,
-    ) {
-        (
-            self.tx_inputs,
-            self.tx_outputs,
-            self.account_delta,
-            self.account_patch,
-            self.tx_measurements,
-        )
+    ) -> (TransactionInputs, TransactionOutputs, AccountPatch, TransactionMeasurements) {
+        (self.tx_inputs, self.tx_outputs, self.account_patch, self.tx_measurements)
     }
 }
 
@@ -191,7 +174,7 @@ impl From<ExecutedTransaction> for TransactionInputs {
 
 impl From<ExecutedTransaction> for TransactionMeasurements {
     fn from(tx: ExecutedTransaction) -> Self {
-        let (_, _, _, _, tx_progress) = tx.into_parts();
+        let (_, _, _, tx_progress) = tx.into_parts();
         tx_progress
     }
 }

--- a/crates/miden-protocol/src/transaction/executed_tx.rs
+++ b/crates/miden-protocol/src/transaction/executed_tx.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 
 use super::{
-    AccountDelta,
     AccountHeader,
     AccountId,
     AdviceInputs,
@@ -42,7 +41,6 @@ pub struct ExecutedTransaction {
     id: TransactionId,
     tx_inputs: TransactionInputs,
     tx_outputs: TransactionOutputs,
-    account_delta: AccountDelta,
     account_patch: AccountPatch,
     tx_measurements: TransactionMeasurements,
 }
@@ -58,7 +56,6 @@ impl ExecutedTransaction {
     pub fn new(
         tx_inputs: TransactionInputs,
         tx_outputs: TransactionOutputs,
-        account_delta: AccountDelta,
         account_patch: AccountPatch,
         tx_measurements: TransactionMeasurements,
     ) -> Self {
@@ -78,7 +75,6 @@ impl ExecutedTransaction {
             id,
             tx_inputs,
             tx_outputs,
-            account_delta,
             account_patch,
             tx_measurements,
         }
@@ -183,7 +179,6 @@ impl Serializable for ExecutedTransaction {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.tx_inputs.write_into(target);
         self.tx_outputs.write_into(target);
-        self.account_delta.write_into(target);
         self.account_patch.write_into(target);
         self.tx_measurements.write_into(target);
     }
@@ -193,11 +188,10 @@ impl Deserializable for ExecutedTransaction {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let tx_inputs = TransactionInputs::read_from(source)?;
         let tx_outputs = TransactionOutputs::read_from(source)?;
-        let account_delta = AccountDelta::read_from(source)?;
         let account_patch = AccountPatch::read_from(source)?;
         let tx_measurements = TransactionMeasurements::read_from(source)?;
 
-        Ok(Self::new(tx_inputs, tx_outputs, account_delta, account_patch, tx_measurements))
+        Ok(Self::new(tx_inputs, tx_outputs, account_patch, tx_measurements))
     }
 }
 

--- a/crates/miden-protocol/src/transaction/mod.rs
+++ b/crates/miden-protocol/src/transaction/mod.rs
@@ -1,4 +1,4 @@
-use super::account::{AccountDelta, AccountHeader, AccountId};
+use super::account::{AccountHeader, AccountId};
 use super::note::{NoteId, Nullifier};
 use super::vm::AdviceInputs;
 use super::{Felt, Hasher, WORD_SIZE, Word, ZERO};

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -1467,12 +1467,15 @@ async fn transaction_executor_account_code_using_custom_library() -> anyhow::Res
     let executed_tx = tx_context.execute().await?;
 
     // Account's initial nonce of 1 should have been incremented by 1.
-    assert_eq!(executed_tx.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        executed_tx.account_patch().final_nonce(),
+        Some(native_account.nonce() + Felt::ONE)
+    );
 
     // Make sure that account storage has been updated as per the tx script call.
-    assert_eq!(executed_tx.account_delta().storage().values().count(), 1);
+    assert_eq!(executed_tx.account_patch().storage().values().count(), 1);
     assert_eq!(
-        executed_tx.account_delta().storage().get(&MOCK_VALUE_SLOT0).unwrap(),
+        executed_tx.account_patch().storage().get(&MOCK_VALUE_SLOT0).unwrap(),
         &StorageSlotPatch::Value(slot_value),
     );
     Ok(())

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -825,29 +825,33 @@ async fn prove_account_creation_with_non_empty_storage() -> anyhow::Result<()> {
         .await
         .context("failed to execute account-creating transaction")?;
 
-    assert_eq!(tx.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        tx.account_patch().final_nonce(),
+        Some(Felt::ONE),
+        "new account should have nonce 1"
+    );
 
     assert_matches!(
-        tx.account_delta().storage().get(&slot_name0).unwrap(),
+        tx.account_patch().storage().get(&slot_name0).unwrap(),
         StorageSlotPatch::Value(value) => {
             assert_eq!(*value, slot0.value())
         }
     );
     assert_matches!(
-        tx.account_delta().storage().get(&slot_name1).unwrap(),
+        tx.account_patch().storage().get(&slot_name1).unwrap(),
         StorageSlotPatch::Value(value) => {
             assert_eq!(*value, slot1.value())
         }
     );
     assert_matches!(
-        tx.account_delta().storage().get(&slot_name2).unwrap(),
+        tx.account_patch().storage().get(&slot_name2).unwrap(),
         StorageSlotPatch::Map(map_patch) => {
             let expected = &BTreeMap::from_iter(map_entries);
             assert_eq!(expected, map_patch.entries())
         }
     );
 
-    assert!(tx.account_delta().vault().is_empty());
+    assert!(tx.account_patch().vault().is_empty());
     assert_eq!(tx.final_account().nonce(), Felt::ONE);
 
     let proven_tx = LocalTransactionProver::default().prove(tx.clone()).await?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
@@ -27,7 +27,7 @@ use miden_protocol::account::{
 };
 use miden_protocol::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
 use miden_protocol::note::{NoteTag, NoteType};
-use miden_protocol::testing::account_id::{ACCOUNT_ID_SENDER, AccountIdBuilder};
+use miden_protocol::testing::account_id::AccountIdBuilder;
 use miden_protocol::testing::storage::{MOCK_MAP_SLOT, MOCK_VALUE_SLOT0};
 use miden_protocol::transaction::TransactionScript;
 use miden_protocol::{EMPTY_WORD, Felt, Word, ZERO};
@@ -43,30 +43,37 @@ use crate::{Auth, MockChain, TransactionContextBuilder};
 // For the approach to these tests, see `AccountUpdateTest::execute`.
 // ================================================================================================
 
-/// Tests that a noop transaction with [`Auth::Noop`] results in an empty nonce delta with an empty
-/// word as its commitment.
-///
-/// In order to make the account delta empty but the transaction still legal, we consume a note
-/// without assets.
+/// Tests that an empty account delta commits to the empty word.
 #[tokio::test]
 async fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
+    let tx_script = CodeBuilder::with_mock_libraries()
+        .compile_tx_script(
+            r#"
+      use miden::protocol::native_account
+
+      begin
+          exec.native_account::compute_delta_commitment
+          # => [DELTA_COMMITMENT]
+
+          padw assert_eqw.err="empty account delta should commit to the empty word"
+      end
+      "#,
+        )
+        .context("failed to compile tx script")?;
+
     let mut builder = MockChain::builder();
-    let account = builder.add_existing_mock_account(Auth::Noop)?;
-    let p2any_note =
-        builder.add_p2any_note(AccountId::try_from(ACCOUNT_ID_SENDER)?, NoteType::Public, [])?;
+    // Use IncrNonce to make the transaction non-empty.
+    let account = builder.add_existing_mock_account(Auth::IncrNonce)?;
     let mock_chain = builder.build()?;
 
-    let executed_tx = mock_chain
-        .build_tx_context(account.id(), &[p2any_note.id()], &[])
+    mock_chain
+        .build_tx_context(account.id(), &[], &[])
         .expect("failed to build tx context")
+        .tx_script(tx_script)
         .build()?
         .execute()
         .await
         .context("failed to execute transaction")?;
-
-    assert_eq!(executed_tx.account_delta().nonce_delta(), ZERO);
-    assert!(executed_tx.account_delta().is_empty());
-    assert_eq!(executed_tx.account_delta().to_commitment(), Word::empty());
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
@@ -875,20 +875,21 @@ async fn adding_amount_zero_fungible_asset_to_account_vault_works() -> anyhow::R
 /// Tests that recomputing a delta correctly resets the account delta tracked by the host.
 ///
 /// The auth procedure adds `asset0` to the vault, explicitly calls `compute_delta_commitment`,
-/// and then removes `asset0` again. The epilogue then implicitly calls `compute_delta_commitment`
-/// a second time. The net vault delta is empty, so the host's tracked delta must end up empty.
+/// and then removes `asset0` again. It then builds the tx summary (which calls
+/// `compute_delta_commitment` a second time) and emits `AUTH_UNAUTHORIZED_EVENT`, so the can access
+/// the delta via `TransactionSummary::account_delta`.
 ///
 /// Without the reset performed at the start of each `compute_delta_commitment`, this would fail:
 /// - The explicit call iterates the asset delta link map, sees the added `asset0`, and fires
 ///   `on_asset_delta_computation`, which accumulates `asset0` into the host's tracked vault delta.
 /// - Removing `asset0` afterwards turns its link map entry into a net-empty entry.
-/// - The implicit call iterates the link map again, but the net-empty entry does NOT fire
+/// - The summary's call iterates the link map again, but the net-empty entry does NOT fire
 ///   `on_asset_delta_computation`, so the previously accumulated `asset0` would remain in the
 ///   host's vault delta forever, leaving it non-empty even though the actual change is zero.
 ///
 /// With the reset (the `before_asset_delta_computation` event emitted at the start of each
 /// `compute_delta_commitment`), the host clears its vault delta before each iteration, so the
-/// implicit call correctly produces an empty delta.
+/// summary's call correctly produces an empty delta.
 #[tokio::test]
 async fn recomputing_delta_resets_host_delta() -> anyhow::Result<()> {
     let mut rng = rand::rng();
@@ -909,29 +910,50 @@ async fn recomputing_delta_resets_host_delta() -> anyhow::Result<()> {
     let auth_code = format!(
         "
     use miden::protocol::native_account
+    use miden::protocol::auth::AUTH_UNAUTHORIZED_EVENT
 
     {TEST_ACCOUNT_CONVENIENCE_WRAPPERS}
 
+    #! Inputs:  [[AUTH_ARGS], pad(12)]
+    #! Outputs: [pad(16)]
     @auth_script
     pub proc auth_test
         exec.native_account::incr_nonce drop
-        # => []
+        # => [[AUTH_ARGS], pad(12)]
 
         # add asset 0 to the vault
         push.{ASSET0_VALUE} push.{ASSET0_KEY}
         exec.add_asset dropw
-        # => []
+        # => [[AUTH_ARGS], pad(12)]
 
         # compute the delta to trigger the host to add the assets to the vault delta
         exec.native_account::compute_delta_commitment
         dropw
-        # => []
+        # => [[AUTH_ARGS], pad(12)]
 
         # remove asset 0 for correct asset preservation
         push.{ASSET0_VALUE}
         push.{ASSET0_KEY}
         exec.remove_asset dropw
-        # => []
+        # => [[AUTH_ARGS], pad(12)]
+
+        # Build the tx summary.
+        # Replace AUTH_ARGS with an EMPTY_WORD salt for the tx summary.
+        dropw padw
+        # => [SALT, pad(12)]
+
+        exec.::miden::standards::auth::create_tx_summary
+        # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, pad(12)]
+
+        adv.insert_hqword
+        # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, pad(12)]
+
+        exec.::miden::standards::auth::hash_tx_summary
+        # => [TX_SUMMARY_COMMITMENT, pad(12)]
+
+        emit.AUTH_UNAUTHORIZED_EVENT
+
+        push.0 assert.err=\"emitting the event should have aborted execution\"
     end
     ",
         ASSET0_KEY = asset0.to_key_word(),
@@ -955,23 +977,19 @@ async fn recomputing_delta_resets_host_delta() -> anyhow::Result<()> {
     builder.add_account(account.clone())?;
     let mock_chain = builder.build()?;
 
-    let executed_tx = mock_chain
+    let tx_summary = mock_chain
         .build_tx_context(account, &[], &[])?
         .build()?
         .execute()
         .await
-        .context("failed to execute transaction")?;
+        .unwrap_err()
+        .unwrap_unauthorized_err();
+    let account_delta = tx_summary.account_delta();
 
-    assert!(
-        executed_tx.account_delta().vault().is_empty(),
-        "vault delta should be effectively empty"
-    );
-    assert!(
-        executed_tx.account_delta().storage().is_empty(),
-        "storage delta should be empty"
-    );
+    assert!(account_delta.vault().is_empty(), "vault delta should be effectively empty");
+    assert!(account_delta.storage().is_empty(), "storage delta should be empty");
     assert_eq!(
-        executed_tx.account_delta().nonce_delta().as_canonical_u64(),
+        account_delta.nonce_delta().as_canonical_u64(),
         1,
         "nonce should have been incremented"
     );

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
@@ -702,7 +702,7 @@ async fn proven_tx_storage_maps_matches_executed_tx_for_new_account() -> anyhow:
     // Build a public account so the proven transaction includes the account update.
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_auth_component(delta_check_auth_component())
         .with_component(MockAccountComponent::with_slots(vec![
             AccountStorage::mock_value_slot0(),
             StorageSlot::with_map(map0_slot_name.clone(), map0.clone()),
@@ -739,19 +739,26 @@ async fn proven_tx_storage_maps_matches_executed_tx_for_new_account() -> anyhow:
     let source_manager = builder.source_manager();
     let tx_script = builder.compile_tx_script(code)?;
 
-    let tx = TransactionContextBuilder::new(account.clone())
+    let tx_builder = TransactionContextBuilder::new(account.clone())
         .tx_script(tx_script)
-        .with_source_manager(source_manager)
+        .with_source_manager(source_manager);
+
+    let tx_summary = tx_builder
+        .clone()
+        .auth_args(emit_delta_args())
         .build()?
         .execute()
-        .await?;
+        .await
+        .unwrap_err()
+        .unwrap_unauthorized_err();
+    let tx = tx_builder.build()?.execute().await?;
 
     map2.insert(existing_key, value0)?;
 
     for (slot_name, expected_map) in
         [(map0_slot_name, map0), (map1_slot_name, map1), (map2_slot_name, map2)]
     {
-        let map_patch_entries = tx.account_delta().storage().get_map(&slot_name).unwrap().entries();
+        let map_patch_entries = tx.account_patch().storage().get_map(&slot_name).unwrap().entries();
         let expected: BTreeMap<_, _> = expected_map.entries().map(|(k, v)| (*k, *v)).collect();
         assert_eq!(map_patch_entries, &expected, "map delta does not match for slot {slot_name}",);
     }
@@ -762,7 +769,7 @@ async fn proven_tx_storage_maps_matches_executed_tx_for_new_account() -> anyhow:
 
     let proven_tx_account = Account::try_from(proven_tx_patch)?;
     let exec_tx_account = Account::try_from(tx.account_patch())?;
-    let exec_tx_delta_account = Account::try_from(tx.account_delta())?;
+    let exec_tx_delta_account = Account::try_from(tx_summary.account_delta())?;
 
     assert_eq!(exec_tx_delta_account, exec_tx_account);
     assert_eq!(proven_tx_account.storage(), exec_tx_account.storage());
@@ -773,6 +780,7 @@ async fn proven_tx_storage_maps_matches_executed_tx_for_new_account() -> anyhow:
 
     let proven_tx_delta_converted = AccountDelta::try_from(proven_tx_account)?;
     let exec_tx_delta_converted = AccountDelta::try_from(exec_tx_account)?;
+    assert_eq!(proven_tx_delta_converted, exec_tx_delta_converted);
 
     // Check that the deltas and patches from proven and executed tx, which were converted from
     // accounts are identical. This is essentially a roundtrip test.
@@ -780,15 +788,21 @@ async fn proven_tx_storage_maps_matches_executed_tx_for_new_account() -> anyhow:
     assert_eq!(&proven_tx_patch_converted, tx.account_patch());
     assert_eq!(&exec_tx_patch_converted, tx.account_patch());
 
-    assert_eq!(&exec_tx_delta_converted, tx.account_delta());
-    assert_eq!(&proven_tx_delta_converted, tx.account_delta());
+    assert_eq!(&exec_tx_delta_converted, tx_summary.account_delta());
+    assert_eq!(&proven_tx_delta_converted, tx_summary.account_delta());
 
     // The commitments should match as well.
     assert_eq!(exec_tx_patch_converted.to_commitment(), tx.account_patch().to_commitment());
     assert_eq!(proven_tx_patch_converted.to_commitment(), tx.account_patch().to_commitment());
 
-    assert_eq!(exec_tx_delta_converted.to_commitment(), tx.account_delta().to_commitment());
-    assert_eq!(proven_tx_delta_converted.to_commitment(), tx.account_delta().to_commitment());
+    assert_eq!(
+        exec_tx_delta_converted.to_commitment(),
+        tx_summary.account_delta().to_commitment()
+    );
+    assert_eq!(
+        proven_tx_delta_converted.to_commitment(),
+        tx_summary.account_delta().to_commitment()
+    );
 
     Ok(())
 }
@@ -1209,10 +1223,9 @@ impl AccountUpdateTest {
 
         // Delta path: emit unauthorized so the host's build_tx_summary cross-checks the delta.
         let delta_run = {
-            let auth_args = Word::from([Felt::ONE, ZERO, ZERO, ZERO]);
             let mut tx = mock_chain
                 .build_tx_context(account.id(), &input_note_ids, &[])?
-                .auth_args(auth_args);
+                .auth_args(emit_delta_args());
             if let Some(ref script) = tx_script {
                 tx = tx.tx_script(script.clone());
             }
@@ -1242,4 +1255,8 @@ impl AccountUpdateTest {
 
         Ok(())
     }
+}
+
+fn emit_delta_args() -> Word {
+    Word::from([Felt::ONE, ZERO, ZERO, ZERO])
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_lazy_loading.rs
@@ -213,7 +213,7 @@ async fn setting_map_item_with_lazy_loading_succeeds() -> anyhow::Result<()> {
         .execute()
         .await?;
 
-    let map_patch = tx.account_delta().storage().get_map(mock_map_slot).unwrap();
+    let map_patch = tx.account_patch().storage().get_map(mock_map_slot).unwrap();
     assert_eq!(map_patch.entries().get(&existing_key).unwrap(), &value0);
     assert_eq!(map_patch.entries().get(&non_existent_key).unwrap(), &value1);
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -551,13 +551,13 @@ async fn create_simple_account() -> anyhow::Result<()> {
         .await
         .context("failed to execute account-creating transaction")?;
 
-    assert_eq!(tx.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(tx.account_patch().final_nonce(), Some(Felt::ONE));
     // except for the nonce, the delta should be empty
-    assert!(tx.account_delta().storage().is_empty());
-    assert!(tx.account_delta().vault().is_empty());
+    assert!(tx.account_patch().storage().is_empty());
+    assert!(tx.account_patch().vault().is_empty());
     assert_eq!(tx.final_account().nonce(), Felt::ONE);
     // account commitment should not be the empty word
-    assert_ne!(tx.account_delta().to_commitment(), EMPTY_WORD);
+    assert_ne!(tx.account_patch().to_commitment(), EMPTY_WORD);
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -11,8 +11,11 @@ use miden_protocol::account::{
     AccountBuilder,
     AccountCode,
     AccountComponent,
+    AccountDelta,
     AccountStorage,
+    AccountStoragePatch,
     AccountType,
+    AccountVaultDelta,
     StorageSlot,
     StorageSlotName,
 };
@@ -47,6 +50,7 @@ use miden_protocol::testing::account_id::{
 use miden_protocol::testing::constants::{FUNGIBLE_ASSET_AMOUNT, NON_FUNGIBLE_ASSET_DATA};
 use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::transaction::{
+    InputNote,
     InputNotes,
     RawOutputNote,
     RawOutputNotes,
@@ -75,6 +79,7 @@ use miden_tx::{
     TransactionExecutorError,
     TransactionProverError,
 };
+use rstest::rstest;
 
 use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::{create_p2any_note, create_public_p2any_note, create_spawn_note};
@@ -522,12 +527,15 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
 
 /// Tests that a transaction consuming and creating one note with basic authentication correctly
 /// signs the transaction summary.
+#[rstest]
+#[case::falcon(AuthScheme::Falcon512Poseidon2)]
+#[case::ecdsa(AuthScheme::EcdsaK256Keccak)]
 #[tokio::test]
-async fn tx_summary_commitment_is_signed_by_falcon_auth() -> anyhow::Result<()> {
+async fn tx_summary_commitment_is_signed_by_auth_singlesig(
+    #[case] auth_scheme: AuthScheme,
+) -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
-    let account = builder.add_existing_mock_account(Auth::BasicAuth {
-        auth_scheme: AuthScheme::Falcon512Poseidon2,
-    })?;
+    let account = builder.add_existing_mock_account(Auth::BasicAuth { auth_scheme })?;
     let mut rng = RandomCoin::new(Word::empty());
     let p2id_note = P2idNote::create(
         account.id(),
@@ -540,81 +548,29 @@ async fn tx_summary_commitment_is_signed_by_falcon_auth() -> anyhow::Result<()> 
     let spawn_note = builder.add_spawn_note([&p2id_note])?;
     let chain = builder.build()?;
 
-    let tx = chain
-        .build_tx_context(account.id(), &[spawn_note.id()], &[])?
-        .build()?
-        .execute()
-        .await?;
+    let tx_builder =
+        chain.build_tx_context(account.id(), &[], core::slice::from_ref(&spawn_note))?;
 
-    let summary = TransactionSummary::new(
-        tx.account_delta().clone(),
-        tx.input_notes().clone(),
-        tx.output_notes().clone(),
-        Word::from([
-            0,
-            0,
-            tx.block_header().block_num().as_u32(),
-            tx.final_account().nonce().as_canonical_u64() as u32,
-        ]),
-    );
-    let summary_commitment = summary.to_commitment();
+    let tx = tx_builder.clone().build()?;
+    let ref_block_num = tx.tx_inputs().block_header().block_num();
+    let tx = tx.execute().await?;
 
-    let account_interface = AccountInterface::from_account(&account);
-    assert!(matches!(
-        account_interface.auth_component(),
-        AccountComponentInterface::AuthSingleSig
-    ));
-    let pub_keys = get_public_keys_from_account(&account);
-    let pub_key = pub_keys.first().expect("expected at least one public key");
-
-    // This is in an internal detail of the tx executor host, but this is the easiest way to check
-    // for the presence of the signature in the advice map.
-    let signature_key = Hasher::merge(&[*pub_key, summary_commitment]);
-
-    // The summary commitment should have been signed as part of transaction execution and inserted
-    // into the advice map.
-    tx.advice_witness().map.get(&signature_key).unwrap();
-
-    Ok(())
-}
-
-/// Tests that a transaction consuming and creating one note with EcdsaK256Keccak authentication
-/// correctly signs the transaction summary.
-#[tokio::test]
-async fn tx_summary_commitment_is_signed_by_ecdsa_auth() -> anyhow::Result<()> {
-    let mut builder = MockChain::builder();
-    let account = builder
-        .add_existing_mock_account(Auth::BasicAuth { auth_scheme: AuthScheme::EcdsaK256Keccak })?;
-    let mut rng = RandomCoin::new(Word::empty());
-    let p2id_note = P2idNote::create(
+    let nonce_delta = Felt::ONE;
+    let final_nonce = account.nonce() + nonce_delta;
+    let account_delta = AccountDelta::new(
         account.id(),
-        account.id(),
-        vec![],
-        NoteType::Private,
-        NoteAttachments::default(),
-        &mut rng,
+        AccountStoragePatch::default(),
+        AccountVaultDelta::default(),
+        nonce_delta,
     )?;
-    let spawn_note = builder.add_spawn_note([&p2id_note])?;
-    let chain = builder.build()?;
-
-    let tx = chain
-        .build_tx_context(account.id(), &[spawn_note.id()], &[])?
-        .build()?
-        .execute()
-        .await?;
-
-    let summary = TransactionSummary::new(
-        tx.account_delta().clone(),
-        tx.input_notes().clone(),
-        tx.output_notes().clone(),
-        Word::from([
-            0,
-            0,
-            tx.block_header().block_num().as_u32(),
-            tx.final_account().nonce().as_canonical_u64() as u32,
-        ]),
+    let expected_summary = TransactionSummary::new(
+        account_delta,
+        InputNotes::new(vec![InputNote::unauthenticated(spawn_note)])?,
+        RawOutputNotes::new(vec![RawOutputNote::Partial(PartialNote::from(p2id_note))])?,
+        Word::from([0, 0, ref_block_num.as_u32(), final_nonce.as_canonical_u64() as u32]),
     );
-    let summary_commitment = summary.to_commitment();
+
+    let summary_commitment = expected_summary.to_commitment();
 
     let account_interface = AccountInterface::from_account(&account);
     assert!(matches!(

--- a/crates/miden-testing/tests/agglayer/remove_ger.rs
+++ b/crates/miden-testing/tests/agglayer/remove_ger.rs
@@ -98,8 +98,8 @@ async fn remove_ger_note_clears_storage_and_updates_chain() -> anyhow::Result<()
 
     // VERIFY GER IS NO LONGER REGISTERED AND CHAIN HASH ADVANCED
     let mut updated_bridge_account = bridge_account.clone();
-    updated_bridge_account.apply_delta(update_executed.account_delta())?;
-    updated_bridge_account.apply_delta(remove_executed.account_delta())?;
+    updated_bridge_account.apply_patch(update_executed.account_patch())?;
+    updated_bridge_account.apply_patch(remove_executed.account_patch())?;
 
     let is_registered = AggLayerBridge::is_ger_registered(ger, &updated_bridge_account)?;
     assert!(!is_registered, "GER should have been removed from the bridge account");
@@ -155,7 +155,7 @@ async fn remove_ger_middle_of_multi_insert_leaves_others_intact() -> anyhow::Res
         let tx_context =
             mock_chain.build_tx_context(bridge_account.id(), &[note.id()], &[])?.build()?;
         let executed = tx_context.execute().await?;
-        updated_bridge_account.apply_delta(executed.account_delta())?;
+        updated_bridge_account.apply_patch(executed.account_patch())?;
         mock_chain.add_pending_executed_transaction(&executed)?;
         mock_chain.prove_next_block()?;
     }
@@ -164,7 +164,7 @@ async fn remove_ger_middle_of_multi_insert_leaves_others_intact() -> anyhow::Res
         .build_tx_context(bridge_account.id(), &[remove_b.id()], &[])?
         .build()?;
     let remove_executed = remove_tx_context.execute().await?;
-    updated_bridge_account.apply_delta(remove_executed.account_delta())?;
+    updated_bridge_account.apply_patch(remove_executed.account_patch())?;
 
     assert!(
         AggLayerBridge::is_ger_registered(ger_a, &updated_bridge_account)?,
@@ -226,7 +226,7 @@ async fn remove_ger_sequential_removals_fold_chain() -> anyhow::Result<()> {
         let tx_context =
             mock_chain.build_tx_context(bridge_account.id(), &[note.id()], &[])?.build()?;
         let executed = tx_context.execute().await?;
-        updated_bridge_account.apply_delta(executed.account_delta())?;
+        updated_bridge_account.apply_patch(executed.account_patch())?;
         mock_chain.add_pending_executed_transaction(&executed)?;
         mock_chain.prove_next_block()?;
     }
@@ -322,7 +322,7 @@ async fn remove_ger_then_reinsert_succeeds() -> anyhow::Result<()> {
         let tx_context =
             mock_chain.build_tx_context(bridge_account.id(), &[note.id()], &[])?.build()?;
         let executed = tx_context.execute().await?;
-        updated_bridge_account.apply_delta(executed.account_delta())?;
+        updated_bridge_account.apply_patch(executed.account_patch())?;
         mock_chain.add_pending_executed_transaction(&executed)?;
         mock_chain.prove_next_block()?;
     }

--- a/crates/miden-testing/tests/auth/hybrid_multisig.rs
+++ b/crates/miden-testing/tests/auth/hybrid_multisig.rs
@@ -409,7 +409,10 @@ async fn test_multisig_update_signers() -> anyhow::Result<()> {
         .unwrap();
 
     // Verify the transaction executed successfully
-    assert_eq!(update_approvers_tx.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        update_approvers_tx.account_patch().final_nonce(),
+        Some(multisig_account.nonce() + Felt::ONE)
+    );
 
     mock_chain.add_pending_executed_transaction(&update_approvers_tx)?;
     mock_chain.prove_next_block()?;
@@ -549,7 +552,10 @@ async fn test_multisig_update_signers() -> anyhow::Result<()> {
         .await?;
 
     // Verify the transaction executed successfully with new signers
-    assert_eq!(tx_context_execute_new.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        tx_context_execute_new.account_patch().final_nonce(),
+        Some(updated_multisig_account.nonce() + Felt::ONE)
+    );
 
     Ok(())
 }
@@ -671,7 +677,10 @@ async fn test_multisig_update_signers_remove_owner() -> anyhow::Result<()> {
         .unwrap();
 
     // Verify transaction success
-    assert_eq!(update_approvers_tx.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        update_approvers_tx.account_patch().final_nonce(),
+        Some(multisig_account.nonce() + Felt::ONE)
+    );
 
     mock_chain.add_pending_executed_transaction(&update_approvers_tx)?;
     mock_chain.prove_next_block()?;

--- a/crates/miden-testing/tests/auth/multisig.rs
+++ b/crates/miden-testing/tests/auth/multisig.rs
@@ -532,7 +532,10 @@ async fn test_multisig_update_signers(#[case] auth_scheme: AuthScheme) -> anyhow
         .await?;
 
     // Verify the transaction executed successfully
-    assert_eq!(update_approvers_tx.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        update_approvers_tx.account_patch().final_nonce(),
+        Some(multisig_account.nonce() + Felt::ONE)
+    );
 
     mock_chain.add_pending_executed_transaction(&update_approvers_tx)?;
     mock_chain.prove_next_block()?;
@@ -672,7 +675,10 @@ async fn test_multisig_update_signers(#[case] auth_scheme: AuthScheme) -> anyhow
         .await?;
 
     // Verify the transaction executed successfully with new signers
-    assert_eq!(tx_context_execute_new.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        tx_context_execute_new.account_patch().final_nonce(),
+        Some(updated_multisig_account.nonce() + Felt::ONE)
+    );
 
     Ok(())
 }
@@ -781,7 +787,10 @@ async fn test_multisig_update_signers_remove_owner(
         .await?;
 
     // Verify transaction success
-    assert_eq!(update_approvers_tx.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        update_approvers_tx.account_patch().final_nonce(),
+        Some(multisig_account.nonce() + Felt::ONE)
+    );
 
     mock_chain.add_pending_executed_transaction(&update_approvers_tx)?;
     mock_chain.prove_next_block()?;

--- a/crates/miden-testing/tests/auth/singlesig_acl.rs
+++ b/crates/miden-testing/tests/auth/singlesig_acl.rs
@@ -2,6 +2,7 @@ use core::slice;
 
 use assert_matches::assert_matches;
 use miden_processor::ExecutionError;
+use miden_protocol::Word;
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
 use miden_protocol::account::{
     Account,
@@ -14,7 +15,6 @@ use miden_protocol::errors::MasmError;
 use miden_protocol::note::Note;
 use miden_protocol::testing::storage::MOCK_VALUE_SLOT0;
 use miden_protocol::transaction::RawOutputNote;
-use miden_protocol::{Felt, Word};
 use miden_standards::account::auth::AuthSingleSigAcl;
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::testing::account_component::MockAccountComponent;
@@ -201,9 +201,9 @@ async fn test_acl(#[case] auth_scheme: AuthScheme) -> anyhow::Result<()> {
         .await
         .expect("no trigger, no auth should succeed");
     assert_eq!(
-        executed.account_delta().nonce_delta(),
-        Felt::ZERO,
-        "no auth but should still trigger nonce increment"
+        executed.account_patch().final_nonce(),
+        None,
+        "no auth should not trigger nonce increment"
     );
 
     Ok(())
@@ -246,9 +246,9 @@ async fn test_acl_with_allow_unauthorized_output_notes(
         .await
         .expect("no trigger, no auth should succeed");
     assert_eq!(
-        executed.account_delta().nonce_delta(),
-        Felt::ZERO,
-        "no auth but should still trigger nonce increment"
+        executed.account_patch().final_nonce(),
+        None,
+        "no auth should not trigger nonce increment"
     );
 
     Ok(())

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -555,11 +555,15 @@ async fn prove_burning_fungible_asset_on_existing_faucet_succeeds() -> anyhow::R
         .execute()
         .await?;
 
+    assert_eq!(
+        executed_transaction.account_patch().final_nonce(),
+        Some(faucet.nonce() + Felt::ONE)
+    );
+    assert_eq!(executed_transaction.input_notes().get_note(0).id(), note.id());
+
     // Prove, serialize/deserialize and verify the transaction
     prove_and_verify_transaction(executed_transaction.clone()).await?;
 
-    assert_eq!(executed_transaction.account_delta().nonce_delta(), Felt::ONE);
-    assert_eq!(executed_transaction.input_notes().get_note(0).id(), note.id());
     Ok(())
 }
 

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -786,7 +786,10 @@ async fn test_public_note_creation_with_script_from_datastore() -> anyhow::Resul
     assert_eq!(full_note.id(), expected_note.id());
 
     // Verify nonce was incremented
-    assert_eq!(executed_transaction.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        executed_transaction.account_patch().final_nonce(),
+        Some(faucet.nonce() + Felt::ONE)
+    );
 
     Ok(())
 }
@@ -1558,7 +1561,10 @@ async fn network_faucet_burn() -> anyhow::Result<()> {
     assert_eq!(executed_transaction.output_notes().num_notes(), 0);
 
     // Verify the transaction was executed successfully
-    assert_eq!(executed_transaction.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        executed_transaction.account_patch().final_nonce(),
+        Some(faucet.nonce() + Felt::ONE)
+    );
     assert_eq!(executed_transaction.input_notes().get_note(0).id(), note.id());
 
     // Apply the delta to the faucet account and verify the token issuance decreased
@@ -1682,7 +1688,11 @@ async fn test_network_faucet_owner_can_burn_when_owner_only_policy_active() -> a
     let executed_transaction = tx_context.execute().await?;
 
     assert_eq!(executed_transaction.output_notes().num_notes(), 0);
-    assert_eq!(executed_transaction.account_delta().nonce_delta(), Felt::ONE);
+    assert_eq!(
+        executed_transaction.account_patch().final_nonce(),
+        Some(faucet.nonce() + Felt::from(2u8),),
+        "nonce should be incremented by 1 in each of the 2 txs"
+    );
 
     Ok(())
 }

--- a/crates/miden-testing/tests/scripts/pswap.rs
+++ b/crates/miden-testing/tests/scripts/pswap.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 use std::slice;
 
 use miden_protocol::account::auth::AuthScheme;
-use miden_protocol::account::{Account, AccountId, AccountType, AccountVaultDelta};
-use miden_protocol::asset::{Asset, AssetAmount, FungibleAsset};
+use miden_protocol::account::{Account, AccountId, AccountType, AccountVaultPatch};
+use miden_protocol::asset::{Asset, AssetAmount, AssetVaultKey, FungibleAsset};
 use miden_protocol::crypto::rand::{FeltRng, RandomCoin};
 use miden_protocol::errors::MasmError;
 use miden_protocol::note::{Note, NoteAttachments, NoteType};
@@ -68,41 +68,26 @@ fn build_pswap_note(
 }
 
 #[track_caller]
-fn assert_fungible_asset_eq(asset: &Asset, expected: FungibleAsset) {
-    match asset {
-        Asset::Fungible(f) => {
-            assert_eq!(f.faucet_id(), expected.faucet_id(), "faucet id mismatch");
-            assert_eq!(
-                f.amount(),
-                expected.amount(),
-                "amount mismatch (expected {}, got {})",
-                expected.amount(),
-                f.amount()
-            );
-        },
-        _ => panic!("expected fungible asset, got non-fungible"),
-    }
-}
-
-#[track_caller]
-fn assert_vault_added_removed(
-    vault_delta: &AccountVaultDelta,
-    expected_added: FungibleAsset,
-    expected_removed: FungibleAsset,
+fn assert_vault_patch(
+    vault_patch: &AccountVaultPatch,
+    expected_assets: impl IntoIterator<Item = FungibleAsset>,
 ) {
-    let added: Vec<Asset> = vault_delta.added_assets().collect();
-    let removed: Vec<Asset> = vault_delta.removed_assets().collect();
-    assert_eq!(added.len(), 1, "expected exactly 1 added asset");
-    assert_eq!(removed.len(), 1, "expected exactly 1 removed asset");
-    assert_fungible_asset_eq(&added[0], expected_added);
-    assert_fungible_asset_eq(&removed[0], expected_removed);
-}
+    let updated: Vec<Asset> = vault_patch.updated_assets().collect();
+    let removed: Vec<AssetVaultKey> = vault_patch.removed_asset_keys().copied().collect();
+    let expected_assets = expected_assets.into_iter().collect::<Vec<_>>();
+    assert_eq!(vault_patch.num_assets(), expected_assets.len());
 
-#[track_caller]
-fn assert_vault_single_added(vault_delta: &AccountVaultDelta, expected: FungibleAsset) {
-    let added: Vec<Asset> = vault_delta.added_assets().collect();
-    assert_eq!(added.len(), 1, "expected exactly 1 added asset");
-    assert_fungible_asset_eq(&added[0], expected);
+    for expected in expected_assets {
+        if expected.amount().as_u64() == 0 {
+            assert!(removed.contains(&expected.vault_key()));
+        } else {
+            let actual = updated
+                .iter()
+                .find(|asset| asset.vault_key() == expected.vault_key())
+                .expect("updated asset should be present");
+            assert_eq!(actual, &Asset::Fungible(expected));
+        }
+    }
 }
 
 // TESTS
@@ -289,8 +274,8 @@ async fn pswap_note_alice_reconstructs_and_consumes_p2id(
     let executed_transaction = tx_context.execute().await?;
 
     // Verify Alice received the filled amount.
-    let vault_delta = executed_transaction.account_delta().vault();
-    assert_vault_single_added(vault_delta, FungibleAsset::new(eth_faucet.id(), fill_amount)?);
+    let vault_patch = executed_transaction.account_patch().vault();
+    assert_vault_patch(vault_patch, [FungibleAsset::new(eth_faucet.id(), fill_amount)?]);
 
     Ok(())
 }
@@ -538,26 +523,29 @@ async fn pswap_fill_test(
     // P2ID note carries fill_amount ETH
     let p2id_assets = output_notes.get_note(0).assets();
     assert_eq!(p2id_assets.num_assets(), 1);
-    assert_fungible_asset_eq(
-        p2id_assets.iter().next().unwrap(),
+    assert_eq!(
+        p2id_assets.iter().next().unwrap().unwrap_fungible(),
         FungibleAsset::new(eth_faucet.id(), fill_amount)?,
     );
 
     // On partial fill, assert remainder note has offered - payout USDC
     if is_partial {
         let remainder_assets = output_notes.get_note(1).assets();
-        assert_fungible_asset_eq(
-            remainder_assets.iter().next().unwrap(),
+        assert_eq!(
+            remainder_assets.iter().next().unwrap().unwrap_fungible(),
             FungibleAsset::new(usdc_faucet.id(), offered_total - payout_amount)?,
         );
     }
 
-    // Consumer's vault delta: +payout USDC, -fill ETH
-    let vault_delta = executed_transaction.account_delta().vault();
-    assert_vault_added_removed(
-        vault_delta,
-        FungibleAsset::new(usdc_faucet.id(), payout_amount)?,
-        FungibleAsset::new(eth_faucet.id(), fill_amount)?,
+    // Consumer's vault: +payout USDC, -fill ETH (the consumer spent its entire ETH balance, results
+    // in 0).
+    let vault_patch = executed_transaction.account_patch().vault();
+    assert_vault_patch(
+        vault_patch,
+        [
+            FungibleAsset::new(usdc_faucet.id(), payout_amount)?,
+            FungibleAsset::new(eth_faucet.id(), 0)?,
+        ],
     );
 
     mock_chain.add_pending_executed_transaction(&executed_transaction)?;
@@ -632,9 +620,10 @@ async fn pswap_note_note_fill_cross_swap_test() -> anyhow::Result<()> {
     );
 
     // Charlie's vault should be unchanged
-    let vault_delta = executed_transaction.account_delta().vault();
-    assert_eq!(vault_delta.added_assets().count(), 0);
-    assert_eq!(vault_delta.removed_assets().count(), 0);
+    assert!(
+        executed_transaction.account_patch().vault().is_empty(),
+        "Charlie's vault should be unchanged"
+    );
 
     Ok(())
 }
@@ -739,10 +728,10 @@ async fn pswap_note_combined_account_fill_and_note_fill_test() -> anyhow::Result
         "Bob's P2ID ({bob_requested:?}) not found",
     );
 
-    // Charlie's vault: -20 ETH (account_fill) + 40 USDC (account_fill_payout).
+    // Charlie's vault: -20 ETH, results in 0 (account_fill) + 40 USDC (account_fill_payout).
     // The note_fill legs flow entirely through inflight and never touch his vault.
-    let vault_delta = executed_transaction.account_delta().vault();
-    assert_vault_added_removed(vault_delta, charlie_payout_usdc, charlie_vault_eth);
+    let vault_patch = executed_transaction.account_patch().vault();
+    assert_vault_patch(vault_patch, [charlie_payout_usdc, FungibleAsset::new(eth_faucet.id(), 0)?]);
 
     Ok(())
 }
@@ -754,15 +743,14 @@ async fn pswap_note_creator_reclaim_test() -> anyhow::Result<()> {
     let usdc_faucet = builder.add_existing_basic_faucet(BASIC_AUTH, "USDC", 1000, Some(50))?;
     let eth_faucet = builder.add_existing_basic_faucet(BASIC_AUTH, "ETH", 1000, Some(25))?;
 
-    let alice = builder.add_existing_wallet_with_assets(
-        BASIC_AUTH,
-        [FungibleAsset::new(usdc_faucet.id(), 50)?.into()],
-    )?;
+    let initial_asset = FungibleAsset::new(usdc_faucet.id(), 40)?;
+    let offered_asset = FungibleAsset::new(usdc_faucet.id(), 50)?;
+    let alice = builder.add_existing_wallet_with_assets(BASIC_AUTH, [initial_asset.into()])?;
 
     let (_, pswap_note) = build_pswap_note(
         &mut builder,
         alice.id(),
-        FungibleAsset::new(usdc_faucet.id(), 50)?,
+        offered_asset,
         FungibleAsset::new(eth_faucet.id(), 25)?,
         NoteType::Public,
     )?;
@@ -777,8 +765,10 @@ async fn pswap_note_creator_reclaim_test() -> anyhow::Result<()> {
     let output_notes = executed_transaction.output_notes();
     assert_eq!(output_notes.num_notes(), 0, "Expected 0 output notes for reclaim");
 
-    let vault_delta = executed_transaction.account_delta().vault();
-    assert_vault_single_added(vault_delta, FungibleAsset::new(usdc_faucet.id(), 50)?);
+    // The patch holds the absolute post-tx balance: Alice's initial balance plus the offered asset
+    // from the reclaimed note.
+    let vault_patch = executed_transaction.account_patch().vault();
+    assert_vault_patch(vault_patch, [initial_asset.add(offered_asset)?]);
 
     Ok(())
 }
@@ -924,17 +914,19 @@ async fn pswap_note_idx_nonzero_regression_test() -> anyhow::Result<()> {
     // P2ID at idx 1 must carry the full 25 ETH.
     let p2id_out = output_notes.get_note(1);
     assert_eq!(p2id_out.assets().num_assets(), 1, "P2ID must have 1 asset");
-    assert_fungible_asset_eq(
-        p2id_out.assets().iter().next().unwrap(),
+    assert_eq!(
+        p2id_out.assets().iter().next().unwrap().unwrap_fungible(),
         FungibleAsset::new(eth_faucet.id(), 25)?,
     );
 
-    // Bob's vault: +50 USDC payout, -25 ETH fill.
-    let vault_delta = executed.account_delta().vault();
-    assert_vault_added_removed(
-        vault_delta,
-        FungibleAsset::new(usdc_faucet.id(), 50)?,
-        FungibleAsset::new(eth_faucet.id(), 25)?,
+    // Bob's vault: +50 USDC payout, -25 ETH fill (Bob spent his entire ETH balance, results in 0).
+    let vault_patch = executed.account_patch().vault();
+    assert_vault_patch(
+        vault_patch,
+        [
+            FungibleAsset::new(usdc_faucet.id(), 50)?,
+            FungibleAsset::new(eth_faucet.id(), 0)?,
+        ],
     );
 
     Ok(())
@@ -1000,9 +992,16 @@ async fn pswap_multiple_partial_fills_test(#[case] fill_amount: u64) -> anyhow::
     let expected_count = if fill_amount < 25 { 2 } else { 1 };
     assert_eq!(output_notes.num_notes(), expected_count);
 
-    // Verify Bob's vault
-    let vault_delta = executed_transaction.account_delta().vault();
-    assert_vault_single_added(vault_delta, FungibleAsset::new(usdc_faucet.id(), payout_amount)?);
+    // Verify Bob's vault: +payout USDC, and -fill ETH (Bob spent his entire ETH balance,
+    // results in 0).
+    let vault_patch = executed_transaction.account_patch().vault();
+    assert_vault_patch(
+        vault_patch,
+        [
+            FungibleAsset::new(usdc_faucet.id(), payout_amount)?,
+            FungibleAsset::new(eth_faucet.id(), 0)?,
+        ],
+    );
 
     Ok(())
 }
@@ -1075,11 +1074,14 @@ async fn run_partial_fill_ratio_case(
     let expected_count = if remaining_requested > 0 { 2 } else { 1 };
     assert_eq!(output_notes.num_notes(), expected_count);
 
-    let vault_delta = executed_tx.account_delta().vault();
-    assert_vault_added_removed(
-        vault_delta,
-        FungibleAsset::new(usdc_faucet.id(), payout_amount)?,
-        FungibleAsset::new(eth_faucet.id(), fill_eth)?,
+    let vault_patch = executed_tx.account_patch().vault();
+    // New ETH balance should be zero.
+    assert_vault_patch(
+        vault_patch,
+        [
+            FungibleAsset::new(usdc_faucet.id(), payout_amount)?,
+            FungibleAsset::new(eth_faucet.id(), 0)?,
+        ],
     );
 
     assert_eq!(payout_amount + remaining_offered, offered_usdc, "conservation");
@@ -1267,10 +1269,15 @@ async fn pswap_chained_partial_fills_test(
         let expected_count = if remaining_requested > 0 { 2 } else { 1 };
         assert_eq!(output_notes.num_notes(), expected_count, "fill {}", fill_index + 1);
 
-        let vault_delta = executed_tx.account_delta().vault();
-        assert_vault_single_added(
-            vault_delta,
-            FungibleAsset::new(usdc_faucet.id(), payout_amount)?,
+        // Bob's vault: +payout USDC, and -fill ETH (Bob spent his entire ETH balance,
+        // results in 0).
+        let vault_patch = executed_tx.account_patch().vault();
+        assert_vault_patch(
+            vault_patch,
+            [
+                FungibleAsset::new(usdc_faucet.id(), payout_amount)?,
+                FungibleAsset::new(eth_faucet.id(), 0)?,
+            ],
         );
 
         // Update state for next fill
@@ -1352,8 +1359,8 @@ fn compare_pswap_create_output_notes_vs_test_helper() {
     assert_eq!(p2id_note.metadata().sender(), bob.id(), "P2ID sender should be consumer");
     assert_eq!(p2id_note.metadata().note_type(), NoteType::Public, "P2ID note type mismatch");
     assert_eq!(p2id_note.assets().num_assets(), 1, "P2ID should have 1 asset");
-    assert_fungible_asset_eq(
-        p2id_note.assets().iter().next().unwrap(),
+    assert_eq!(
+        p2id_note.assets().iter().next().unwrap().unwrap_fungible(),
         FungibleAsset::new(eth_faucet.id(), 25).unwrap(),
     );
 
@@ -1364,8 +1371,8 @@ fn compare_pswap_create_output_notes_vs_test_helper() {
     let remainder_pswap = remainder_partial.expect("Partial fill should produce remainder");
 
     assert_eq!(p2id_partial.assets().num_assets(), 1);
-    assert_fungible_asset_eq(
-        p2id_partial.assets().iter().next().unwrap(),
+    assert_eq!(
+        p2id_partial.assets().iter().next().unwrap().unwrap_fungible(),
         FungibleAsset::new(eth_faucet.id(), 10).unwrap(),
     );
 
@@ -1515,6 +1522,9 @@ async fn pswap_creator_reconstructs_lineage_from_attachments() -> anyhow::Result
     let mut current_pswap_note = original_pswap_note;
     let mut current_offered = initial_offered;
     let mut current_requested = initial_requested;
+    // Alice starts with an empty wallet and accumulates `fill_amount` ETH each round, so the
+    // patch's absolute balance is the running total of all fills consumed so far.
+    let mut alice_eth_balance = 0;
 
     for (idx, fill_amount) in fills.iter().copied().enumerate() {
         let depth = (idx + 1) as u32;
@@ -1606,9 +1616,10 @@ async fn pswap_creator_reconstructs_lineage_from_attachments() -> anyhow::Result
             .build()?
             .execute()
             .await?;
-        assert_vault_single_added(
-            alice_tx.account_delta().vault(),
-            FungibleAsset::new(eth_faucet.id(), fill_amount)?,
+        alice_eth_balance += fill_amount;
+        assert_vault_patch(
+            alice_tx.account_patch().vault(),
+            [FungibleAsset::new(eth_faucet.id(), alice_eth_balance)?],
         );
         mock_chain.add_pending_executed_transaction(&alice_tx)?;
         mock_chain.prove_next_block()?;

--- a/crates/miden-testing/tests/scripts/send_note.rs
+++ b/crates/miden-testing/tests/scripts/send_note.rs
@@ -1,6 +1,5 @@
 use core::num::NonZeroU16;
 use core::slice;
-use std::collections::BTreeMap;
 
 use miden_protocol::Word;
 use miden_protocol::account::auth::AuthScheme;
@@ -110,24 +109,34 @@ async fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
         .execute()
         .await?;
 
-    // assert that the removed asset is in the delta
-    let mut removed_assets: BTreeMap<_, _> = executed_transaction
-        .account_delta()
-        .vault()
-        .removed_assets()
-        .map(|asset| (asset.vault_key(), asset))
-        .collect();
-    assert_eq!(removed_assets.len(), 2, "two assets should have been removed");
+    // Assert that the non-fungible asset was removed
+    let vault_patch = executed_transaction.account_patch().vault();
     assert_eq!(
-        removed_assets.remove(&sent_asset0.vault_key()).unwrap(),
-        sent_asset0,
-        "sent asset0 should be in removed assets"
+        vault_patch.removed_asset_keys().count(),
+        1,
+        "the non-fungible asset should have been completely removed"
     );
     assert_eq!(
-        removed_assets.remove(&sent_asset1.vault_key()).unwrap(),
-        sent_asset1.unwrap_fungible().add(sent_asset2.unwrap_fungible())?.into(),
-        "sent asset1 + sent_asset2 should be in removed assets"
+        vault_patch.removed_asset_keys().next().unwrap(),
+        &sent_asset0.vault_key(),
+        "the non-fungible asset should have been completely removed"
     );
+
+    // Assert that the fungible asset's value was decremented
+    assert_eq!(
+        vault_patch.updated_assets().count(),
+        1,
+        "the fungible asset should have been updated"
+    );
+    // Expected value is total - (sent_asset1 + sent_asset2).
+    let expected_removed = sent_asset1.unwrap_fungible().add(sent_asset2.unwrap_fungible())?;
+    let expected_asset_value = total_asset.unwrap_fungible().sub(expected_removed)?.into();
+    assert_eq!(
+        vault_patch.updated_assets().next().unwrap(),
+        expected_asset_value,
+        "fungible asset should have been decremented"
+    );
+
     assert_eq!(
         executed_transaction.output_notes().get_note(0),
         &RawOutputNote::Partial(p2any_note.into())

--- a/crates/miden-tx/src/errors/mod.rs
+++ b/crates/miden-tx/src/errors/mod.rs
@@ -113,8 +113,6 @@ pub enum TransactionExecutorError {
         input_id: AccountId,
         output_id: AccountId,
     },
-    #[error("expected account nonce delta to be {expected}, found {actual}")]
-    InconsistentAccountNonceDelta { expected: Felt, actual: Felt },
     #[error("account witness provided for account ID {0} is invalid")]
     InvalidAccountWitness(AccountId, #[source] SmtProofError),
     #[error(

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -10,7 +10,6 @@ use miden_processor::{BaseHost, FutureMaybeSend, Host, ProcessorState};
 use miden_protocol::account::auth::PublicKeyCommitment;
 use miden_protocol::account::{
     AccountCode,
-    AccountDelta,
     AccountId,
     AccountPatch,
     PartialAccount,
@@ -389,7 +388,6 @@ where
     pub fn into_parts(
         self,
     ) -> (
-        AccountDelta,
         AccountPatch,
         InputNotes<InputNote>,
         Vec<RawOutputNote>,
@@ -398,10 +396,9 @@ where
         TransactionProgress,
         BTreeMap<StorageSlotId, StorageSlotName>,
     ) {
-        let (account_delta, account_patch, input_notes, output_notes) = self.base_host.into_parts();
+        let (account_patch, input_notes, output_notes) = self.base_host.into_parts();
 
         (
-            account_delta,
             account_patch,
             input_notes,
             output_notes,

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -383,7 +383,6 @@ fn build_executed_transaction<STORE: DataStore + Sync, AUTH: TransactionAuthenti
     host: TransactionExecutorHost<STORE, AUTH>,
 ) -> Result<ExecutedTransaction, TransactionExecutorError> {
     let (
-        account_delta,
         account_patch,
         _input_notes,
         output_notes,
@@ -415,15 +414,6 @@ fn build_executed_transaction<STORE: DataStore + Sync, AUTH: TransactionAuthenti
         });
     }
 
-    // Make sure nonce delta was computed correctly.
-    let nonce_delta = final_account.nonce() - initial_account.nonce();
-    if nonce_delta != account_delta.nonce_delta() {
-        return Err(TransactionExecutorError::InconsistentAccountNonceDelta {
-            expected: nonce_delta,
-            actual: account_delta.nonce_delta(),
-        });
-    }
-
     // Introduce generated signatures into the witness inputs.
     advice_inputs.map.extend(generated_signatures);
 
@@ -437,7 +427,6 @@ fn build_executed_transaction<STORE: DataStore + Sync, AUTH: TransactionAuthenti
     Ok(ExecutedTransaction::new(
         tx_inputs,
         tx_outputs,
-        account_delta,
         account_patch,
         tx_progress.into(),
     ))

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -198,17 +198,10 @@ impl<'store, STORE> TransactionBaseHost<'store, STORE> {
     }
 
     /// Consumes `self` and returns the account delta, input and output notes.
-    pub fn into_parts(
-        self,
-    ) -> (AccountDelta, AccountPatch, InputNotes<InputNote>, Vec<RawOutputNote>) {
+    pub fn into_parts(self) -> (AccountPatch, InputNotes<InputNote>, Vec<RawOutputNote>) {
         let output_notes = self.output_notes.into_values().map(|builder| builder.build()).collect();
 
-        (
-            self.update_tracker.clone().into_delta(),
-            self.update_tracker.into_patch(),
-            self.input_notes,
-            output_notes,
-        )
+        (self.update_tracker.into_patch(), self.input_notes, output_notes)
     }
 
     // MUTATORS

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -145,7 +145,7 @@ impl LocalTransactionProver {
         .map_err(TransactionProverError::TransactionProgramExecutionFailed)?;
 
         // Extract transaction outputs and process transaction data.
-        let (_account_delta, account_patch, input_notes, output_notes) = host.into_parts();
+        let (account_patch, input_notes, output_notes) = host.into_parts();
         let tx_outputs =
             TransactionKernel::from_transaction_parts(&stack_outputs, &advice_inputs, output_notes)
                 .map_err(TransactionProverError::TransactionOutputConstructionFailed)?;

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -168,8 +168,7 @@ impl LocalTransactionProver {
         &self,
         executed_transaction: miden_protocol::transaction::ExecutedTransaction,
     ) -> Result<ProvenTransaction, TransactionProverError> {
-        let (tx_inputs, tx_outputs, _account_delta, account_patch, _) =
-            executed_transaction.into_parts();
+        let (tx_inputs, tx_outputs, account_patch, _) = executed_transaction.into_parts();
 
         let (partial_account, ref_block, _, input_notes, _) = tx_inputs.into_parts();
 

--- a/crates/miden-tx/src/prover/prover_host.rs
+++ b/crates/miden-tx/src/prover/prover_host.rs
@@ -6,7 +6,7 @@ use miden_processor::event::EventError;
 use miden_processor::mast::MastForest;
 use miden_processor::{BaseHost, FutureMaybeSend, Host, MastForestStore, ProcessorState};
 use miden_protocol::Word;
-use miden_protocol::account::{AccountDelta, AccountPatch, PartialAccount};
+use miden_protocol::account::{AccountPatch, PartialAccount};
 use miden_protocol::assembly::debuginfo::Location;
 use miden_protocol::assembly::{SourceFile, SourceSpan};
 use miden_protocol::transaction::{InputNote, InputNotes, RawOutputNote};
@@ -55,9 +55,7 @@ where
     // --------------------------------------------------------------------------------------------
 
     /// Consumes `self` and returns the account delta, input and output notes.
-    pub fn into_parts(
-        self,
-    ) -> (AccountDelta, AccountPatch, InputNotes<InputNote>, Vec<RawOutputNote>) {
+    pub fn into_parts(self) -> (AccountPatch, InputNotes<InputNote>, Vec<RawOutputNote>) {
         self.base_host.into_parts()
     }
 }


### PR DESCRIPTION
Removes `AccountDelta` from `ExecutedTransaction` which is replaced by `AccountPatch`.

The main changes in this PR are test-related and deal with updating tests to use the patch instead of delta. This required changing the semantics of the assertions from relative to absolute.

follow-up to https://github.com/0xMiden/protocol/pull/3089