### PR TITLE
refactor: procedure reordering and documentation for `Ownable2Step` and `Rbac` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - [BREAKING] Moved asset callback flag from asset vault key to account ID, making it immutable ([#3167](https://github.com/0xMiden/protocol/pull/3167)).
 - [BREAKING] Added `@account_procedure` attribute to mark which procedures should be included in the account component interface ([#3171](https://github.com/0xMiden/protocol/pull/3171)).
 - Documented that the `ecdsa_k256_keccak` authentication scheme discloses the signer's public key and signature at proving time via precompile calldata ([#3178](https://github.com/0xMiden/protocol/pull/3178)).
+- Unified procedure ordering and document sender-based access control's authentication assumption in the `ownable2step` and `rbac` access control modules ([#3205](https://github.com/0xMiden/protocol/pull/3205)).
 
 ### Fixes
 

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -16,6 +16,15 @@
 # Storage layout (single slot):
 #   Word:  [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
 #           word[0]       word[1]        word[2]                  word[3]
+#
+# Security model:
+# Access control is based on the note sender, i.e. the account ID that created the note
+# (`active_note::get_sender`). This authenticates which account created the note, not the code
+# that ran when it was created. It is therefore meaningful only when every account registered as
+# owner enforces strong authentication. Registering a permissionless account (for example one
+# using the `no_auth` component) as owner provides no protection: anyone can make such an account
+# emit a note carrying an arbitrary script root with that account's ID as sender, defeating the
+# owner check.
 
 use miden::protocol::active_account
 use miden::protocol::account_id

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -40,103 +40,8 @@ const ERR_SENDER_NOT_OWNER = "note sender is not the owner"
 const ERR_SENDER_NOT_NOMINATED_OWNER = "note sender is not the nominated owner"
 const ERR_NO_NOMINATED_OWNER = "no nominated ownership transfer exists"
 
-# INTERNAL PROCEDURES
+# PUBLIC INTERFACE
 # ================================================================================================
-
-#! Returns the full ownership word from storage.
-#!
-#! Inputs:  []
-#! Outputs: [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
-#!
-#! Where:
-#! - owner_{suffix, prefix} are the suffix and prefix felts of the current owner account ID.
-#! - nominated_owner_{suffix, prefix} are the suffix and prefix felts of the nominated
-#!   owner account ID.
-proc load_ownership_info
-    push.OWNER_CONFIG_SLOT[0..2] exec.active_account::get_item
-    # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
-end
-
-#! Writes the ownership word to storage and drops the old value.
-#!
-#! Inputs:  [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
-#! Outputs: []
-proc save_ownership_info
-    push.OWNER_CONFIG_SLOT[0..2]
-    # => [slot_suffix, slot_prefix, owner_suffix, owner_prefix,
-    #     nominated_owner_suffix, nominated_owner_prefix]
-
-    exec.native_account::set_item
-    # => [OLD_OWNERSHIP_WORD]
-
-    dropw
-    # => []
-end
-
-#! Returns the owner account ID from storage.
-#!
-#! Inputs:  []
-#! Outputs: [owner_suffix, owner_prefix]
-#!
-#! Where:
-#! - owner_{suffix, prefix} are the suffix and prefix felts of the owner account ID.
-proc get_owner_internal
-    exec.load_ownership_info
-    # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
-
-    movup.2 drop
-    # => [owner_suffix, owner_prefix, nominated_owner_prefix]
-
-    movup.2 drop
-    # => [owner_suffix, owner_prefix]
-end
-
-#! Returns the nominated owner account ID from storage.
-#!
-#! Inputs:  []
-#! Outputs: [nominated_owner_suffix, nominated_owner_prefix]
-#!
-#! Where:
-#! - nominated_owner_{suffix, prefix} are the suffix and prefix felts of the nominated
-#!   owner account ID.
-proc get_nominated_owner_internal
-    exec.load_ownership_info
-    # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
-
-    drop drop
-    # => [nominated_owner_suffix, nominated_owner_prefix]
-end
-
-#! Checks if the given account ID is the owner of this component.
-#!
-#! Inputs:  [account_id_suffix, account_id_prefix]
-#! Outputs: [is_owner]
-#!
-#! Where:
-#! - is_owner is 1 if the account is the owner, 0 otherwise.
-proc is_owner_internal
-    exec.get_owner_internal
-    # => [owner_suffix, owner_prefix, account_id_suffix, account_id_prefix]
-
-    exec.account_id::is_equal
-    # => [is_owner]
-end
-
-#! Checks if the given account ID is the nominated owner of this component.
-#!
-#! Inputs:  [account_id_suffix, account_id_prefix]
-#! Outputs: [is_nominated_owner]
-#!
-#! Where:
-#! - account_id_{suffix, prefix} are the suffix and prefix felts of the account ID to check.
-#! - is_nominated_owner is 1 if the account is the nominated owner, 0 otherwise.
-proc is_nominated_owner_internal
-    exec.get_nominated_owner_internal
-    # => [nominated_owner_suffix, nominated_owner_prefix, account_id_suffix, account_id_prefix]
-
-    exec.account_id::is_equal
-    # => [is_nominated_owner]
-end
 
 #! Returns 1 if the note sender is the current owner, otherwise 0.
 #!
@@ -171,9 +76,6 @@ pub proc assert_sender_is_owner
     assert.err=ERR_SENDER_NOT_OWNER
     # => []
 end
-
-# PUBLIC INTERFACE
-# ================================================================================================
 
 #! Returns the owner account ID.
 #!
@@ -333,4 +235,102 @@ pub proc renounce_ownership
 
     exec.save_ownership_info
     # => [pad(16)]
+end
+
+# HELPER PROCEDURES
+# ================================================================================================
+
+#! Returns the full ownership word from storage.
+#!
+#! Inputs:  []
+#! Outputs: [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
+#!
+#! Where:
+#! - owner_{suffix, prefix} are the suffix and prefix felts of the current owner account ID.
+#! - nominated_owner_{suffix, prefix} are the suffix and prefix felts of the nominated
+#!   owner account ID.
+proc load_ownership_info
+    push.OWNER_CONFIG_SLOT[0..2] exec.active_account::get_item
+    # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
+end
+
+#! Writes the ownership word to storage and drops the old value.
+#!
+#! Inputs:  [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
+#! Outputs: []
+proc save_ownership_info
+    push.OWNER_CONFIG_SLOT[0..2]
+    # => [slot_suffix, slot_prefix, owner_suffix, owner_prefix,
+    #     nominated_owner_suffix, nominated_owner_prefix]
+
+    exec.native_account::set_item
+    # => [OLD_OWNERSHIP_WORD]
+
+    dropw
+    # => []
+end
+
+#! Returns the owner account ID from storage.
+#!
+#! Inputs:  []
+#! Outputs: [owner_suffix, owner_prefix]
+#!
+#! Where:
+#! - owner_{suffix, prefix} are the suffix and prefix felts of the owner account ID.
+proc get_owner_internal
+    exec.load_ownership_info
+    # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
+
+    movup.2 drop
+    # => [owner_suffix, owner_prefix, nominated_owner_prefix]
+
+    movup.2 drop
+    # => [owner_suffix, owner_prefix]
+end
+
+#! Returns the nominated owner account ID from storage.
+#!
+#! Inputs:  []
+#! Outputs: [nominated_owner_suffix, nominated_owner_prefix]
+#!
+#! Where:
+#! - nominated_owner_{suffix, prefix} are the suffix and prefix felts of the nominated
+#!   owner account ID.
+proc get_nominated_owner_internal
+    exec.load_ownership_info
+    # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
+
+    drop drop
+    # => [nominated_owner_suffix, nominated_owner_prefix]
+end
+
+#! Checks if the given account ID is the owner of this component.
+#!
+#! Inputs:  [account_id_suffix, account_id_prefix]
+#! Outputs: [is_owner]
+#!
+#! Where:
+#! - is_owner is 1 if the account is the owner, 0 otherwise.
+proc is_owner_internal
+    exec.get_owner_internal
+    # => [owner_suffix, owner_prefix, account_id_suffix, account_id_prefix]
+
+    exec.account_id::is_equal
+    # => [is_owner]
+end
+
+#! Checks if the given account ID is the nominated owner of this component.
+#!
+#! Inputs:  [account_id_suffix, account_id_prefix]
+#! Outputs: [is_nominated_owner]
+#!
+#! Where:
+#! - account_id_{suffix, prefix} are the suffix and prefix felts of the account ID to check.
+#! - is_nominated_owner is 1 if the account is the nominated owner, 0 otherwise.
+proc is_nominated_owner_internal
+    exec.get_nominated_owner_internal
+    # => [nominated_owner_suffix, nominated_owner_prefix, account_id_suffix, account_id_prefix]
+
+    exec.account_id::is_equal
+    # => [is_nominated_owner]
 end

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -308,36 +308,6 @@ proc get_role_config
     # => [member_count, admin_role_symbol]
 end
 
-#! Writes the config word for a role.
-#!
-#! The trailing zeros of the stored config word are appended internally so callers do
-#! not need to push them themselves.
-#!
-#! Inputs:  [role_symbol, member_count, admin_role_symbol]
-#! Outputs: []
-#!
-#! Invocation: exec
-proc set_role_config
-    push.0.0
-    # => [0, 0, role_symbol, member_count, admin_role_symbol]
-
-    movdn.4 movdn.4
-    # => [role_symbol, member_count, admin_role_symbol, 0, 0]
-
-    push.0.0.0
-    # => [0, 0, 0, role_symbol, member_count, admin_role_symbol, 0, 0]
-
-    push.ROLE_CONFIG_SLOT[0..2]
-    # => [slot_suffix, slot_prefix, 0, 0, 0, role_symbol,
-    #     member_count, admin_role_symbol, 0, 0]
-
-    exec.native_account::set_map_item
-    # => [OLD_ROLE_CONFIG]
-
-    dropw
-    # => []
-end
-
 #! Returns whether an account holds a role.
 #!
 #! Inputs:  [role_symbol, account_suffix, account_prefix]
@@ -437,6 +407,36 @@ proc assert_sender_is_owner_or_role_admin
         assert.err=ERR_SENDER_NOT_OWNER_OR_ROLE_ADMIN
         # => []
     end
+end
+
+#! Writes the config word for a role.
+#!
+#! The trailing zeros of the stored config word are appended internally so callers do
+#! not need to push them themselves.
+#!
+#! Inputs:  [role_symbol, member_count, admin_role_symbol]
+#! Outputs: []
+#!
+#! Invocation: exec
+proc set_role_config
+    push.0.0
+    # => [0, 0, role_symbol, member_count, admin_role_symbol]
+
+    movdn.4 movdn.4
+    # => [role_symbol, member_count, admin_role_symbol, 0, 0]
+
+    push.0.0.0
+    # => [0, 0, 0, role_symbol, member_count, admin_role_symbol, 0, 0]
+
+    push.ROLE_CONFIG_SLOT[0..2]
+    # => [slot_suffix, slot_prefix, 0, 0, 0, role_symbol,
+    #     member_count, admin_role_symbol, 0, 0]
+
+    exec.native_account::set_map_item
+    # => [OLD_ROLE_CONFIG]
+
+    dropw
+    # => []
 end
 
 #! Internal helper used by `grant_role` to assign a role to an account.

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -22,6 +22,14 @@
 # - A role is considered to "exist" when it has at least one member. Role admin
 #   relationships set via `set_role_admin` are stored in the config but do not, by
 #   themselves, make the role exist.
+#
+# Security model:
+# Access control is based on the note sender (`active_note::get_sender`), i.e. the account ID
+# that created the note, not the code that ran when it was created. It is meaningful only when
+# every account registered as owner or role member enforces strong authentication. Registering a
+# permissionless account (for example one using the `no_auth` component) as owner or role member
+# provides no protection: anyone can make such an account emit a note carrying an arbitrary script
+# root with that account's ID as sender, defeating the sender check.
 
 use miden::protocol::account_id
 use miden::protocol::active_account

--- a/crates/miden-standards/src/account/access/ownable2step.rs
+++ b/crates/miden-standards/src/account/access/ownable2step.rs
@@ -32,6 +32,15 @@ static OWNER_CONFIG_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// must explicitly accept the transfer before it takes effect, preventing accidental transfers
 /// to incorrect addresses.
 ///
+/// ## Security considerations
+///
+/// Access control is based on the note sender (the account ID that created the note), which
+/// authenticates *which account* created a note but not the *code* that executed when it was
+/// created. It is meaningful only when every account registered as owner enforces strong
+/// authentication. Registering a permissionless account (for example one using `no_auth`) as
+/// owner provides no access restriction: anyone can make such an account emit a note with an
+/// arbitrary script root and that account's ID as sender, defeating the owner check.
+///
 /// ## Storage Layout
 ///
 /// The ownership data is stored in a single word:

--- a/crates/miden-standards/src/account/access/rbac.rs
+++ b/crates/miden-standards/src/account/access/rbac.rs
@@ -37,6 +37,15 @@ static ROLE_MEMBERSHIP_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// membership. It allows role assignment with domain isolation to minimize the scope of
 /// damage from a compromised role.
 ///
+/// ## Security considerations
+///
+/// Access control is based on the note sender (the account ID that created the note), which
+/// authenticates *which account* created a note but not the *code* that executed when it was
+/// created. It is meaningful only when every account registered as owner or role member enforces
+/// strong authentication. Registering a permissionless account (for example one using `no_auth`)
+/// as owner or role member provides no access restriction: anyone can make such an account emit a
+/// note with an arbitrary script root and that account's ID as sender, defeating the sender check.
+///
 /// ## Relation to [`Ownable2Step`]
 ///
 /// RBAC is a superset of [`Ownable2Step`] and depends on it: the top-level authority is


### PR DESCRIPTION
This PR unifies procedure ordering across the access control modules and documents the authentication assumption behind sender-based access control.