### PR TITLE
Update `AuthRequest` event to carry either signature or TX summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
+
 - [BREAKING] Replaced the `P2idNote` marker type and its `P2idNote::create` factory with a `P2idNote` struct built via a `bon` typestate builder (`P2idNote::builder()`). P2ID notes must now carry at least one asset; a `P2idNote` converts into a `Note` via `Note::from`, and the builder offers `.asset()`/`.assets()`, `.attachment()`/`.attachments()`, and `.generate_serial_number()` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
 - [BREAKING] Replaced the `MintNote` marker type and its `MintNote::create` factory with a struct built via a `bon` typestate builder (`MintNote::builder()`); a `MintNote` converts into a `Note` via `Note::from` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
 - [BREAKING] Replaced the `BurnNote` marker type and its `BurnNote::create` factory with a struct built via a `bon` typestate builder (`BurnNote::builder()`); a `BurnNote` converts into a `Note` via `Note::from` ([#2283](https://github.com/0xMiden/protocol/issues/2283)).
@@ -59,14 +60,16 @@
 - Refactored `is_max_supply_mutable_internal` in the fungible faucet to read the mutability config through the `get_mutability_config_word` getter instead of accessing the storage slot directly ([#3120](https://github.com/0xMiden/protocol/pull/3120)).
 - Added a zero-root check before dispatching the active mint and burn policy in `TokenPolicyManager`, failing with a descriptive error ([#3121](https://github.com/0xMiden/protocol/pull/3121)).
 - [BREAKING] Renamed `create_user_fungible_faucet` to `create_singlesig_user_fungible_faucet` and added the `create_multisig_user_fungible_faucet(auth_component: AuthMultisig, ...)` and `create_guarded_user_fungible_faucet(auth_component: AuthGuardedMultisig, ...)`. `create_network_fungible_faucet` now allowlists the canonical `ExpirationTransactionScript` in its tx-script allowlist ([#3143](https://github.com/0xMiden/protocol/pull/3143)).
+- Updated `AuthRequest` event to carry either signature of TX summary, but not both ([#3157](https://github.com/0xMiden/protocol/pull/3157)).
 
 ### Fixes
+
 - Fixed `update_ger` to explicitly reject duplicate GER insertions with `ERR_GER_ALREADY_REGISTERED` instead of silently accepting them ([#2983](https://github.com/0xMiden/protocol/pull/2983)).
 - AggLayer `bridge_out` now rejects B2AGG notes whose `NoteType` is not `Public`, preventing a recipient-identical private note from desyncing the Local Exit Tree from AggLayer's off-chain mirror ([#2988](https://github.com/0xMiden/protocol/pull/2988)).
 - Fixed `pausable::assert_not_paused` to guard its storage read with `active_account::has_storage_slot`, making it a no-op on accounts without the `Pausable` component instead of panicking on the missing `is_paused` slot ([#3047](https://github.com/0xMiden/protocol/pull/3047)).
 - [BREAKING] Fixed batch ID being serialized/deserialized and potentially not matching the serialized transaction headers ([#3061](https://github.com/0xMiden/protocol/pull/3061)).
 
-## v0.15.2 (TBD)
+## v0.15.2 (2026-06-05)
 
 ### Changes
 
@@ -74,7 +77,7 @@
 - [BREAKING] `TransactionScript::root()` now returns `TransactionScriptRoot` instead of `Word` ([#3028](https://github.com/0xMiden/protocol/pull/3028)).
 - Renamed `AuthNetworkAccount::with_allowlist` to `with_allowed_notes` and aligned the component's internal allowlist field names, for consistency with `with_allowed_tx_scripts` ([#3049](https://github.com/0xMiden/protocol/pull/3049)).
 
-## v0.15.1 (TBD)
+## v0.15.0 (2026-05-22)
 
 ### Changes
 

--- a/crates/miden-tx/src/executor/exec_host.rs
+++ b/crates/miden-tx/src/executor/exec_host.rs
@@ -49,6 +49,7 @@ use crate::host::{
     TransactionEvent,
     TransactionProgress,
     TransactionProgressEvent,
+    TxSummaryOrSignature,
 };
 use crate::{AccountProcedureIndexMap, DataStore};
 
@@ -580,14 +581,14 @@ where
 
                 TransactionEvent::AuthRequest {
                     pub_key_commitment,
-                    tx_summary,
-                    signature,
-                } => {
-                    if let Some(signature) = signature {
+                    tx_summary_or_signature,
+                } => match tx_summary_or_signature {
+                    TxSummaryOrSignature::Signature(signature) => {
                         Ok(self.base_host.on_auth_requested(signature))
-                    } else {
+                    },
+                    TxSummaryOrSignature::TxSummary(tx_summary) => {
                         self.on_auth_requested(pub_key_commitment, tx_summary).await
-                    }
+                    },
                 },
 
                 // This always returns an error to abort the transaction.

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -60,7 +60,12 @@ use miden_protocol::transaction::{
     TransactionMeasurements,
     TransactionSummary,
 };
-pub(crate) use tx_event::{RecipientData, TransactionEvent, TransactionProgressEvent};
+pub(crate) use tx_event::{
+    RecipientData,
+    TransactionEvent,
+    TransactionProgressEvent,
+    TxSummaryOrSignature,
+};
 pub use tx_progress::TransactionProgress;
 
 use crate::errors::TransactionKernelError;

--- a/crates/miden-tx/src/host/tx_event.rs
+++ b/crates/miden-tx/src/host/tx_event.rs
@@ -147,8 +147,7 @@ pub(crate) enum TransactionEvent {
     /// The data necessary to handle an auth request.
     AuthRequest {
         pub_key_commitment: PublicKeyCommitment,
-        tx_summary: TransactionSummary,
-        signature: Option<Vec<Felt>>,
+        tx_summary_or_signature: TxSummaryOrSignature,
     },
 
     Unauthorized {
@@ -163,21 +162,6 @@ pub(crate) enum TransactionEvent {
     },
 
     Progress(TransactionProgressEvent),
-}
-
-#[derive(Debug)]
-pub(crate) struct AssetPatch {
-    pub asset_key: AssetVaultKey,
-    /// The absolute value of `asset_key` in the vault before the operation.
-    pub initial_vault_value: Word,
-    /// The absolute value of `asset_key` in the vault after the operation.
-    pub final_vault_value: Word,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct AssetDelta {
-    pub delta_op: AssetDeltaOperation,
-    pub asset: Asset,
 }
 
 impl TransactionEvent {
@@ -494,18 +478,24 @@ impl TransactionEvent {
                 let pub_key_commitment = PublicKeyCommitment::from(process.get_stack_word(5));
                 let signature_key = Hasher::merge(&[pub_key_commitment.into(), message]);
 
-                let signature = process
+                let auth_request = if let Some(signature) = process
                     .advice_provider()
                     .get_mapped_values(&signature_key)
-                    .map(|slice| slice.to_vec());
+                    .map(|slice| slice.to_vec())
+                {
+                    TransactionEvent::AuthRequest {
+                        pub_key_commitment,
+                        tx_summary_or_signature: TxSummaryOrSignature::Signature(signature),
+                    }
+                } else {
+                    let tx_summary = extract_tx_summary(base_host, process, message)?;
+                    TransactionEvent::AuthRequest {
+                        pub_key_commitment,
+                        tx_summary_or_signature: TxSummaryOrSignature::TxSummary(tx_summary),
+                    }
+                };
 
-                let tx_summary = extract_tx_summary(base_host, process, message)?;
-
-                Some(TransactionEvent::AuthRequest {
-                    pub_key_commitment,
-                    tx_summary,
-                    signature,
-                })
+                Some(auth_request)
             },
 
             TransactionEventId::Unauthorized => {
@@ -579,6 +569,34 @@ impl TransactionEvent {
 
         Ok(tx_event)
     }
+}
+
+// TX SUMMARY OR SIGNATURE
+// ================================================================================================
+
+#[expect(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub(crate) enum TxSummaryOrSignature {
+    TxSummary(TransactionSummary),
+    Signature(Vec<Felt>),
+}
+
+// ASSET PATCH AND DELTA
+// ================================================================================================
+
+#[derive(Debug)]
+pub(crate) struct AssetPatch {
+    pub asset_key: AssetVaultKey,
+    /// The absolute value of `asset_key` in the vault before the operation.
+    pub initial_vault_value: Word,
+    /// The absolute value of `asset_key` in the vault after the operation.
+    pub final_vault_value: Word,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AssetDelta {
+    pub delta_op: AssetDeltaOperation,
+    pub asset: Asset,
 }
 
 // RECIPIENT DATA

--- a/crates/miden-tx/src/prover/prover_host.rs
+++ b/crates/miden-tx/src/prover/prover_host.rs
@@ -12,7 +12,13 @@ use miden_protocol::assembly::{SourceFile, SourceSpan};
 use miden_protocol::transaction::{InputNote, InputNotes, RawOutputNote};
 use miden_protocol::vm::{EventId, EventName};
 
-use crate::host::{RecipientData, ScriptMastForestStore, TransactionBaseHost, TransactionEvent};
+use crate::host::{
+    RecipientData,
+    ScriptMastForestStore,
+    TransactionBaseHost,
+    TransactionEvent,
+    TxSummaryOrSignature,
+};
 use crate::{AccountProcedureIndexMap, TransactionKernelError};
 
 /// The transaction prover host is responsible for handling [`Host`] requests made by the
@@ -185,8 +191,8 @@ where
                 .on_note_before_add_attachment(note_idx, attachment)
                 .map(|_| Vec::new()),
 
-            TransactionEvent::AuthRequest { signature, .. } => {
-                if let Some(signature) = signature {
+            TransactionEvent::AuthRequest { tx_summary_or_signature, .. } => {
+                if let TxSummaryOrSignature::Signature(signature) = tx_summary_or_signature {
                     Ok(self.base_host.on_auth_requested(signature))
                 } else {
                     Err(TransactionKernelError::other(


### PR DESCRIPTION
This PR changes the structure of the `AuthRequest` event from:

```rust
AuthRequest {
    pub_key_commitment: PublicKeyCommitment,
    tx_summary: Option<TransactionSummary>,
    signature: Option<Vec<Felt>>,
}
```

To

```rust
AuthRequest {
    pub_key_commitment: PublicKeyCommitment,
    tx_summary_or_signature: TxSummaryOrSignature,
}
```

The intent here is to make it so that when a signature for a given message is already present in the advice provider, we do not require constructing the TX summary matching the specified message. This allows the code to verify signatures over arbitrary messages.

For more context see https://github.com/0xMiden/protocol/pull/3044#discussion_r3476503850.