### PR TITLE
fix(standards): add `FUNGIBLE_ASSET_MAX_AMOUNT` to `set_max_supply`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
+- Added a validation inside `set_max_supply` rejects a new cap above `FUNGIBLE_ASSET_MAX_AMOUNT`, keeping the stored cap consistent with the bound enforced at mint time ([#3118](https://github.com/0xMiden/protocol/pull/3118)).
 - [BREAKING] Removed the automatic fee computation and removal from the transaction kernel ([#3108](https://github.com/0xMiden/protocol/issues/3108)).
 - Simplified the Ownable2Step owner-check API: merged the owner assertion into a single `exec` `assert_sender_is_owner` and renamed `is_sender_owner_internal` to `is_sender_owner` ([#3088](https://github.com/0xMiden/protocol/pull/3088)).
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).

--- a/crates/miden-standards/asm/standards/faucets/fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/fungible.masm
@@ -174,6 +174,7 @@ end
 #! Panics if:
 #! - the max supply mutability flag is not 1.
 #! - the caller is not authorized per the installed [`Authority`].
+#! - the new max supply exceeds the maximum representable fungible asset amount.
 #! - the new max supply is less than the current token supply.
 #!
 #! Invocation: call
@@ -190,20 +191,26 @@ pub proc set_max_supply
     exec.pausable::assert_not_paused
     # => [new_max_supply, pad(15)]
 
-    # 3. Read current token config word
+    # 3. Validate that the new max supply does not exceed the maximum representable fungible
+    # asset amount, so the stored cap stays consistent with the bound enforced at mint time.
+    dup lte.FUNGIBLE_ASSET_MAX_AMOUNT
+    assert.err=ERR_FUNGIBLE_ASSET_MAX_SUPPLY_EXCEEDS_FUNGIBLE_ASSET_MAX_AMOUNT
+    # => [new_max_supply, pad(15)]
+
+    # 4. Read current token config word
     exec.get_token_config_internal
     # => [token_supply, max_supply, decimals, token_symbol, new_max_supply, pad(15)]
 
-    # 4. Validate: token_supply <= new_max_supply
+    # 5. Validate: token_supply <= new_max_supply
     dup dup.5
     lte assert.err=ERR_NEW_MAX_SUPPLY_BELOW_TOKEN_SUPPLY
     # => [token_supply, max_supply, decimals, token_symbol, new_max_supply, pad(15)]
 
-    # 5. Replace max_supply (word[1]) with new_max_supply
+    # 6. Replace max_supply (word[1]) with new_max_supply
     movup.4 swap movup.2 drop
     # => [token_supply, new_max_supply, decimals, token_symbol, pad(15)]
 
-    # 6. Write updated token config word back to storage
+    # 7. Write updated token config word back to storage
     push.TOKEN_CONFIG_SLOT[0..2]
     exec.native_account::set_item
     dropw

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -43,6 +43,7 @@ use miden_standards::errors::standards::{
     ERR_BURN_POLICY_ROOT_NOT_ALLOWED,
     ERR_FAUCET_BURN_AMOUNT_EXCEEDS_TOKEN_SUPPLY,
     ERR_FUNGIBLE_ASSET_DISTRIBUTE_AMOUNT_EXCEEDS_MAX_SUPPLY,
+    ERR_FUNGIBLE_ASSET_MAX_SUPPLY_EXCEEDS_FUNGIBLE_ASSET_MAX_AMOUNT,
     ERR_MINT_POLICY_ROOT_NOT_ALLOWED,
     ERR_SENDER_NOT_OWNER,
 };
@@ -1906,6 +1907,95 @@ async fn test_network_faucet_non_owner_cannot_set_min_burn_amount() -> anyhow::R
     let result = tx_context.execute().await;
 
     assert_transaction_executor_error!(result, ERR_SENDER_NOT_OWNER);
+
+    Ok(())
+}
+
+/// Builds a network faucet whose `max_supply` is mutable so the owner-gated `set_max_supply`
+/// setter can be exercised.
+fn build_network_faucet_mutable_max_supply(
+    builder: &mut MockChainBuilder,
+    token_symbol: &str,
+    max_supply: u64,
+    owner: AccountId,
+) -> anyhow::Result<Account> {
+    let name = TokenName::new(token_symbol)?;
+    let symbol = TokenSymbol::new(token_symbol)?;
+    let max_supply = AssetAmount::new(max_supply)?;
+    let faucet = FungibleFaucet::builder()
+        .name(name)
+        .symbol(symbol)
+        .decimals(10)
+        .max_supply(max_supply)
+        .is_max_supply_mutable(true)
+        .build()?;
+
+    let token_policy_manager = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::owner_only())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .active_send_policy(TransferPolicy::allow_all())
+        .active_receive_policy(TransferPolicy::allow_all())
+        .build();
+
+    let account_builder = AccountBuilder::new(builder.rng_mut().random())
+        .account_type(AccountType::Public)
+        .with_component(faucet)
+        .with_component(Ownable2Step::new(owner))
+        .with_component(Authority::OwnerControlled)
+        .with_components(token_policy_manager)
+        .with_component(Pausable::unpaused());
+
+    builder.add_account_from_builder(Auth::IncrNonce, account_builder, AccountState::Exists)
+}
+
+/// Builds a note script that calls the owner-gated `set_max_supply` procedure with the given
+/// new cap.
+fn create_set_max_supply_note_script(new_max_supply: u64) -> NoteScript {
+    let code = format!(
+        r#"
+        @note_script
+        pub proc main
+            padw padw padw push.0.0.0
+            push.{new_max_supply}
+            call.::miden::standards::faucets::fungible::set_max_supply
+            dropw dropw dropw dropw
+        end
+        "#
+    );
+    CodeBuilder::default().compile_note_script(&code).unwrap()
+}
+
+/// Tests that `set_max_supply` rejects a cap above `FUNGIBLE_ASSET_MAX_AMOUNT`, keeping the
+/// stored cap consistent with the bound enforced at mint time.
+#[tokio::test]
+async fn test_set_max_supply_rejects_cap_above_fungible_asset_max_amount() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let owner_account_id =
+        AccountId::dummy([1; 15], AccountIdVersion::Version1, AccountType::Private);
+
+    let faucet =
+        build_network_faucet_mutable_max_supply(&mut builder, "NET", 200, owner_account_id)?;
+
+    // One above the maximum representable fungible asset amount.
+    let new_max_supply = FungibleAsset::MAX_AMOUNT.as_u64() + 1;
+    let set_note_script = create_set_max_supply_note_script(new_max_supply);
+    let mut rng = RandomCoin::new([Felt::from(630u32); 4].into());
+    let set_note = NoteBuilder::new(owner_account_id, &mut rng)
+        .note_type(NoteType::Private)
+        .script(set_note_script)
+        .build()?;
+    builder.add_output_note(RawOutputNote::Full(set_note.clone()));
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    let tx_context = mock_chain.build_tx_context(faucet.id(), &[set_note.id()], &[])?.build()?;
+    let result = tx_context.execute().await;
+
+    assert_transaction_executor_error!(
+        result,
+        ERR_FUNGIBLE_ASSET_MAX_SUPPLY_EXCEEDS_FUNGIBLE_ASSET_MAX_AMOUNT
+    );
 
     Ok(())
 }


### PR DESCRIPTION
- Added an assertion that the new max supply value does not exceed `FUNGIBLE_ASSET_MAX_AMOUNT` inside `set_max_supply`
- Add tests to validate the behaviour.