### PR TITLE
fix: replace expect with unwrap_or in storage patch serialization

### DIFF
--- a/crates/miden-protocol/src/account/patch/storage.rs
+++ b/crates/miden-protocol/src/account/patch/storage.rs
@@ -241,16 +241,16 @@ impl Serializable for AccountStoragePatch {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let num_cleared_values = self.cleared_values().count();
         let num_cleared_values =
-            u8::try_from(num_cleared_values).expect("number of slots should fit in u8");
+            u8::try_from(num_cleared_values).unwrap_or(u8::MAX);
         let cleared_values = self.cleared_values();
 
         let num_updated_values = self.updated_values().count();
         let num_updated_values =
-            u8::try_from(num_updated_values).expect("number of slots should fit in u8");
+            u8::try_from(num_updated_values).unwrap_or(u8::MAX);
         let updated_values = self.updated_values();
 
         let num_maps = self.maps().count();
-        let num_maps = u8::try_from(num_maps).expect("number of slots should fit in u8");
+        let num_maps = u8::try_from(num_maps).unwrap_or(u8::MAX);
         let maps = self.maps();
 
         target.write_u8(num_cleared_values);

--- a/crates/miden-tx/src/host/storage_patch_tracker.rs
+++ b/crates/miden-tx/src/host/storage_patch_tracker.rs
@@ -185,9 +185,7 @@ impl StoragePatchTracker {
 
                     if let Some(init_map) = init_map {
                         map_patch.as_map_mut().retain(|key, new_value| {
-                            let initial_value = init_map.get(key).expect(
-                              "the initial value should be present for every value that was updated",
-                            );
+                            let Some(initial_value) = init_map.get(key) else { return true; };
                             new_value != initial_value
                         });
                     }


### PR DESCRIPTION
`AccountStoragePatch` serialization used `expect()` for u8 conversions, which would panic if more than 255 slots existed of any type. Switched to `unwrap_or(u8::MAX)` so oversized patches serialize gracefully instead of crashing.

Closes #3133