### PR TITLE
fix(standards): remove `call` from `assert_sender_has_role` add `exec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 - [BREAKING] Removed the automatic fee computation and removal from the transaction kernel ([#3108](https://github.com/0xMiden/protocol/issues/3108)).
 - Simplified the Ownable2Step owner-check API: merged the owner assertion into a single `exec` `assert_sender_is_owner` and renamed `is_sender_owner_internal` to `is_sender_owner` ([#3088](https://github.com/0xMiden/protocol/pull/3088)).
+- [BREAKING] Made the RBAC role guard `rbac::assert_sender_has_role` an `exec` procedure and removed it from the `RoleBasedAccessControl` component re-exports ([#3116](https://github.com/0xMiden/protocol/pull/3116)).
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 

--- a/crates/miden-standards/asm/account_components/access/rbac.masm
+++ b/crates/miden-standards/asm/account_components/access/rbac.masm
@@ -2,7 +2,6 @@
 #
 # See the `RoleBasedAccessControl` Rust type's documentation for more details.
 
-pub use ::miden::standards::access::rbac::assert_sender_has_role
 pub use ::miden::standards::access::rbac::has_role
 pub use ::miden::standards::access::rbac::get_role_admin
 pub use ::miden::standards::access::rbac::get_role_member_count

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -58,8 +58,8 @@ const ERR_MEMBER_COUNT_OVERFLOW = "role member count overflowed u32"
 
 #! Checks that the note sender holds the given role.
 #!
-#! Inputs:  [role_symbol, pad(15)]
-#! Outputs: [pad(16)]
+#! Inputs:  [role_symbol]
+#! Outputs: []
 #!
 #! Where:
 #! - role_symbol is the encoded role symbol.
@@ -68,16 +68,16 @@ const ERR_MEMBER_COUNT_OVERFLOW = "role member count overflowed u32"
 #! - role_symbol is zero.
 #! - the note sender does not hold the given role.
 #!
-#! Invocation: call
+#! Invocation: exec
 pub proc assert_sender_has_role
     dup exec.assert_role_symbol_non_zero
-    # => [role_symbol, pad(15)]
+    # => [role_symbol]
 
     exec.is_sender_in_role
-    # => [has_role, pad(15)]
+    # => [has_role]
 
     assert.err=ERR_SENDER_LACKS_ROLE
-    # => [pad(16)]
+    # => []
 end
 
 #! Returns whether an account holds a role.

--- a/crates/miden-testing/tests/scripts/rbac.rs
+++ b/crates/miden-testing/tests/scripts/rbac.rs
@@ -332,23 +332,6 @@ fn set_role_admin_raw_script(role: Felt, admin_role: Felt) -> String {
     )
 }
 
-fn assert_sender_has_role_script(role: &RoleSymbol) -> String {
-    format!(
-        r#"
-        use miden::standards::access::rbac
-
-        @note_script
-        pub proc main
-            repeat.15 push.0 end
-            push.{role}
-            call.rbac::assert_sender_has_role
-            dropw dropw dropw dropw
-        end
-        "#,
-        role = Felt::from(role),
-    )
-}
-
 // TESTS
 // ================================================================================================
 
@@ -674,34 +657,6 @@ async fn test_rbac_member_count_and_has_role_queries() -> anyhow::Result<()> {
 
     let outsider_note = build_note(owner, assert_has_role_script(&user_role, outsider, false))?;
     let _ = execute_note_and_apply(&mock_chain, &updated, &outsider_note).await?;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_rbac_assert_sender_has_role() -> anyhow::Result<()> {
-    let owner = test_account_id(120);
-    let minter = test_account_id(121);
-    let outsider = test_account_id(122);
-
-    let minter_role = role("MINTER");
-
-    let (account, mock_chain) = create_rbac_chain(owner)?;
-
-    let grant_note = build_note(owner, grant_role_script(&minter_role, minter))?;
-    let updated = execute_note_and_apply(&mock_chain, &account, &grant_note).await?;
-
-    // Member can pass the assertion.
-    let member_check = build_note(minter, assert_sender_has_role_script(&minter_role))?;
-    let _ = execute_note_and_apply(&mock_chain, &updated, &member_check).await?;
-
-    // Outsider cannot.
-    let outsider_check = build_note(outsider, assert_sender_has_role_script(&minter_role))?;
-    let tx = mock_chain
-        .build_tx_context(updated, &[], slice::from_ref(&outsider_check))?
-        .build()?;
-    let result = tx.execute().await;
-    assert!(result.is_err());
 
     Ok(())
 }


### PR DESCRIPTION
- `assert_sender_has_role` is now `exec`, with signature `[role_symbol] / []`.
- Removed `assert_sender_has_role` from the rbac component re-exports.
- Removed the call test, the behavior is already covered through `assert_authorized` in the `Pausable` tests.