### PR TITLE
cherry pick package CI changes to `release/v0.16.0-alpha`

### DIFF
--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -6,13 +6,15 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # Required for OIDC token exchange
 
 jobs:
   publish:
     if: ${{ github.repository_owner == '0xMiden' }}
     runs-on: ubuntu-latest
-    environment: release  # Optional: for enhanced security
+    environment: release # Optional: for enhanced security
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC token exchange
 
     steps:
       - name: Checkout repository
@@ -34,3 +36,48 @@ jobs:
           release-branch: ${{ github.event.release.target_commitish }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # Upload the pre-compiled artifacts (miden-protocol.masp) on the
+  # GitHub release page.
+  # Used by midenup to speed up installs.
+  upload-artifacts:
+    name: upload pre-built miden-protocol library artifacts
+    if: ${{ github.repository_owner == '0xMiden' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+          persist-credentials: false
+      - uses: ./.github/actions/cleanup-runner
+      - name: Install Rust
+        run: |
+          rustup update --no-self-update
+          rustc --version
+      - name: Build packages
+        run: |
+          cargo build --release --locked -p miden-protocol -p miden-standards
+      - name: Prepare artifacts
+        run: |
+          set -euo pipefail
+          cp target/release/miden-protocol.masp protocol.masp
+          cp target/release/miden-standards.masp standards.masp
+      - name: Attest packages
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: |
+            protocol.masp
+            standards.masp
+      - name: Upload packages
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          gh release upload ${RELEASE_TAG} protocol.masp standards.masp --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.16.0-alpha.2 (2026-07-12)
 
 - [BREAKING] Change proving from being `async` to `sync` ([#3281](https://github.com/0xMiden/protocol/pull/3281)).
+- Added a CI release job that uploads the pre-built `protocol.masp` and `standards.masp` packages to the GitHub release page to aid `midenup`'s installation speed ([#2859](https://github.com/0xMiden/protocol/pull/2859)).
+
 
 ## v0.16.0-alpha.1 (2026-07-12)
 

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -31,14 +31,9 @@ const PROJECT_MANIFEST: &str = "miden-project.toml";
 
 /// The build profile used when assembling the Miden projects.
 ///
-/// With the `testing` feature enabled the projects are built with the `dev` profile so that the
-/// assembled packages retain their debug info.
-/// Otherwise the projects are built with the `release` profile, which strips debug info to keep the
-/// embedded packages small.
-#[cfg(any(feature = "testing", test))]
+/// Packages are assembled with the debug-info (`dev`) so published packages carry debug
+/// information; consumers can strip it as needed.
 const BUILD_PROFILE: &str = "dev";
-#[cfg(not(any(feature = "testing", test)))]
-const BUILD_PROFILE: &str = "release";
 
 // Executable target names, as declared in the respective `miden-project.toml` files.
 const TX_KERNEL_MAIN_TARGET: &str = "main";
@@ -342,7 +337,9 @@ fn compile_protocol_lib(
     let protocol_package =
         project_assembler.assemble(ProjectTargetSelector::Library, BUILD_PROFILE)?;
 
-    protocol_package.write_masp_file(target_dir).into_diagnostic()
+    protocol_package.write_masp_file(target_dir).into_diagnostic()?;
+
+    write_release_package(&protocol_package)
 }
 
 // HELPER FUNCTIONS
@@ -351,6 +348,33 @@ fn compile_protocol_lib(
 /// Returns a new [Assembler] using the provided source manager, with warnings treated as errors.
 fn build_assembler(source_manager: Arc<dyn SourceManager>) -> Assembler {
     Assembler::new(source_manager).with_warnings_as_errors(true)
+}
+
+/// Writes the package to a fixed path: `<target>/<profile>/<name>.masp`.
+fn write_release_package(package: &Package) -> Result<()> {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR is always set for build scripts");
+    let out_path = Path::new(&out_dir);
+    // OUT_DIR is `<target>/<profile>/build/<pkg>-<hash>/out` so the profile dir is its 3rd
+    // ancestor.
+    let profile_dir = out_path
+        .ancestors()
+        .nth(3)
+        .expect("OUT_DIR should live under <target>/<profile>/build/<pkg>/out");
+
+    let name: &str = &package.name;
+    let final_path = profile_dir.join(name).with_extension(Package::EXTENSION);
+
+    let unique = out_path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|s| s.to_str())
+        .unwrap_or(name);
+    // Because multiple build-script runs may write this same path, the package is created as a temp
+    // file and atomically renamed into place.
+    let tmp_path = profile_dir.join(format!(".{name}.{unique}.masp.tmp"));
+
+    package.write_to_file(&tmp_path).into_diagnostic()?;
+    fs::rename(&tmp_path, &final_path).into_diagnostic()
 }
 
 fn is_dynamic_kernel_api_export(path: &MasmPath) -> bool {

--- a/crates/miden-protocol/src/protocol.rs
+++ b/crates/miden-protocol/src/protocol.rs
@@ -26,6 +26,11 @@ static PROTOCOL_PACKAGE: LazyLock<Arc<Package>> = LazyLock::new(|| {
 pub struct ProtocolLib(Arc<Package>);
 
 impl ProtocolLib {
+    /// Returns the underlying [`Arc<Package>`]
+    pub fn package(&self) -> Arc<Package> {
+        self.0.clone()
+    }
+
     /// Returns a reference to the [`MastForest`] of the inner [`Library`].
     pub fn mast_forest(&self) -> &Arc<MastForest> {
         self.0.mast_forest()

--- a/crates/miden-standards/build.rs
+++ b/crates/miden-standards/build.rs
@@ -24,7 +24,10 @@ const ASM_COMPONENTS_DIR: &str = "components";
 const PROJECT_MANIFEST: &str = "miden-project.toml";
 
 /// The build profile used when assembling the Miden projects.
-const BUILD_PROFILE: &str = "release";
+///
+/// Packages are assembled with the debug-info (`dev`) so published packages carry debug
+/// information; consumers can strip it as needed.
+const BUILD_PROFILE: &str = "dev";
 
 const STANDARDS_ERRORS_RS_FILE: &str = "standards_errors.rs";
 const STANDARDS_ERRORS_ARRAY_NAME: &str = "STANDARDS_ERRORS";
@@ -114,9 +117,39 @@ fn compile_standards_lib(
         .assemble(ProjectTargetSelector::Library, BUILD_PROFILE)?;
 
     package.write_masp_file(target_dir).into_diagnostic()?;
+
+    write_release_package(&package)?;
+
     registry.cache_package(package).into_diagnostic()?;
 
     Ok(())
+}
+
+/// Writes the package to a fixed path: `<target>/<profile>/<name>.masp`.
+fn write_release_package(package: &Package) -> Result<()> {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR is always set for build scripts");
+    let out_path = Path::new(&out_dir);
+    // OUT_DIR is `<target>/<profile>/build/<pkg>-<hash>/out` so the profile dir is its 3rd
+    // ancestor.
+    let profile_dir = out_path
+        .ancestors()
+        .nth(3)
+        .expect("OUT_DIR should live under <target>/<profile>/build/<pkg>/out");
+
+    let name: &str = &package.name;
+    let final_path = profile_dir.join(name).with_extension(Package::EXTENSION);
+
+    let tmp = out_path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|s| s.to_str())
+        .unwrap_or(name);
+    // Because multiple build-script runs may write this same path, the package is created as a temp
+    // file and atomically renamed into place.
+    let tmp_path = profile_dir.join(format!(".{name}.{tmp}.masp.tmp"));
+
+    package.write_to_file(&tmp_path).into_diagnostic()?;
+    std::fs::rename(&tmp_path, &final_path).into_diagnostic()
 }
 
 // COMPILE ACCOUNT COMPONENTS


### PR DESCRIPTION
so that we can re-create the release and it should trigger the new `upload-artifacts` job