### PR TITLE
P2IDE note builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Changes
 - [BREAKING] Replaced the `P2idNote` marker type and its `P2idNote::create` factory with a `P2idNote` struct built via a `bon` typestate builder (`P2idNote::builder()`). P2ID notes must now carry at least one asset; a `P2idNote` converts into a `Note` via `Note::from`, and the builder offers `.asset()`/`.assets()`, `.attachment()`/`.attachments()`, and `.generate_serial_number()` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
+- [BREAKING] Replaced the `P2ideNote` marker type and its `P2ideNote::create` factory with a `P2ideNote` struct built via a `bon` typestate builder (`P2ideNote::builder()`). P2IDE notes must now carry at least one asset (new `NoteError::MissingAsset`); the optional `reclaim_height`/`timelock_height` are set via the builder, `P2ideNoteStorage::into_recipient` is now infallible, and a `P2ideNote` converts into a `Note` via `Note::from` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
+- Fixed misleading documentation in the faucet and transfer policy procedures ([#3119](https://github.com/0xMiden/protocol/pull/3119)).
+- [BREAKING] Removed the automatic fee computation and removal from the transaction kernel ([#3108](https://github.com/0xMiden/protocol/issues/3108)).
+- Simplified the Ownable2Step owner-check API: merged the owner assertion into a single `exec` `assert_sender_is_owner` and renamed `is_sender_owner_internal` to `is_sender_owner` ([#3088](https://github.com/0xMiden/protocol/pull/3088)).
+- [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).
+- Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
+
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 - [BREAKING] Renamed `AccountStorageDelta` to `AccountStoragePatch` ([#3002](https://github.com/0xMiden/protocol/pull/3002)).
 - [BREAKING] Replaced the per-tree account and nullifier backend traits with shared `SmtBackend` and `SmtBackendReader` traits, split into read-only and read-write capabilities, enabling read-only `LargeSmt`-backed tree views via `reader()` ([#2755](https://github.com/0xMiden/protocol/pull/2755), [#3009](https://github.com/0xMiden/protocol/pull/3009)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@
 
 ### Changes
 - [BREAKING] Replaced the `P2idNote` marker type and its `P2idNote::create` factory with a `P2idNote` struct built via a `bon` typestate builder (`P2idNote::builder()`). P2ID notes must now carry at least one asset; a `P2idNote` converts into a `Note` via `Note::from`, and the builder offers `.asset()`/`.assets()`, `.attachment()`/`.attachments()`, and `.generate_serial_number()` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
-- [BREAKING] Replaced the `P2ideNote` marker type and its `P2ideNote::create` factory with a `P2ideNote` struct built via a `bon` typestate builder (`P2ideNote::builder()`). P2IDE notes must now carry at least one asset (new `NoteError::MissingAsset`); the optional `reclaim_height`/`timelock_height` are set via the builder, `P2ideNoteStorage::into_recipient` is now infallible, and a `P2ideNote` converts into a `Note` via `Note::from` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
-- Fixed misleading documentation in the faucet and transfer policy procedures ([#3119](https://github.com/0xMiden/protocol/pull/3119)).
-- [BREAKING] Removed the automatic fee computation and removal from the transaction kernel ([#3108](https://github.com/0xMiden/protocol/issues/3108)).
-- Simplified the Ownable2Step owner-check API: merged the owner assertion into a single `exec` `assert_sender_is_owner` and renamed `is_sender_owner_internal` to `is_sender_owner` ([#3088](https://github.com/0xMiden/protocol/pull/3088)).
-- [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).
-- Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
-
 - [BREAKING] Replaced the `P2ideNote` marker type and its `P2ideNote::create` factory with a `P2ideNote` struct built via a `bon` typestate builder (`P2ideNote::builder()`). P2IDE notes must now carry at least one asset; the optional `reclaim_height`/`timelock_height` are set via the builder, `P2ideNoteStorage::into_recipient` is now infallible, and a `P2ideNote` converts into a `Note` via `Note::from` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 - [BREAKING] Renamed `AccountStorageDelta` to `AccountStoragePatch` ([#3002](https://github.com/0xMiden/protocol/pull/3002)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [BREAKING] Renamed the `miden-tx-batch-prover` crate to `miden-tx-batch` ([#3035](https://github.com/0xMiden/protocol/pull/3035)).
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 
+- [BREAKING] Replaced the `P2ideNote` marker type and its `P2ideNote::create` factory with a `P2ideNote` struct built via a `bon` typestate builder (`P2ideNote::builder()`). P2IDE notes must now carry at least one asset; the optional `reclaim_height`/`timelock_height` are set via the builder, `P2ideNoteStorage::into_recipient` is now infallible, and a `P2ideNote` converts into a `Note` via `Note::from` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
 - Added a skeleton batch kernel ([#1122](https://github.com/0xMiden/protocol/issues/1122)) wired through `LocalBatchProver::prove` and attached to `ProvenBatch` as an `ExecutionProof`. It does not yet perform any verification.
 - [BREAKING] Renamed `AccountStorageDelta` to `AccountStoragePatch` ([#3002](https://github.com/0xMiden/protocol/pull/3002)).
 - [BREAKING] Replaced the per-tree account and nullifier backend traits with shared `SmtBackend` and `SmtBackendReader` traits, split into read-only and read-write capabilities, enabling read-only `LargeSmt`-backed tree views via `reader()` ([#2755](https://github.com/0xMiden/protocol/pull/2755), [#3009](https://github.com/0xMiden/protocol/pull/3009)).

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -736,6 +736,8 @@ pub enum NoteError {
     NoteScriptAssemblyError(Report),
     #[error("failed to deserialize note script")]
     NoteScriptDeserializationError(#[source] DeserializationError),
+    #[error("note must contain at least one asset")]
+    MissingAsset,
     #[error("note contains {0} assets which exceeds the maximum of {max}", max = NoteAssets::MAX_NUM_ASSETS)]
     TooManyAssets(usize),
     #[error("note contains {0} storage items which exceeds the maximum of {max}", max = MAX_NOTE_STORAGE_ITEMS)]

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -736,8 +736,6 @@ pub enum NoteError {
     NoteScriptAssemblyError(Report),
     #[error("failed to deserialize note script")]
     NoteScriptDeserializationError(#[source] DeserializationError),
-    #[error("note must contain at least one asset")]
-    MissingAsset,
     #[error("note contains {0} assets which exceeds the maximum of {max}", max = NoteAssets::MAX_NUM_ASSETS)]
     TooManyAssets(usize),
     #[error("note contains {0} storage items which exceeds the maximum of {max}", max = MAX_NOTE_STORAGE_ITEMS)]

--- a/crates/miden-standards/src/note/p2id.rs
+++ b/crates/miden-standards/src/note/p2id.rs
@@ -279,6 +279,7 @@ impl TryFrom<&[Felt]> for P2idNoteStorage {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use miden_protocol::account::{AccountId, AccountIdVersion, AccountType};
     use miden_protocol::asset::FungibleAsset;
     use miden_protocol::crypto::rand::RandomCoin;
@@ -392,6 +393,8 @@ mod tests {
             .build()
             .expect_err("a note without assets must be rejected");
 
-        assert!(matches!(err, NoteError::Other { .. }));
+        assert_matches!(err, NoteError::Other { error_msg, .. } => {
+            assert!(error_msg.contains("note must contain at least one asset"))
+        });
     }
 }

--- a/crates/miden-standards/src/note/p2ide.rs
+++ b/crates/miden-standards/src/note/p2ide.rs
@@ -66,7 +66,7 @@ impl P2ideNote {
     /// # Errors
     ///
     /// Returns an error if:
-    /// - No assets were provided ([`NoteError::MissingAsset`]).
+    /// - No assets were provided.
     /// - The assets or attachments exceed their protocol limits (see [`NoteAssets::new`] and
     ///   [`NoteAttachments::new`]).
     #[builder]
@@ -81,7 +81,7 @@ impl P2ideNote {
         #[builder(default)] note_type: NoteType,
     ) -> Result<Self, NoteError> {
         if assets.is_empty() {
-            return Err(NoteError::MissingAsset);
+            return Err(NoteError::other("a P2IDE note must contain at least one asset"));
         }
 
         let storage = P2ideNoteStorage::new(target, reclaim_height, timelock_height);
@@ -480,16 +480,18 @@ mod tests {
     /// `.asset()` and `.assets()` both append, so they can be combined and called repeatedly.
     #[test]
     fn builder_accumulates_assets() {
+        let mut rng = RandomCoin::new(Word::empty());
         let note = P2ideNote::builder()
             .sender(sender())
             .target(target())
-            .serial_number(Word::empty())
             .asset(FungibleAsset::new(faucet_a(), 100).unwrap())
             .assets([Asset::from(FungibleAsset::new(faucet_b(), 200).unwrap())])
+            .generate_serial_number(&mut rng)
             .build()
             .unwrap();
 
         assert_eq!(note.assets().num_assets(), 2);
+        assert_ne!(note.serial_number(), Word::empty());
     }
 
     /// A P2IDE note must carry at least one asset.
@@ -502,7 +504,7 @@ mod tests {
             .build()
             .expect_err("a note without assets must be rejected");
 
-        assert!(matches!(err, NoteError::MissingAsset));
+        assert!(matches!(err, NoteError::Other { .. }));
     }
 
     /// The reclaim and timelock heights are optional and surfaced through the getters.
@@ -520,38 +522,5 @@ mod tests {
 
         assert_eq!(note.reclaim_height(), Some(BlockNumber::from(42u32)));
         assert_eq!(note.timelock_height(), Some(BlockNumber::from(100u32)));
-    }
-
-    /// `.generate_serial_number()` draws the serial from the RNG.
-    #[test]
-    fn builder_generates_serial_number() {
-        let mut rng = RandomCoin::new(Word::empty());
-        let note = P2ideNote::builder()
-            .sender(sender())
-            .target(target())
-            .asset(FungibleAsset::new(faucet_a(), 1).unwrap())
-            .generate_serial_number(&mut rng)
-            .build()
-            .unwrap();
-
-        assert_ne!(note.serial_number(), Word::empty());
-    }
-
-    /// `Note::from(p2ide_note)` is infallible and preserves the assets.
-    #[test]
-    fn into_note_preserves_assets() {
-        let p2ide_note = P2ideNote::builder()
-            .sender(sender())
-            .target(target())
-            .serial_number(Word::empty())
-            .asset(FungibleAsset::new(faucet_a(), 42).unwrap())
-            .note_type(NoteType::Public)
-            .build()
-            .unwrap();
-
-        let assets = p2ide_note.assets().clone();
-        let note = Note::from(p2ide_note);
-
-        assert_eq!(note.assets(), &assets);
     }
 }

--- a/crates/miden-standards/src/note/p2ide.rs
+++ b/crates/miden-standards/src/note/p2ide.rs
@@ -335,6 +335,7 @@ impl TryFrom<&[Felt]> for P2ideNoteStorage {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use miden_protocol::account::{AccountId, AccountIdVersion, AccountType};
     use miden_protocol::asset::FungibleAsset;
     use miden_protocol::block::BlockNumber;
@@ -504,7 +505,9 @@ mod tests {
             .build()
             .expect_err("a note without assets must be rejected");
 
-        assert!(matches!(err, NoteError::Other { .. }));
+        assert_matches!(err, NoteError::Other { error_msg, .. } => {
+            assert!(error_msg.contains("note must contain at least one asset"))
+        });
     }
 
     /// The reclaim and timelock heights are optional and surfaced through the getters.

--- a/crates/miden-standards/src/note/p2ide.rs
+++ b/crates/miden-standards/src/note/p2ide.rs
@@ -63,12 +63,6 @@ pub struct P2ideNote {
 impl P2ideNote {
     /// Builds a new [`P2ideNote`].
     ///
-    /// Set the recipient with `.target(account_id)`, add assets with `.asset()` / `.assets()`
-    /// (at least one is required), and optionally add attachments with `.attachment()`, a
-    /// `.reclaim_height()`, and a `.timelock_height()`. The note type defaults to
-    /// [`NoteType::Private`]. The serial number can be set explicitly with `.serial_number(word)`
-    /// or drawn from an RNG with `.generate_serial_number(rng)`.
-    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -175,27 +169,25 @@ impl P2ideNote {
 // ================================================================================================
 
 impl<S: p2ide_note_builder::State> P2ideNoteBuilder<S> {
-    /// Adds a single asset to the note. At least one asset is required for `.build()` to succeed;
-    /// this can be called multiple times to add several assets.
+    /// Adds a single asset to the note. At least one asset is required for `.build()` to succeed.
     pub fn asset(mut self, asset: impl Into<Asset>) -> Self {
         self.assets.push(asset.into());
         self
     }
 
-    /// Adds multiple assets to the note. Can be combined freely with [`Self::asset`].
+    /// Adds multiple assets to the note.
     pub fn assets(mut self, assets: impl IntoIterator<Item = impl Into<Asset>>) -> Self {
         self.assets.extend(assets.into_iter().map(Into::into));
         self
     }
 
-    /// Adds a single attachment to the note. Can be called multiple times to add several
-    /// attachments.
+    /// Adds a single attachment to the note.
     pub fn attachment(mut self, attachment: impl Into<NoteAttachment>) -> Self {
         self.attachments.push(attachment.into());
         self
     }
 
-    /// Adds multiple attachments to the note. Can be combined freely with [`Self::attachment`].
+    /// Adds multiple attachments to the note.
     pub fn attachments(
         mut self,
         attachments: impl IntoIterator<Item = impl Into<NoteAttachment>>,
@@ -210,6 +202,27 @@ where
     S::SerialNumber: p2ide_note_builder::IsUnset,
 {
     /// Draws a serial number from `rng` and sets it on the builder.
+    ///
+    /// This and `serial_number` are mutually exclusive: the builder's typestate rejects setting
+    /// the serial number twice at compile time.
+    ///
+    /// ```compile_fail
+    /// # #[allow(dead_code)]
+    /// # fn demo(
+    /// #     sender: miden_protocol::account::AccountId,
+    /// #     target: miden_protocol::account::AccountId,
+    /// #     rng: &mut impl miden_protocol::crypto::rand::FeltRng,
+    /// # ) {
+    /// use miden_protocol::Word;
+    /// use miden_standards::note::P2ideNote;
+    ///
+    /// let _ = P2ideNote::builder()
+    ///     .sender(sender)
+    ///     .target(target)
+    ///     .serial_number(Word::empty())
+    ///     .generate_serial_number(rng); // serial number already set: compile error
+    /// # }
+    /// ```
     pub fn generate_serial_number(
         self,
         rng: &mut impl FeltRng,
@@ -478,7 +491,7 @@ mod tests {
 
         assert_eq!(note.sender(), sender());
         assert_eq!(note.target(), target());
-        assert_eq!(note.note_type(), NoteType::Private);
+        assert_eq!(note.note_type(), NoteType::default());
         assert_eq!(note.reclaim_height(), None);
         assert_eq!(note.timelock_height(), None);
         assert_eq!(note.assets().num_assets(), 1);

--- a/crates/miden-standards/src/note/p2ide.rs
+++ b/crates/miden-standards/src/note/p2ide.rs
@@ -9,6 +9,7 @@ use miden_protocol::errors::NoteError;
 use miden_protocol::note::{
     Note,
     NoteAssets,
+    NoteAttachment,
     NoteAttachments,
     NoteRecipient,
     NoteScript,
@@ -39,16 +40,70 @@ static P2IDE_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
 // P2IDE NOTE
 // ================================================================================================
 
-/// Pay-to-ID Extended (P2IDE) note abstraction.
+/// A Pay-to-ID Extended (P2IDE) note: transfers `assets` from `sender` to the `target` account,
+/// with optional reclaim and timelock constraints.
 ///
-/// A P2IDE note enables transferring assets to a target account specified in the note storage.
-/// The note may optionally include:
+/// - A reclaim height allows the sender to recover the assets if the note remains unconsumed.
+/// - A timelock height prevents consumption before a given block.
 ///
-/// - A reclaim height allowing the sender to recover assets if the note remains unconsumed
-/// - A timelock height preventing consumption before a given block
-///
-/// These constraints are encoded in `P2ideNoteStorage` and enforced by the associated note script.
-pub struct P2ideNote;
+/// Construct one with the [builder](P2ideNote::builder), which defaults the optional parameters
+/// (private note type, no attachments, no reclaim/timelock height) and requires at least one
+/// asset. Convert a `P2ideNote` into a protocol [`Note`] infallibly via `Note::from`.
+#[derive(Debug, Clone)]
+pub struct P2ideNote {
+    sender: AccountId,
+    storage: P2ideNoteStorage,
+    serial_number: Word,
+    note_type: NoteType,
+    assets: NoteAssets,
+    attachments: NoteAttachments,
+}
+
+#[bon::bon]
+impl P2ideNote {
+    /// Builds a new [`P2ideNote`].
+    ///
+    /// Set the recipient with `.target(account_id)`, add assets with `.asset()` / `.assets()`
+    /// (at least one is required), and optionally add attachments with `.attachment()`, a
+    /// `.reclaim_height()`, and a `.timelock_height()`. The note type defaults to
+    /// [`NoteType::Private`]. The serial number can be set explicitly with `.serial_number(word)`
+    /// or drawn from an RNG with `.generate_serial_number(rng)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - No assets were provided ([`NoteError::MissingAsset`]).
+    /// - The assets or attachments exceed their protocol limits (see [`NoteAssets::new`] and
+    ///   [`NoteAttachments::new`]).
+    #[builder]
+    pub fn new(
+        #[builder(field)] assets: Vec<Asset>,
+        #[builder(field)] attachments: Vec<NoteAttachment>,
+        sender: AccountId,
+        target: AccountId,
+        reclaim_height: Option<BlockNumber>,
+        timelock_height: Option<BlockNumber>,
+        serial_number: Word,
+        #[builder(default)] note_type: NoteType,
+    ) -> Result<Self, NoteError> {
+        if assets.is_empty() {
+            return Err(NoteError::MissingAsset);
+        }
+
+        let storage = P2ideNoteStorage::new(target, reclaim_height, timelock_height);
+        let assets = NoteAssets::new(assets)?;
+        let attachments = NoteAttachments::new(attachments)?;
+
+        Ok(Self {
+            sender,
+            storage,
+            serial_number,
+            note_type,
+            assets,
+            attachments,
+        })
+    }
+}
 
 impl P2ideNote {
     // CONSTANTS
@@ -70,33 +125,109 @@ impl P2ideNote {
         P2IDE_SCRIPT.root()
     }
 
-    // BUILDERS
-    // --------------------------------------------------------------------------------------------
+    /// Returns the account ID of the note's sender.
+    pub fn sender(&self) -> AccountId {
+        self.sender
+    }
 
-    /// Generates a P2IDE note using the provided storage configuration.
-    ///
-    /// The note recipient and execution constraints are derived from
-    /// `P2ideNoteStorage`. A random serial number is generated using `rng`,
-    /// and the note tag is set to the storage target account.
-    ///
-    /// # Errors
-    /// Returns an error if construction of the note recipient or asset vault fails.
-    pub fn create<R: FeltRng>(
-        sender: AccountId,
-        storage: P2ideNoteStorage,
-        assets: Vec<Asset>,
-        note_type: NoteType,
-        attachments: NoteAttachments,
-        rng: &mut R,
-    ) -> Result<Note, NoteError> {
-        let serial_num = rng.draw_word();
-        let recipient = storage.into_recipient(serial_num)?;
-        let tag = NoteTag::with_account_target(storage.target());
+    /// Returns the note's storage.
+    pub fn storage(&self) -> P2ideNoteStorage {
+        self.storage
+    }
 
-        let metadata = PartialNoteMetadata::new(sender, note_type).with_tag(tag);
-        let vault = NoteAssets::new(assets)?;
+    /// Returns the account ID of the note's target (the only account that can consume it).
+    pub fn target(&self) -> AccountId {
+        self.storage.target()
+    }
 
-        Ok(Note::with_attachments(vault, metadata, recipient, attachments))
+    /// Returns the reclaim block height (if any).
+    pub fn reclaim_height(&self) -> Option<BlockNumber> {
+        self.storage.reclaim_height()
+    }
+
+    /// Returns the timelock block height (if any).
+    pub fn timelock_height(&self) -> Option<BlockNumber> {
+        self.storage.timelock_height()
+    }
+
+    /// Returns the note's serial number.
+    pub fn serial_number(&self) -> Word {
+        self.serial_number
+    }
+
+    /// Returns the note's type.
+    pub fn note_type(&self) -> NoteType {
+        self.note_type
+    }
+
+    /// Returns the assets carried by the note.
+    pub fn assets(&self) -> &NoteAssets {
+        &self.assets
+    }
+
+    /// Returns the attachments carried by the note.
+    pub fn attachments(&self) -> &NoteAttachments {
+        &self.attachments
+    }
+}
+
+// BUILDER EXTENSIONS
+// ================================================================================================
+
+impl<S: p2ide_note_builder::State> P2ideNoteBuilder<S> {
+    /// Adds a single asset to the note. At least one asset is required for `.build()` to succeed;
+    /// this can be called multiple times to add several assets.
+    pub fn asset(mut self, asset: impl Into<Asset>) -> Self {
+        self.assets.push(asset.into());
+        self
+    }
+
+    /// Adds multiple assets to the note. Can be combined freely with [`Self::asset`].
+    pub fn assets(mut self, assets: impl IntoIterator<Item = impl Into<Asset>>) -> Self {
+        self.assets.extend(assets.into_iter().map(Into::into));
+        self
+    }
+
+    /// Adds a single attachment to the note. Can be called multiple times to add several
+    /// attachments.
+    pub fn attachment(mut self, attachment: impl Into<NoteAttachment>) -> Self {
+        self.attachments.push(attachment.into());
+        self
+    }
+
+    /// Adds multiple attachments to the note. Can be combined freely with [`Self::attachment`].
+    pub fn attachments(
+        mut self,
+        attachments: impl IntoIterator<Item = impl Into<NoteAttachment>>,
+    ) -> Self {
+        self.attachments.extend(attachments.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl<S: p2ide_note_builder::State> P2ideNoteBuilder<S>
+where
+    S::SerialNumber: p2ide_note_builder::IsUnset,
+{
+    /// Draws a serial number from `rng` and sets it on the builder.
+    pub fn generate_serial_number(
+        self,
+        rng: &mut impl FeltRng,
+    ) -> P2ideNoteBuilder<p2ide_note_builder::SetSerialNumber<S>> {
+        self.serial_number(rng.draw_word())
+    }
+}
+
+// CONVERSIONS
+// ================================================================================================
+
+impl From<P2ideNote> for Note {
+    fn from(note: P2ideNote) -> Self {
+        let recipient = note.storage.into_recipient(note.serial_number);
+        let tag = NoteTag::with_account_target(note.storage.target());
+        let metadata = PartialNoteMetadata::new(note.sender, note.note_type).with_tag(tag);
+
+        Note::with_attachments(note.assets, metadata, recipient, note.attachments)
     }
 }
 
@@ -132,9 +263,8 @@ impl P2ideNoteStorage {
     }
 
     /// Consumes the storage and returns a P2IDE [`NoteRecipient`] with the provided serial number.
-    pub fn into_recipient(self, serial_num: Word) -> Result<NoteRecipient, NoteError> {
-        let note_script = P2ideNote::script();
-        Ok(NoteRecipient::new(serial_num, note_script, self.into()))
+    pub fn into_recipient(self, serial_num: Word) -> NoteRecipient {
+        NoteRecipient::new(serial_num, P2ideNote::script(), self.into())
     }
 
     /// Returns the target account ID.
@@ -213,16 +343,21 @@ impl TryFrom<&[Felt]> for P2ideNoteStorage {
 
 #[cfg(test)]
 mod tests {
-    use miden_protocol::Felt;
     use miden_protocol::account::{AccountId, AccountIdVersion, AccountType};
+    use miden_protocol::asset::FungibleAsset;
     use miden_protocol::block::BlockNumber;
+    use miden_protocol::crypto::rand::RandomCoin;
     use miden_protocol::errors::NoteError;
+    use miden_protocol::{Felt, Word};
 
     use super::*;
 
     fn dummy_account() -> AccountId {
         AccountId::dummy([3u8; 15], AccountIdVersion::Version1, AccountType::Private)
     }
+
+    // STORAGE TESTS
+    // --------------------------------------------------------------------------------------------
 
     #[test]
     fn try_from_valid_storage_with_all_fields_succeeds() {
@@ -308,5 +443,123 @@ mod tests {
             .expect_err("overflow timelock height must fail");
 
         assert!(matches!(err, NoteError::Other { source: Some(_), .. }));
+    }
+
+    // BUILDER TESTS
+    // --------------------------------------------------------------------------------------------
+
+    fn sender() -> AccountId {
+        AccountId::dummy([1u8; 15], AccountIdVersion::Version1, AccountType::Private)
+    }
+
+    fn target() -> AccountId {
+        AccountId::dummy([2u8; 15], AccountIdVersion::Version1, AccountType::Private)
+    }
+
+    fn faucet_a() -> AccountId {
+        AccountId::dummy([3u8; 15], AccountIdVersion::Version1, AccountType::Public)
+    }
+
+    fn faucet_b() -> AccountId {
+        AccountId::dummy([4u8; 15], AccountIdVersion::Version1, AccountType::Public)
+    }
+
+    /// The minimal builder uses defaults for everything but the required fields (no reclaim or
+    /// timelock height, private note type).
+    #[test]
+    fn builder_minimal_uses_defaults() {
+        let note = P2ideNote::builder()
+            .sender(sender())
+            .target(target())
+            .serial_number(Word::empty())
+            .asset(FungibleAsset::new(faucet_a(), 1).unwrap())
+            .build()
+            .unwrap();
+
+        assert_eq!(note.sender(), sender());
+        assert_eq!(note.target(), target());
+        assert_eq!(note.note_type(), NoteType::Private);
+        assert_eq!(note.reclaim_height(), None);
+        assert_eq!(note.timelock_height(), None);
+        assert_eq!(note.assets().num_assets(), 1);
+        assert_eq!(note.attachments().num_attachments(), 0);
+    }
+
+    /// `.asset()` and `.assets()` both append, so they can be combined and called repeatedly.
+    #[test]
+    fn builder_accumulates_assets() {
+        let note = P2ideNote::builder()
+            .sender(sender())
+            .target(target())
+            .serial_number(Word::empty())
+            .asset(FungibleAsset::new(faucet_a(), 100).unwrap())
+            .assets([Asset::from(FungibleAsset::new(faucet_b(), 200).unwrap())])
+            .build()
+            .unwrap();
+
+        assert_eq!(note.assets().num_assets(), 2);
+    }
+
+    /// A P2IDE note must carry at least one asset.
+    #[test]
+    fn builder_rejects_empty_assets() {
+        let err = P2ideNote::builder()
+            .sender(sender())
+            .target(target())
+            .serial_number(Word::empty())
+            .build()
+            .expect_err("a note without assets must be rejected");
+
+        assert!(matches!(err, NoteError::MissingAsset));
+    }
+
+    /// The reclaim and timelock heights are optional and surfaced through the getters.
+    #[test]
+    fn builder_sets_reclaim_and_timelock() {
+        let note = P2ideNote::builder()
+            .sender(sender())
+            .target(target())
+            .serial_number(Word::empty())
+            .asset(FungibleAsset::new(faucet_a(), 1).unwrap())
+            .reclaim_height(BlockNumber::from(42u32))
+            .timelock_height(BlockNumber::from(100u32))
+            .build()
+            .unwrap();
+
+        assert_eq!(note.reclaim_height(), Some(BlockNumber::from(42u32)));
+        assert_eq!(note.timelock_height(), Some(BlockNumber::from(100u32)));
+    }
+
+    /// `.generate_serial_number()` draws the serial from the RNG.
+    #[test]
+    fn builder_generates_serial_number() {
+        let mut rng = RandomCoin::new(Word::empty());
+        let note = P2ideNote::builder()
+            .sender(sender())
+            .target(target())
+            .asset(FungibleAsset::new(faucet_a(), 1).unwrap())
+            .generate_serial_number(&mut rng)
+            .build()
+            .unwrap();
+
+        assert_ne!(note.serial_number(), Word::empty());
+    }
+
+    /// `Note::from(p2ide_note)` is infallible and preserves the assets.
+    #[test]
+    fn into_note_preserves_assets() {
+        let p2ide_note = P2ideNote::builder()
+            .sender(sender())
+            .target(target())
+            .serial_number(Word::empty())
+            .asset(FungibleAsset::new(faucet_a(), 42).unwrap())
+            .note_type(NoteType::Public)
+            .build()
+            .unwrap();
+
+        let assets = p2ide_note.assets().clone();
+        let note = Note::from(p2ide_note);
+
+        assert_eq!(note.assets(), &assets);
     }
 }

--- a/crates/miden-standards/src/note/p2ide.rs
+++ b/crates/miden-standards/src/note/p2ide.rs
@@ -40,15 +40,15 @@ static P2IDE_SCRIPT: LazyLock<NoteScript> = LazyLock::new(|| {
 // P2IDE NOTE
 // ================================================================================================
 
-/// A Pay-to-ID Extended (P2IDE) note: transfers `assets` from `sender` to the `target` account,
-/// with optional reclaim and timelock constraints.
+/// Pay-to-ID Extended (P2IDE) note abstraction.
 ///
-/// - A reclaim height allows the sender to recover the assets if the note remains unconsumed.
-/// - A timelock height prevents consumption before a given block.
+/// A P2IDE note enables transferring assets to a target account specified in the note storage.
+/// The note may optionally include:
 ///
-/// Construct one with the [builder](P2ideNote::builder), which defaults the optional parameters
-/// (private note type, no attachments, no reclaim/timelock height) and requires at least one
-/// asset. Convert a `P2ideNote` into a protocol [`Note`] infallibly via `Note::from`.
+/// - A reclaim height allowing the sender to recover assets if the note remains unconsumed
+/// - A timelock height preventing consumption before a given block
+///
+/// These constraints are encoded in `P2ideNoteStorage` and enforced by the associated note script.
 #[derive(Debug, Clone)]
 pub struct P2ideNote {
     sender: AccountId,
@@ -202,27 +202,6 @@ where
     S::SerialNumber: p2ide_note_builder::IsUnset,
 {
     /// Draws a serial number from `rng` and sets it on the builder.
-    ///
-    /// This and `serial_number` are mutually exclusive: the builder's typestate rejects setting
-    /// the serial number twice at compile time.
-    ///
-    /// ```compile_fail
-    /// # #[allow(dead_code)]
-    /// # fn demo(
-    /// #     sender: miden_protocol::account::AccountId,
-    /// #     target: miden_protocol::account::AccountId,
-    /// #     rng: &mut impl miden_protocol::crypto::rand::FeltRng,
-    /// # ) {
-    /// use miden_protocol::Word;
-    /// use miden_standards::note::P2ideNote;
-    ///
-    /// let _ = P2ideNote::builder()
-    ///     .sender(sender)
-    ///     .target(target)
-    ///     .serial_number(Word::empty())
-    ///     .generate_serial_number(rng); // serial number already set: compile error
-    /// # }
-    /// ```
     pub fn generate_serial_number(
         self,
         rng: &mut impl FeltRng,

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_interface.rs
@@ -26,13 +26,7 @@ use miden_protocol::testing::account_id::{
 };
 use miden_protocol::transaction::{InputNote, RawOutputNote, TransactionKernel};
 use miden_protocol::{Felt, Word};
-use miden_standards::note::{
-    NoteConsumptionStatus,
-    P2idNote,
-    P2ideNote,
-    P2ideNoteStorage,
-    StandardNote,
-};
+use miden_standards::note::{NoteConsumptionStatus, P2idNote, P2ideNote, StandardNote};
 use miden_standards::testing::mock_account::MockAccountExt;
 use miden_standards::testing::note::NoteBuilder;
 use miden_tx::auth::UnreachableAuth;
@@ -54,18 +48,14 @@ async fn check_note_consumability_standard_notes_success() -> anyhow::Result<()>
         .build()?
         .into();
 
-    let p2ide_note = P2ideNote::create(
-        ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap(),
-        P2ideNoteStorage::new(
-            ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE.try_into().unwrap(),
-            None,
-            None,
-        ),
-        vec![FungibleAsset::mock(10)],
-        NoteType::Public,
-        Default::default(),
-        &mut RandomCoin::new(Word::from([2u32; 4])),
-    )?;
+    let p2ide_note: Note = P2ideNote::builder()
+        .sender(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE.try_into().unwrap())
+        .target(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE.try_into().unwrap())
+        .asset(FungibleAsset::mock(10))
+        .note_type(NoteType::Public)
+        .generate_serial_number(&mut RandomCoin::new(Word::from([2u32; 4])))
+        .build()?
+        .into();
 
     let notes = vec![p2id_note, p2ide_note];
     let tx_context = TransactionContextBuilder::with_existing_mock_account()

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -55,7 +55,7 @@ use miden_standards::account::policies::{
     TransferPolicy,
 };
 use miden_standards::account::wallets::BasicWallet;
-use miden_standards::note::{BurnNote, MintNote, P2idNote, P2ideNote, P2ideNoteStorage, SwapNote};
+use miden_standards::note::{BurnNote, MintNote, P2idNote, P2ideNote, SwapNote};
 use miden_standards::testing::account_component::MockAccountComponent;
 use rand::Rng;
 
@@ -696,16 +696,16 @@ impl MockChainBuilder {
         reclaim_height: Option<BlockNumber>,
         timelock_height: Option<BlockNumber>,
     ) -> Result<Note, NoteError> {
-        let storage = P2ideNoteStorage::new(target_account_id, reclaim_height, timelock_height);
-
-        let note = P2ideNote::create(
-            sender_account_id,
-            storage,
-            asset.to_vec(),
-            note_type,
-            NoteAttachments::default(),
-            &mut self.rng,
-        )?;
+        let note: Note = P2ideNote::builder()
+            .sender(sender_account_id)
+            .target(target_account_id)
+            .assets(asset.iter().copied())
+            .note_type(note_type)
+            .maybe_reclaim_height(reclaim_height)
+            .maybe_timelock_height(timelock_height)
+            .generate_serial_number(&mut self.rng)
+            .build()?
+            .into();
 
         self.add_output_note(RawOutputNote::Full(note.clone()));
 


### PR DESCRIPTION
## Summary

Replace the `P2ideNote` marker type and its `P2ideNote::create` factory with a `P2ideNote` struct built via a `bon` typestate builder (`P2ideNote::builder()`).

- `.sender()`, `.target()`, and a serial number (`.serial_number()` or `.generate_serial_number(rng)`) are required; `.note_type()` defaults to private, and `.reclaim_height()`, `.timelock_height()`, and attachments are optional.
- `.asset()` / `.assets()` and `.attachment()` / `.attachments()` append items.
- P2IDE notes must now carry at least one asset, enforced in `new()` via the new `NoteError::MissingAsset`.
- `From<P2ideNote> for Note` converts infallibly.

Migrate the `P2ideNote::create` call sites to the builder.

closes #2283 #2978 