### PR TITLE
feat: make proving sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.16.0-alpha.2 (2026-07-12)
+
+- [BREAKING] Change proving from being `async` to `sync` ([#3281](https://github.com/0xMiden/protocol/pull/3281)).
+
 ## v0.16.0-alpha.1 (2026-07-12)
 
 ### Features

--- a/bin/bench-transaction/src/time_counting_benchmarks/prove.rs
+++ b/bin/bench-transaction/src/time_counting_benchmarks/prove.rs
@@ -175,14 +175,12 @@ fn core_benchmarks(c: &mut Criterion) {
                             .expect("failed to create a context which consumes single P2ID note")
                     },
                     |tx_context| async move {
-                        black_box(
-                            prove_transaction(
-                                tx_context.execute().await.expect(
-                                    "execution of the single P2ID note consumption tx failed",
-                                ),
-                            )
-                            .await,
-                        )
+                        black_box(prove_transaction(
+                            tx_context
+                                .execute()
+                                .await
+                                .expect("execution of the single P2ID note consumption tx failed"),
+                        ))
                     },
                     BatchSize::SmallInput,
                 );
@@ -199,14 +197,12 @@ fn core_benchmarks(c: &mut Criterion) {
                             .expect("failed to create a context which consumes single P2ID note")
                     },
                     |tx_context| async move {
-                        black_box(
-                            prove_transaction(
-                                tx_context.execute().await.expect(
-                                    "execution of the single P2ID note consumption tx failed",
-                                ),
-                            )
-                            .await,
-                        )
+                        black_box(prove_transaction(
+                            tx_context
+                                .execute()
+                                .await
+                                .expect("execution of the single P2ID note consumption tx failed"),
+                        ))
                     },
                     BatchSize::SmallInput,
                 );
@@ -224,15 +220,12 @@ fn core_benchmarks(c: &mut Criterion) {
                     },
                     |tx_context| async move {
                         // benchmark the transaction execution and proving
-                        black_box(
-                            prove_transaction(
-                                tx_context
-                                    .execute()
-                                    .await
-                                    .expect("execution of the two P2ID note consumption tx failed"),
-                            )
-                            .await,
-                        )
+                        black_box(prove_transaction(
+                            tx_context
+                                .execute()
+                                .await
+                                .expect("execution of the two P2ID note consumption tx failed"),
+                        ))
                     },
                     BatchSize::SmallInput,
                 );
@@ -250,15 +243,12 @@ fn core_benchmarks(c: &mut Criterion) {
                     },
                     |tx_context| async move {
                         // benchmark the transaction execution and proving
-                        black_box(
-                            prove_transaction(
-                                tx_context
-                                    .execute()
-                                    .await
-                                    .expect("execution of the two P2ID note consumption tx failed"),
-                            )
-                            .await,
-                        )
+                        black_box(prove_transaction(
+                            tx_context
+                                .execute()
+                                .await
+                                .expect("execution of the two P2ID note consumption tx failed"),
+                        ))
                     },
                     BatchSize::SmallInput,
                 );
@@ -280,10 +270,10 @@ fn core_benchmarks(c: &mut Criterion) {
     execute_and_prove_group.finish();
 }
 
-async fn prove_transaction(executed_transaction: ExecutedTransaction) -> Result<()> {
+fn prove_transaction(executed_transaction: ExecutedTransaction) -> Result<()> {
     let executed_transaction_id = executed_transaction.id();
     let proven_transaction: ProvenTransaction =
-        LocalTransactionProver::default().prove(executed_transaction).await?;
+        LocalTransactionProver::default().prove(executed_transaction)?;
 
     assert_eq!(proven_transaction.id(), executed_transaction_id);
     Ok(())
@@ -326,7 +316,7 @@ where
                 let tx_context = build_context().await.expect("failed to build tx context");
                 let start = Instant::now();
                 let executed = tx_context.execute().await.expect("execute failed");
-                let _ = black_box(prove_transaction(executed).await);
+                let _ = black_box(prove_transaction(executed));
                 total += start.elapsed();
             }
             total

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -1069,7 +1069,7 @@ async fn prove_account_creation_with_non_empty_storage() -> anyhow::Result<()> {
     assert!(tx.account_patch().vault().is_empty());
     assert_eq!(tx.final_account().nonce(), Felt::ONE);
 
-    let proven_tx = LocalTransactionProver::default().prove(tx.clone()).await?;
+    let proven_tx = LocalTransactionProver::default().prove(tx.clone())?;
 
     // The patch should be present on the proven tx.
     let patch = proven_tx.account_update().details().unwrap_public();

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -1264,7 +1264,7 @@ async fn test_prove_fpi_two_foreign_accounts_chain() -> anyhow::Result<()> {
         .await?;
 
     // Prove the executed transaction which uses FPI across two foreign accounts.
-    LocalTransactionProver::default().prove(executed_transaction).await?;
+    LocalTransactionProver::default().prove(executed_transaction)?;
 
     Ok(())
 }

--- a/crates/miden-testing/tests/lib.rs
+++ b/crates/miden-testing/tests/lib.rs
@@ -39,7 +39,7 @@ pub async fn prove_and_verify_transaction(
 
     let proof_options = ProvingOptions::default();
     let prover = LocalTransactionProver::new(proof_options);
-    let proven_transaction = prover.prove(executed_transaction).await.unwrap();
+    let proven_transaction = prover.prove(executed_transaction).unwrap();
     let proven_tx_header = TransactionHeader::from(&proven_transaction);
 
     assert_eq!(proven_transaction.id(), executed_transaction_id);

--- a/crates/miden-tx/src/prover/mod.rs
+++ b/crates/miden-tx/src/prover/mod.rs
@@ -14,7 +14,7 @@ use miden_protocol::transaction::{
 };
 use miden_prover::HashFunction::Poseidon2;
 pub use miden_prover::ProvingOptions;
-use miden_prover::{ExecutionProof, Word, prove};
+use miden_prover::{ExecutionProof, Word, prove_sync};
 
 use super::TransactionProverError;
 use crate::host::{AccountProcedureIndexMap, ScriptMastForestStore};
@@ -33,6 +33,7 @@ pub use mast_store::TransactionMastStore;
 /// Each `prove()` call creates a fresh [`TransactionMastStore`] loaded with only the current
 /// transaction's account code, ensuring no state accumulates across calls. This is important
 /// in WASM environments where accumulated MAST forests fragment the linear memory.
+#[derive(Debug, Clone)]
 pub struct LocalTransactionProver {
     proof_options: ProvingOptions,
 }
@@ -102,7 +103,7 @@ impl LocalTransactionProver {
         .map_err(TransactionProverError::ProvenTransactionBuildFailed)
     }
 
-    pub async fn prove(
+    pub fn prove(
         &self,
         tx_inputs: impl Into<TransactionInputs>,
     ) -> Result<ProvenTransaction, TransactionProverError> {
@@ -141,7 +142,7 @@ impl LocalTransactionProver {
 
         let advice_inputs = advice_inputs.into_advice_inputs();
 
-        let (stack_outputs, proof) = prove(
+        let (stack_outputs, proof) = prove_sync(
             &TransactionKernel::main(),
             stack_inputs,
             advice_inputs.clone(),
@@ -149,7 +150,6 @@ impl LocalTransactionProver {
             ExecutionOptions::default(),
             self.proof_options.clone(),
         )
-        .await
         .map_err(TransactionProverError::TransactionProgramExecutionFailed)?;
 
         // Extract transaction outputs and process transaction data.

--- a/crates/miden-tx/src/prover/prover_host.rs
+++ b/crates/miden-tx/src/prover/prover_host.rs
@@ -21,7 +21,7 @@ use crate::host::{
 };
 use crate::{AccountProcedureIndexMap, TransactionKernelError};
 
-/// The transaction prover host is responsible for handling [`Host`] requests made by the
+/// The transaction prover host is responsible for handling [`SyncHost`] requests made by the
 /// transaction kernel during proving.
 pub struct TransactionProverHost<'store, STORE>
 where

--- a/crates/miden-tx/src/prover/prover_host.rs
+++ b/crates/miden-tx/src/prover/prover_host.rs
@@ -3,20 +3,14 @@ use alloc::vec::Vec;
 
 use miden_processor::advice::AdviceMutation;
 use miden_processor::event::EventError;
-use miden_processor::{
-    BaseHost,
-    FutureMaybeSend,
-    Host,
-    LoadedMastForest,
-    MastForestStore,
-    ProcessorState,
-};
+use miden_processor::{BaseHost, LoadedMastForest, MastForestStore, ProcessorState};
 use miden_protocol::Word;
 use miden_protocol::account::{AccountPatch, PartialAccount};
 use miden_protocol::assembly::debuginfo::Location;
 use miden_protocol::assembly::{SourceFile, SourceSpan};
 use miden_protocol::transaction::{InputNote, InputNotes, RawOutputNote};
 use miden_protocol::vm::{EventId, EventName};
+use miden_prover::SyncHost;
 
 use crate::host::{
     RecipientData,
@@ -94,24 +88,16 @@ where
     }
 }
 
-impl<STORE> Host for TransactionProverHost<'_, STORE>
+impl<STORE> SyncHost for TransactionProverHost<'_, STORE>
 where
     STORE: MastForestStore,
 {
-    fn get_mast_forest(
-        &self,
-        node_digest: &Word,
-    ) -> impl FutureMaybeSend<Option<LoadedMastForest>> {
-        let result = self.base_host.get_mast_forest(node_digest);
-        async move { result }
+    fn get_mast_forest(&self, node_digest: &Word) -> Option<LoadedMastForest> {
+        self.base_host.get_mast_forest(node_digest)
     }
 
-    fn on_event(
-        &mut self,
-        process: &ProcessorState,
-    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
-        let result = self.on_event_sync(process);
-        async move { result }
+    fn on_event(&mut self, process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
+        self.on_event_sync(process)
     }
 }
 


### PR DESCRIPTION
- Changes `LocalTransactionProver::prove` from `async` to `sync` and makes the prover host implement `SyncHost` instead of `Host`
- Implements `Clone` for `LocalTransactionProver`

This addresses:
- https://github.com/0xMiden/node/pull/2320#discussion_r3551752693
- https://github.com/0xMiden/node/issues/2324
