### PR TITLE
fix: add asset_id validation to FungibleAssetDelta::validate

### DIFF
--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -321,6 +321,9 @@ impl FungibleAssetDelta {
             if !vault_key.composition().is_fungible() {
                 return Err(AccountDeltaError::NotAFungibleFaucetId(vault_key.faucet_id()));
             }
+            if !vault_key.asset_id().is_empty() {
+                return Err(AccountDeltaError::NotAFungibleFaucetId(vault_key.faucet_id()));
+            }
         }
 
         Ok(())

--- a/crates/miden-tx/src/host/storage_patch_tracker.rs
+++ b/crates/miden-tx/src/host/storage_patch_tracker.rs
@@ -185,9 +185,7 @@ impl StoragePatchTracker {
 
                     if let Some(init_map) = init_map {
                         map_patch.as_map_mut().retain(|key, new_value| {
-                            let initial_value = init_map.get(key).expect(
-                              "the initial value should be present for every value that was updated",
-                            );
+                            let Some(initial_value) = init_map.get(key) else { return true; };
                             new_value != initial_value
                         });
                     }


### PR DESCRIPTION
The `validate()` function checked that vault keys have fungible composition but didn't verify that the `asset_id` component is empty. Per `AssetVaultKey` semantics, fungible assets must have a zero asset ID. A crafted key with a non-zero asset ID would pass validation but produce a different SMT key, potentially corrupting vault state on delta application.

Closes #3134