### PR TITLE
chore: replace ChaCha RNG with rand::random

### DIFF
--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -63,8 +63,6 @@ use miden_standards::code_builder::CodeBuilder;
 use miden_standards::testing::account_component::MockAccountComponent;
 use miden_standards::testing::mock_account::MockAccountExt;
 use miden_tx::LocalTransactionProver;
-use rand::{RngExt, SeedableRng};
-use rand_chacha::ChaCha20Rng;
 
 use super::{Felt, StackInputs, ZERO};
 use crate::executor::CodeExecutor;
@@ -328,7 +326,7 @@ async fn test_get_item() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_get_map_item() -> anyhow::Result<()> {
     let slot = AccountStorage::mock_map_slot();
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![slot.clone()]))
         .build_existing()
@@ -592,7 +590,7 @@ async fn test_set_map_item() -> anyhow::Result<()> {
     );
 
     let slot = AccountStorage::mock_map_slot();
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![slot.clone()]))
         .build_existing()
@@ -1322,7 +1320,7 @@ async fn test_authenticate_and_track_procedure() -> anyhow::Result<()> {
 async fn test_was_procedure_called() -> anyhow::Result<()> {
     // Create a standard account using the mock component
     let mock_component = MockAccountComponent::with_slots(AccountStorage::mock_storage_slots());
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(mock_component)
         .build_existing()
@@ -1467,7 +1465,7 @@ async fn transaction_executor_account_code_using_custom_library() -> anyhow::Res
     )?;
 
     // Build an existing account with nonce 1.
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(account_component)
         .build_existing()?;
@@ -1535,7 +1533,7 @@ async fn incrementing_nonce_twice_fails() -> anyhow::Result<()> {
 async fn test_has_procedure() -> anyhow::Result<()> {
     // Create a standard account using the mock component
     let mock_component = MockAccountComponent::with_slots(AccountStorage::mock_storage_slots());
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(mock_component)
         .build_existing()
@@ -1688,7 +1686,7 @@ async fn test_get_initial_item() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_get_initial_map_item() -> anyhow::Result<()> {
     let map_slot = AccountStorage::mock_map_slot();
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![map_slot.clone()]))
         .build_existing()
@@ -1778,7 +1776,7 @@ async fn test_get_item_and_get_initial_item_for_all_slots() -> anyhow::Result<()
         })
         .collect();
 
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(slots.clone()))
         .build_existing()

--- a/crates/miden-testing/src/kernel_tests/tx/test_array.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_array.rs
@@ -11,8 +11,6 @@ use miden_protocol::account::{
     StorageSlotName,
 };
 use miden_standards::code_builder::CodeBuilder;
-use rand::{RngExt, SeedableRng};
-use rand_chacha::ChaCha20Rng;
 
 use crate::{Auth, TestTransactionBuilder};
 
@@ -75,7 +73,7 @@ async fn test_array_get_and_set() -> anyhow::Result<()> {
     )?;
 
     // Build an account with the wrapper component that uses the array utility
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(wrapper_component)
         .build_existing()?;
@@ -194,7 +192,7 @@ async fn test_double_word_array_get_and_set() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("wrapper::component"),
     )?;
 
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(wrapper_component)
         .build_existing()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -53,8 +53,6 @@ use miden_protocol::{Word, ZERO};
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::testing::account_component::MockAccountComponent;
 use miden_tx::LocalTransactionProver;
-use rand::{RngExt, SeedableRng};
-use rand_chacha::ChaCha20Rng;
 
 use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::{Auth, MockChainBuilder, assert_execution_error, assert_transaction_executor_error};
@@ -101,12 +99,12 @@ async fn test_fpi_memory_single_account() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("test::foreign_account"),
     )?;
 
-    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component)
         .build_existing()?;
 
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![AccountStorage::mock_map_slot()]))
         .account_type(AccountType::Public)
@@ -373,17 +371,17 @@ async fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("test::foreign_account_2"),
     )?;
 
-    let foreign_account_1 = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account_1 = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component_1)
         .build_existing()?;
 
-    let foreign_account_2 = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account_2 = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component_2)
         .build_existing()?;
 
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -608,12 +606,12 @@ async fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("foreign_account"),
     )?;
 
-    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;
 
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -795,13 +793,13 @@ async fn foreign_account_can_get_balance_and_presence_of_asset() -> anyhow::Resu
         AccountComponentMetadata::mock("foreign_account_code"),
     )?;
 
-    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .with_assets(vec![fungible_asset, non_fungible_asset])
         .build_existing()?;
 
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -901,13 +899,13 @@ async fn foreign_account_get_initial_balance() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("foreign_account_code"),
     )?;
 
-    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .with_assets(vec![fungible_asset])
         .build_existing()?;
 
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -1047,11 +1045,10 @@ async fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("test::second_foreign_account"),
     )?;
 
-    let second_foreign_account =
-        AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
-            .with_auth_component(Auth::IncrNonce)
-            .with_component(second_foreign_account_component)
-            .build_existing()?;
+    let second_foreign_account = AccountBuilder::new(rand::random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(second_foreign_account_component)
+        .build_existing()?;
 
     // ------ FIRST FOREIGN ACCOUNT ---------------------------------------------------------------
     let first_foreign_account_code_source = format!(
@@ -1112,14 +1109,13 @@ async fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("first_foreign_account"),
     )?;
 
-    let first_foreign_account =
-        AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
-            .with_auth_component(Auth::IncrNonce)
-            .with_component(first_foreign_account_component.clone())
-            .build_existing()?;
+    let first_foreign_account = AccountBuilder::new(rand::random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(first_foreign_account_component.clone())
+        .build_existing()?;
 
     // ------ NATIVE ACCOUNT ---------------------------------------------------------------
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -1245,11 +1241,10 @@ async fn test_prove_fpi_two_foreign_accounts_chain() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("foreign_account"),
     )?;
 
-    let second_foreign_account =
-        AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
-            .with_auth_component(Auth::IncrNonce)
-            .with_component(second_foreign_account_component.clone())
-            .build_existing()?;
+    let second_foreign_account = AccountBuilder::new(rand::random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(second_foreign_account_component.clone())
+        .build_existing()?;
 
     // ------ FIRST FOREIGN ACCOUNT ---------------------------------------------------------------
     // unique procedure which calls the second foreign account via FPI and then returns
@@ -1293,14 +1288,13 @@ async fn test_prove_fpi_two_foreign_accounts_chain() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("first_foreign_account"),
     )?;
 
-    let first_foreign_account =
-        AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
-            .with_auth_component(Auth::IncrNonce)
-            .with_component(first_foreign_account_component.clone())
-            .build_existing()?;
+    let first_foreign_account = AccountBuilder::new(rand::random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(first_foreign_account_component.clone())
+        .build_existing()?;
 
     // ------ NATIVE ACCOUNT ---------------------------------------------------------------
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -1422,12 +1416,11 @@ async fn test_nested_fpi_stack_overflow() -> anyhow::Result<()> {
     )
     .unwrap();
 
-    let last_foreign_account =
-        AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
-            .with_auth_component(Auth::IncrNonce)
-            .with_component(last_foreign_account_component)
-            .build_existing()
-            .unwrap();
+    let last_foreign_account = AccountBuilder::new(rand::random())
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(last_foreign_account_component)
+        .build_existing()
+        .unwrap();
 
     foreign_accounts.push(last_foreign_account);
 
@@ -1476,7 +1469,7 @@ async fn test_nested_fpi_stack_overflow() -> anyhow::Result<()> {
         )
         .unwrap();
 
-        let foreign_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+        let foreign_account = AccountBuilder::new(rand::random())
             .with_auth_component(Auth::IncrNonce)
             .with_component(foreign_account_component)
             .build_existing()
@@ -1486,7 +1479,7 @@ async fn test_nested_fpi_stack_overflow() -> anyhow::Result<()> {
     }
 
     // ------ NATIVE ACCOUNT ---------------------------------------------------------------
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -1591,13 +1584,13 @@ async fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("foreign_account"),
     )?;
 
-    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;
 
     // ------ NATIVE ACCOUNT ---------------------------------------------------------------
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -1800,12 +1793,12 @@ async fn test_fpi_get_account_id() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("foreign_account"),
     )?;
 
-    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;
 
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -1888,7 +1881,7 @@ async fn test_fpi_get_account_id() -> anyhow::Result<()> {
 async fn test_get_initial_item_and_get_initial_map_item_with_foreign_account() -> anyhow::Result<()>
 {
     // Create a native account
-    let native_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let native_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
@@ -1929,7 +1922,7 @@ async fn test_get_initial_item_and_get_initial_map_item_with_foreign_account() -
         AccountComponentMetadata::mock("foreign_account"),
     )?;
 
-    let foreign_account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let foreign_account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_note.rs
@@ -454,13 +454,12 @@ pub async fn test_timelock() -> anyhow::Result<()> {
 
     let lock_timestamp = 2_000_000_000;
     let source_manager = Arc::new(DefaultSourceManager::default());
-    let timelock_note =
-        NoteBuilder::new(account.id(), &mut ChaCha20Rng::from_rng(&mut rand::rng()))
-            .note_storage([Felt::from(lock_timestamp)])?
-            .source_manager(source_manager.clone())
-            .code(code.clone())
-            .dynamically_linked_libraries(CodeBuilder::mock_libraries())
-            .build()?;
+    let timelock_note = NoteBuilder::new(account.id(), &mut rand::rng())
+        .note_storage([Felt::from(lock_timestamp)])?
+        .source_manager(source_manager.clone())
+        .code(code.clone())
+        .dynamically_linked_libraries(CodeBuilder::mock_libraries())
+        .build()?;
 
     builder.add_output_note(RawOutputNote::Full(timelock_note.clone()));
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -82,8 +82,6 @@ use miden_standards::code_builder::CodeBuilder;
 use miden_standards::testing::account_component::MockAccountComponent;
 use miden_standards::testing::mock_account::MockAccountExt;
 use miden_tx::TransactionExecutorError;
-use rand::{RngExt, SeedableRng};
-use rand_chacha::ChaCha20Rng;
 
 use super::{Felt, ZERO};
 use crate::kernel_tests::tx::ExecutionOutputExt;
@@ -567,7 +565,7 @@ pub async fn create_account_test(
 pub async fn create_multiple_accounts_test(account_type: AccountType) -> anyhow::Result<()> {
     let mut accounts = Vec::new();
 
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .account_type(account_type)
         .with_auth_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![StorageSlot::with_value(
@@ -602,7 +600,7 @@ pub async fn create_account_invalid_seed() -> anyhow::Result<()> {
     let mut mock_chain = MockChain::new();
     mock_chain.prove_next_block()?;
 
-    let account = AccountBuilder::new(ChaCha20Rng::from_rng(&mut rand::rng()).random())
+    let account = AccountBuilder::new(rand::random())
         .with_auth_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .build()?;


### PR DESCRIPTION
Small follow-up to #3146 to replace ChaCha rng with a more concise `rand::random`. Afaict, we don't care about the exact RNG used in tests.