### PR TITLE
fix(standards):  misleading documentation in faucet and transfer policy procedures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
+- Fixed misleading documentation in the faucet and transfer policy procedures ([#3119](https://github.com/0xMiden/protocol/pull/3119)).
 - [BREAKING] Removed the automatic fee computation and removal from the transaction kernel ([#3108](https://github.com/0xMiden/protocol/issues/3108)).
 - Simplified the Ownable2Step owner-check API: merged the owner assertion into a single `exec` `assert_sender_is_owner` and renamed `is_sender_owner_internal` to `is_sender_owner` ([#3088](https://github.com/0xMiden/protocol/pull/3088)).
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -249,7 +249,7 @@ pub proc transfer_ownership
     # => [owner_suffix, owner_prefix, new_owner_suffix, new_owner_prefix, pad(14)]
 
     exec.save_ownership_info
-    # => [pad(14)]
+    # => [pad(16)]
 end
 
 #! Accepts a nominated ownership transfer. The nominated owner becomes the new owner

--- a/crates/miden-standards/asm/standards/faucets/fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/fungible.masm
@@ -262,12 +262,12 @@ pub proc mint_and_send
     # ---------------------------------------------------------------------------------------------
 
     push.TOKEN_CONFIG_SLOT[0..2] exec.active_account::get_item
-    # => [token_supply, max_supply, decimals, token_symbol, amount, tag, note_type, RECIPIENT]
+    # => [token_supply, max_supply, decimals, token_symbol, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # store a copy of the current slot content for the token_supply update later
     loc_storew_le.TOKEN_CONFIG_SLOT_LOCAL
     swap movup.2 drop movup.2 drop
-    # => [max_supply, token_supply, amount, tag, note_type, RECIPIENT]
+    # => [max_supply, token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # Assert that minting does not violate any supply constraints.
     #
@@ -286,55 +286,55 @@ pub proc mint_and_send
     # ---------------------------------------------------------------------------------------------
 
     dup.1 dup.1
-    # => [max_supply, token_supply, max_supply, token_supply, amount, tag, note_type, RECIPIENT]
+    # => [max_supply, token_supply, max_supply, token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # assert that token_supply <= max_supply
     lte assert.err=ERR_FUNGIBLE_ASSET_TOKEN_SUPPLY_EXCEEDS_MAX_SUPPLY
-    # => [max_supply, token_supply, amount, tag, note_type, RECIPIENT]
+    # => [max_supply, token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # assert max_supply <= FUNGIBLE_ASSET_MAX_AMOUNT
     dup lte.FUNGIBLE_ASSET_MAX_AMOUNT
     assert.err=ERR_FUNGIBLE_ASSET_MAX_SUPPLY_EXCEEDS_FUNGIBLE_ASSET_MAX_AMOUNT
-    # => [max_supply, token_supply, amount, tag, note_type, RECIPIENT]
+    # => [max_supply, token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     dup.2 swap dup.2
-    # => [token_supply, max_supply, amount, token_supply, amount, tag, note_type, RECIPIENT]
+    # => [token_supply, max_supply, new_amount, token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # compute maximum amount that can be minted, max_mint_amount = max_supply - token_supply
     sub
-    # => [max_mint_amount, amount, token_supply, amount, tag, note_type, RECIPIENT]
+    # => [max_mint_amount, new_amount, token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # assert amount <= max_mint_amount
     lte assert.err=ERR_FUNGIBLE_ASSET_DISTRIBUTE_AMOUNT_EXCEEDS_MAX_SUPPLY
-    # => [token_supply, amount, tag, note_type, RECIPIENT]
+    # => [token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # Compute the new token_supply and update in storage.
     # ---------------------------------------------------------------------------------------------
 
     dup.1 add
-    # => [new_token_supply, amount, tag, note_type, RECIPIENT]
+    # => [new_token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     padw loc_loadw_le.TOKEN_CONFIG_SLOT_LOCAL
-    # => [[token_supply, max_supply, decimals, token_symbol], new_token_supply, amount, tag, note_type, RECIPIENT]
+    # => [[token_supply, max_supply, decimals, token_symbol], new_token_supply, new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     drop movup.3
-    # => [[new_token_supply, max_supply, decimals, token_symbol], amount, tag, note_type, RECIPIENT]
+    # => [[new_token_supply, max_supply, decimals, token_symbol], new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # update the token config slot with the new supply
     push.TOKEN_CONFIG_SLOT[0..2] exec.native_account::set_item dropw
-    # => [amount, tag, note_type, RECIPIENT]
+    # => [new_amount, new_tag, new_note_type, NEW_RECIPIENT]
 
     # Create a new note.
     # ---------------------------------------------------------------------------------------------
 
     movdn.6 exec.output_note::create
-    # => [note_idx, amount]
+    # => [note_idx, new_amount]
 
     # Mint the asset.
     # ---------------------------------------------------------------------------------------------
 
     dup movup.2
-    # => [amount, note_idx, note_idx]
+    # => [new_amount, note_idx, note_idx]
 
     # derive the asset to mint for the active faucet from the (possibly policy-adjusted) amount
     exec.faucet::create_fungible_asset

--- a/crates/miden-standards/asm/standards/faucets/mod.masm
+++ b/crates/miden-standards/asm/standards/faucets/mod.masm
@@ -231,7 +231,7 @@ end
 #! Updates the description (7 Words) if the description mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
 #!
-#! The caller passes the Poseidon hash of the new description on the stack and provides
+#! The caller passes the Poseidon2 hash of the new description on the stack and provides
 #! the actual 7 Words in the advice map under that hash. The hash is verified against
 #! the preimage during loading.
 #!
@@ -311,7 +311,7 @@ end
 #! Updates the logo URI (7 Words) if the logo URI mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
 #!
-#! The caller passes the Poseidon hash of the new logo URI on the stack and provides
+#! The caller passes the Poseidon2 hash of the new logo URI on the stack and provides
 #! the actual 7 Words in the advice map under that hash. The hash is verified against
 #! the preimage during loading.
 #!
@@ -390,7 +390,7 @@ end
 #! Updates the external link (7 Words) if the external link mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
 #!
-#! The caller passes the Poseidon hash of the new external link on the stack and provides
+#! The caller passes the Poseidon2 hash of the new external link on the stack and provides
 #! the actual 7 Words in the advice map under that hash. The hash is verified against
 #! the preimage during loading.
 #!

--- a/crates/miden-standards/asm/standards/faucets/policies/burn/owner_controlled/owner_only.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/burn/owner_controlled/owner_only.masm
@@ -1,3 +1,12 @@
+# miden::standards::faucets::policies::burn::owner_controlled::owner_only
+#
+# Owner-only burn policy: gates burning on the Ownable2Step owner via
+# `ownable2step::assert_sender_is_owner`, rejecting the burn when the note sender is not the
+# current owner.
+#
+# Companion components required on the faucet:
+# - `Ownable2Step` — provides the owner storage slot the auth check reads.
+
 use miden::standards::access::ownable2step
 
 # POLICY PROCEDURES

--- a/crates/miden-standards/asm/standards/faucets/policies/mint/owner_controlled/owner_only.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/mint/owner_controlled/owner_only.masm
@@ -1,3 +1,12 @@
+# miden::standards::faucets::policies::mint::owner_controlled::owner_only
+#
+# Owner-only mint policy: gates minting on the Ownable2Step owner via
+# `ownable2step::assert_sender_is_owner`, rejecting the mint when the note sender is not the
+# current owner.
+#
+# Companion components required on the faucet:
+# - `Ownable2Step` — provides the owner storage slot the auth check reads.
+
 use miden::standards::access::ownable2step
 
 # POLICY PROCEDURES

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/allow_all.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/allow_all.masm
@@ -8,10 +8,15 @@
 #! Invoked as the active send or receive policy via `TokenPolicyManager`, which applies the
 #! account-wide pause check.
 #!
-#! Inputs:  [ASSET_KEY, ASSET_VALUE]
-#! Outputs: [ASSET_VALUE]
+#! Inputs:  [ASSET_KEY, ASSET_VALUE, custom_data, pad(7)]
+#! Outputs: [ASSET_VALUE, pad(12)]
+#!
+#! Where:
+#! - custom_data is `0` for the receive (account) callback and the output note index for the
+#!   send (note) callback. This policy does not inspect it; it passes through unchanged.
 #!
 #! Invocation: call
 pub proc check_policy
     dropw
+    # => [ASSET_VALUE, pad(12)]
 end

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/allowlist/owner_controlled.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/allowlist/owner_controlled.masm
@@ -29,7 +29,7 @@ pub proc allow_account
     # => [account_id_suffix, account_id_prefix, pad(14)]
 
     exec.allowlist::allow_account
-    # => [pad(14)]
+    # => [pad(16)]
 end
 
 #! Disallow an account, gated by the Ownable2Step owner.
@@ -46,5 +46,5 @@ pub proc disallow_account
     # => [account_id_suffix, account_id_prefix, pad(14)]
 
     exec.allowlist::disallow_account
-    # => [pad(14)]
+    # => [pad(16)]
 end

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/basic_allowlist.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/basic_allowlist.masm
@@ -17,8 +17,12 @@ use miden::standards::faucets::policies::transfer::allowlist
 #! consumes the top eight felts (`ASSET_KEY`, `ASSET_VALUE`) and leaves the rest of the call
 #! frame untouched — any `note_idx` carried in the send signature passes through unchanged.
 #!
-#! Inputs:  [ASSET_KEY, ASSET_VALUE, pad(8)]
+#! Inputs:  [ASSET_KEY, ASSET_VALUE, custom_data, pad(7)]
 #! Outputs: [ASSET_VALUE, pad(12)]
+#!
+#! Where:
+#! - custom_data is `0` for the receive (account) callback and the output note index for the
+#!   send (note) callback. This policy does not inspect it; it passes through unchanged.
 #!
 #! Panics if:
 #! - the native account is not allowed on the issuing faucet.
@@ -26,10 +30,10 @@ use miden::standards::faucets::policies::transfer::allowlist
 #! Invocation: call
 pub proc check_policy
     exec.native_account::get_id
-    # => [account_id_suffix, account_id_prefix, ASSET_KEY, ASSET_VALUE, pad(8)]
+    # => [account_id_suffix, account_id_prefix, ASSET_KEY, ASSET_VALUE, custom_data, pad(7)]
 
     exec.allowlist::assert_allowed
-    # => [ASSET_KEY, ASSET_VALUE, pad(8)]
+    # => [ASSET_KEY, ASSET_VALUE, custom_data, pad(7)]
 
     dropw
     # => [ASSET_VALUE, pad(12)]

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/basic_blocklist.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/basic_blocklist.masm
@@ -16,8 +16,12 @@ use miden::standards::faucets::policies::transfer::blocklist
 #! consumes the top eight felts (`ASSET_KEY`, `ASSET_VALUE`) and leaves the rest of the call
 #! frame untouched — any `note_idx` carried in the send signature passes through unchanged.
 #!
-#! Inputs:  [ASSET_KEY, ASSET_VALUE, pad(8)]
+#! Inputs:  [ASSET_KEY, ASSET_VALUE, custom_data, pad(7)]
 #! Outputs: [ASSET_VALUE, pad(12)]
+#!
+#! Where:
+#! - custom_data is `0` for the receive (account) callback and the output note index for the
+#!   send (note) callback. This policy does not inspect it; it passes through unchanged.
 #!
 #! Panics if:
 #! - the native account is blocked on the issuing faucet.
@@ -25,10 +29,10 @@ use miden::standards::faucets::policies::transfer::blocklist
 #! Invocation: call
 pub proc check_policy
     exec.native_account::get_id
-    # => [account_id_suffix, account_id_prefix, ASSET_KEY, ASSET_VALUE, pad(8)]
+    # => [account_id_suffix, account_id_prefix, ASSET_KEY, ASSET_VALUE, custom_data, pad(7)]
 
     exec.blocklist::assert_not_blocked
-    # => [ASSET_KEY, ASSET_VALUE, pad(8)]
+    # => [ASSET_KEY, ASSET_VALUE, custom_data, pad(7)]
 
     dropw
     # => [ASSET_VALUE, pad(12)]

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/blocklist/owner_controlled.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/blocklist/owner_controlled.masm
@@ -29,7 +29,7 @@ pub proc block_account
     # => [account_id_suffix, account_id_prefix, pad(14)]
 
     exec.blocklist::block_account
-    # => [pad(14)]
+    # => [pad(16)]
 end
 
 #! Unblock an account, gated by the Ownable2Step owner.
@@ -46,5 +46,5 @@ pub proc unblock_account
     # => [account_id_suffix, account_id_prefix, pad(14)]
 
     exec.blocklist::unblock_account
-    # => [pad(14)]
+    # => [pad(16)]
 end

--- a/crates/miden-standards/src/account/policies/burn/owner_only.rs
+++ b/crates/miden-standards/src/account/policies/burn/owner_only.rs
@@ -24,6 +24,10 @@ procedure_root!(
 /// Pair with a [`crate::account::policies::TokenPolicyManager`] whose allowed burn-policies
 /// map includes [`BurnOwnerOnly::root`]. When active, only the account owner (as recorded by
 /// the `Ownable2Step` component) may trigger burn operations.
+///
+/// Companion components required:
+/// - [`crate::account::access::Ownable2Step`] — provides the owner storage slot the auth check
+///   reads. Without it, the faucet builds successfully but every burn reverts.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct BurnOwnerOnly;
 

--- a/crates/miden-standards/src/account/policies/mint/owner_only.rs
+++ b/crates/miden-standards/src/account/policies/mint/owner_only.rs
@@ -24,6 +24,10 @@ procedure_root!(
 /// Pair with a [`crate::account::policies::TokenPolicyManager`] whose allowed mint-policies
 /// map includes [`MintOwnerOnly::root`]. When active, only the account owner (as recorded by
 /// the `Ownable2Step` component) may trigger mint operations.
+///
+/// Companion components required:
+/// - [`crate::account::access::Ownable2Step`] — provides the owner storage slot the auth check
+///   reads. Without it, the faucet builds successfully but every mint reverts.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MintOwnerOnly;
 


### PR DESCRIPTION
- Changed "Poseidon hash" to "Poseidon2 hash" in the `set_description`, `set_logo_uri`, and `set_external_link`documentation.
- Made the stack comments after executing `execute_mint_policy`  in `mint_and_send` consistently use the `new_` prefix.
- Added the `custom_data` element to the documented inputs of the some transfer policies.
- Fixed the final stack comments from `[pad(14)]` to `[pad(16)]` in `allow_account/disallow_account`, `block_account/unblock_account`, and `transfer_ownership`.
- Added a "Companion components required" note naming `Ownable2Step` to the owner-only mint/burn MASM modules and their Rust components.