### PR TITLE
refactor(standards): separate exec helpers from public interface in remaining mixed components

### DIFF
--- a/crates/miden-standards/asm/standards/auth/guardian.masm
+++ b/crates/miden-standards/asm/standards/auth/guardian.masm
@@ -46,11 +46,12 @@ const GUARDIAN_SCHEME_ID_SLOT = word("miden::standards::auth::guardian::scheme")
 const GUARDIAN_MAP_KEY = [0, 0, 0, 0]
 
 # ERRORS
-# -------------------------------------------------------------------------------------------------
+# =================================================================================================
+
 const ERR_INVALID_GUARDIAN_SIGNATURE = "invalid guardian signature"
 
 # PUBLIC INTERFACE
-# ================================================================================================
+# =================================================================================================
 
 #! Updates the guardian public key.
 #!
@@ -106,6 +107,9 @@ pub proc update_guardian_public_key(new_guardian_scheme_id: felt, new_guardian_p
     dropw
     # => []
 end
+
+# PUBLIC HELPERS
+# =================================================================================================
 
 #! Conditionally verifies a guardian signature.
 #!

--- a/crates/miden-standards/asm/standards/auth/multisig.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig.masm
@@ -94,219 +94,8 @@ const ERR_PROC_ROOT_NOT_IN_ACCOUNT = "procedure root is not one of the account's
 
 const ERR_DUPLICATE_APPROVER_PUBLIC_KEY = "duplicate approver public keys are not allowed"
 
-#! Remove old approver public keys and the corresponding scheme ids from the approver public key and
-#! scheme id mappings.
-#!
-#! This procedure clears the approver entries in the range [new_num_of_approvers,
-#! init_num_of_approvers) from APPROVER_PUBLIC_KEYS_SLOT and APPROVER_SCHEME_ID_SLOT. It does not
-#! touch THRESHOLD_CONFIG_SLOT or PROC_THRESHOLD_ROOTS_SLOT.
-#!
-#! Caller contract: before calling this, the caller must have already updated THRESHOLD_CONFIG_SLOT
-#! so that the threshold is still reachable with the reduced signer set, i.e. threshold <=
-#! new_num_of_approvers. Otherwise the account is left with a threshold that no remaining quorum can
-#! reach, making it permanently unable to authenticate. In-tree this is guaranteed by
-#! `update_signers_and_threshold`, which calls `assert_threshold_is_reachable` before this procedure.
-#!
-#! Inputs: [init_num_of_approvers, new_num_of_approvers]
-#! Outputs: []
-#!
-#! Where:
-#! - init_num_of_approvers is the original number of approvers before the update
-#! - new_num_of_approvers is the new number of approvers after the update
-#!
-#! Panics if:
-#! - init_num_of_approvers or new_num_of_approvers is not a u32 value.
-pub proc cleanup_pubkey_and_scheme_id_mapping(init_num_of_approvers: u32, new_num_of_approvers: u32)
-    dup.1 dup.1
-    u32assert2.err=ERR_APPROVER_COUNTS_NOT_U32
-    u32lt
-    # => [should_loop, i = init_num_of_approvers, new_num_of_approvers]
-
-    while.true
-        # => [i, new_num_of_approvers]
-
-        sub.1
-        # => [i-1, new_num_of_approvers]
-
-        # clear scheme id at APPROVER_MAP_KEY(i-1)
-        dup exec.signature::create_approver_map_key
-        # => [APPROVER_MAP_KEY, i-1, new_num_of_approvers]
-
-        padw swapw
-        # => [APPROVER_MAP_KEY, EMPTY_WORD, i-1, new_num_of_approvers]
-
-        push.APPROVER_SCHEME_ID_SLOT[0..2]
-        # => [scheme_id_slot_suffix, scheme_id_slot_prefix, APPROVER_MAP_KEY, EMPTY_WORD, i-1, new_num_of_approvers]
-
-        exec.native_account::set_map_item
-        # => [OLD_VALUE, i-1, new_num_of_approvers]
-
-        dropw
-        # => [i-1, new_num_of_approvers]
-
-        # clear public key at APPROVER_MAP_KEY(i-1)
-        dup exec.signature::create_approver_map_key
-        # => [APPROVER_MAP_KEY, i-1, new_num_of_approvers]
-
-        padw swapw
-        # => [APPROVER_MAP_KEY, EMPTY_WORD, i-1, new_num_of_approvers]
-
-        push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
-        # => [pub_key_slot_suffix, pub_key_slot_prefix, APPROVER_MAP_KEY, EMPTY_WORD, i-1, new_num_of_approvers]
-
-        exec.native_account::set_map_item
-        # => [OLD_VALUE, i-1, new_num_of_approvers]
-
-        dropw
-        # => [i-1, new_num_of_approvers]
-
-        dup.1 dup.1
-        u32lt
-        # => [should_loop, i-1, new_num_of_approvers]
-    end
-
-    drop drop
-end
-
-#! Asserts the threshold is reachable with the given number of approvers, i.e. threshold is not
-#! greater than num_approvers.
-#!
-#! Inputs:  [num_approvers, threshold]
-#! Outputs: []
-#!
-#! Panics if:
-#! - num_approvers or threshold is not a u32 value.
-#! - threshold > num_approvers.
-pub proc assert_threshold_is_reachable
-    u32assert2.err=ERR_MALFORMED_MULTISIG_CONFIG
-    u32gt assertz.err=ERR_MALFORMED_MULTISIG_CONFIG
-end
-
-#! Asserts that all configured per-procedure threshold overrides are less than or equal to
-#! number of approvers.
-#!
-#! Inputs:  [num_approvers]
-#! Outputs: []
-#! Panics if:
-#! - any configured procedure threshold is not a u32 value.
-#! - any configured procedure threshold exceeds num_approvers.
-proc assert_proc_thresholds_lte_num_approvers(num_approvers: u32)
-    exec.active_account::get_num_procedures
-    # => [num_procedures, num_approvers]
-
-    # num_procedures is always >= MIN_NUM_PROCEDURES (2), so enter the loop unconditionally
-    push.1
-    # => [should_continue, num_procedures, num_approvers]
-    while.true
-        sub.1 dup
-        # => [num_procedures-1, num_procedures-1, num_approvers]
-
-        exec.active_account::get_procedure_root
-        # => [PROC_ROOT, num_procedures-1, num_approvers]
-
-        push.PROC_THRESHOLD_ROOTS_SLOT[0..2]
-        # => [proc_roots_slot_suffix, proc_roots_slot_prefix, PROC_ROOT, num_procedures-1, num_approvers]
-
-        # Use the *current* policy state, not the initial one; otherwise a `set_proc_threshold`
-        # call earlier in the same transaction that raised a threshold above the new num_approvers
-        # would be missed and the multisig could end up with an unreachable threshold.
-        exec.active_account::get_map_item
-        # => [[proc_threshold, 0, 0, 0], num_procedures-1, num_approvers]
-
-        movdn.3 drop drop drop
-        # => [proc_threshold, num_procedures-1, num_approvers]
-
-        dup.2
-        # => [num_approvers, proc_threshold, num_procedures-1, num_approvers]
-
-        u32assert2.err=ERR_PROC_THRESHOLD_NOT_U32
-        u32gt assertz.err=ERR_PROC_THRESHOLD_EXCEEDS_NUM_APPROVERS
-        # => [num_procedures-1, num_approvers]
-
-        dup neq.0
-        # => [should_continue, num_procedures-1, num_approvers]
-    end
-    # => [num_procedures-1, num_approvers]
-
-    drop drop
-    # => []
-end
-
-#! Asserts that the `num_approvers` public keys currently stored in APPROVER_PUBLIC_KEYS_SLOT are
-#! pairwise distinct, reverting on the first duplicate.
-#!
-#! Reads the current account state, so it validates the keys just written by the caller.
-#!
-#! Inputs:  [num_approvers]
-#! Outputs: []
-#! Panics if:
-#! - any two approver public keys are equal.
-#!
-#! Cost: O(num_approvers^2) map reads; num_approvers is small for a multisig.
-@locals(2)
-pub proc assert_unique_approver_public_keys(num_approvers: u32)
-    dup neq.0
-    # => [outer_continue, num_approvers]
-    while.true
-        sub.1
-        # => [i]
-
-        dup loc_store.UNIQUE_OUTER_INDEX_LOC
-        # => [i]
-
-        # read PK_i from the current state
-        dup exec.signature::create_approver_map_key
-        # => [APPROVER_MAP_KEY, i]
-
-        push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
-        exec.active_account::get_map_item
-        # => [PK_I, i]
-
-        movup.4
-        # => [i, PK_I]
-
-        dup neq.0
-        # => [inner_continue, i, PK_I]
-        while.true
-            sub.1
-            # => [j, PK_I]
-
-            dup loc_store.UNIQUE_INNER_INDEX_LOC
-            exec.signature::create_approver_map_key
-            # => [APPROVER_MAP_KEY, PK_I]
-
-            push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
-            exec.active_account::get_map_item
-            # => [PK_J, PK_I]
-
-            # assert PK_I != PK_J
-            dupw.1 exec.word::eq
-            # => [is_equal, PK_I]
-
-            assertz.err=ERR_DUPLICATE_APPROVER_PUBLIC_KEY
-            # => [PK_I]
-
-            loc_load.UNIQUE_INNER_INDEX_LOC
-            # => [j, PK_I]
-
-            dup neq.0
-            # => [inner_continue, j, PK_I]
-        end
-        # => [0, PK_I]
-
-        drop dropw
-        # => []
-
-        loc_load.UNIQUE_OUTER_INDEX_LOC
-        # => [i]
-
-        dup neq.0
-        # => [outer_continue, i]
-    end
-
-    drop
-    # => []
-end
+# PUBLIC INTERFACE
+# =================================================================================================
 
 #! Update threshold config, add & remove approvers, and update the approver scheme ids
 #!
@@ -466,161 +255,6 @@ pub proc update_signers_and_threshold(multisig_config_hash: word)
     # => [pad(12)]
 end
 
-# Computes the effective transaction threshold based on called procedures and per-procedure
-# overrides stored in PROC_THRESHOLD_ROOTS_SLOT. Falls back to default_threshold if no
-# overrides apply.
-#
-# Each called non-auth procedure contributes a threshold to a max accumulator:
-# - if the procedure has a stored override, its override value is the contribution.
-# - if the procedure has no override, `default_threshold` is the contribution so a procedure
-#   without a policy cannot be authorized at a lower threshold by being called alongside a
-#   low-override procedure (e.g. `receive_asset` configured at 1) in the same transaction.
-#
-# The auth procedure (procedure index 0) is skipped — it is the auth flow itself, not a
-# user-callable account procedure, and counting it would make `transaction_threshold` always
-# include `default_threshold`.
-#
-# When no non-auth procedure was called, `transaction_threshold` stays 0 and is reverted to
-# `default_threshold` at the end.
-#
-#! Inputs:  [default_threshold]
-#! Outputs: [transaction_threshold]
-@locals(1)
-proc compute_transaction_threshold(default_threshold: u32) -> u32
-    # 1. initialize transaction_threshold = 0
-    # 2. iterate through all non-auth account procedures
-    #   a. check if the procedure was called during the transaction
-    #   b. if called, get the override threshold of that procedure from the config map
-    #   c. if the procedure has no override (proc_threshold == 0), contribute default_threshold
-    #      instead so the unpolicied call is still constrained
-    #   d. if contribution > transaction_threshold, set transaction_threshold = contribution
-    # 3. if transaction_threshold == 0 at the end (no non-auth proc was called), revert to
-    #    using default_threshold
-
-    # store default_threshold for later
-    loc_store.DEFAULT_THRESHOLD_LOC
-    # => []
-
-    # 1. initialize transaction_threshold = 0
-    push.0
-    # => [transaction_threshold]
-
-    # get the number of account procedures
-    exec.active_account::get_num_procedures
-    # => [num_procedures, transaction_threshold]
-
-    # 2. iterate through all account procedures
-    # num_procedures is always >= MIN_NUM_PROCEDURES (2), so enter the loop unconditionally
-    push.1
-    # => [should_continue, num_procedures, transaction_threshold]
-    while.true
-        sub.1
-        # => [num_procedures-1, transaction_threshold]
-
-        # Skip the auth procedure at index 0 — it is the auth flow itself, not a user-callable
-        # account procedure. Counting it would make transaction_threshold always include
-        # default_threshold and break the override-down semantic for single-proc transactions.
-        dup neq.0
-        # => [is_non_auth, num_procedures-1, transaction_threshold]
-        if.true
-            # get procedure root of the procedure with index i
-            dup exec.active_account::get_procedure_root dupw
-            # => [PROC_ROOT, PROC_ROOT, num_procedures-1, transaction_threshold]
-
-            # 2a. check if this procedure has been called in the transaction
-            exec.native_account::was_procedure_called
-            # => [was_called, PROC_ROOT, num_procedures-1, transaction_threshold]
-
-            # if it has been called, compute and apply its threshold contribution
-            if.true
-                # => [PROC_ROOT, num_procedures-1, transaction_threshold]
-
-                push.PROC_THRESHOLD_ROOTS_SLOT[0..2]
-                # => [proc_roots_slot_suffix, proc_roots_slot_prefix, PROC_ROOT, num_procedures-1, transaction_threshold]
-
-                # 2b. get the override proc_threshold of that procedure
-                # if the procedure has no override threshold, the returned map item will be [0, 0, 0, 0]
-                exec.native_account::get_initial_map_item
-                # => [[proc_threshold, 0, 0, 0], num_procedures-1, transaction_threshold]
-
-                movdn.3 drop drop drop
-                # => [proc_threshold, num_procedures-1, transaction_threshold]
-
-                # 2c. if the procedure has no override (proc_threshold == 0), contribute
-                # default_threshold instead so the unpolicied call cannot be silently authorized
-                # at a lower threshold by being called alongside a low-override procedure
-                # (e.g. `receive_asset` configured at 1) in the same transaction.
-                dup eq.0
-                if.true
-                    drop
-                    loc_load.DEFAULT_THRESHOLD_LOC
-                end
-                # => [contribution, num_procedures-1, transaction_threshold]
-
-                # 2d. transaction_threshold = max(transaction_threshold, contribution)
-                movup.2 u32max
-                # => [new_transaction_threshold, num_procedures-1]
-
-                swap
-                # => [num_procedures-1, new_transaction_threshold]
-            # if it has not been called during this transaction, nothing to do, move to the next procedure
-            else
-                dropw
-                # => [num_procedures-1, transaction_threshold]
-            end
-        end
-
-        dup neq.0
-        # => [should_continue, num_procedures-1, transaction_threshold]
-    end
-
-    drop
-    # => [transaction_threshold]
-
-    loc_load.DEFAULT_THRESHOLD_LOC
-    # => [default_threshold, transaction_threshold]
-
-    # 3. if no non-auth proc was called, transaction_threshold is 0; fall back to default_threshold
-    dup.1 eq.0
-    # => [is_zero, default_threshold, transaction_threshold]
-
-    cdrop
-    # => [effective_transaction_threshold]
-end
-
-#! Returns the initial threshold and num_approvers from `THRESHOLD_CONFIG_SLOT`.
-#!
-#! Inputs: []
-#! Outputs: [default_threshold, num_approvers]
-#!
-#! Invocation: exec
-pub proc get_initial_threshold_and_num_approvers
-    push.THRESHOLD_CONFIG_SLOT[0..2]
-    exec.native_account::get_initial_item
-    # => [default_threshold, num_approvers, 0, 0]
-
-    movup.2 drop movup.2 drop
-    # => [default_threshold, num_approvers]
-end
-
-#! Returns the current threshold and num_approvers from `THRESHOLD_CONFIG_SLOT`.
-#!
-#! This is the internal `exec` helper shared by internal callers and the public `call`
-#! wrapper `get_threshold_and_num_approvers`.
-#!
-#! Inputs: []
-#! Outputs: [default_threshold, num_approvers]
-#!
-#! Invocation: exec
-proc get_current_threshold_and_num_approvers
-    push.THRESHOLD_CONFIG_SLOT[0..2]
-    exec.active_account::get_item
-    # => [default_threshold, num_approvers, 0, 0]
-
-    movup.2 drop movup.2 drop
-    # => [default_threshold, num_approvers]
-end
-
 #! Returns the current threshold and num_approvers from `THRESHOLD_CONFIG_SLOT`.
 #!
 #! Inputs:  [pad(16)]
@@ -754,7 +388,6 @@ pub proc get_signer_at
     # => [PUB_KEY, scheme_id, pad(11)]
 end
 
-
 #! Returns 1 if PUB_KEY is a signer, else 0.
 #!
 #! Reads the initial account state: the result reflects the approver set at the start of the
@@ -832,6 +465,194 @@ pub proc is_signer(pub_key: word) -> felt
     # => [is_signer, pad(15)]
 end
 
+# PUBLIC HELPERS
+# =================================================================================================
+
+#! Remove old approver public keys and the corresponding scheme ids from the approver public key and
+#! scheme id mappings.
+#!
+#! This procedure clears the approver entries in the range [new_num_of_approvers,
+#! init_num_of_approvers) from APPROVER_PUBLIC_KEYS_SLOT and APPROVER_SCHEME_ID_SLOT. It does not
+#! touch THRESHOLD_CONFIG_SLOT or PROC_THRESHOLD_ROOTS_SLOT.
+#!
+#! Caller contract: before calling this, the caller must have already updated THRESHOLD_CONFIG_SLOT
+#! so that the threshold is still reachable with the reduced signer set, i.e. threshold <=
+#! new_num_of_approvers. Otherwise the account is left with a threshold that no remaining quorum can
+#! reach, making it permanently unable to authenticate. In-tree this is guaranteed by
+#! `update_signers_and_threshold`, which calls `assert_threshold_is_reachable` before this procedure.
+#!
+#! Inputs: [init_num_of_approvers, new_num_of_approvers]
+#! Outputs: []
+#!
+#! Where:
+#! - init_num_of_approvers is the original number of approvers before the update
+#! - new_num_of_approvers is the new number of approvers after the update
+#!
+#! Panics if:
+#! - init_num_of_approvers or new_num_of_approvers is not a u32 value.
+#!
+#! Invocation: exec
+pub proc cleanup_pubkey_and_scheme_id_mapping(init_num_of_approvers: u32, new_num_of_approvers: u32)
+    dup.1 dup.1
+    u32assert2.err=ERR_APPROVER_COUNTS_NOT_U32
+    u32lt
+    # => [should_loop, i = init_num_of_approvers, new_num_of_approvers]
+
+    while.true
+        # => [i, new_num_of_approvers]
+
+        sub.1
+        # => [i-1, new_num_of_approvers]
+
+        # clear scheme id at APPROVER_MAP_KEY(i-1)
+        dup exec.signature::create_approver_map_key
+        # => [APPROVER_MAP_KEY, i-1, new_num_of_approvers]
+
+        padw swapw
+        # => [APPROVER_MAP_KEY, EMPTY_WORD, i-1, new_num_of_approvers]
+
+        push.APPROVER_SCHEME_ID_SLOT[0..2]
+        # => [scheme_id_slot_suffix, scheme_id_slot_prefix, APPROVER_MAP_KEY, EMPTY_WORD, i-1, new_num_of_approvers]
+
+        exec.native_account::set_map_item
+        # => [OLD_VALUE, i-1, new_num_of_approvers]
+
+        dropw
+        # => [i-1, new_num_of_approvers]
+
+        # clear public key at APPROVER_MAP_KEY(i-1)
+        dup exec.signature::create_approver_map_key
+        # => [APPROVER_MAP_KEY, i-1, new_num_of_approvers]
+
+        padw swapw
+        # => [APPROVER_MAP_KEY, EMPTY_WORD, i-1, new_num_of_approvers]
+
+        push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
+        # => [pub_key_slot_suffix, pub_key_slot_prefix, APPROVER_MAP_KEY, EMPTY_WORD, i-1, new_num_of_approvers]
+
+        exec.native_account::set_map_item
+        # => [OLD_VALUE, i-1, new_num_of_approvers]
+
+        dropw
+        # => [i-1, new_num_of_approvers]
+
+        dup.1 dup.1
+        u32lt
+        # => [should_loop, i-1, new_num_of_approvers]
+    end
+
+    drop drop
+end
+
+#! Asserts the threshold is reachable with the given number of approvers, i.e. threshold is not
+#! greater than num_approvers.
+#!
+#! Inputs:  [num_approvers, threshold]
+#! Outputs: []
+#!
+#! Panics if:
+#! - num_approvers or threshold is not a u32 value.
+#! - threshold > num_approvers.
+#!
+#! Invocation: exec
+pub proc assert_threshold_is_reachable
+    u32assert2.err=ERR_MALFORMED_MULTISIG_CONFIG
+    u32gt assertz.err=ERR_MALFORMED_MULTISIG_CONFIG
+end
+
+#! Asserts that the `num_approvers` public keys currently stored in APPROVER_PUBLIC_KEYS_SLOT are
+#! pairwise distinct, reverting on the first duplicate.
+#!
+#! Reads the current account state, so it validates the keys just written by the caller.
+#!
+#! Inputs:  [num_approvers]
+#! Outputs: []
+#! Panics if:
+#! - any two approver public keys are equal.
+#!
+#! Cost: O(num_approvers^2) map reads; num_approvers is small for a multisig.
+#!
+#! Invocation: exec
+@locals(2)
+pub proc assert_unique_approver_public_keys(num_approvers: u32)
+    dup neq.0
+    # => [outer_continue, num_approvers]
+    while.true
+        sub.1
+        # => [i]
+
+        dup loc_store.UNIQUE_OUTER_INDEX_LOC
+        # => [i]
+
+        # read PK_i from the current state
+        dup exec.signature::create_approver_map_key
+        # => [APPROVER_MAP_KEY, i]
+
+        push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
+        exec.active_account::get_map_item
+        # => [PK_I, i]
+
+        movup.4
+        # => [i, PK_I]
+
+        dup neq.0
+        # => [inner_continue, i, PK_I]
+        while.true
+            sub.1
+            # => [j, PK_I]
+
+            dup loc_store.UNIQUE_INNER_INDEX_LOC
+            exec.signature::create_approver_map_key
+            # => [APPROVER_MAP_KEY, PK_I]
+
+            push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
+            exec.active_account::get_map_item
+            # => [PK_J, PK_I]
+
+            # assert PK_I != PK_J
+            dupw.1 exec.word::eq
+            # => [is_equal, PK_I]
+
+            assertz.err=ERR_DUPLICATE_APPROVER_PUBLIC_KEY
+            # => [PK_I]
+
+            loc_load.UNIQUE_INNER_INDEX_LOC
+            # => [j, PK_I]
+
+            dup neq.0
+            # => [inner_continue, j, PK_I]
+        end
+        # => [0, PK_I]
+
+        drop dropw
+        # => []
+
+        loc_load.UNIQUE_OUTER_INDEX_LOC
+        # => [i]
+
+        dup neq.0
+        # => [outer_continue, i]
+    end
+
+    drop
+    # => []
+end
+
+#! Returns the initial threshold and num_approvers from `THRESHOLD_CONFIG_SLOT`.
+#!
+#! Inputs: []
+#! Outputs: [default_threshold, num_approvers]
+#!
+#! Invocation: exec
+pub proc get_initial_threshold_and_num_approvers
+    push.THRESHOLD_CONFIG_SLOT[0..2]
+    exec.native_account::get_initial_item
+    # => [default_threshold, num_approvers, 0, 0]
+
+    movup.2 drop movup.2 drop
+    # => [default_threshold, num_approvers]
+end
+
 #! Records the transaction as executed and asserts it was not already executed, providing replay
 #! protection and finalizing multisig authentication.
 #!
@@ -901,7 +722,7 @@ end
 #! Panics if:
 #! - insufficient number of valid signatures (below threshold).
 #!
-#! Invocation: call
+#! Invocation: exec
 pub proc auth_tx(salt: word)
     exec.native_account::incr_nonce drop
     # => [SALT]
@@ -956,4 +777,197 @@ pub proc auth_tx(salt: word)
     # TX_SUMMARY_COMMITMENT is returned so wrappers can run optional checks
     # (e.g. guardian verification) before replay-protection finalization.
     # => [TX_SUMMARY_COMMITMENT]
+end
+
+# HELPER PROCEDURES
+# =================================================================================================
+
+#! Asserts that all configured per-procedure threshold overrides are less than or equal to
+#! number of approvers.
+#!
+#! Inputs:  [num_approvers]
+#! Outputs: []
+#! Panics if:
+#! - any configured procedure threshold is not a u32 value.
+#! - any configured procedure threshold exceeds num_approvers.
+proc assert_proc_thresholds_lte_num_approvers(num_approvers: u32)
+    exec.active_account::get_num_procedures
+    # => [num_procedures, num_approvers]
+
+    # num_procedures is always >= MIN_NUM_PROCEDURES (2), so enter the loop unconditionally
+    push.1
+    # => [should_continue, num_procedures, num_approvers]
+    while.true
+        sub.1 dup
+        # => [num_procedures-1, num_procedures-1, num_approvers]
+
+        exec.active_account::get_procedure_root
+        # => [PROC_ROOT, num_procedures-1, num_approvers]
+
+        push.PROC_THRESHOLD_ROOTS_SLOT[0..2]
+        # => [proc_roots_slot_suffix, proc_roots_slot_prefix, PROC_ROOT, num_procedures-1, num_approvers]
+
+        # Use the *current* policy state, not the initial one; otherwise a `set_proc_threshold`
+        # call earlier in the same transaction that raised a threshold above the new num_approvers
+        # would be missed and the multisig could end up with an unreachable threshold.
+        exec.active_account::get_map_item
+        # => [[proc_threshold, 0, 0, 0], num_procedures-1, num_approvers]
+
+        movdn.3 drop drop drop
+        # => [proc_threshold, num_procedures-1, num_approvers]
+
+        dup.2
+        # => [num_approvers, proc_threshold, num_procedures-1, num_approvers]
+
+        u32assert2.err=ERR_PROC_THRESHOLD_NOT_U32
+        u32gt assertz.err=ERR_PROC_THRESHOLD_EXCEEDS_NUM_APPROVERS
+        # => [num_procedures-1, num_approvers]
+
+        dup neq.0
+        # => [should_continue, num_procedures-1, num_approvers]
+    end
+    # => [num_procedures-1, num_approvers]
+
+    drop drop
+    # => []
+end
+
+# Computes the effective transaction threshold based on called procedures and per-procedure
+# overrides stored in PROC_THRESHOLD_ROOTS_SLOT. Falls back to default_threshold if no
+# overrides apply.
+#
+# Each called non-auth procedure contributes a threshold to a max accumulator:
+# - if the procedure has a stored override, its override value is the contribution.
+# - if the procedure has no override, `default_threshold` is the contribution so a procedure
+#   without a policy cannot be authorized at a lower threshold by being called alongside a
+#   low-override procedure (e.g. `receive_asset` configured at 1) in the same transaction.
+#
+# The auth procedure (procedure index 0) is skipped — it is the auth flow itself, not a
+# user-callable account procedure, and counting it would make `transaction_threshold` always
+# include `default_threshold`.
+#
+# When no non-auth procedure was called, `transaction_threshold` stays 0 and is reverted to
+# `default_threshold` at the end.
+#
+#! Inputs:  [default_threshold]
+#! Outputs: [transaction_threshold]
+@locals(1)
+proc compute_transaction_threshold(default_threshold: u32) -> u32
+    # 1. initialize transaction_threshold = 0
+    # 2. iterate through all non-auth account procedures
+    #   a. check if the procedure was called during the transaction
+    #   b. if called, get the override threshold of that procedure from the config map
+    #   c. if the procedure has no override (proc_threshold == 0), contribute default_threshold
+    #      instead so the unpolicied call is still constrained
+    #   d. if contribution > transaction_threshold, set transaction_threshold = contribution
+    # 3. if transaction_threshold == 0 at the end (no non-auth proc was called), revert to
+    #    using default_threshold
+
+    # store default_threshold for later
+    loc_store.DEFAULT_THRESHOLD_LOC
+    # => []
+
+    # 1. initialize transaction_threshold = 0
+    push.0
+    # => [transaction_threshold]
+
+    # get the number of account procedures
+    exec.active_account::get_num_procedures
+    # => [num_procedures, transaction_threshold]
+
+    # 2. iterate through all account procedures
+    # num_procedures is always >= MIN_NUM_PROCEDURES (2), so enter the loop unconditionally
+    push.1
+    # => [should_continue, num_procedures, transaction_threshold]
+    while.true
+        sub.1
+        # => [num_procedures-1, transaction_threshold]
+
+        # Skip the auth procedure at index 0 — it is the auth flow itself, not a user-callable
+        # account procedure. Counting it would make transaction_threshold always include
+        # default_threshold and break the override-down semantic for single-proc transactions.
+        dup neq.0
+        # => [is_non_auth, num_procedures-1, transaction_threshold]
+        if.true
+            # get procedure root of the procedure with index i
+            dup exec.active_account::get_procedure_root dupw
+            # => [PROC_ROOT, PROC_ROOT, num_procedures-1, transaction_threshold]
+
+            # 2a. check if this procedure has been called in the transaction
+            exec.native_account::was_procedure_called
+            # => [was_called, PROC_ROOT, num_procedures-1, transaction_threshold]
+
+            # if it has been called, compute and apply its threshold contribution
+            if.true
+                # => [PROC_ROOT, num_procedures-1, transaction_threshold]
+
+                push.PROC_THRESHOLD_ROOTS_SLOT[0..2]
+                # => [proc_roots_slot_suffix, proc_roots_slot_prefix, PROC_ROOT, num_procedures-1, transaction_threshold]
+
+                # 2b. get the override proc_threshold of that procedure
+                # if the procedure has no override threshold, the returned map item will be [0, 0, 0, 0]
+                exec.native_account::get_initial_map_item
+                # => [[proc_threshold, 0, 0, 0], num_procedures-1, transaction_threshold]
+
+                movdn.3 drop drop drop
+                # => [proc_threshold, num_procedures-1, transaction_threshold]
+
+                # 2c. if the procedure has no override (proc_threshold == 0), contribute
+                # default_threshold instead so the unpolicied call cannot be silently authorized
+                # at a lower threshold by being called alongside a low-override procedure
+                # (e.g. `receive_asset` configured at 1) in the same transaction.
+                dup eq.0
+                if.true
+                    drop
+                    loc_load.DEFAULT_THRESHOLD_LOC
+                end
+                # => [contribution, num_procedures-1, transaction_threshold]
+
+                # 2d. transaction_threshold = max(transaction_threshold, contribution)
+                movup.2 u32max
+                # => [new_transaction_threshold, num_procedures-1]
+
+                swap
+                # => [num_procedures-1, new_transaction_threshold]
+            # if it has not been called during this transaction, nothing to do, move to the next procedure
+            else
+                dropw
+                # => [num_procedures-1, transaction_threshold]
+            end
+        end
+
+        dup neq.0
+        # => [should_continue, num_procedures-1, transaction_threshold]
+    end
+
+    drop
+    # => [transaction_threshold]
+
+    loc_load.DEFAULT_THRESHOLD_LOC
+    # => [default_threshold, transaction_threshold]
+
+    # 3. if no non-auth proc was called, transaction_threshold is 0; fall back to default_threshold
+    dup.1 eq.0
+    # => [is_zero, default_threshold, transaction_threshold]
+
+    cdrop
+    # => [effective_transaction_threshold]
+end
+
+#! Returns the current threshold and num_approvers from `THRESHOLD_CONFIG_SLOT`.
+#!
+#! This is the internal `exec` helper shared by internal callers and the public `call`
+#! wrapper `get_threshold_and_num_approvers`.
+#!
+#! Inputs: []
+#! Outputs: [default_threshold, num_approvers]
+#!
+#! Invocation: exec
+proc get_current_threshold_and_num_approvers
+    push.THRESHOLD_CONFIG_SLOT[0..2]
+    exec.active_account::get_item
+    # => [default_threshold, num_approvers, 0, 0]
+
+    movup.2 drop movup.2 drop
+    # => [default_threshold, num_approvers]
 end

--- a/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
@@ -78,6 +78,261 @@ const DEFAULT_THRESHOLD_LOC = 1
 const NEW_NUM_OF_APPROVERS_LOC = 0
 const INIT_NUM_OF_APPROVERS_LOC = 1
 
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Sets or clears a smart per-procedure policy.
+#!
+#! Inputs:  [immediate_threshold, delayed_threshold, note_restrictions, PROC_ROOT]
+#! Outputs: []
+#!
+#! Where:
+#! - immediate_threshold is the threshold for direct execution, or 0 when disabled.
+#! - delayed_threshold is the threshold for delayed execution, or 0 when disabled.
+#! - note_restrictions is the note restriction enum value in the 0..=NOTE_RESTRICTION_MAX range.
+#! - PROC_ROOT is the root of the account procedure whose policy is being updated.
+#!
+#! Panics if:
+#! - immediate_threshold or delayed_threshold is not a u32 value.
+#! - note_restrictions is outside the supported range.
+#! - either threshold exceeds the current number of approvers.
+#! - delayed_threshold exceeds immediate_threshold when immediate_threshold is non-zero.
+#! - note_restrictions is non-zero while both thresholds are zero.
+#! - PROC_ROOT is not one of the account's procedures.
+#!
+#! Invocation: call
+@locals(3)
+@account_procedure
+pub proc set_procedure_policy
+    loc_store.IMMEDIATE_THRESHOLD_LOC
+    # => [delayed_threshold, note_restrictions, PROC_ROOT]
+
+    loc_store.DELAYED_THRESHOLD_LOC
+    # => [note_restrictions, PROC_ROOT]
+
+    loc_store.NOTE_RESTRICTIONS_LOC
+    # => [PROC_ROOT]
+
+    # ----- Validate immediate_threshold <= num_approvers (preserving num_approvers for the
+    # delayed check that follows). -----
+    exec.get_current_num_approvers
+    # => [num_approvers, PROC_ROOT]
+
+    dup loc_load.IMMEDIATE_THRESHOLD_LOC swap
+    # => [num_approvers, immediate_threshold, num_approvers, PROC_ROOT]
+
+    u32assert2.err=ERR_NUM_APPROVERS_OR_PROC_THRESHOLD_NOT_U32
+    u32gt assertz.err=ERR_PROC_THRESHOLD_EXCEEDS_NUM_APPROVERS
+    # => [num_approvers, PROC_ROOT]
+
+    # ----- Validate delayed_threshold <= num_approvers (consumes num_approvers). -----
+    loc_load.DELAYED_THRESHOLD_LOC swap
+    # => [num_approvers, delayed_threshold, PROC_ROOT]
+
+    u32assert2.err=ERR_NUM_APPROVERS_OR_PROC_THRESHOLD_NOT_U32
+    u32gt assertz.err=ERR_PROC_THRESHOLD_EXCEEDS_NUM_APPROVERS
+    # => [PROC_ROOT]
+
+    # ----- Validate note_restrictions is in 0..=NOTE_RESTRICTION_MAX. -----
+    loc_load.NOTE_RESTRICTIONS_LOC
+    exec.assert_valid_note_restrictions
+    # => [PROC_ROOT]
+
+    # ----- Validate (immediate, delayed, note_restrictions) shape. -----
+    # `if.true` consumes its boolean condition, so the body branches operate on `[PROC_ROOT]`
+    # without any leading `drop`.
+    loc_load.IMMEDIATE_THRESHOLD_LOC eq.0
+    # => [is_immediate_threshold_zero, PROC_ROOT]
+
+    if.true
+        # immediate is zero. If delayed is also zero, note_restrictions must be zero, otherwise
+        # the policy would forbid notes for a procedure that has no threshold to authorize them.
+        loc_load.DELAYED_THRESHOLD_LOC eq.0
+        # => [is_delayed_threshold_zero, PROC_ROOT]
+
+        if.true
+            # `eq.0 assert` produces the proper error when note_restrictions is non-zero;
+            # `assertz` would surface a generic "binary value expected" error for values 2 or 3.
+            loc_load.NOTE_RESTRICTIONS_LOC eq.0 assert.err=ERR_NOTE_RESTRICTIONS_REQUIRE_THRESHOLD
+            # => [PROC_ROOT]
+        end
+    else
+        # immediate is non-zero. Validate delayed_threshold <= immediate_threshold.
+        loc_load.DELAYED_THRESHOLD_LOC loc_load.IMMEDIATE_THRESHOLD_LOC
+        # => [immediate_threshold, delayed_threshold, PROC_ROOT]
+
+        u32assert2.err=ERR_NUM_APPROVERS_OR_PROC_THRESHOLD_NOT_U32
+        u32gt assertz.err=ERR_DELAYED_THRESHOLD_EXCEEDS_IMMEDIATE
+        # => [PROC_ROOT]
+    end
+
+    # ----- Validate PROC_ROOT is one of the account's procedures. -----
+    dupw exec.active_account::has_procedure
+    assert.err=ERR_PROC_ROOT_NOT_IN_ACCOUNT
+    # => [PROC_ROOT]
+
+    # ----- Write [immediate, delayed, note_restrictions, 0] to PROCEDURE_POLICIES_SLOT[PROC_ROOT].
+    push.0
+    loc_load.NOTE_RESTRICTIONS_LOC
+    loc_load.DELAYED_THRESHOLD_LOC
+    loc_load.IMMEDIATE_THRESHOLD_LOC
+    # => [immediate_threshold, delayed_threshold, note_restrictions, 0, PROC_ROOT]
+
+    swapw
+    # => [PROC_ROOT, immediate_threshold, delayed_threshold, note_restrictions, 0]
+
+    push.PROCEDURE_POLICIES_SLOT[0..2]
+    # => [procedure_policies_slot_suffix, procedure_policies_slot_prefix, PROC_ROOT, POLICY_WORD]
+
+    exec.native_account::set_map_item
+    # => [OLD_POLICY_WORD]
+
+    dropw
+    # => []
+end
+
+#! Updates threshold config, approvers, and approver scheme ids for smart multisig accounts.
+#!
+#! Same advice map and config layout as [`multisig::update_signers_and_threshold`]. Differs by
+#! validating smart procedure policies ([`assert_proc_policies_lte_num_approvers`]) instead
+#! of per-procedure threshold overrides.
+#!
+#! Note: like [`multisig::update_signers_and_threshold`], this procedure does NOT re-scale existing
+#! smart procedure policies. Their immediate/delayed thresholds are absolute signature counts, not
+#! ratios, and `assert_proc_policies_lte_num_approvers` only enforces the reachability bound
+#! (`threshold <= num_approvers`). Growing the signer set silently lowers the effective signing ratio
+#! of every policy; operators must re-evaluate and, where appropriate, raise the affected policies in
+#! the same transaction that grows the signer set.
+#!
+#! Inputs:
+#!   Operand stack: [MULTISIG_CONFIG_COMMITMENT, pad(12)]
+#! Outputs:
+#!   Operand stack: []
+#!
+#! Panics if:
+#! - the new threshold exceeds the new number of approvers.
+#! - the new threshold or number of approvers is zero.
+#! - any existing smart procedure policy becomes unreachable under the new number of approvers.
+#! - any provided scheme identifier word is malformed.
+#!
+#! Locals:
+#! 0: new_num_of_approvers
+#! 1: init_num_of_approvers
+#!
+#! Invocation: call
+@locals(2)
+@account_procedure
+pub proc update_signers_and_threshold(multisig_config_commitment: word)
+    # The signer configuration is read from the advice provider without an inline hash check. Every
+    # value written below via set_item / set_map_item is folded into ACCOUNT_DELTA_COMMITMENT, which
+    # is part of the TX_SUMMARY_COMMITMENT the current signers sign, so a substituted configuration
+    # produces a different delta commitment and thus a summary the current signers never signed. The
+    # same applies to the per-signer loads in the loop below.
+    adv.push_mapval
+    # => [MULTISIG_CONFIG_COMMITMENT, pad(12)]
+
+    adv_loadw
+    # => [MULTISIG_CONFIG, pad(12)]
+
+    # store new_num_of_approvers for later
+    exec.multisig_config_to_num_approvers loc_store.NEW_NUM_OF_APPROVERS_LOC
+    # => [MULTISIG_CONFIG, pad(12)]
+
+    dup dup.2
+    # => [num_approvers, threshold, MULTISIG_CONFIG, pad(12)]
+
+    # make sure that the threshold is reachable with the number of approvers
+    exec.multisig::assert_threshold_is_reachable
+    # => [MULTISIG_CONFIG, pad(12)]
+
+    dup dup.2
+    # => [num_approvers, threshold, MULTISIG_CONFIG, pad(12)]
+
+    eq.0 assertz.err=ERR_ZERO_IN_MULTISIG_CONFIG
+    eq.0 assertz.err=ERR_ZERO_IN_MULTISIG_CONFIG
+    # => [MULTISIG_CONFIG, pad(12)]
+
+    loc_load.NEW_NUM_OF_APPROVERS_LOC
+    # => [num_approvers, MULTISIG_CONFIG, pad(12)]
+
+    exec.assert_proc_policies_lte_num_approvers
+    # => [MULTISIG_CONFIG, pad(12)]
+
+    push.THRESHOLD_CONFIG_SLOT[0..2]
+    # => [config_slot_suffix, config_slot_prefix, MULTISIG_CONFIG, pad(12)]
+
+    exec.native_account::set_item
+    # => [OLD_THRESHOLD_CONFIG, pad(12)]
+
+    # Save the old num_of_approvers for the post-loop scheme/pubkey cleanup, then drop the rest
+    # of OLD_THRESHOLD_CONFIG.
+    drop loc_store.INIT_NUM_OF_APPROVERS_LOC drop drop
+    # => [pad(12)]
+
+    loc_load.NEW_NUM_OF_APPROVERS_LOC
+    # => [num_approvers, pad(12)]
+
+    dup neq.0
+    while.true
+        sub.1
+        # => [i-1, pad(12)]
+
+        dup exec.signature::create_approver_map_key
+        # => [APPROVER_MAP_KEY, i-1, pad(12)]
+
+        padw adv_loadw
+        # => [PUB_KEY, APPROVER_MAP_KEY, i-1, pad(12)]
+
+        swapw
+        # => [APPROVER_MAP_KEY, PUB_KEY, i-1, pad(12)]
+
+        push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
+        # => [pub_key_slot_suffix, pub_key_slot_prefix, APPROVER_MAP_KEY, PUB_KEY, i-1, pad(12)]
+
+        exec.native_account::set_map_item
+        # => [OLD_VALUE, i-1, pad(12)]
+
+        adv_loadw
+        # => [SCHEME_ID_WORD, i-1, pad(12)]
+
+        exec.auth::signature::assert_supported_scheme_word
+        # => [SCHEME_ID_WORD, i-1, pad(12)]
+
+        dup.4 exec.signature::create_approver_map_key
+        # => [APPROVER_MAP_KEY, SCHEME_ID_WORD, i-1, pad(12)]
+
+        push.APPROVER_SCHEME_ID_SLOT[0..2]
+        # => [scheme_id_slot_id_suffix, scheme_id_slot_id_prefix, APPROVER_MAP_KEY, SCHEME_ID_WORD, i-1, pad(12)]
+
+        exec.native_account::set_map_item
+        # => [OLD_VALUE, i-1, pad(12)]
+
+        dropw
+        # => [i-1, pad(12)]
+
+        dup neq.0
+        # => [is_non_zero, i-1, pad(12)]
+    end
+    # => [pad(13)]
+
+    drop
+    # => [pad(12)]
+
+    # assert all approver public keys are unique.
+    loc_load.NEW_NUM_OF_APPROVERS_LOC
+    exec.multisig::assert_unique_approver_public_keys
+    # => [pad(12)]
+
+    loc_load.NEW_NUM_OF_APPROVERS_LOC loc_load.INIT_NUM_OF_APPROVERS_LOC
+    # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
+
+    exec.multisig::cleanup_pubkey_and_scheme_id_mapping
+    # => [pad(12)]
+end
+
+# PUBLIC HELPERS
+# =================================================================================================
+
 #! Gets the procedure policy entry for PROC_ROOT from the account's initial state.
 #!
 #! Inputs:  [PROC_ROOT]
@@ -98,6 +353,117 @@ pub proc get_procedure_policy
     movup.3 drop
     # => [immediate_threshold, delayed_threshold, note_restrictions]
 end
+
+#! Enforces note_restrictions against the current transaction.
+#!
+#! `note_restrictions` is treated as a bit set (see `NOTE_RESTRICTION_*_MASK`):
+#! - bit 0 (mask 1) → forbid input notes
+#! - bit 1 (mask 2) → forbid output notes
+#!
+#! Inputs:  [note_restrictions]
+#! Outputs: []
+#!
+#! Invocation: exec
+pub proc enforce_note_restrictions
+    dup u32and.NOTE_RESTRICTION_INPUT_NOTES_MASK eq.NOTE_RESTRICTION_INPUT_NOTES_MASK
+    # => [has_input_note_restriction, note_restrictions]
+
+    if.true
+        exec.tx_policy::assert_no_input_notes
+    end
+    # => [note_restrictions]
+
+    u32and.NOTE_RESTRICTION_OUTPUT_NOTES_MASK eq.NOTE_RESTRICTION_OUTPUT_NOTES_MASK
+    # => [has_output_note_restriction]
+
+    if.true
+        exec.tx_policy::assert_no_output_notes
+    end
+    # => []
+end
+
+#! Authenticate a transaction using multisig smart-policy rules.
+#!
+#! Inputs:
+#!   Operand stack: [SALT]
+#! Outputs:
+#!   Operand stack: [TX_SUMMARY_COMMITMENT]
+#!
+#! Locals:
+#! 0: policy_threshold
+#! 1: default_threshold
+#!
+#! Invocation: exec
+#!
+#! NOTE: This procedure is a temporary form covering signer verification and
+#! per-procedure policy enforcement. The following sections will be added:
+#! - Spending Limits + Amount-Based Thresholds: a prologue that calls
+#!   `exec.spending_limits::compute_spending_policy` to derive a spending-derived threshold and
+#!   `spending_requires_delay` flag, and combines it via `u32max` with `policy_threshold` before
+#!   the final `compute_tx_threshold` fallback.
+#! - TimelockedAccount: after signature verification, assert the execute-path vs.
+#!   `policy_requires_delay`/`spending_requires_delay` consistency (restoring
+#!   `ERR_EXECUTE_PATH_MISMATCH`), then call
+#!   `exec.timelock_controller::finalize_timelock_proposals` to advance any pending
+#!   propose/cancel/execute state.
+@locals(2)
+pub proc auth_tx(salt: word)
+    exec.native_account::incr_nonce drop
+    # => [SALT]
+
+    # ------ Computing transaction summary ------
+    exec.auth::create_tx_summary
+    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
+
+    adv.insert_hqword
+    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
+
+    exec.auth::hash_tx_summary
+    # => [TX_SUMMARY_COMMITMENT]
+
+    # ------ Reading threshold config (default + num_approvers) ------
+    exec.multisig::get_initial_threshold_and_num_approvers
+    # => [default_threshold, num_of_approvers, TX_SUMMARY_COMMITMENT]
+
+    # Save default_threshold for the procedure-policy enforcement and the final tx-threshold
+    # fallback below.
+    dup loc_store.1
+    # => [default_threshold, num_of_approvers, TX_SUMMARY_COMMITMENT]
+
+    # ------ Enforcing procedure policy (consumes default_threshold) ------
+    exec.enforce_procedure_policy
+    # => [policy_threshold, num_of_approvers, TX_SUMMARY_COMMITMENT]
+
+    loc_store.0
+    # => [num_of_approvers, TX_SUMMARY_COMMITMENT]
+
+    # ------ Verifying approver signatures ------
+    push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
+    push.APPROVER_SCHEME_ID_SLOT[0..2]
+    exec.::miden::standards::auth::signature::verify_signatures
+    # => [num_verified_signatures, TX_SUMMARY_COMMITMENT]
+
+    # ------ Computing final transaction threshold ------
+    # If no non-auth procedure was called, `policy_threshold` is 0 and `compute_tx_threshold`
+    # falls back to `default_threshold`; otherwise it returns the policy max directly.
+    loc_load.0
+    loc_load.1
+    # => [default_threshold, policy_threshold, num_verified_signatures, TX_SUMMARY_COMMITMENT]
+
+    exec.compute_tx_threshold
+    # => [transaction_threshold, num_verified_signatures, TX_SUMMARY_COMMITMENT]
+
+    u32assert2 u32lt
+    # => [is_unauthorized, TX_SUMMARY_COMMITMENT]
+
+    if.true
+        emit.AUTH_UNAUTHORIZED_EVENT
+        push.0 assert.err=ERR_INSUFFICIENT_SIGNATURES
+    end
+end
+
+# HELPER PROCEDURES
+# =================================================================================================
 
 #! Validates that note_restrictions is within the supported range.
 #!
@@ -122,9 +488,6 @@ proc assert_valid_note_restrictions
     assert.err=ERR_INVALID_NOTE_RESTRICTIONS
     # => []
 end
-
-# HELPER PROCEDURES
-# =================================================================================================
 
 #! Returns the current number of approvers after any in-transaction signer update has been applied.
 #!
@@ -383,34 +746,6 @@ proc compute_called_proc_policy(execution_mode: u32, default_threshold: u32)
     # => [threshold_acc, requires_delay_acc, restrictions_acc]
 end
 
-#! Enforces note_restrictions against the current transaction.
-#!
-#! `note_restrictions` is treated as a bit set (see `NOTE_RESTRICTION_*_MASK`):
-#! - bit 0 (mask 1) → forbid input notes
-#! - bit 1 (mask 2) → forbid output notes
-#!
-#! Inputs:  [note_restrictions]
-#! Outputs: []
-#!
-#! Invocation: exec
-pub proc enforce_note_restrictions
-    dup u32and.NOTE_RESTRICTION_INPUT_NOTES_MASK eq.NOTE_RESTRICTION_INPUT_NOTES_MASK
-    # => [has_input_note_restriction, note_restrictions]
-
-    if.true
-        exec.tx_policy::assert_no_input_notes
-    end
-    # => [note_restrictions]
-
-    u32and.NOTE_RESTRICTION_OUTPUT_NOTES_MASK eq.NOTE_RESTRICTION_OUTPUT_NOTES_MASK
-    # => [has_output_note_restriction]
-
-    if.true
-        exec.tx_policy::assert_no_output_notes
-    end
-    # => []
-end
-
 #! Enforces the procedure-policy for the current transaction:
 #! - asserts each called procedure supports the active execution mode,
 #! - asserts the union of note restrictions against the transaction's input/output notes,
@@ -514,336 +849,4 @@ proc assert_proc_policies_lte_num_approvers
 
     drop drop
     # => []
-end
-
-# PUBLIC INTERFACE
-# =================================================================================================
-
-#! Sets or clears a smart per-procedure policy.
-#!
-#! Inputs:  [immediate_threshold, delayed_threshold, note_restrictions, PROC_ROOT]
-#! Outputs: []
-#!
-#! Where:
-#! - immediate_threshold is the threshold for direct execution, or 0 when disabled.
-#! - delayed_threshold is the threshold for delayed execution, or 0 when disabled.
-#! - note_restrictions is the note restriction enum value in the 0..=NOTE_RESTRICTION_MAX range.
-#! - PROC_ROOT is the root of the account procedure whose policy is being updated.
-#!
-#! Panics if:
-#! - immediate_threshold or delayed_threshold is not a u32 value.
-#! - note_restrictions is outside the supported range.
-#! - either threshold exceeds the current number of approvers.
-#! - delayed_threshold exceeds immediate_threshold when immediate_threshold is non-zero.
-#! - note_restrictions is non-zero while both thresholds are zero.
-#! - PROC_ROOT is not one of the account's procedures.
-#!
-#! Invocation: call
-@locals(3)
-@account_procedure
-pub proc set_procedure_policy
-    loc_store.IMMEDIATE_THRESHOLD_LOC
-    # => [delayed_threshold, note_restrictions, PROC_ROOT]
-
-    loc_store.DELAYED_THRESHOLD_LOC
-    # => [note_restrictions, PROC_ROOT]
-
-    loc_store.NOTE_RESTRICTIONS_LOC
-    # => [PROC_ROOT]
-
-    # ----- Validate immediate_threshold <= num_approvers (preserving num_approvers for the
-    # delayed check that follows). -----
-    exec.get_current_num_approvers
-    # => [num_approvers, PROC_ROOT]
-
-    dup loc_load.IMMEDIATE_THRESHOLD_LOC swap
-    # => [num_approvers, immediate_threshold, num_approvers, PROC_ROOT]
-
-    u32assert2.err=ERR_NUM_APPROVERS_OR_PROC_THRESHOLD_NOT_U32
-    u32gt assertz.err=ERR_PROC_THRESHOLD_EXCEEDS_NUM_APPROVERS
-    # => [num_approvers, PROC_ROOT]
-
-    # ----- Validate delayed_threshold <= num_approvers (consumes num_approvers). -----
-    loc_load.DELAYED_THRESHOLD_LOC swap
-    # => [num_approvers, delayed_threshold, PROC_ROOT]
-
-    u32assert2.err=ERR_NUM_APPROVERS_OR_PROC_THRESHOLD_NOT_U32
-    u32gt assertz.err=ERR_PROC_THRESHOLD_EXCEEDS_NUM_APPROVERS
-    # => [PROC_ROOT]
-
-    # ----- Validate note_restrictions is in 0..=NOTE_RESTRICTION_MAX. -----
-    loc_load.NOTE_RESTRICTIONS_LOC
-    exec.assert_valid_note_restrictions
-    # => [PROC_ROOT]
-
-    # ----- Validate (immediate, delayed, note_restrictions) shape. -----
-    # `if.true` consumes its boolean condition, so the body branches operate on `[PROC_ROOT]`
-    # without any leading `drop`.
-    loc_load.IMMEDIATE_THRESHOLD_LOC eq.0
-    # => [is_immediate_threshold_zero, PROC_ROOT]
-
-    if.true
-        # immediate is zero. If delayed is also zero, note_restrictions must be zero, otherwise
-        # the policy would forbid notes for a procedure that has no threshold to authorize them.
-        loc_load.DELAYED_THRESHOLD_LOC eq.0
-        # => [is_delayed_threshold_zero, PROC_ROOT]
-
-        if.true
-            # `eq.0 assert` produces the proper error when note_restrictions is non-zero;
-            # `assertz` would surface a generic "binary value expected" error for values 2 or 3.
-            loc_load.NOTE_RESTRICTIONS_LOC eq.0 assert.err=ERR_NOTE_RESTRICTIONS_REQUIRE_THRESHOLD
-            # => [PROC_ROOT]
-        end
-    else
-        # immediate is non-zero. Validate delayed_threshold <= immediate_threshold.
-        loc_load.DELAYED_THRESHOLD_LOC loc_load.IMMEDIATE_THRESHOLD_LOC
-        # => [immediate_threshold, delayed_threshold, PROC_ROOT]
-
-        u32assert2.err=ERR_NUM_APPROVERS_OR_PROC_THRESHOLD_NOT_U32
-        u32gt assertz.err=ERR_DELAYED_THRESHOLD_EXCEEDS_IMMEDIATE
-        # => [PROC_ROOT]
-    end
-
-    # ----- Validate PROC_ROOT is one of the account's procedures. -----
-    dupw exec.active_account::has_procedure
-    assert.err=ERR_PROC_ROOT_NOT_IN_ACCOUNT
-    # => [PROC_ROOT]
-
-    # ----- Write [immediate, delayed, note_restrictions, 0] to PROCEDURE_POLICIES_SLOT[PROC_ROOT].
-    push.0
-    loc_load.NOTE_RESTRICTIONS_LOC
-    loc_load.DELAYED_THRESHOLD_LOC
-    loc_load.IMMEDIATE_THRESHOLD_LOC
-    # => [immediate_threshold, delayed_threshold, note_restrictions, 0, PROC_ROOT]
-
-    swapw
-    # => [PROC_ROOT, immediate_threshold, delayed_threshold, note_restrictions, 0]
-
-    push.PROCEDURE_POLICIES_SLOT[0..2]
-    # => [procedure_policies_slot_suffix, procedure_policies_slot_prefix, PROC_ROOT, POLICY_WORD]
-
-    exec.native_account::set_map_item
-    # => [OLD_POLICY_WORD]
-
-    dropw
-    # => []
-end
-
-#! Updates threshold config, approvers, and approver scheme ids for smart multisig accounts.
-#!
-#! Same advice map and config layout as [`multisig::update_signers_and_threshold`]. Differs by
-#! validating smart procedure policies ([`assert_proc_policies_lte_num_approvers`]) instead
-#! of per-procedure threshold overrides.
-#!
-#! Note: like [`multisig::update_signers_and_threshold`], this procedure does NOT re-scale existing
-#! smart procedure policies. Their immediate/delayed thresholds are absolute signature counts, not
-#! ratios, and `assert_proc_policies_lte_num_approvers` only enforces the reachability bound
-#! (`threshold <= num_approvers`). Growing the signer set silently lowers the effective signing ratio
-#! of every policy; operators must re-evaluate and, where appropriate, raise the affected policies in
-#! the same transaction that grows the signer set.
-#!
-#! Inputs:
-#!   Operand stack: [MULTISIG_CONFIG_COMMITMENT, pad(12)]
-#! Outputs:
-#!   Operand stack: []
-#!
-#! Panics if:
-#! - the new threshold exceeds the new number of approvers.
-#! - the new threshold or number of approvers is zero.
-#! - any existing smart procedure policy becomes unreachable under the new number of approvers.
-#! - any provided scheme identifier word is malformed.
-#!
-#! Locals:
-#! 0: new_num_of_approvers
-#! 1: init_num_of_approvers
-#!
-#! Invocation: call
-@locals(2)
-@account_procedure
-pub proc update_signers_and_threshold(multisig_config_commitment: word)
-    # The signer configuration is read from the advice provider without an inline hash check. Every
-    # value written below via set_item / set_map_item is folded into ACCOUNT_DELTA_COMMITMENT, which
-    # is part of the TX_SUMMARY_COMMITMENT the current signers sign, so a substituted configuration
-    # produces a different delta commitment and thus a summary the current signers never signed. The
-    # same applies to the per-signer loads in the loop below.
-    adv.push_mapval
-    # => [MULTISIG_CONFIG_COMMITMENT, pad(12)]
-
-    adv_loadw
-    # => [MULTISIG_CONFIG, pad(12)]
-
-    # store new_num_of_approvers for later
-    exec.multisig_config_to_num_approvers loc_store.NEW_NUM_OF_APPROVERS_LOC
-    # => [MULTISIG_CONFIG, pad(12)]
-
-    dup dup.2
-    # => [num_approvers, threshold, MULTISIG_CONFIG, pad(12)]
-
-    # make sure that the threshold is reachable with the number of approvers
-    exec.multisig::assert_threshold_is_reachable
-    # => [MULTISIG_CONFIG, pad(12)]
-
-    dup dup.2
-    # => [num_approvers, threshold, MULTISIG_CONFIG, pad(12)]
-
-    eq.0 assertz.err=ERR_ZERO_IN_MULTISIG_CONFIG
-    eq.0 assertz.err=ERR_ZERO_IN_MULTISIG_CONFIG
-    # => [MULTISIG_CONFIG, pad(12)]
-
-    loc_load.NEW_NUM_OF_APPROVERS_LOC
-    # => [num_approvers, MULTISIG_CONFIG, pad(12)]
-
-    exec.assert_proc_policies_lte_num_approvers
-    # => [MULTISIG_CONFIG, pad(12)]
-
-    push.THRESHOLD_CONFIG_SLOT[0..2]
-    # => [config_slot_suffix, config_slot_prefix, MULTISIG_CONFIG, pad(12)]
-
-    exec.native_account::set_item
-    # => [OLD_THRESHOLD_CONFIG, pad(12)]
-
-    # Save the old num_of_approvers for the post-loop scheme/pubkey cleanup, then drop the rest
-    # of OLD_THRESHOLD_CONFIG.
-    drop loc_store.INIT_NUM_OF_APPROVERS_LOC drop drop
-    # => [pad(12)]
-
-    loc_load.NEW_NUM_OF_APPROVERS_LOC
-    # => [num_approvers, pad(12)]
-
-    dup neq.0
-    while.true
-        sub.1
-        # => [i-1, pad(12)]
-
-        dup exec.signature::create_approver_map_key
-        # => [APPROVER_MAP_KEY, i-1, pad(12)]
-
-        padw adv_loadw
-        # => [PUB_KEY, APPROVER_MAP_KEY, i-1, pad(12)]
-
-        swapw
-        # => [APPROVER_MAP_KEY, PUB_KEY, i-1, pad(12)]
-
-        push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
-        # => [pub_key_slot_suffix, pub_key_slot_prefix, APPROVER_MAP_KEY, PUB_KEY, i-1, pad(12)]
-
-        exec.native_account::set_map_item
-        # => [OLD_VALUE, i-1, pad(12)]
-
-        adv_loadw
-        # => [SCHEME_ID_WORD, i-1, pad(12)]
-
-        exec.auth::signature::assert_supported_scheme_word
-        # => [SCHEME_ID_WORD, i-1, pad(12)]
-
-        dup.4 exec.signature::create_approver_map_key
-        # => [APPROVER_MAP_KEY, SCHEME_ID_WORD, i-1, pad(12)]
-
-        push.APPROVER_SCHEME_ID_SLOT[0..2]
-        # => [scheme_id_slot_id_suffix, scheme_id_slot_id_prefix, APPROVER_MAP_KEY, SCHEME_ID_WORD, i-1, pad(12)]
-
-        exec.native_account::set_map_item
-        # => [OLD_VALUE, i-1, pad(12)]
-
-        dropw
-        # => [i-1, pad(12)]
-
-        dup neq.0
-        # => [is_non_zero, i-1, pad(12)]
-    end
-    # => [pad(13)]
-
-    drop
-    # => [pad(12)]
-
-    # assert all approver public keys are unique.
-    loc_load.NEW_NUM_OF_APPROVERS_LOC
-    exec.multisig::assert_unique_approver_public_keys
-    # => [pad(12)]
-
-    loc_load.NEW_NUM_OF_APPROVERS_LOC loc_load.INIT_NUM_OF_APPROVERS_LOC
-    # => [init_num_of_approvers, new_num_of_approvers, pad(12)]
-
-    exec.multisig::cleanup_pubkey_and_scheme_id_mapping
-    # => [pad(12)]
-end
-
-#! Authenticate a transaction using multisig smart-policy rules.
-#!
-#! Inputs:
-#!   Operand stack: [SALT]
-#! Outputs:
-#!   Operand stack: [TX_SUMMARY_COMMITMENT]
-#!
-#! Locals:
-#! 0: policy_threshold
-#! 1: default_threshold
-#!
-#! Invocation: call
-#!
-#! NOTE: This procedure is a temporary form covering signer verification and
-#! per-procedure policy enforcement. The following sections will be added:
-#! - Spending Limits + Amount-Based Thresholds: a prologue that calls
-#!   `exec.spending_limits::compute_spending_policy` to derive a spending-derived threshold and
-#!   `spending_requires_delay` flag, and combines it via `u32max` with `policy_threshold` before
-#!   the final `compute_tx_threshold` fallback.
-#! - TimelockedAccount: after signature verification, assert the execute-path vs.
-#!   `policy_requires_delay`/`spending_requires_delay` consistency (restoring
-#!   `ERR_EXECUTE_PATH_MISMATCH`), then call
-#!   `exec.timelock_controller::finalize_timelock_proposals` to advance any pending
-#!   propose/cancel/execute state.
-@locals(2)
-pub proc auth_tx(salt: word)
-    exec.native_account::incr_nonce drop
-    # => [SALT]
-
-    # ------ Computing transaction summary ------
-    exec.auth::create_tx_summary
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-    adv.insert_hqword
-    # => [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT]
-
-    exec.auth::hash_tx_summary
-    # => [TX_SUMMARY_COMMITMENT]
-
-    # ------ Reading threshold config (default + num_approvers) ------
-    exec.multisig::get_initial_threshold_and_num_approvers
-    # => [default_threshold, num_of_approvers, TX_SUMMARY_COMMITMENT]
-
-    # Save default_threshold for the procedure-policy enforcement and the final tx-threshold
-    # fallback below.
-    dup loc_store.1
-    # => [default_threshold, num_of_approvers, TX_SUMMARY_COMMITMENT]
-
-    # ------ Enforcing procedure policy (consumes default_threshold) ------
-    exec.enforce_procedure_policy
-    # => [policy_threshold, num_of_approvers, TX_SUMMARY_COMMITMENT]
-
-    loc_store.0
-    # => [num_of_approvers, TX_SUMMARY_COMMITMENT]
-
-    # ------ Verifying approver signatures ------
-    push.APPROVER_PUBLIC_KEYS_SLOT[0..2]
-    push.APPROVER_SCHEME_ID_SLOT[0..2]
-    exec.::miden::standards::auth::signature::verify_signatures
-    # => [num_verified_signatures, TX_SUMMARY_COMMITMENT]
-
-    # ------ Computing final transaction threshold ------
-    # If no non-auth procedure was called, `policy_threshold` is 0 and `compute_tx_threshold`
-    # falls back to `default_threshold`; otherwise it returns the policy max directly.
-    loc_load.0
-    loc_load.1
-    # => [default_threshold, policy_threshold, num_verified_signatures, TX_SUMMARY_COMMITMENT]
-
-    exec.compute_tx_threshold
-    # => [transaction_threshold, num_verified_signatures, TX_SUMMARY_COMMITMENT]
-
-    u32assert2 u32lt
-    # => [is_unauthorized, TX_SUMMARY_COMMITMENT]
-
-    if.true
-        emit.AUTH_UNAUTHORIZED_EVENT
-        push.0 assert.err=ERR_INSUFFICIENT_SIGNATURES
-    end
 end

--- a/crates/miden-standards/asm/standards/faucets/mod.masm
+++ b/crates/miden-standards/asm/standards/faucets/mod.masm
@@ -17,8 +17,7 @@ pub mod fungible
 pub mod non_fungible
 pub mod policies
 
-# =================================================================================================
-# CONSTANTS — slot names
+# CONSTANTS
 # =================================================================================================
 
 pub const TOKEN_NAME_0_SLOT = word("miden::standards::faucets::token_name_0")
@@ -49,68 +48,14 @@ const EXTERNAL_LINK_4_SLOT = word("miden::standards::faucets::external_link_4")
 const EXTERNAL_LINK_5_SLOT = word("miden::standards::faucets::external_link_5")
 const EXTERNAL_LINK_6_SLOT = word("miden::standards::faucets::external_link_6")
 
+# ERRORS
+# =================================================================================================
+
 const ERR_DESCRIPTION_NOT_MUTABLE = "description is not mutable"
 const ERR_LOGO_URI_NOT_MUTABLE = "logo URI is not mutable"
 const ERR_EXTERNAL_LINK_NOT_MUTABLE = "external link is not mutable"
 
-# =================================================================================================
-# PRIVATE HELPERS
-# =================================================================================================
-
-#! Loads name chunk 0 (1 Word).
-#!
-#! Inputs:  []
-#! Outputs: [NAME_CHUNK_0]
-#!
-#! Invocation: exec
-proc get_name_chunk_0
-    push.TOKEN_NAME_0_SLOT[0..2]
-    exec.active_account::get_item
-end
-
-#! Loads name chunk 1 (1 Word).
-#!
-#! Inputs:  []
-#! Outputs: [NAME_CHUNK_1]
-#!
-#! Invocation: exec
-proc get_name_chunk_1
-    push.TOKEN_NAME_1_SLOT[0..2]
-    exec.active_account::get_item
-end
-
-#! Loads the mutability config word.
-#!
-#! Inputs:  []
-#! Outputs: [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
-#!
-#! Where:
-#! - is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable are boolean flags
-#!   (word[0] on top after get_item, little-endian).
-#!
-#! Invocation: exec
-pub proc get_mutability_config_word
-    push.MUTABILITY_CONFIG_SLOT[0..2]
-    exec.active_account::get_item
-end
-
-#! Pipes 28 felts (7 words) from the advice stack into write_ptr and asserts the hash
-#! matches COMMITMENT. adv.push_mapval must be called before this procedure to load
-#! the data onto the advice stack.
-#!
-#! Inputs:  [write_ptr, COMMITMENT]
-#! Outputs: []
-#!
-#! Invocation: exec
-proc pipe_to_memory
-    push.7
-    exec.mem::pipe_preimage_to_memory
-    # => [write_ptr']
-    drop
-end
-
-# =================================================================================================
-# NAME (2 words)
+# PUBLIC INTERFACE
 # =================================================================================================
 
 #! Returns the token name.
@@ -127,10 +72,6 @@ pub proc get_name
     # => [NAME_CHUNK_0, NAME_CHUNK_1, pad(8)]
 end
 
-# =================================================================================================
-# MUTABILITY CONFIG — [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
-# =================================================================================================
-
 #! Returns the mutability config word.
 #!
 #! Inputs:  [pad(16)]
@@ -143,52 +84,6 @@ pub proc get_mutability_config
     # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable, pad(16)]
     swapw dropw
     # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable, pad(12)]
-end
-
-# =================================================================================================
-# MUTABILITY CHECKS — read mutability_config
-# =================================================================================================
-
-# Private helpers — load the mutability config word and extract a single flag.
-# Used by both the public is_* procedures and the set_* procedures.
-
-#! Extracts the is_description_mutable flag from the mutability config word.
-#!
-#! Inputs:  []
-#! Outputs: [is_description_mutable]
-#!
-#! Invocation: exec
-proc is_description_mutable_internal
-    exec.get_mutability_config_word
-    # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
-    movdn.3 drop drop drop
-    # => [is_description_mutable]
-end
-
-#! Extracts the is_logo_uri_mutable flag from the mutability config word.
-#!
-#! Inputs:  []
-#! Outputs: [is_logo_uri_mutable]
-#!
-#! Invocation: exec
-proc is_logo_uri_mutable_internal
-    exec.get_mutability_config_word
-    # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
-    drop movdn.2 drop drop
-    # => [is_logo_uri_mutable]
-end
-
-#! Extracts the is_external_link_mutable flag from the mutability config word.
-#!
-#! Inputs:  []
-#! Outputs: [is_external_link_mutable]
-#!
-#! Invocation: exec
-proc is_external_link_mutable_internal
-    exec.get_mutability_config_word
-    # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
-    drop drop swap drop
-    # => [is_external_link_mutable]
 end
 
 #! Returns 1 if description is mutable, and 0 otherwise.
@@ -232,10 +127,6 @@ pub proc is_external_link_mutable
     swap drop
     # => [is_external_link_mutable, pad(15)]
 end
-
-# =================================================================================================
-# SET DESCRIPTION (gated by Authority when is_description_mutable == 1)
-# =================================================================================================
 
 #! Updates the description (7 Words) if the description mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
@@ -314,10 +205,6 @@ pub proc set_description
     exec.native_account::set_item dropw
 end
 
-# =================================================================================================
-# SET LOGO URI (gated by Authority when is_logo_uri_mutable == 1)
-# =================================================================================================
-
 #! Updates the logo URI (7 Words) if the logo URI mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
 #!
@@ -394,10 +281,6 @@ pub proc set_logo_uri
     exec.native_account::set_item dropw
 end
 
-# =================================================================================================
-# SET EXTERNAL LINK (gated by Authority when is_external_link_mutable == 1)
-# =================================================================================================
-
 #! Updates the external link (7 Words) if the external link mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
 #!
@@ -472,4 +355,104 @@ pub proc set_external_link
     loc_loadw_le.24
     push.EXTERNAL_LINK_6_SLOT[0..2]
     exec.native_account::set_item dropw
+end
+
+# PUBLIC HELPERS
+# =================================================================================================
+
+#! Loads the mutability config word.
+#!
+#! Inputs:  []
+#! Outputs: [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
+#!
+#! Where:
+#! - is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable are boolean flags
+#!   (word[0] on top after get_item, little-endian).
+#!
+#! Invocation: exec
+pub proc get_mutability_config_word
+    push.MUTABILITY_CONFIG_SLOT[0..2]
+    exec.active_account::get_item
+end
+
+# HELPER PROCEDURES
+# =================================================================================================
+
+#! Loads name chunk 0 (1 Word).
+#!
+#! Inputs:  []
+#! Outputs: [NAME_CHUNK_0]
+#!
+#! Invocation: exec
+proc get_name_chunk_0
+    push.TOKEN_NAME_0_SLOT[0..2]
+    exec.active_account::get_item
+end
+
+#! Loads name chunk 1 (1 Word).
+#!
+#! Inputs:  []
+#! Outputs: [NAME_CHUNK_1]
+#!
+#! Invocation: exec
+proc get_name_chunk_1
+    push.TOKEN_NAME_1_SLOT[0..2]
+    exec.active_account::get_item
+end
+
+#! Pipes 28 felts (7 words) from the advice stack into write_ptr and asserts the hash
+#! matches COMMITMENT. adv.push_mapval must be called before this procedure to load
+#! the data onto the advice stack.
+#!
+#! Inputs:  [write_ptr, COMMITMENT]
+#! Outputs: []
+#!
+#! Invocation: exec
+proc pipe_to_memory
+    push.7
+    exec.mem::pipe_preimage_to_memory
+    # => [write_ptr']
+    drop
+end
+
+# Private helpers — load the mutability config word and extract a single flag.
+# Used by both the public is_* procedures and the set_* procedures.
+
+#! Extracts the is_description_mutable flag from the mutability config word.
+#!
+#! Inputs:  []
+#! Outputs: [is_description_mutable]
+#!
+#! Invocation: exec
+proc is_description_mutable_internal
+    exec.get_mutability_config_word
+    # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
+    movdn.3 drop drop drop
+    # => [is_description_mutable]
+end
+
+#! Extracts the is_logo_uri_mutable flag from the mutability config word.
+#!
+#! Inputs:  []
+#! Outputs: [is_logo_uri_mutable]
+#!
+#! Invocation: exec
+proc is_logo_uri_mutable_internal
+    exec.get_mutability_config_word
+    # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
+    drop movdn.2 drop drop
+    # => [is_logo_uri_mutable]
+end
+
+#! Extracts the is_external_link_mutable flag from the mutability config word.
+#!
+#! Inputs:  []
+#! Outputs: [is_external_link_mutable]
+#!
+#! Invocation: exec
+proc is_external_link_mutable_internal
+    exec.get_mutability_config_word
+    # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
+    drop drop swap drop
+    # => [is_external_link_mutable]
 end

--- a/crates/miden-standards/asm/standards/faucets/policies/policy_manager.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/policy_manager.masm
@@ -12,7 +12,7 @@ use miden::standards::access::pausable
 # authority discriminator.
 
 # CONSTANTS
-# ================================================================================================
+# =================================================================================================
 
 # Active mint policy root slot. Layout: [PROC_ROOT]
 const ACTIVE_MINT_POLICY_PROC_ROOT_SLOT=word("miden::standards::faucets::policies::policy_manager::active_mint_policy_proc_root")
@@ -42,7 +42,7 @@ const ALLOWED_RECEIVE_POLICY_PROC_ROOTS_SLOT=word("miden::standards::faucets::po
 const POLICY_PROC_ROOT_PTR=0
 
 # ERRORS
-# ================================================================================================
+# =================================================================================================
 
 const ERR_MINT_POLICY_ROOT_IS_ZERO="mint policy root is zero"
 const ERR_MINT_POLICY_ROOT_NOT_IN_ACCOUNT="mint policy root is not a procedure of this account"
@@ -62,240 +62,8 @@ const ERR_RECEIVE_POLICY_ROOT_IS_ZERO="receive policy root is zero"
 const ERR_RECEIVE_POLICY_ROOT_NOT_IN_ACCOUNT="receive policy root is not a procedure of this account"
 const ERR_RECEIVE_POLICY_ROOT_NOT_ALLOWED="receive policy root is not allowed"
 
-# MINT INTERNAL PROCEDURES
-# ================================================================================================
-
-#! Reads active mint policy root from storage.
-#!
-#! Inputs:  []
-#! Outputs: [MINT_POLICY_ROOT]
-#!
-#! Invocation: exec
-proc get_mint_policy_root
-    push.ACTIVE_MINT_POLICY_PROC_ROOT_SLOT[0..2] exec.active_account::get_item
-    # => [MINT_POLICY_ROOT]
-end
-
-#! Validates a mint policy root at config time.
-#!
-#! Inputs:  [MINT_POLICY_ROOT]
-#! Outputs: [MINT_POLICY_ROOT]
-#!
-#! Panics if:
-#! - policy root is zero.
-#! - policy root is not present in this account's procedures.
-#!
-#! Invocation: exec
-proc assert_existing_mint_policy_root
-    exec.word::testz
-    assertz.err=ERR_MINT_POLICY_ROOT_IS_ZERO
-    # => [MINT_POLICY_ROOT]
-
-    dupw exec.active_account::has_procedure
-    assert.err=ERR_MINT_POLICY_ROOT_NOT_IN_ACCOUNT
-    # => [MINT_POLICY_ROOT]
-end
-
-#! Validates that the mint policy root is one of the allowed mint policy roots.
-#!
-#! Inputs:  [MINT_POLICY_ROOT]
-#! Outputs: [MINT_POLICY_ROOT]
-#!
-#! Panics if:
-#! - policy root is not in the allowed mint policy roots map.
-#!
-#! Invocation: exec
-proc assert_allowed_mint_policy_root
-    dupw
-    push.ALLOWED_MINT_POLICY_PROC_ROOTS_SLOT[0..2]
-    exec.active_account::get_map_item
-    # => [ALLOWED_FLAG, MINT_POLICY_ROOT]
-
-    exec.word::eqz
-    assertz.err=ERR_MINT_POLICY_ROOT_NOT_ALLOWED
-    # => [MINT_POLICY_ROOT]
-end
-
-# BURN INTERNAL PROCEDURES
-# ================================================================================================
-
-#! Reads active burn policy root from storage.
-#!
-#! Inputs:  []
-#! Outputs: [BURN_POLICY_ROOT]
-#!
-#! Invocation: exec
-proc get_burn_policy_root
-    push.ACTIVE_BURN_POLICY_PROC_ROOT_SLOT[0..2] exec.active_account::get_item
-    # => [BURN_POLICY_ROOT]
-end
-
-#! Validates a burn policy root at config time.
-#!
-#! Inputs:  [BURN_POLICY_ROOT]
-#! Outputs: [BURN_POLICY_ROOT]
-#!
-#! Panics if:
-#! - policy root is zero.
-#! - policy root is not present in this account's procedures.
-#!
-#! Invocation: exec
-proc assert_existing_burn_policy_root
-    exec.word::testz
-    assertz.err=ERR_BURN_POLICY_ROOT_IS_ZERO
-    # => [BURN_POLICY_ROOT]
-
-    dupw exec.active_account::has_procedure
-    assert.err=ERR_BURN_POLICY_ROOT_NOT_IN_ACCOUNT
-    # => [BURN_POLICY_ROOT]
-end
-
-#! Validates that the burn policy root is one of the allowed burn policy roots.
-#!
-#! Inputs:  [BURN_POLICY_ROOT]
-#! Outputs: [BURN_POLICY_ROOT]
-#!
-#! Panics if:
-#! - policy root is not in the allowed burn policy roots map.
-#!
-#! Invocation: exec
-proc assert_allowed_burn_policy_root
-    dupw
-    push.ALLOWED_BURN_POLICY_PROC_ROOTS_SLOT[0..2]
-    exec.active_account::get_map_item
-    # => [ALLOWED_FLAG, BURN_POLICY_ROOT]
-
-    exec.word::eqz
-    assertz.err=ERR_BURN_POLICY_ROOT_NOT_ALLOWED
-    # => [BURN_POLICY_ROOT]
-end
-
-# SEND INTERNAL PROCEDURES
-# ================================================================================================
-
-#! Validates a send policy root at config time.
-#!
-#! Inputs:  [SEND_POLICY_ROOT]
-#! Outputs: [SEND_POLICY_ROOT]
-#!
-#! Panics if:
-#! - policy root is zero.
-#! - policy root is not present in this account's procedures.
-#!
-#! Invocation: exec
-proc assert_existing_send_policy_root
-    exec.word::testz
-    assertz.err=ERR_SEND_POLICY_ROOT_IS_ZERO
-    # => [SEND_POLICY_ROOT]
-
-    dupw exec.active_account::has_procedure
-    assert.err=ERR_SEND_POLICY_ROOT_NOT_IN_ACCOUNT
-    # => [SEND_POLICY_ROOT]
-end
-
-#! Validates that the send policy root is one of the allowed send policy roots.
-#!
-#! Inputs:  [SEND_POLICY_ROOT]
-#! Outputs: [SEND_POLICY_ROOT]
-#!
-#! Panics if:
-#! - policy root is not in the allowed send policy roots map.
-#!
-#! Invocation: exec
-proc assert_allowed_send_policy_root
-    dupw
-    push.ALLOWED_SEND_POLICY_PROC_ROOTS_SLOT[0..2]
-    exec.active_account::get_map_item
-    # => [ALLOWED_FLAG, SEND_POLICY_ROOT]
-
-    exec.word::eqz
-    assertz.err=ERR_SEND_POLICY_ROOT_NOT_ALLOWED
-    # => [SEND_POLICY_ROOT]
-end
-
-# RECEIVE INTERNAL PROCEDURES
-# ================================================================================================
-
-#! Validates a receive policy root at config time.
-#!
-#! Inputs:  [RECEIVE_POLICY_ROOT]
-#! Outputs: [RECEIVE_POLICY_ROOT]
-#!
-#! Panics if:
-#! - policy root is zero.
-#! - policy root is not present in this account's procedures.
-#!
-#! Invocation: exec
-proc assert_existing_receive_policy_root
-    exec.word::testz
-    assertz.err=ERR_RECEIVE_POLICY_ROOT_IS_ZERO
-    # => [RECEIVE_POLICY_ROOT]
-
-    dupw exec.active_account::has_procedure
-    assert.err=ERR_RECEIVE_POLICY_ROOT_NOT_IN_ACCOUNT
-    # => [RECEIVE_POLICY_ROOT]
-end
-
-#! Validates that the receive policy root is one of the allowed receive policy roots.
-#!
-#! Inputs:  [RECEIVE_POLICY_ROOT]
-#! Outputs: [RECEIVE_POLICY_ROOT]
-#!
-#! Panics if:
-#! - policy root is not in the allowed receive policy roots map.
-#!
-#! Invocation: exec
-proc assert_allowed_receive_policy_root
-    dupw
-    push.ALLOWED_RECEIVE_POLICY_PROC_ROOTS_SLOT[0..2]
-    exec.active_account::get_map_item
-    # => [ALLOWED_FLAG, RECEIVE_POLICY_ROOT]
-
-    exec.word::eqz
-    assertz.err=ERR_RECEIVE_POLICY_ROOT_NOT_ALLOWED
-    # => [RECEIVE_POLICY_ROOT]
-end
-
-# MINT PUBLIC INTERFACE
-# ================================================================================================
-
-#! Executes active mint policy by dynamic execution.
-#!
-#! The policy operates on the full asset value word so the interface is shared across fungible
-#! and non-fungible faucets. The policy may adjust the asset value and the output note's `tag`,
-#! `note_type`, and `RECIPIENT`.
-#!
-#! Inputs:  [ASSET_VALUE, tag, note_type, RECIPIENT]
-#! Outputs: [ASSET_VALUE, tag, note_type, RECIPIENT]
-#!
-#! Panics if:
-#! - the account is paused (`exec.pausable::assert_not_paused` is a no-op when the [`Pausable`]
-#!   component is not installed).
-#! - the active mint policy root is zero.
-#! - active mint policy predicate fails.
-#!
-#! Invocation: exec
-@locals(4)
-pub proc execute_mint_policy
-    exec.pausable::assert_not_paused
-    # => [ASSET_VALUE, tag, note_type, RECIPIENT]
-
-    exec.get_mint_policy_root
-    # => [MINT_POLICY_ROOT, ASSET_VALUE, tag, note_type, RECIPIENT]
-
-    exec.word::testz
-    assertz.err=ERR_ACTIVE_MINT_POLICY_NOT_SET
-    # => [MINT_POLICY_ROOT, ASSET_VALUE, tag, note_type, RECIPIENT]
-
-    loc_storew_le.POLICY_PROC_ROOT_PTR dropw
-    # => [ASSET_VALUE, tag, note_type, RECIPIENT]
-
-    locaddr.POLICY_PROC_ROOT_PTR
-    # => [policy_root_ptr, ASSET_VALUE, tag, note_type, RECIPIENT]
-
-    dynexec
-    # => [ASSET_VALUE, tag, note_type, RECIPIENT]
-end
+# PUBLIC INTERFACE
+# =================================================================================================
 
 #! Returns active mint policy root.
 #!
@@ -339,42 +107,6 @@ pub proc set_mint_policy
     # => [pad(16)]
 end
 
-# BURN PUBLIC INTERFACE
-# ================================================================================================
-
-#! Executes active burn policy for the provided asset by dynamic execution.
-#!
-#! Inputs:  [ASSET_ID, ASSET_VALUE]
-#! Outputs: []
-#!
-#! Panics if:
-#! - the account is paused.
-#! - the active burn policy root is zero.
-#! - active burn policy predicate fails.
-#!
-#! Invocation: exec
-@locals(4)
-pub proc execute_burn_policy
-    exec.pausable::assert_not_paused
-    # => [ASSET_ID, ASSET_VALUE]
-
-    exec.get_burn_policy_root
-    # => [BURN_POLICY_ROOT, ASSET_ID, ASSET_VALUE]
-
-    exec.word::testz
-    assertz.err=ERR_ACTIVE_BURN_POLICY_NOT_SET
-    # => [BURN_POLICY_ROOT, ASSET_ID, ASSET_VALUE]
-
-    loc_storew_le.POLICY_PROC_ROOT_PTR dropw
-    # => [ASSET_ID, ASSET_VALUE]
-
-    locaddr.POLICY_PROC_ROOT_PTR
-    # => [policy_root_ptr, ASSET_ID, ASSET_VALUE]
-
-    dynexec
-    # => []
-end
-
 #! Returns active burn policy root.
 #!
 #! Inputs:  [pad(16)]
@@ -416,63 +148,6 @@ pub proc set_burn_policy
     push.ACTIVE_BURN_POLICY_PROC_ROOT_SLOT[0..2] exec.native_account::set_item dropw
     # => [pad(16)]
 end
-
-# TRANSFER POLICY FOR PAUSE CHECK
-# ================================================================================================
-
-#! Reads the active transfer policy root from the provided slot, applies the pause check, and
-#! invokes the policy via `dyncall`. Shared by `invoke_send_policy` / `invoke_receive_policy`,
-#! which differ only in which slot they bind.
-#!
-#! If the active root is the empty word (no policy configured for this kind), the transfer is
-#! accepted unchanged and the pause check is skipped — mirroring the kernel's behavior when a
-#! callback slot holds the empty word. Otherwise the account-wide pause flag is asserted (a no-op
-#! when the [`Pausable`] component is not installed) and the policy is invoked via `dyncall`.
-#!
-#! Inputs:  [slot_id_suffix, slot_id_prefix, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
-#! Outputs: [PROCESSED_ASSET_VALUE, pad(12)]
-#!
-#! Where:
-#! - slot_id_{suffix, prefix} identify the storage slot holding the active policy root.
-#! - custom_data is `0` for the receive callback and the output note index for the send callback.
-#! - PROCESSED_ASSET_VALUE is the asset value returned by the policy, or the original ASSET_VALUE
-#!   if no policy is configured.
-#!
-#! Panics if:
-#! - the account is paused.
-#! - the invoked policy predicate fails.
-#!
-#! Invocation: exec
-@locals(4)
-proc invoke_transfer_policy
-    exec.active_account::get_item
-    # => [POLICY_ROOT, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
-
-    exec.word::testz
-    # => [is_empty, POLICY_ROOT, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
-
-    if.true
-        # No policy configured: drop the empty root and asset ID, return the asset value
-        # unchanged. `movup.4 drop` removes custom_data so only ASSET_VALUE is returned.
-        dropw dropw movup.4 drop
-        # => [ASSET_VALUE, pad(7)]
-    else
-        exec.pausable::assert_not_paused
-        # => [POLICY_ROOT, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
-
-        loc_storew_le.POLICY_PROC_ROOT_PTR dropw
-        # => [ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
-
-        locaddr.POLICY_PROC_ROOT_PTR
-        # => [policy_root_ptr, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
-
-        dyncall
-        # => [PROCESSED_ASSET_VALUE, pad(12)]
-    end
-end
-
-# SEND PUBLIC INTERFACE
-# ================================================================================================
 
 #! Invokes the active send policy. Stored in the protocol-reserved `on_before_asset_added_to_note`
 #! callback slot and `dyncall`-invoked by the kernel when an asset with the callback flag is added
@@ -546,9 +221,6 @@ pub proc set_send_policy
     # => [pad(16)]
 end
 
-# RECEIVE PUBLIC INTERFACE
-# ================================================================================================
-
 #! Invokes the active receive policy. Stored in the protocol-reserved
 #! `on_before_asset_added_to_account` callback slot and `dyncall`-invoked by the kernel when an
 #! asset with the callback flag is added to an account vault.
@@ -621,4 +293,314 @@ pub proc set_receive_policy
 
     push.ACTIVE_RECEIVE_POLICY_PROC_ROOT_SLOT[0..2] exec.native_account::set_item dropw
     # => [pad(16)]
+end
+
+# PUBLIC HELPERS
+# =================================================================================================
+
+#! Executes active mint policy by dynamic execution.
+#!
+#! The policy operates on the full asset value word so the interface is shared across fungible
+#! and non-fungible faucets. The policy may adjust the asset value and the output note's `tag`,
+#! `note_type`, and `RECIPIENT`.
+#!
+#! Inputs:  [ASSET_VALUE, tag, note_type, RECIPIENT]
+#! Outputs: [ASSET_VALUE, tag, note_type, RECIPIENT]
+#!
+#! Panics if:
+#! - the account is paused (`exec.pausable::assert_not_paused` is a no-op when the [`Pausable`]
+#!   component is not installed).
+#! - the active mint policy root is zero.
+#! - active mint policy predicate fails.
+#!
+#! Invocation: exec
+@locals(4)
+pub proc execute_mint_policy
+    exec.pausable::assert_not_paused
+    # => [ASSET_VALUE, tag, note_type, RECIPIENT]
+
+    exec.get_mint_policy_root
+    # => [MINT_POLICY_ROOT, ASSET_VALUE, tag, note_type, RECIPIENT]
+
+    exec.word::testz
+    assertz.err=ERR_ACTIVE_MINT_POLICY_NOT_SET
+    # => [MINT_POLICY_ROOT, ASSET_VALUE, tag, note_type, RECIPIENT]
+
+    loc_storew_le.POLICY_PROC_ROOT_PTR dropw
+    # => [ASSET_VALUE, tag, note_type, RECIPIENT]
+
+    locaddr.POLICY_PROC_ROOT_PTR
+    # => [policy_root_ptr, ASSET_VALUE, tag, note_type, RECIPIENT]
+
+    dynexec
+    # => [ASSET_VALUE, tag, note_type, RECIPIENT]
+end
+
+#! Executes active burn policy for the provided asset by dynamic execution.
+#!
+#! Inputs:  [ASSET_ID, ASSET_VALUE]
+#! Outputs: []
+#!
+#! Panics if:
+#! - the account is paused.
+#! - the active burn policy root is zero.
+#! - active burn policy predicate fails.
+#!
+#! Invocation: exec
+@locals(4)
+pub proc execute_burn_policy
+    exec.pausable::assert_not_paused
+    # => [ASSET_ID, ASSET_VALUE]
+
+    exec.get_burn_policy_root
+    # => [BURN_POLICY_ROOT, ASSET_ID, ASSET_VALUE]
+
+    exec.word::testz
+    assertz.err=ERR_ACTIVE_BURN_POLICY_NOT_SET
+    # => [BURN_POLICY_ROOT, ASSET_ID, ASSET_VALUE]
+
+    loc_storew_le.POLICY_PROC_ROOT_PTR dropw
+    # => [ASSET_ID, ASSET_VALUE]
+
+    locaddr.POLICY_PROC_ROOT_PTR
+    # => [policy_root_ptr, ASSET_ID, ASSET_VALUE]
+
+    dynexec
+    # => []
+end
+
+# HELPER PROCEDURES
+# =================================================================================================
+
+#! Reads active mint policy root from storage.
+#!
+#! Inputs:  []
+#! Outputs: [MINT_POLICY_ROOT]
+#!
+#! Invocation: exec
+proc get_mint_policy_root
+    push.ACTIVE_MINT_POLICY_PROC_ROOT_SLOT[0..2] exec.active_account::get_item
+    # => [MINT_POLICY_ROOT]
+end
+
+#! Validates a mint policy root at config time.
+#!
+#! Inputs:  [MINT_POLICY_ROOT]
+#! Outputs: [MINT_POLICY_ROOT]
+#!
+#! Panics if:
+#! - policy root is zero.
+#! - policy root is not present in this account's procedures.
+#!
+#! Invocation: exec
+proc assert_existing_mint_policy_root
+    exec.word::testz
+    assertz.err=ERR_MINT_POLICY_ROOT_IS_ZERO
+    # => [MINT_POLICY_ROOT]
+
+    dupw exec.active_account::has_procedure
+    assert.err=ERR_MINT_POLICY_ROOT_NOT_IN_ACCOUNT
+    # => [MINT_POLICY_ROOT]
+end
+
+#! Validates that the mint policy root is one of the allowed mint policy roots.
+#!
+#! Inputs:  [MINT_POLICY_ROOT]
+#! Outputs: [MINT_POLICY_ROOT]
+#!
+#! Panics if:
+#! - policy root is not in the allowed mint policy roots map.
+#!
+#! Invocation: exec
+proc assert_allowed_mint_policy_root
+    dupw
+    push.ALLOWED_MINT_POLICY_PROC_ROOTS_SLOT[0..2]
+    exec.active_account::get_map_item
+    # => [ALLOWED_FLAG, MINT_POLICY_ROOT]
+
+    exec.word::eqz
+    assertz.err=ERR_MINT_POLICY_ROOT_NOT_ALLOWED
+    # => [MINT_POLICY_ROOT]
+end
+
+#! Reads active burn policy root from storage.
+#!
+#! Inputs:  []
+#! Outputs: [BURN_POLICY_ROOT]
+#!
+#! Invocation: exec
+proc get_burn_policy_root
+    push.ACTIVE_BURN_POLICY_PROC_ROOT_SLOT[0..2] exec.active_account::get_item
+    # => [BURN_POLICY_ROOT]
+end
+
+#! Validates a burn policy root at config time.
+#!
+#! Inputs:  [BURN_POLICY_ROOT]
+#! Outputs: [BURN_POLICY_ROOT]
+#!
+#! Panics if:
+#! - policy root is zero.
+#! - policy root is not present in this account's procedures.
+#!
+#! Invocation: exec
+proc assert_existing_burn_policy_root
+    exec.word::testz
+    assertz.err=ERR_BURN_POLICY_ROOT_IS_ZERO
+    # => [BURN_POLICY_ROOT]
+
+    dupw exec.active_account::has_procedure
+    assert.err=ERR_BURN_POLICY_ROOT_NOT_IN_ACCOUNT
+    # => [BURN_POLICY_ROOT]
+end
+
+#! Validates that the burn policy root is one of the allowed burn policy roots.
+#!
+#! Inputs:  [BURN_POLICY_ROOT]
+#! Outputs: [BURN_POLICY_ROOT]
+#!
+#! Panics if:
+#! - policy root is not in the allowed burn policy roots map.
+#!
+#! Invocation: exec
+proc assert_allowed_burn_policy_root
+    dupw
+    push.ALLOWED_BURN_POLICY_PROC_ROOTS_SLOT[0..2]
+    exec.active_account::get_map_item
+    # => [ALLOWED_FLAG, BURN_POLICY_ROOT]
+
+    exec.word::eqz
+    assertz.err=ERR_BURN_POLICY_ROOT_NOT_ALLOWED
+    # => [BURN_POLICY_ROOT]
+end
+
+#! Validates a send policy root at config time.
+#!
+#! Inputs:  [SEND_POLICY_ROOT]
+#! Outputs: [SEND_POLICY_ROOT]
+#!
+#! Panics if:
+#! - policy root is zero.
+#! - policy root is not present in this account's procedures.
+#!
+#! Invocation: exec
+proc assert_existing_send_policy_root
+    exec.word::testz
+    assertz.err=ERR_SEND_POLICY_ROOT_IS_ZERO
+    # => [SEND_POLICY_ROOT]
+
+    dupw exec.active_account::has_procedure
+    assert.err=ERR_SEND_POLICY_ROOT_NOT_IN_ACCOUNT
+    # => [SEND_POLICY_ROOT]
+end
+
+#! Validates that the send policy root is one of the allowed send policy roots.
+#!
+#! Inputs:  [SEND_POLICY_ROOT]
+#! Outputs: [SEND_POLICY_ROOT]
+#!
+#! Panics if:
+#! - policy root is not in the allowed send policy roots map.
+#!
+#! Invocation: exec
+proc assert_allowed_send_policy_root
+    dupw
+    push.ALLOWED_SEND_POLICY_PROC_ROOTS_SLOT[0..2]
+    exec.active_account::get_map_item
+    # => [ALLOWED_FLAG, SEND_POLICY_ROOT]
+
+    exec.word::eqz
+    assertz.err=ERR_SEND_POLICY_ROOT_NOT_ALLOWED
+    # => [SEND_POLICY_ROOT]
+end
+
+#! Validates a receive policy root at config time.
+#!
+#! Inputs:  [RECEIVE_POLICY_ROOT]
+#! Outputs: [RECEIVE_POLICY_ROOT]
+#!
+#! Panics if:
+#! - policy root is zero.
+#! - policy root is not present in this account's procedures.
+#!
+#! Invocation: exec
+proc assert_existing_receive_policy_root
+    exec.word::testz
+    assertz.err=ERR_RECEIVE_POLICY_ROOT_IS_ZERO
+    # => [RECEIVE_POLICY_ROOT]
+
+    dupw exec.active_account::has_procedure
+    assert.err=ERR_RECEIVE_POLICY_ROOT_NOT_IN_ACCOUNT
+    # => [RECEIVE_POLICY_ROOT]
+end
+
+#! Validates that the receive policy root is one of the allowed receive policy roots.
+#!
+#! Inputs:  [RECEIVE_POLICY_ROOT]
+#! Outputs: [RECEIVE_POLICY_ROOT]
+#!
+#! Panics if:
+#! - policy root is not in the allowed receive policy roots map.
+#!
+#! Invocation: exec
+proc assert_allowed_receive_policy_root
+    dupw
+    push.ALLOWED_RECEIVE_POLICY_PROC_ROOTS_SLOT[0..2]
+    exec.active_account::get_map_item
+    # => [ALLOWED_FLAG, RECEIVE_POLICY_ROOT]
+
+    exec.word::eqz
+    assertz.err=ERR_RECEIVE_POLICY_ROOT_NOT_ALLOWED
+    # => [RECEIVE_POLICY_ROOT]
+end
+
+#! Reads the active transfer policy root from the provided slot, applies the pause check, and
+#! invokes the policy via `dyncall`. Shared by `invoke_send_policy` / `invoke_receive_policy`,
+#! which differ only in which slot they bind.
+#!
+#! If the active root is the empty word (no policy configured for this kind), the transfer is
+#! accepted unchanged and the pause check is skipped — mirroring the kernel's behavior when a
+#! callback slot holds the empty word. Otherwise the account-wide pause flag is asserted (a no-op
+#! when the [`Pausable`] component is not installed) and the policy is invoked via `dyncall`.
+#!
+#! Inputs:  [slot_id_suffix, slot_id_prefix, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
+#! Outputs: [PROCESSED_ASSET_VALUE, pad(12)]
+#!
+#! Where:
+#! - slot_id_{suffix, prefix} identify the storage slot holding the active policy root.
+#! - custom_data is `0` for the receive callback and the output note index for the send callback.
+#! - PROCESSED_ASSET_VALUE is the asset value returned by the policy, or the original ASSET_VALUE
+#!   if no policy is configured.
+#!
+#! Panics if:
+#! - the account is paused.
+#! - the invoked policy predicate fails.
+#!
+#! Invocation: exec
+@locals(4)
+proc invoke_transfer_policy
+    exec.active_account::get_item
+    # => [POLICY_ROOT, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
+
+    exec.word::testz
+    # => [is_empty, POLICY_ROOT, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
+
+    if.true
+        # No policy configured: drop the empty root and asset ID, return the asset value
+        # unchanged. `movup.4 drop` removes custom_data so only ASSET_VALUE is returned.
+        dropw dropw movup.4 drop
+        # => [ASSET_VALUE, pad(7)]
+    else
+        exec.pausable::assert_not_paused
+        # => [POLICY_ROOT, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
+
+        loc_storew_le.POLICY_PROC_ROOT_PTR dropw
+        # => [ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
+
+        locaddr.POLICY_PROC_ROOT_PTR
+        # => [policy_root_ptr, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
+
+        dyncall
+        # => [PROCESSED_ASSET_VALUE, pad(12)]
+    end
 end

--- a/crates/miden-standards/asm/standards/wallets/basic.masm
+++ b/crates/miden-standards/asm/standards/wallets/basic.masm
@@ -4,7 +4,7 @@ use miden::protocol::native_account
 use miden::protocol::output_note
 use miden::protocol::active_note
 
-# PUBLIC API
+# PUBLIC INTERFACE
 # =================================================================================================
 
 #! Adds the provided asset to the active account.
@@ -67,10 +67,15 @@ pub proc move_asset_to_note
     # => [pad(16)]
 end
 
+# PUBLIC HELPERS
+# =================================================================================================
+
 #! Adds all assets from the active note to the native account's vault.
 #!
 #! Inputs:  []
 #! Outputs: []
+#!
+#! Invocation: exec
 @locals(512)
 pub proc add_assets_to_account
     # write assets to local memory starting at offset 0


### PR DESCRIPTION
## Summary

Applies the `PUBLIC INTERFACE` / `PUBLIC HELPERS` / `HELPER PROCEDURES` section convention to the remaining standards components that still mixed `@account_procedure` procedures with exec-invoked `pub proc` helpers in a single section, or had no section separation at all

## Notes

- The multisig / smart-multisig `auth_tx` procedures are exec-invoked from their `@auth_script` component wrappers, so they are placed under `PUBLIC HELPERS` and their `Invocation` doc line is corrected from `call` to `exec`.
- Adds missing `Invocation` doc lines to three multisig exec helpers.
- Structural only: procedures are reordered into sections and doc lines adjusted; no bytecode or behavior change.