### PR TITLE
feat: add `tx::get_fee_faucet_id` kernel accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- Added the `tx::get_fee_faucet_id` kernel accessor, exposing the fee faucet ID from the transaction's reference block to user code ([#2899](https://github.com/0xMiden/protocol/discussions/2899)).
 - [BREAKING] Replaced the owner-only transfer allowlist/blocklist admin components (`AllowlistOwnerControlled` / `BlocklistOwnerControlled`) with authority-gated `AllowlistManager` / `BlocklistManager` ([#3277](https://github.com/0xMiden/protocol/pull/3277)).
 
 ## v0.16.0-alpha.2 (2026-07-13)

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
@@ -755,6 +755,18 @@ pub proc get_verification_base_fee
     mem_load.VERIFICATION_BASE_FEE_PTR
 end
 
+#! Returns the fee faucet ID from the transaction's reference block.
+#!
+#! Inputs:  []
+#! Outputs: [fee_faucet_id_suffix, fee_faucet_id_prefix]
+#!
+#! Where:
+#! - fee_faucet_id_{suffix,prefix} are the suffix and prefix felts of the ID of the faucet issuing
+#!   the native fee asset.
+pub proc get_fee_faucet_id
+    mem_load.FEE_FAUCET_ID_PREFIX_PTR mem_load.FEE_FAUCET_ID_SUFFIX_PTR
+end
+
 #! Returns the chain commitment of the transaction reference block.
 #!
 #! Inputs:  []

--- a/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
@@ -1774,6 +1774,25 @@ pub proc tx_compute_fee
     # => [fee_amount, pad(15)]
 end
 
+#! Returns the fee faucet ID of the transaction's reference block.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [fee_faucet_id_suffix, fee_faucet_id_prefix, pad(14)]
+#!
+#! Where:
+#! - fee_faucet_id_{suffix,prefix} are the suffix and prefix felts of the ID of the faucet issuing
+#!   the native fee asset.
+#!
+#! Invocation: dynexec
+pub proc tx_get_fee_faucet_id
+    exec.memory::get_fee_faucet_id
+    # => [fee_faucet_id_suffix, fee_faucet_id_prefix, pad(16)]
+
+    # truncate the stack
+    movup.2 drop movup.2 drop
+    # => [fee_faucet_id_suffix, fee_faucet_id_prefix, pad(14)]
+end
+
 #! Returns the block commitment of the reference block.
 #!
 #! Inputs:  [pad(16)]

--- a/crates/miden-protocol/asm/protocol/src/kernel_proc_offsets.masm
+++ b/crates/miden-protocol/asm/protocol/src/kernel_proc_offsets.masm
@@ -103,3 +103,4 @@ pub const TX_GET_TX_SCRIPT_ROOT_OFFSET = 57
 
 # fee
 pub const TX_COMPUTE_FEE_OFFSET = 58
+pub const TX_GET_FEE_FAUCET_ID_OFFSET = 59 # accessor

--- a/crates/miden-protocol/asm/protocol/src/tx.masm
+++ b/crates/miden-protocol/asm/protocol/src/tx.masm
@@ -1,4 +1,4 @@
-use {TX_EXEC_FOREIGN_PROC_OFFSET, TX_GET_BLOCK_COMMITMENT_OFFSET, TX_GET_BLOCK_NUMBER_OFFSET, TX_GET_BLOCK_TIMESTAMP_OFFSET, TX_GET_EXPIRATION_DELTA_OFFSET, TX_GET_INPUT_NOTES_COMMITMENT_OFFSET, TX_GET_NUM_INPUT_NOTES_OFFSET, TX_GET_NUM_OUTPUT_NOTES_OFFSET, TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET, TX_GET_TX_SCRIPT_ROOT_OFFSET, TX_PREPARE_FPI_OFFSET, TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET, TX_COMPUTE_FEE_OFFSET}
+use {TX_EXEC_FOREIGN_PROC_OFFSET, TX_GET_BLOCK_COMMITMENT_OFFSET, TX_GET_BLOCK_NUMBER_OFFSET, TX_GET_BLOCK_TIMESTAMP_OFFSET, TX_GET_EXPIRATION_DELTA_OFFSET, TX_GET_FEE_FAUCET_ID_OFFSET, TX_GET_INPUT_NOTES_COMMITMENT_OFFSET, TX_GET_NUM_INPUT_NOTES_OFFSET, TX_GET_NUM_OUTPUT_NOTES_OFFSET, TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET, TX_GET_TX_SCRIPT_ROOT_OFFSET, TX_PREPARE_FPI_OFFSET, TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET, TX_COMPUTE_FEE_OFFSET}
     from miden::protocol::kernel_proc_offsets
 use {AccountId, AccountProcedureRoot, BlockNumber, TransactionScriptRoot}
     from miden::protocol::types
@@ -385,4 +385,30 @@ pub proc compute_fee(num_extra_cycles: u32, exclude_notes_commitment: word) -> f
     # truncate the stack
     movdn.15 dropw dropw dropw drop drop drop
     # => [fee_amount]
+end
+
+#! Returns the fee faucet ID of the transaction's reference block.
+#!
+#! Inputs:  []
+#! Outputs: [fee_faucet_id_suffix, fee_faucet_id_prefix]
+#!
+#! Where:
+#! - fee_faucet_id_{suffix,prefix} are the suffix and prefix felts of the ID of the faucet issuing
+#!   the native fee asset.
+#!
+#! Invocation: exec
+pub proc get_fee_faucet_id() -> AccountId
+    # pad the stack
+    padw padw padw push.0.0.0
+    # => [pad(15)]
+
+    push.TX_GET_FEE_FAUCET_ID_OFFSET
+    # => [offset, pad(15)]
+
+    syscall.exec_kernel_proc
+    # => [fee_faucet_id_suffix, fee_faucet_id_prefix, pad(14)]
+
+    # clean the stack
+    swapdw dropw dropw swapw dropw movdn.3 movdn.3 drop drop
+    # => [fee_faucet_id_suffix, fee_faucet_id_prefix]
 end

--- a/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fee.rs
@@ -81,6 +81,35 @@ fn compute_fee_code(
 }
 
 #[tokio::test]
+async fn get_fee_faucet_id_returns_reference_block_fee_faucet() -> anyhow::Result<()> {
+    let (mock_chain, account) = mock_chain_with_fee()?;
+    let tx_context = mock_chain.build_tx_context(account, &[], &[])?.build()?;
+
+    let fee_faucet_id = tx_context.tx_inputs().block_header().fee_parameters().fee_faucet_id();
+
+    let code = "
+        use miden::tx_kernel_core::prologue
+        use miden::protocol::tx
+        use miden::core::sys
+
+        begin
+            exec.prologue::prepare_transaction
+
+            exec.tx::get_fee_faucet_id
+            # => [fee_faucet_id_suffix, fee_faucet_id_prefix]
+
+            exec.sys::truncate_stack
+        end
+    ";
+    let exec_output = tx_context.execute_code(code).await?;
+
+    assert_eq!(exec_output.get_stack_element(0), fee_faucet_id.suffix());
+    assert_eq!(exec_output.get_stack_element(1), fee_faucet_id.prefix().as_felt());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn compute_fee_adds_extra_cycles() -> anyhow::Result<()> {
     let (mock_chain, account) = mock_chain_with_fee()?;
     let tx_context = mock_chain.build_tx_context(account, &[], &[])?.build()?;


### PR DESCRIPTION
A previous accessor for this value was removed together with the automatic fee deduction in [#3108](https://github.com/0xMiden/protocol/pull/3108). This PR reintroduces it.

## Why

Account code needs the fee faucet ID to construct the native fee asset in-VM when paying transaction fees: the fee amount comes from the existing `tx::compute_fee` accessor and is denominated in the native fee asset, but without the faucet ID user code cannot assemble the corresponding fungible asset.

It might not be strictly necessary, I think we might be able to supply the native token id as e.g. auth arguments like is done in https://github.com/0xMiden/protocol/pull/3298, but I think it might be useful at some point for network accounts. Keeping as draft for now.