### PR TITLE
chore: ignore quick-xml rustsec issue

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,8 @@ ignore = [
   "RUSTSEC-2024-0436", # paste is unmaintained but no alternative available
   "RUSTSEC-2025-0141", # bincode is unmaintained, replace with wincode (https://github.com/0xMiden/miden-vm/issues/2550)
   "RUSTSEC-2026-0173", # proc-macro-error2 is unmaintained, ignore until `alloy-sol-macro` has migrated away
+  "RUSTSEC-2026-0194", # quick-xml has a vulnerability - ignore as we only depend on it for non-security-critical benchmarking functionality
+  "RUSTSEC-2026-0195", # quick-xml has a vulnerability - ignore as we only depend on it for non-security-critical benchmarking functionality
 ]
 yanked = "warn"
 
@@ -66,7 +68,7 @@ skip-tree = [
   { name = "unicode-width", version = "=0.1.*" },
   # Allow syn v1.x and v2.x - our derive macros need v1.x while ecosystem uses v2.x
   { name = "syn", version = "=1.0.109" },
-  { name = "syn", version = "=2.0.117" },
+  { name = "syn", version = "=2.0.118" },
   # Allow spin v0.9.x - legacy version used by some dependencies
   { name = "spin", version = "=0.9.*" },
 ]


### PR DESCRIPTION
Adds `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` to the ignore section in `deny.toml` which are vulnerabilities in `quick-xml`. We only use this as a dev-dependency and through `pprof` which we use for benchmarking, so it is not security critical. No newer version of `pprof` is available at this time either.