### PR TITLE
chore: use `CoreLibrary` package directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,7 +1878,6 @@ dependencies = [
  "miden-mast-package",
  "miden-package-registry",
  "miden-processor",
- "miden-project",
  "miden-protocol",
  "miden-utils-sync",
  "miden-verifier",

--- a/crates/miden-protocol/Cargo.toml
+++ b/crates/miden-protocol/Cargo.toml
@@ -76,7 +76,6 @@ miden-core             = { workspace = true }
 miden-core-lib         = { workspace = true }
 miden-mast-package     = { features = ["std"], workspace = true }
 miden-package-registry = { features = ["std"], workspace = true }
-miden-project          = { features = ["serde", "std"], workspace = true }
 regex                  = { workspace = true }
 walkdir                = { workspace = true }
 

--- a/crates/miden-protocol/asm/miden-project.toml
+++ b/crates/miden-protocol/asm/miden-project.toml
@@ -5,7 +5,7 @@ members = ["kernels/batch", "kernels/transaction", "kernels/transaction-core", "
 version = "0.16.0"
 
 [workspace.dependencies]
-miden-core           = { linkage = "dynamic", version = "0.24" }
+miden-core           = { linkage = "dynamic", version = "0.22" }
 miden-protocol-utils = { linkage = "static", path = "protocol_utils" }
 miden-tx-kernel      = { linkage = "dynamic", path = "kernels/transaction" }
 miden-tx-kernel-core = { linkage = "static", path = "kernels/transaction-core" }

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -87,7 +87,8 @@ fn main() -> Result<()> {
     let target_dir = Path::new(&build_dir).join(ASSETS_DIR);
 
     // The miden-core library is provided through an in-memory registry
-    let mut store = core_package_registry()?;
+    let mut store = InMemoryPackageRegistry::default();
+    store.cache_package(CoreLibrary::default().package()).into_diagnostic()?;
 
     // compile transaction kernel
     compile_tx_kernel(&source_dir, &target_dir.join("kernels"), &build_dir, &mut store)?;
@@ -346,14 +347,6 @@ fn build_assembler(source_manager: Arc<dyn SourceManager>) -> Assembler {
 
 fn is_dynamic_kernel_api_export(path: &MasmPath) -> bool {
     path.parent().is_some_and(|parent| parent.to_relative().as_str() == "$kernel")
-}
-
-/// Builds an in-memory package registry loaded with the `miden-core` library, so the projects can
-/// just declare it by version in the manifest.
-fn core_package_registry() -> Result<InMemoryPackageRegistry> {
-    let mut registry = InMemoryPackageRegistry::default();
-    registry.cache_package(CoreLibrary::default().package()).into_diagnostic()?;
-    Ok(registry)
 }
 
 // ERROR CONSTANTS FILE GENERATION

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -4,14 +4,13 @@ use std::path::Path;
 use std::sync::Arc;
 
 use fs_err as fs;
-use miden_assembly::debuginfo::{DefaultSourceManager, SourceManager, SourceManagerExt};
+use miden_assembly::debuginfo::{DefaultSourceManager, SourceManager};
 use miden_assembly::diagnostics::{IntoDiagnostic, Result, WrapErr, miette};
 use miden_assembly::{Assembler, Path as MasmPath, ProjectTargetSelector};
 use miden_core::events::EventId;
-use miden_mast_package::{Package, PackageExport, PackageId, TargetType, Version};
+use miden_core_lib::CoreLibrary;
+use miden_mast_package::{Package, PackageExport};
 use miden_package_registry::{InMemoryPackageRegistry, PackageCache};
-use miden_project::ast::MidenProject;
-use miden_project::{VersionRequirement, semver};
 use regex::Regex;
 use walkdir::WalkDir;
 
@@ -352,78 +351,9 @@ fn is_dynamic_kernel_api_export(path: &MasmPath) -> bool {
 /// Builds an in-memory package registry loaded with the `miden-core` library, so the projects can
 /// just declare it by version in the manifest.
 fn core_package_registry() -> Result<InMemoryPackageRegistry> {
-    let core_package = miden_core_lib::CoreLibrary::default().package();
-    let core_package_version =
-        dependency_package_version(Path::new(ASM_DIR).join(PROJECT_MANIFEST), "miden-core")?;
-    let package = Package::create_with_modules(
-        PackageId::from("miden-core"),
-        core_package_version,
-        TargetType::Library,
-        core_package.mast_forest().clone(),
-        core_package.manifest.exports().cloned(),
-        core_package.manifest.modules().cloned(),
-        core_package.manifest.dependencies().cloned(),
-    )
-    .into_diagnostic()?;
-
     let mut registry = InMemoryPackageRegistry::default();
-    registry.cache_package(Arc::new(package)).into_diagnostic()?;
+    registry.cache_package(CoreLibrary::default().package()).into_diagnostic()?;
     Ok(registry)
-}
-
-fn dependency_package_version(
-    manifest_path: impl AsRef<Path>,
-    dependency_name: &str,
-) -> Result<Version> {
-    let source_manager = DefaultSourceManager::default();
-    let source_file = source_manager
-        .load_file(manifest_path.as_ref())
-        .map_err(|err| miette::miette!("{err}"))?;
-    let project = MidenProject::parse(source_file).map_err(|err| miette::miette!("{err}"))?;
-    let dependencies = match &project {
-        MidenProject::Workspace(workspace) => &workspace.workspace.config.dependencies,
-        MidenProject::Package(package) => &package.config.dependencies,
-    };
-    let dependency = dependencies
-        .iter()
-        .find(|(name, _)| name.inner().as_ref() == dependency_name)
-        .map(|(_, dependency)| dependency.inner())
-        .ok_or_else(|| miette::miette!("manifest does not depend on `{dependency_name}`"))?;
-
-    match dependency.version() {
-        Some(VersionRequirement::Semantic(version_req)) => {
-            semantic_requirement_lower_bound(dependency_name, version_req.inner())
-        },
-        Some(VersionRequirement::Exact(version)) => Ok(version.version.clone()),
-        Some(VersionRequirement::Digest(_)) | None => Err(miette::miette!(
-            "dependency `{dependency_name}` must use a semantic version requirement"
-        )),
-    }
-}
-
-fn semantic_requirement_lower_bound(
-    dependency_name: &str,
-    version_req: &semver::VersionReq,
-) -> Result<Version> {
-    let [comparator] = version_req.comparators.as_slice() else {
-        return Err(miette::miette!(
-            "dependency `{dependency_name}` must use a single semantic version requirement"
-        ));
-    };
-
-    if !matches!(comparator.op, semver::Op::Caret | semver::Op::Exact)
-        || comparator.pre != semver::Prerelease::EMPTY
-    {
-        return Err(miette::miette!(
-            "dependency `{dependency_name}` must use a simple semantic version requirement"
-        ));
-    }
-
-    Ok(Version::new(
-        comparator.major,
-        comparator.minor.unwrap_or_default(),
-        comparator.patch.unwrap_or_default(),
-    ))
 }
 
 // ERROR CONSTANTS FILE GENERATION

--- a/crates/miden-standards/asm/components/miden-project.toml
+++ b/crates/miden-standards/asm/components/miden-project.toml
@@ -34,6 +34,6 @@ members = [
 version = "0.16.0"
 
 [workspace.dependencies]
-miden-core      = { linkage = "dynamic", version = "0.24" }
+miden-core      = { linkage = "dynamic", version = "0.22" }
 miden-protocol  = { linkage = "dynamic", version = "0.16.0" }
 miden-standards = { linkage = "static", version = "0.16.0" }

--- a/crates/miden-standards/asm/standards/miden-project.toml
+++ b/crates/miden-standards/asm/standards/miden-project.toml
@@ -7,5 +7,5 @@ namespace = "miden::standards"
 path      = "mod.masm"
 
 [dependencies]
-miden-core     = { linkage = "dynamic", version = "0.24" }
+miden-core     = { linkage = "dynamic", version = "0.22" }
 miden-protocol = { linkage = "dynamic", version = "0.16.0" }

--- a/crates/miden-standards/build.rs
+++ b/crates/miden-standards/build.rs
@@ -3,13 +3,12 @@ use std::path::Path;
 use std::sync::Arc;
 
 use miden_assembly::debuginfo::{DefaultSourceManager, SourceManager, SourceManagerExt};
-use miden_assembly::diagnostics::{IntoDiagnostic, Result, WrapErr, miette};
+use miden_assembly::diagnostics::{IntoDiagnostic, Result, WrapErr};
 use miden_assembly::{Assembler, ProjectTargetSelector};
 use miden_core_lib::CoreLibrary;
-use miden_mast_package::{Package, PackageId, TargetType, Version};
+use miden_mast_package::Package;
 use miden_package_registry::{InMemoryPackageRegistry, PackageCache};
-use miden_project::ast::MidenProject;
-use miden_project::{VersionRequirement, Workspace, semver};
+use miden_project::Workspace;
 use miden_protocol::ProtocolLib;
 use miden_protocol::transaction::TransactionKernel;
 
@@ -83,26 +82,10 @@ fn main() -> Result<()> {
 fn build_registry() -> Result<InMemoryPackageRegistry> {
     let mut registry = InMemoryPackageRegistry::default();
 
-    let core_package = CoreLibrary::default().package();
-    let core_package_version = dependency_package_version(
-        Path::new(ASM_DIR).join(ASM_STANDARDS_DIR).join(PROJECT_MANIFEST),
-        "miden-core",
-    )?;
-    let core_package = Package::create_with_modules(
-        PackageId::from("miden-core"),
-        core_package_version,
-        TargetType::Library,
-        core_package.mast_forest().clone(),
-        core_package.manifest.exports().cloned(),
-        core_package.manifest.modules().cloned(),
-        core_package.manifest.dependencies().cloned(),
-    )
-    .into_diagnostic()?;
-
     // The protocol package declares dependencies on the kernel and core packages, so all three
     // must be available in the registry for project dependency resolution to succeed.
     for package in [
-        Arc::new(core_package),
+        CoreLibrary::default().package(),
         Arc::new(Package::from(ProtocolLib::default())),
         TransactionKernel::package(),
     ] {
@@ -110,61 +93,6 @@ fn build_registry() -> Result<InMemoryPackageRegistry> {
     }
 
     Ok(registry)
-}
-
-fn dependency_package_version(
-    manifest_path: impl AsRef<Path>,
-    dependency_name: &str,
-) -> Result<Version> {
-    let source_manager = DefaultSourceManager::default();
-    let source_file = source_manager
-        .load_file(manifest_path.as_ref())
-        .map_err(|err| miette::miette!("{err}"))?;
-    let project = MidenProject::parse(source_file).map_err(|err| miette::miette!("{err}"))?;
-    let dependencies = match &project {
-        MidenProject::Workspace(workspace) => &workspace.workspace.config.dependencies,
-        MidenProject::Package(package) => &package.config.dependencies,
-    };
-    let dependency = dependencies
-        .iter()
-        .find(|(name, _)| name.inner().as_ref() == dependency_name)
-        .map(|(_, dependency)| dependency.inner())
-        .ok_or_else(|| miette::miette!("manifest does not depend on `{dependency_name}`"))?;
-
-    match dependency.version() {
-        Some(VersionRequirement::Semantic(version_req)) => {
-            semantic_requirement_lower_bound(dependency_name, version_req.inner())
-        },
-        Some(VersionRequirement::Exact(version)) => Ok(version.version.clone()),
-        Some(VersionRequirement::Digest(_)) | None => Err(miette::miette!(
-            "dependency `{dependency_name}` must use a semantic version requirement"
-        )),
-    }
-}
-
-fn semantic_requirement_lower_bound(
-    dependency_name: &str,
-    version_req: &semver::VersionReq,
-) -> Result<Version> {
-    let [comparator] = version_req.comparators.as_slice() else {
-        return Err(miette::miette!(
-            "dependency `{dependency_name}` must use a single semantic version requirement"
-        ));
-    };
-
-    if !matches!(comparator.op, semver::Op::Caret | semver::Op::Exact)
-        || comparator.pre != semver::Prerelease::EMPTY
-    {
-        return Err(miette::miette!(
-            "dependency `{dependency_name}` must use a simple semantic version requirement"
-        ));
-    }
-
-    Ok(Version::new(
-        comparator.major,
-        comparator.minor.unwrap_or_default(),
-        comparator.patch.unwrap_or_default(),
-    ))
 }
 
 // COMPILE STANDARDS LIB


### PR DESCRIPTION
Small follow-up to #3094. Use `CoreLibrary` package directly without recreating it in the `build.rs` files and remove additional code that was necessary because of it. 

The version of `CoreLibrary` that ships with [crate version 0.24](https://github.com/0xMiden/miden-vm/blob/v0.24.2/crates/lib/core/asm/miden-project.toml#L3) is (probably unintentionally?) 0.22, so using `0.22` means we can use the `CoreLibrary` package as-is without dependency resolution issues.

IIUC, the version of the package should be fixed in VM repo, cc @huitseeker.