### PR TITLE
fix(standards): bind block commitment and expiration into signed tx summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.16.0 (TBD)
 
 ### Changes
+- [BREAKING] Bound the reference block commitment and the transaction expiration into the signed transaction summary. `auth::create_tx_summary` now produces six words (`[ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, BLOCK_COMMITMENT, REF_PARAMS, SALT]`, where `REF_PARAMS = [0, 0, expiration_delta, ref_block_num]`), inserted into the advice map via the new `auth::build_signed_message` procedure, and `TransactionSummary` gained `block_commitment` and `ref_params` fields ([#3221](https://github.com/0xMiden/protocol/pull/3221)).
 - Split `account_id::validate` into `account_id::validate_structure` (version-independent structural checks) and `account_id::validate` (structure and the version check) ([#3188](https://github.com/0xMiden/protocol/pull/3188)).
 - Changed the default `LocalTransactionProver` hash function from `BLAKE3` to `Poseidon2`, added ECDSA variants for every signature-authenticated transaction benchmark, and restructured the time counting benchmark IDs to encode the signing scheme and proving hash function (e.g. `poseidon2/falcon/single-p2id-note`) ([#3152](https://github.com/0xMiden/protocol/pull/3152)).
 - [BREAKING] Renamed `AssetId` to `AssetClass`, the identifier that distinguishes assets within a faucet ([#3079](https://github.com/0xMiden/protocol/issues/3079)).

--- a/crates/miden-protocol/src/transaction/tx_summary.rs
+++ b/crates/miden-protocol/src/transaction/tx_summary.rs
@@ -21,6 +21,8 @@ pub struct TransactionSummary {
     account_delta: AccountDelta,
     input_notes: InputNotes<InputNote>,
     output_notes: RawOutputNotes,
+    block_commitment: Word,
+    ref_params: Word,
     salt: Word,
 }
 
@@ -29,16 +31,25 @@ impl TransactionSummary {
     // --------------------------------------------------------------------------------------------
 
     /// Creates a new [`TransactionSummary`] from the provided parts.
+    ///
+    /// `block_commitment` is the commitment to the transaction's reference block, and `ref_params`
+    /// is `[0, 0, expiration_delta, ref_block_num]`. Both are bound into the signed summary so that
+    /// a delegated prover cannot alter the reference block or the transaction expiration without
+    /// invalidating the signature.
     pub fn new(
         account_delta: AccountDelta,
         input_notes: InputNotes<InputNote>,
         output_notes: RawOutputNotes,
+        block_commitment: Word,
+        ref_params: Word,
         salt: Word,
     ) -> Self {
         Self {
             account_delta,
             input_notes,
             output_notes,
+            block_commitment,
+            ref_params,
             salt,
         }
     }
@@ -61,6 +72,17 @@ impl TransactionSummary {
         &self.output_notes
     }
 
+    /// Returns the reference block commitment of this transaction summary.
+    pub fn block_commitment(&self) -> Word {
+        self.block_commitment
+    }
+
+    /// Returns the reference parameters `[0, 0, expiration_delta, ref_block_num]` of this
+    /// transaction summary.
+    pub fn ref_params(&self) -> Word {
+        self.ref_params
+    }
+
     /// Returns the salt of this transaction summary.
     pub fn salt(&self) -> Word {
         self.salt
@@ -78,10 +100,12 @@ impl SequentialCommit for TransactionSummary {
     type Commitment = Word;
 
     fn to_elements(&self) -> Vec<Felt> {
-        let mut elements = Vec::with_capacity(16);
+        let mut elements = Vec::with_capacity(24);
         elements.extend_from_slice(self.account_delta.to_commitment().as_elements());
         elements.extend_from_slice(self.input_notes.commitment().as_elements());
         elements.extend_from_slice(self.output_notes.commitment().as_elements());
+        elements.extend_from_slice(self.block_commitment.as_elements());
+        elements.extend_from_slice(self.ref_params.as_elements());
         elements.extend_from_slice(self.salt.as_elements());
         elements
     }
@@ -92,6 +116,8 @@ impl Serializable for TransactionSummary {
         self.account_delta.write_into(target);
         self.input_notes.write_into(target);
         self.output_notes.write_into(target);
+        self.block_commitment.write_into(target);
+        self.ref_params.write_into(target);
         self.salt.write_into(target);
     }
 }
@@ -101,8 +127,17 @@ impl Deserializable for TransactionSummary {
         let account_delta = source.read()?;
         let input_notes = source.read()?;
         let output_notes = source.read()?;
+        let block_commitment = source.read()?;
+        let ref_params = source.read()?;
         let salt = source.read()?;
 
-        Ok(Self::new(account_delta, input_notes, output_notes, salt))
+        Ok(Self::new(
+            account_delta,
+            input_notes,
+            output_notes,
+            block_commitment,
+            ref_params,
+            salt,
+        ))
     }
 }

--- a/crates/miden-standards/asm/standards/auth/mod.masm
+++ b/crates/miden-standards/asm/standards/auth/mod.masm
@@ -13,50 +13,129 @@ pub mod tx_script_allowlist
 #! Creates the transaction summary and returns it in the order in which it will be hashed.
 #!
 #! Inputs:  [SALT]
-#! Outputs: [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
+#! Outputs: [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT,
+#!           BLOCK_COMMITMENT, REF_PARAMS, SALT]
 #!
 #! Where:
 #! - SALT is a user-defined input recommended to use as replay protection.
+#! - REF_PARAMS is [0, 0, expiration_delta, ref_block_num]. It binds the transaction expiration
+#!   and the readable reference block number.
+#! - BLOCK_COMMITMENT is the commitment to the transaction's reference block. It binds the block
+#!   canonically instead of by height only, closing the reorg and (up to shared history)
+#!   cross-network replay ambiguity.
 #! - OUTPUT_NOTES_COMMITMENT is the commitment to the transaction's output notes.
 #! - INPUT_NOTES_COMMITMENT is the commitment to the transaction's inputs notes.
 #! - ACCOUNT_DELTA_COMMITMENT is the commitment to the transaction's account delta.
 pub proc create_tx_summary
+    # Bind the  reference block and expiration into the summary.
+    # REF_PARAMS = [0, 0, expiration_delta, ref_block_num]
+    exec.tx::get_block_number
+    exec.tx::get_expiration_block_delta
+    push.0.0
+    # => [REF_PARAMS, SALT]
+
+    # Bind the reference block by its commitment.
+    exec.tx::get_block_commitment
+    # => [BLOCK_COMMITMENT, REF_PARAMS, SALT]
+
     exec.tx::get_output_notes_commitment
-    # => [OUTPUT_NOTES_COMMITMENT, SALT]
+    # => [OUTPUT_NOTES_COMMITMENT, BLOCK_COMMITMENT, REF_PARAMS, SALT]
 
     exec.tx::get_input_notes_commitment
-    # => [INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
+    # => [INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, BLOCK_COMMITMENT, REF_PARAMS, SALT]
 
     exec.native_account::compute_delta_commitment
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
+    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT,
+    #     BLOCK_COMMITMENT, REF_PARAMS, SALT]
 end
 
 #! Hashes the provided transaction summary and returns its commitment.
 #!
-#! Inputs:  [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
+#! The summary is six words, absorbed in three permutation rounds (the sponge rate is two words).
+#!
+#! Inputs:  [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT,
+#!           BLOCK_COMMITMENT, REF_PARAMS, SALT]
 #! Outputs: [TX_SUMMARY_COMMITMENT]
 #!
 #! Where:
 #! - SALT is an arbitrary word used for replay protection.
+#! - REF_PARAMS is [0, 0, expiration_delta, ref_block_num].
+#! - BLOCK_COMMITMENT is the commitment to the transaction's reference block.
 #! - OUTPUT_NOTES_COMMITMENT is the commitment to the transaction's output notes.
 #! - INPUT_NOTES_COMMITMENT is the commitment to the transaction's inputs notes.
 #! - ACCOUNT_DELTA_COMMITMENT is the commitment to the transaction's account delta.
 pub proc hash_tx_summary
     # pad capacity element of the hasher
     padw movdnw.2
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, CAPACITY, OUTPUT_NOTES_COMMITMENT, SALT]
+    # => [DELTA, INPUT, CAPACITY, OUTPUT, BLOCK_COMMITMENT, REF_PARAMS, SALT]
 
+    # Round 1: absorb DELTA + INPUT
     exec.poseidon2::permute
-    # => [RATE0, RATE1, CAPACITY, OUTPUT_NOTES_COMMITMENT, SALT]
-
-    # drop rate words
     dropw dropw
-    # => [CAPACITY, OUTPUT_NOTES_COMMITMENT, SALT]
+    # => [CAPACITY, OUTPUT, BLOCK_COMMITMENT, REF_PARAMS, SALT]
 
+    # Round 2: absorb OUTPUT + BLOCK_COMMITMENT
     movdnw.2
-    # => [OUTPUT_NOTES_COMMITMENT, SALT, CAPACITY]
+    # => [OUTPUT, BLOCK_COMMITMENT, CAPACITY, REF_PARAMS, SALT]
+    exec.poseidon2::permute
+    dropw dropw
+    # => [CAPACITY, REF_PARAMS, SALT]
 
+    # Round 3: absorb REF_PARAMS + SALT
+    movdnw.2
+    # => [REF_PARAMS, SALT, CAPACITY]
     exec.poseidon2::permute
     exec.poseidon2::squeeze_digest
+    # => [TX_SUMMARY_COMMITMENT]
+end
+
+#! Builds the transaction summary, inserts it into the advice map keyed by its commitment, and
+#! returns that commitment.
+#!
+#! Inputs:  [SALT]
+#! Outputs: [TX_SUMMARY_COMMITMENT]
+#!
+#! Where:
+#! - SALT is a user-defined input recommended to use as replay protection.
+#! - TX_SUMMARY_COMMITMENT is the commitment to the transaction summary, used as the signed message.
+#!
+#! Invocation: exec
+@locals(24)
+pub proc build_signed_message
+    exec.create_tx_summary
+    # => [DELTA, INPUT, OUTPUT, BLOCK_COMMITMENT, REF_PARAMS, SALT]
+
+    # Persist the six summary words to local memory in the order the host reads them.
+    loc_storew_le.0  dropw
+    loc_storew_le.4  dropw
+    loc_storew_le.8  dropw
+    loc_storew_le.12 dropw
+    loc_storew_le.16 dropw
+    loc_storew_le.20 dropw
+    # => []
+
+    # Reload the six words in reverse so DELTA ends up on top, matching hash_tx_summary's inputs.
+    padw loc_loadw_le.20
+    padw loc_loadw_le.16
+    padw loc_loadw_le.12
+    padw loc_loadw_le.8
+    padw loc_loadw_le.4
+    padw loc_loadw_le.0
+    # => [DELTA, INPUT, OUTPUT, BLOCK_COMMITMENT, REF_PARAMS, SALT]
+
+    exec.hash_tx_summary
+    # => [TX_SUMMARY_COMMITMENT]
+
+    # Insert the six words into the advice map keyed by the summary commitment.
+    locaddr.0 movdn.4
+    # => [TX_SUMMARY_COMMITMENT, start_ptr]
+
+    locaddr.0 add.24 movdn.5
+    # => [TX_SUMMARY_COMMITMENT, start_ptr, end_ptr]
+
+    adv.insert_mem
+    # => [TX_SUMMARY_COMMITMENT, start_ptr, end_ptr]
+
+    movup.4 drop movup.4 drop
     # => [TX_SUMMARY_COMMITMENT]
 end

--- a/crates/miden-standards/asm/standards/auth/multisig.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig.masm
@@ -724,15 +724,9 @@ pub proc auth_tx(salt: word)
 
     # ------ Computing transaction summary ------
 
-    exec.auth::create_tx_summary
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-    # insert tx summary into advice provider for extraction by the host
-    adv.insert_hqword
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-    # the commitment to the tx summary is the message that is signed
-    exec.auth::hash_tx_summary
+    # The summary binds the reference block, its commitment and the expiration delta, and is
+    # inserted into the advice map for extraction by the host. The commitment is the signed message.
+    exec.auth::build_signed_message
     # => [TX_SUMMARY_COMMITMENT]
 
     # ------ Verifying approver signatures ------

--- a/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
@@ -769,13 +769,9 @@ pub proc auth_tx(salt: word)
     # => [SALT]
 
     # ------ Computing transaction summary ------
-    exec.auth::create_tx_summary
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-    adv.insert_hqword
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-    exec.auth::hash_tx_summary
+    # The summary binds the reference block, its commitment and the expiration delta, and is
+    # inserted into the advice map for extraction by the host. The commitment is the signed message.
+    exec.auth::build_signed_message
     # => [TX_SUMMARY_COMMITMENT]
 
     # ------ Reading threshold config (default + num_approvers) ------

--- a/crates/miden-standards/asm/standards/auth/signature.masm
+++ b/crates/miden-standards/asm/standards/auth/signature.masm
@@ -4,7 +4,6 @@ use miden::core::crypto::dsa::ecdsa_k256_keccak
 use miden::protocol::active_account
 use {AUTH_REQUEST_EVENT} from miden::protocol::auth
 use miden::protocol::native_account
-use miden::protocol::tx
 use miden::standards::auth
 
 # CONSTANTS
@@ -36,13 +35,14 @@ const ERR_INVALID_SCHEME_ID_WORD = "invalid scheme ID word format expected three
 #! - 2 => falcon512_poseidon2
 #!
 #! It first increments the nonce of the account, independent of whether the account's state has
-#! changed or not. Then it computes and signs the following message (in memory order):
-#! [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT,
-#!  OUTPUT_NOTES_COMMITMENT, [0, 0, ref_block_num, final_nonce]]
+#! changed or not. Then it computes and signs the commitment to the following summary
+#! (in memory order):
+#! [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT,
+#!  BLOCK_COMMITMENT, [0, 0, expiration_delta, ref_block_num], [0, 0, 0, final_nonce]]
 #!
-#! Including the final_nonce is necessary for replay protection. The reference block number is
-#! included to commit to the transaction creator's intended reference block of the transaction
-#! which determines the fee parameters and therefore the fee amount that is deducted.
+#! Including the final_nonce is necessary for replay protection. The reference block number and
+#! commitment, and the expiration delta are bound by the summary itself, so the SALT only needs to
+#! carry the final_nonce.
 #!
 #! Inputs:  [PUB_KEY, scheme_id]
 #! Outputs: []
@@ -53,21 +53,14 @@ pub proc authenticate_transaction
     # ---------------------------------------------------------------------------------------------
     # This has to happen before computing the delta commitment, otherwise that procedure will abort
     exec.native_account::incr_nonce
-    exec.tx::get_block_number
-    push.0.0
-    # => [[0, 0, ref_block_num, final_nonce], PUB_KEY, scheme_id]
+    push.0.0.0
+    # => [[0, 0, 0, final_nonce], PUB_KEY, scheme_id]
 
     # Compute the message that is signed.
     # ---------------------------------------------------------------------------------------------
-    exec.auth::create_tx_summary
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, PUB_KEY, scheme_id]
-
-    # insert tx summary into advice provider for extraction by the host
-    adv.insert_hqword
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, PUB_KEY, scheme_id]
-
-    # The commitment to the tx summary is the message that is signed
-    exec.auth::hash_tx_summary
+    # ref_block_num, BLOCK_COMMITMENT and expiration_delta are bound inside the summary, and the
+    # summary is inserted into the advice map for extraction by the host.
+    exec.auth::build_signed_message
     # OS => [MESSAGE, PUB_KEY, scheme_id]
     # AS => []
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
@@ -1041,13 +1041,7 @@ async fn recomputing_delta_resets_host_delta() -> anyhow::Result<()> {
         dropw padw
         # => [SALT, pad(12)]
 
-        exec.::miden::standards::auth::create_tx_summary
-        # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, pad(12)]
-
-        adv.insert_hqword
-        # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, pad(12)]
-
-        exec.::miden::standards::auth::hash_tx_summary
+        exec.::miden::standards::auth::build_signed_message
         # => [TX_SUMMARY_COMMITMENT, pad(12)]
 
         emit.AUTH_UNAUTHORIZED_EVENT
@@ -1195,13 +1189,7 @@ const DELTA_CHECK_AUTH_CODE: &str = r#"
             dropw padw
             # => [SALT, pad(12)]
 
-            exec.::miden::standards::auth::create_tx_summary
-            # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, pad(12)]
-
-            adv.insert_hqword
-            # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, pad(12)]
-
-            exec.::miden::standards::auth::hash_tx_summary
+            exec.::miden::standards::auth::build_signed_message
             # => [TX_SUMMARY_COMMITMENT, pad(12)]
 
             emit.AUTH_UNAUTHORIZED_EVENT

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -441,7 +441,6 @@ async fn executed_transaction_output_notes() -> anyhow::Result<()> {
 async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
     let source_code = r#"
       use miden::standards::auth
-      use miden::protocol::tx
       const AUTH_UNAUTHORIZED_EVENT=event("miden::protocol::auth::unauthorized")
       #! Inputs:  [AUTH_ARGS, pad(12)]
       #! Outputs: [pad(16)]
@@ -451,19 +450,13 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
           # => [pad(16)]
 
           exec.::miden::protocol::native_account::incr_nonce
-          exec.tx::get_block_number
-          push.0.0
-          # => [[0, 0, block_num, final_nonce], pad(16)]
+          push.0.0.0
+          # => [[0, 0, 0, final_nonce], pad(16)]
           # => [SALT, pad(16)]
 
-          exec.auth::create_tx_summary
-          # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-          # insert tx summary into advice provider for extraction by the host
-          adv.insert_hqword
-          # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-          exec.auth::hash_tx_summary
+          # Builds the six-word summary, inserts it into the advice map, and returns its commitment.
+          # The reference block, its commitment and the expiration delta are bound by the summary.
+          exec.auth::build_signed_message
           # => [MESSAGE, pad(16)]
 
           emit.AUTH_UNAUTHORIZED_EVENT
@@ -498,6 +491,7 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
 
     let tx_context = mock_chain.build_tx_context(account, &[input_note.id()], &[])?.build()?;
     let ref_block_num = tx_context.tx_inputs().block_header().block_num().as_u32();
+    let ref_block_commitment = tx_context.tx_inputs().block_header().commitment();
     let final_nonce = tx_context.account().nonce().as_canonical_u64() as u32 + 1;
     let input_notes = tx_context.input_notes().clone();
     let output_notes = RawOutputNotes::new(vec![RawOutputNote::Partial(output_note.into())])?;
@@ -510,9 +504,10 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
         assert_eq!(tx_summary.account_delta().nonce_delta().as_canonical_u64(), 1);
         assert_eq!(tx_summary.input_notes(), &input_notes);
         assert_eq!(tx_summary.output_notes(), &output_notes);
-        assert_eq!(tx_summary.salt(), Word::from(
-          [0, 0, ref_block_num, final_nonce]
-        ));
+        assert_eq!(tx_summary.block_commitment(), ref_block_commitment);
+        // No expiration delta is set, so REF_PARAMS is [0, 0, 0, ref_block_num].
+        assert_eq!(tx_summary.ref_params(), Word::from([0, 0, 0, ref_block_num]));
+        assert_eq!(tx_summary.salt(), Word::from([0, 0, 0, final_nonce]));
     });
 
     Ok(())
@@ -539,6 +534,7 @@ async fn tx_summary_commitment_is_signed_by_auth_singlesig(
 
     let tx = tx_builder.clone().build()?;
     let ref_block_num = tx.tx_inputs().block_header().block_num();
+    let ref_block_commitment = tx.tx_inputs().block_header().commitment();
     let tx = tx.execute().await?;
 
     let nonce_delta = Felt::ONE;
@@ -554,7 +550,10 @@ async fn tx_summary_commitment_is_signed_by_auth_singlesig(
         account_delta,
         InputNotes::new(vec![InputNote::unauthenticated(spawn_note)])?,
         RawOutputNotes::new(vec![RawOutputNote::Partial(PartialNote::from(p2any_note))])?,
-        Word::from([0, 0, ref_block_num.as_u32(), final_nonce.as_canonical_u64() as u32]),
+        ref_block_commitment,
+        // No expiration delta is set, so REF_PARAMS is [0, 0, 0, ref_block_num].
+        Word::from([0, 0, 0, ref_block_num.as_u32()]),
+        Word::from([0, 0, 0, final_nonce.as_canonical_u64() as u32]),
     );
 
     let summary_commitment = expected_summary.to_commitment();

--- a/crates/miden-testing/tests/auth/multisig.rs
+++ b/crates/miden-testing/tests/auth/multisig.rs
@@ -362,6 +362,11 @@ async fn test_multisig_replay_protection(#[case] auth_scheme: AuthScheme) -> any
 
     let salt = Word::from([Felt::new_unchecked(3); 4]);
 
+    // The reference block the signed summary is bound to. The replay below must reference the same
+    // block, otherwise the summary (which now binds the reference block and its commitment) would
+    // differ and the signatures would fail to verify before the replay-protection check is reached.
+    let ref_block = mock_chain.latest_block_header().block_num();
+
     // Build base transaction context
     let tx_context_builder =
         mock_chain.build_tx_context(multisig_account.id(), &[], &[])?.auth_args(salt);
@@ -398,10 +403,11 @@ async fn test_multisig_replay_protection(#[case] auth_scheme: AuthScheme) -> any
     mock_chain.add_pending_executed_transaction(&tx_context_execute)?;
     mock_chain.prove_next_block()?;
 
-    // Attempt to execute the same transaction again - should fail due to replay protection
-    // Must rebuild from the updated mock chain to pick up the new account state
+    // Attempt to execute the same transaction again - should fail due to replay protection.
+    // Rebuild from the updated mock chain to pick up the new account state, but reference the
+    // original block so the summary (and therefore the signed message) matches the first execution.
     let tx_context_replay = mock_chain
-        .build_tx_context(multisig_account.id(), &[], &[])?
+        .build_tx_context_at(ref_block, multisig_account.id(), &[], &[])?
         .add_signature(public_keys[0].to_commitment(), msg, sig_1)
         .add_signature(public_keys[1].to_commitment(), msg, sig_2)
         .auth_args(salt)

--- a/crates/miden-tx/src/host/mod.rs
+++ b/crates/miden-tx/src/host/mod.rs
@@ -429,6 +429,8 @@ impl<'store, STORE> TransactionBaseHost<'store, STORE> {
         account_delta_commitment: Word,
         input_notes_commitment: Word,
         output_notes_commitment: Word,
+        block_commitment: Word,
+        ref_params: Word,
         salt: Word,
     ) -> Result<TransactionSummary, TransactionKernelError> {
         let account_delta = self.build_account_delta();
@@ -469,7 +471,14 @@ impl<'store, STORE> TransactionBaseHost<'store, STORE> {
             ));
         }
 
-        Ok(TransactionSummary::new(account_delta, input_notes, output_notes, salt))
+        Ok(TransactionSummary::new(
+            account_delta,
+            input_notes,
+            output_notes,
+            block_commitment,
+            ref_params,
+            salt,
+        ))
     }
 
     /// Returns the underlying store of the base host.

--- a/crates/miden-tx/src/host/tx_event.rs
+++ b/crates/miden-tx/src/host/tx_event.rs
@@ -712,7 +712,8 @@ fn on_account_storage_map_item_accessed<'store, STORE>(
 /// ```text
 /// Expected advice map state: {
 ///     MESSAGE: [
-///         SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT
+///         ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT,
+///         BLOCK_COMMITMENT, REF_PARAMS, SALT
 ///     ]
 /// }
 /// ```
@@ -727,21 +728,25 @@ fn extract_tx_summary<'store, STORE>(
         ));
     };
 
-    if commitments.len() != 16 {
+    if commitments.len() != 24 {
         return Err(TransactionKernelError::TransactionSummaryConstructionFailed(
-            "expected 4 words for transaction summary commitments".into(),
+            "expected 6 words for transaction summary commitments".into(),
         ));
     }
 
     let account_delta_commitment = extract_word(commitments, 0);
     let input_notes_commitment = extract_word(commitments, 4);
     let output_notes_commitment = extract_word(commitments, 8);
-    let salt = extract_word(commitments, 12);
+    let block_commitment = extract_word(commitments, 12);
+    let ref_params = extract_word(commitments, 16);
+    let salt = extract_word(commitments, 20);
 
     let tx_summary = base_host.build_tx_summary(
         account_delta_commitment,
         input_notes_commitment,
         output_notes_commitment,
+        block_commitment,
+        ref_params,
         salt,
     )?;
 


### PR DESCRIPTION
Closes: https://github.com/0xMiden/protocol/issues/3210
It's a draft PR in case we decide to change `TxSummary` related the issue expressed above.