### PR TITLE
fix(multisig): signer cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
+- Fixed `update_signers_and_threshold` producing a STARK-invalid proof when adding a signer to a single-signer multisig: the pubkey/scheme-id mapping cleanup now runs only when the signer set shrinks (`init_num_of_approvers > new_num_of_approvers`), in both the standard and smart multisig auth components.
 - [BREAKING] Removed the automatic fee computation and removal from the transaction kernel ([#3108](https://github.com/0xMiden/protocol/issues/3108)).
 - Simplified the Ownable2Step owner-check API: merged the owner assertion into a single `exec` `assert_sender_is_owner` and renamed `is_sender_owner_internal` to `is_sender_owner` ([#3088](https://github.com/0xMiden/protocol/pull/3088)).
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).

--- a/crates/miden-standards/asm/standards/auth/multisig.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig.masm
@@ -331,8 +331,21 @@ pub proc update_signers_and_threshold(multisig_config_hash: word)
     loc_load.NEW_NUM_OF_APPROVERS_LOC loc_load.INIT_NUM_OF_APPROVERS_LOC
     # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
 
-    exec.cleanup_pubkey_and_scheme_id_mapping
-    # => [pad(12)]
+    dup.1 dup.1
+    u32assert2 u32lt
+    # => [should_cleanup, init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    # Only clean up the pubkey/scheme-id mapping when the signer set actually
+    # shrinks (init_num_of_approvers > new_num_of_approvers). Entering the
+    # cleanup proc otherwise perturbs the prover trace enough to fail node-side
+    # STARK verification when the map has exactly one entry.
+    if.true
+        exec.cleanup_pubkey_and_scheme_id_mapping
+        # => [pad(12)]
+    else
+        drop drop
+        # => [pad(12)]
+    end
 end
 
 # Computes the effective transaction threshold based on called procedures and per-procedure

--- a/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
@@ -733,8 +733,21 @@ pub proc update_signers_and_threshold(multisig_config_commitment: word)
     loc_load.0 loc_load.1
     # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
 
-    exec.multisig::cleanup_pubkey_and_scheme_id_mapping
-    # => [pad(12)]
+    dup.1 dup.1
+    u32assert2 u32lt
+    # => [should_cleanup, init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    # Only clean up the pubkey/scheme-id mapping when the signer set actually
+    # shrinks (init_num_of_approvers > new_num_of_approvers). Entering the
+    # cleanup proc otherwise perturbs the prover trace enough to fail node-side
+    # STARK verification when the map has exactly one entry.
+    if.true
+        exec.multisig::cleanup_pubkey_and_scheme_id_mapping
+        # => [pad(12)]
+    else
+        drop drop
+        # => [pad(12)]
+    end
 end
 
 #! Authenticate a transaction using multisig smart-policy rules.

--- a/crates/miden-testing/tests/auth/multisig.rs
+++ b/crates/miden-testing/tests/auth/multisig.rs
@@ -36,6 +36,8 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use rstest::rstest;
 
+use crate::prove_and_verify_transaction;
+
 // ================================================================================================
 // HELPER FUNCTIONS
 // ================================================================================================
@@ -673,6 +675,136 @@ async fn test_multisig_update_signers(#[case] auth_scheme: AuthScheme) -> anyhow
 
     // Verify the transaction executed successfully with new signers
     assert_eq!(tx_context_execute_new.account_delta().nonce_delta(), Felt::ONE);
+
+    Ok(())
+}
+
+/// Regression test: adding a signer to a single-signer multisig must produce a STARK-valid proof.
+///
+/// When the approver map holds exactly one entry (a 1-of-1 multisig), unconditionally entering
+/// `cleanup_pubkey_and_scheme_id_mapping` after `update_signers_and_threshold` perturbs the prover
+/// trace enough to fail node-side STARK verification, even though the proc's internal loop guard
+/// short-circuits and never clears anything. The fix gates the cleanup on the signer set actually
+/// shrinking (`init_num_of_approvers > new_num_of_approvers`), so growing from 1 to 2 signers skips
+/// it. Proving the next block here exercises proof generation and guards against that regression.
+///
+/// **Roles:**
+/// - 1 Original Approver (multisig signer, threshold 1)
+/// - 2 Updated Approvers (after adding a signer, threshold 2)
+/// - 1 Multisig Contract
+/// - 1 Transaction Script calling `update_signers_and_threshold`
+#[rstest]
+#[case::ecdsa(AuthScheme::EcdsaK256Keccak)]
+#[case::falcon(AuthScheme::Falcon512Poseidon2)]
+#[tokio::test]
+async fn test_multisig_add_signer_from_single_signer(
+    #[case] auth_scheme: AuthScheme,
+) -> anyhow::Result<()> {
+    // Start with a single approver, threshold 1.
+    let (_secret_keys, auth_schemes, public_keys, authenticators) =
+        setup_keys_and_authenticators_with_scheme(1, 1, auth_scheme)?;
+
+    let approvers = public_keys
+        .iter()
+        .zip(auth_schemes.iter())
+        .map(|(pk, scheme)| (pk.clone(), *scheme))
+        .collect::<Vec<_>>();
+
+    let multisig_account = create_multisig_account(1, &approvers, 10, vec![])?;
+
+    let mock_chain = MockChainBuilder::with_accounts([multisig_account.clone()])
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let salt = Word::from([Felt::new_unchecked(7); 4]);
+
+    // Grow the signer set to 2 approvers, threshold 2.
+    let mut advice_map = AdviceMap::default();
+    let (_new_secret_keys, _new_auth_schemes, new_public_keys, _new_authenticators) =
+        setup_keys_and_authenticators_with_scheme(2, 2, auth_scheme)?;
+
+    let threshold = 2u64;
+    let num_of_approvers = 2u64;
+
+    let config_and_pubkeys_vector = build_update_signers_config_vector(
+        threshold,
+        num_of_approvers,
+        &new_public_keys,
+        auth_scheme,
+    );
+    let multisig_config_hash = Hasher::hash_elements(&config_and_pubkeys_vector);
+    advice_map.insert(multisig_config_hash, config_and_pubkeys_vector);
+
+    let tx_script_code = "
+        begin
+            call.::miden::standards::components::auth::multisig::update_signers_and_threshold
+        end
+    ";
+
+    let tx_script = CodeBuilder::default()
+        .with_dynamically_linked_library(AuthMultisig::code())?
+        .compile_tx_script(tx_script_code)?;
+
+    let advice_inputs = AdviceInputs { map: advice_map, ..Default::default() };
+
+    let tx_context_builder = mock_chain
+        .build_tx_context(multisig_account.id(), &[], &[])?
+        .tx_script(tx_script)
+        .tx_script_args(multisig_config_hash)
+        .extend_advice_inputs(advice_inputs)
+        .auth_args(salt);
+
+    // Execute without signatures first to get the tx summary.
+    let tx_summary = tx_context_builder
+        .clone()
+        .build()?
+        .execute()
+        .await
+        .unwrap_err()
+        .unwrap_unauthorized_err();
+
+    // Sign with the single original approver (threshold 1).
+    let msg = tx_summary.as_ref().to_commitment();
+    let tx_summary = SigningInputs::TransactionSummary(tx_summary);
+
+    let sig = authenticators[0]
+        .get_signature(public_keys[0].to_commitment(), &tx_summary)
+        .await?;
+
+    let update_approvers_tx = tx_context_builder
+        .add_signature(public_keys[0].to_commitment(), msg, sig)
+        .build()?
+        .execute()
+        .await?;
+
+    assert_eq!(update_approvers_tx.account_delta().nonce_delta(), Felt::ONE);
+
+    // Generate and verify a real STARK proof for the transaction. With the approver map holding a
+    // single entry, unconditionally entering the cleanup proc perturbs the prover trace enough to
+    // fail verification with a constraint mismatch; the conditional cleanup fix avoids that. A
+    // dummy block proof (`add_pending_executed_transaction` + `prove_next_block`) would not
+    // exercise this path, so we prove the transaction directly.
+    prove_and_verify_transaction(update_approvers_tx.clone()).await?;
+
+    // Confirm the signer set actually grew to the two new approvers.
+    let mut updated_multisig_account = multisig_account.clone();
+    updated_multisig_account.apply_patch(update_approvers_tx.account_patch())?;
+
+    let extracted_pub_keys = get_public_keys_from_account(&updated_multisig_account);
+    assert_eq!(
+        extracted_pub_keys.len(),
+        2,
+        "get_public_keys_from_account should return 2 public keys after adding a signer"
+    );
+
+    for expected_key in new_public_keys.iter() {
+        let expected_word: Word = expected_key.to_commitment().into();
+        assert!(
+            extracted_pub_keys.iter().any(|key| *key == expected_word),
+            "new approver public key {expected_word:?} not found after update"
+        );
+    }
 
     Ok(())
 }

--- a/crates/miden-testing/tests/auth/multisig_smart.rs
+++ b/crates/miden-testing/tests/auth/multisig_smart.rs
@@ -26,6 +26,7 @@ use super::multisig::{
     build_update_signers_config_vector,
     setup_keys_and_authenticators_with_scheme,
 };
+use crate::prove_and_verify_transaction;
 
 // ================================================================================================
 // HELPER FUNCTIONS
@@ -378,6 +379,90 @@ async fn test_multisig_smart_update_signers_and_thresholds(
         let expected_word: Word = expected_key.to_commitment().into();
         assert_eq!(stored_pub_key, expected_word, "public key at index {i} mismatch");
     }
+
+    Ok(())
+}
+
+/// Regression test: adding a signer to a single-signer multisig smart account must produce a
+/// STARK-valid proof. When the approver map holds exactly one entry, unconditionally entering
+/// `cleanup_pubkey_and_scheme_id_mapping` after `update_signers_and_threshold` perturbs the prover
+/// trace enough to fail verification, even though the proc's loop guard short-circuits. The fix
+/// gates the cleanup on the signer set actually shrinking, so growing from 1 to 2 signers skips it.
+#[rstest]
+#[case::ecdsa(AuthScheme::EcdsaK256Keccak)]
+#[case::falcon(AuthScheme::Falcon512Poseidon2)]
+#[tokio::test]
+async fn test_multisig_smart_add_signer_from_single_signer(
+    #[case] auth_scheme: AuthScheme,
+) -> anyhow::Result<()> {
+    // Start with a single approver, threshold 1.
+    let (_secret_keys, _auth_schemes, public_keys, authenticators) =
+        setup_keys_and_authenticators_with_scheme(1, 1, auth_scheme)?;
+
+    let multisig_account = create_multisig_smart_account(1, &public_keys, auth_scheme, 10, vec![])?;
+    let account_id = multisig_account.id();
+    let mock_chain =
+        MockChainBuilder::with_accounts([multisig_account.clone()]).unwrap().build()?;
+
+    // Grow the signer set to 2 approvers, threshold 2.
+    let (_new_secret_keys, _new_auth_schemes, new_public_keys, _new_authenticators) =
+        setup_keys_and_authenticators_with_scheme(2, 2, auth_scheme)?;
+
+    let new_threshold: u64 = 2;
+    let new_num_approvers: u64 = 2;
+    let multisig_config_data = build_update_signers_config_vector(
+        new_threshold,
+        new_num_approvers,
+        &new_public_keys,
+        auth_scheme,
+    );
+    let multisig_config_hash = Hasher::hash_elements(&multisig_config_data);
+
+    let mut advice_map = AdviceMap::default();
+    advice_map.insert(multisig_config_hash, multisig_config_data);
+    let advice_inputs = AdviceInputs { map: advice_map, ..Default::default() };
+
+    let update_signers_script = compile_multisig_smart_tx_script(
+        "
+        begin
+            call.::miden::standards::components::auth::multisig_smart::update_signers_and_threshold
+        end
+        ",
+    )?;
+
+    let salt = Word::from([Felt::new_unchecked(7); 4]);
+
+    let tx_context_builder = mock_chain
+        .build_tx_context(account_id, &[], &[])?
+        .tx_script(update_signers_script)
+        .tx_script_args(multisig_config_hash)
+        .extend_advice_inputs(advice_inputs)
+        .auth_args(salt);
+
+    // Dry-run to obtain the tx summary that the single current approver must sign.
+    let tx_summary = tx_context_builder
+        .clone()
+        .build()?
+        .execute()
+        .await
+        .unwrap_err()
+        .unwrap_unauthorized_err();
+
+    let msg = tx_summary.as_ref().to_commitment();
+    let signing_inputs = SigningInputs::TransactionSummary(tx_summary);
+    let sig = authenticators[0]
+        .get_signature(public_keys[0].to_commitment(), &signing_inputs)
+        .await?;
+
+    let executed_tx = tx_context_builder
+        .add_signature(public_keys[0].to_commitment(), msg, sig)
+        .build()?
+        .execute()
+        .await?;
+
+    // Generate and verify a real STARK proof. Without the conditional cleanup fix this fails with
+    // a constraint mismatch because the approver map holds a single entry.
+    prove_and_verify_transaction(executed_tx).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Potential fix for https://github.com/0xMiden/protocol/issues/3113

> 
> update_signers_and_threshold produces a STARK-invalid proof when adding a
> signer to a single-signer multisig (a 1-of-1 account). The transaction
> executes fine, but proving/verifying it fails with:
> 
> constraint mismatch: quotient * vanishing != folded constraints
> 
> This affects both the standard (auth::multisig) and smart
> (auth::multisig_smart) multisig auth components.

