### PR TITLE
fix(standards): use `get_mutability_config_word` in `is_max_supply_mutable_internal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
+- Refactored `is_max_supply_mutable_internal` in the fungible faucet to read the mutability config through the `get_mutability_config_word` getter instead of accessing the storage slot directly ([#3120](https://github.com/0xMiden/protocol/pull/3120)).
 - [BREAKING] Removed the automatic fee computation and removal from the transaction kernel ([#3108](https://github.com/0xMiden/protocol/issues/3108)).
 - Simplified the Ownable2Step owner-check API: merged the owner assertion into a single `exec` `assert_sender_is_owner` and renamed `is_sender_owner_internal` to `is_sender_owner` ([#3088](https://github.com/0xMiden/protocol/pull/3088)).
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).

--- a/crates/miden-standards/asm/standards/faucets/fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/fungible.masm
@@ -16,7 +16,7 @@ use miden::protocol::asset
 use miden::protocol::asset::FUNGIBLE_ASSET_MAX_AMOUNT
 use miden::standards::access::authority
 use miden::standards::faucets::policies::policy_manager
-use miden::standards::faucets::MUTABILITY_CONFIG_SLOT
+use miden::standards::faucets
 use miden::standards::access::pausable
 
 # =================================================================================================
@@ -73,8 +73,7 @@ end
 #!
 #! Invocation: exec
 proc is_max_supply_mutable_internal
-    push.MUTABILITY_CONFIG_SLOT[0..2]
-    exec.active_account::get_item
+    exec.faucets::get_mutability_config_word
     # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
     drop drop drop
     # => [is_max_supply_mutable]


### PR DESCRIPTION
- Remove direct storage slot read from `is_max_supply_mutable_internal` and add invocation of `get_mutability_config_word` instead.