### PR TITLE
protocol: ensure ProtocolLib exposes the actual package

### DIFF
--- a/crates/miden-protocol/src/protocol.rs
+++ b/crates/miden-protocol/src/protocol.rs
@@ -26,6 +26,11 @@ static PROTOCOL_PACKAGE: LazyLock<Arc<Package>> = LazyLock::new(|| {
 pub struct ProtocolLib(Arc<Package>);
 
 impl ProtocolLib {
+    /// Returns the underlying [`Arc<Package>`]
+    pub fn package(&self) -> Arc<Package> {
+        self.0.clone()
+    }
+
     /// Returns a reference to the [`MastForest`] of the inner [`Library`].
     pub fn mast_forest(&self) -> &Arc<MastForest> {
         self.0.mast_forest()


### PR DESCRIPTION
Somehow we managed to migrate `ProtocolLib` to wrap a `Package` without exposing the package - this PR adds the missing method to extract it, mirroring `CoreLibrary`.

This will need to go out in a new alpha release of v0.16 to unblock the compiler migration