### PR TITLE
fix: stack padding after note creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
-## v0.16.0-alpha.2 (2026-07-12)
+## v0.16.0-alpha.2 (2026-07-13)
 
+### Changes
+- [BREAKING] Hardened multisig auth and account code construction: rejected duplicate procedure roots (`AccountCode::from_parts` is now fallible) and duplicate approver public keys, unenforceable procedure threshold overrides, out-of-range `get_signer_at` indices, and foreign roots in `set_procedure_policy` ([#3246](https://github.com/0xMiden/protocol/pull/3246)).
 - [BREAKING] Change proving from being `async` to `sync` ([#3281](https://github.com/0xMiden/protocol/pull/3281)).
 - Added a CI release job that uploads the pre-built `protocol.masp` and `standards.masp` packages to the GitHub release page to aid `midenup`'s installation speed ([#2859](https://github.com/0xMiden/protocol/pull/2859)).
+
+### Fixes
+
+- Fixed `SendNotesTransactionScript` generating a script that returned at an invalid stack depth when a note carried no assets, causing the VM to reject the transaction with `InvalidStackDepthOnReturn` ([#3302](https://github.com/0xMiden/protocol/pull/3302)).
 
 
 ## v0.16.0-alpha.1 (2026-07-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
-## v0.16.0-alpha.2 (2026-07-13)
-
-### Changes
-- [BREAKING] Hardened multisig auth and account code construction: rejected duplicate procedure roots (`AccountCode::from_parts` is now fallible) and duplicate approver public keys, unenforceable procedure threshold overrides, out-of-range `get_signer_at` indices, and foreign roots in `set_procedure_policy` ([#3246](https://github.com/0xMiden/protocol/pull/3246)).
-- [BREAKING] Change proving from being `async` to `sync` ([#3281](https://github.com/0xMiden/protocol/pull/3281)).
-- Added a CI release job that uploads the pre-built `protocol.masp` and `standards.masp` packages to the GitHub release page to aid `midenup`'s installation speed ([#2859](https://github.com/0xMiden/protocol/pull/2859)).
+## v0.16.0-alpha.3 (2026-07-15)
 
 ### Fixes
 
 - Fixed `SendNotesTransactionScript` generating a script that returned at an invalid stack depth when a note carried no assets, causing the VM to reject the transaction with `InvalidStackDepthOnReturn` ([#3302](https://github.com/0xMiden/protocol/pull/3302)).
+
+## v0.16.0-alpha.2 (2026-07-12)
+
+- [BREAKING] Change proving from being `async` to `sync` ([#3281](https://github.com/0xMiden/protocol/pull/3281)).
+- Added a CI release job that uploads the pre-built `protocol.masp` and `standards.masp` packages to the GitHub release page to aid `midenup`'s installation speed ([#2859](https://github.com/0xMiden/protocol/pull/2859)).
 
 
 ## v0.16.0-alpha.1 (2026-07-12)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-alpha.2"
+version = "0.16.0-alpha.3"
 dependencies = [
  "miden-processor",
  "miden-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.96.1"
-version      = "0.16.0-alpha.2"
+version      = "0.16.0-alpha.3"
 
 [profile.release]
 codegen-units = 1
@@ -36,13 +36,13 @@ lto           = true
 
 [workspace.dependencies]
 # Workspace crates
-miden-agglayer     = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-alpha.2" }
-miden-block-prover = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-alpha.2" }
-miden-protocol     = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-alpha.2" }
-miden-standards    = { default-features = false, path = "crates/miden-standards", version = "0.16.0-alpha.2" }
-miden-testing      = { default-features = false, path = "crates/miden-testing", version = "0.16.0-alpha.2" }
-miden-tx           = { default-features = false, path = "crates/miden-tx", version = "0.16.0-alpha.2" }
-miden-tx-batch     = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-alpha.2" }
+miden-agglayer     = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-alpha.3" }
+miden-block-prover = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-alpha.3" }
+miden-protocol     = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-alpha.3" }
+miden-standards    = { default-features = false, path = "crates/miden-standards", version = "0.16.0-alpha.3" }
+miden-testing      = { default-features = false, path = "crates/miden-testing", version = "0.16.0-alpha.3" }
+miden-tx           = { default-features = false, path = "crates/miden-tx", version = "0.16.0-alpha.3" }
+miden-tx-batch     = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-alpha.3" }
 
 # Miden dependencies
 miden-assembly         = { default-features = false, version = "0.25" }

--- a/crates/miden-standards/src/tx_script/send_notes_script.rs
+++ b/crates/miden-standards/src/tx_script/send_notes_script.rs
@@ -165,24 +165,27 @@ fn move_asset_to_note_body(
         body.push_str(
             "
             call.::miden::standards::note::note_creator::create_note
-            # => [note_idx, pad(21)]\n
+            # => [note_idx, pad(21)]
+
+            movdn.5 dropw drop
+            # => [note_idx, pad(16)]\n
             ",
         );
 
         for asset in note.assets().iter() {
             body.push_str(&format!(
                 "
-                dup movdn.8
-                # => [note_idx, pad(7), note_idx, pad(14)]
+                padw push.0 push.0 push.0 dup.7
+                # => [note_idx, pad(7), note_idx, pad(16)]
 
                 push.{ASSET_VALUE}
                 push.{ASSET_ID}
-                # => [ASSET_ID, ASSET_VALUE, note_idx, pad(7), note_idx, pad(14)]
+                # => [ASSET_ID, ASSET_VALUE, note_idx, pad(7), note_idx, pad(16)]
 
                 call.::miden::standards::wallets::basic::move_asset_to_note
-                # => [pad(16), note_idx, pad(14)]
+                # => [pad(16), note_idx, pad(16)]
 
-                dropw dropw dropw drop drop movup.2
+                dropw dropw dropw dropw
                 # => [note_idx, pad(16)]\n
                 ",
                 ASSET_ID = asset.to_id_word(),

--- a/crates/miden-testing/tests/scripts/send_note.rs
+++ b/crates/miden-testing/tests/scripts/send_note.rs
@@ -22,7 +22,7 @@ use miden_protocol::testing::note::DEFAULT_NOTE_SCRIPT;
 use miden_protocol::transaction::{RawOutputNote, TransactionScript};
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::note::P2idNote;
-use miden_standards::tx_script::SendNotesTransactionScript;
+use miden_standards::tx_script::{SendNotesTransactionScript, SendNotesTransactionScriptError};
 use miden_testing::utils::create_p2any_note;
 use miden_testing::{Auth, MockChain};
 
@@ -144,6 +144,84 @@ async fn test_send_note_script_basic_wallet() -> anyhow::Result<()> {
         &RawOutputNote::Partial(p2any_note.into())
     );
     assert_eq!(executed_transaction.output_notes().get_note(1), &RawOutputNote::Full(p2id_note));
+
+    Ok(())
+}
+
+/// Creates a private note with the default note script and an empty asset list.
+fn create_assetless_note(sender: miden_protocol::account::AccountId) -> anyhow::Result<Note> {
+    let tag = NoteTag::with_account_target(sender);
+    let metadata = PartialNoteMetadata::new(sender, NoteType::Private).with_tag(tag);
+    let assets = NoteAssets::new(vec![])?;
+    let note_script = CodeBuilder::default().compile_note_script(DEFAULT_NOTE_SCRIPT)?;
+    let serial_num = RandomCoin::new(Word::from([1, 2, 3, 4u32])).draw_word();
+    let recipient = NoteRecipient::new(serial_num, note_script, NoteStorage::default());
+    Ok(Note::new(assets, metadata, recipient))
+}
+
+/// Tests that a basic wallet can send a note that carries no assets.
+///
+/// Regression test: the generated script must return at stack depth 16 even when the per-asset
+/// loop is never emitted (zero-asset note), otherwise the VM rejects the transaction with
+/// `InvalidStackDepthOnReturn`.
+///
+/// [wallet]: miden_standards::account::interface::AccountComponentInterface::BasicWallet
+#[tokio::test]
+async fn test_send_note_script_basic_wallet_without_assets() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let sender_basic_wallet_account = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
+    let mock_chain = builder.build()?;
+
+    let assetless_note = create_assetless_note(sender_basic_wallet_account.id())?;
+    let partial_note = PartialNote::from(assetless_note.clone());
+
+    let send_note_transaction_script = TransactionScript::from(SendNotesTransactionScript::new(
+        &sender_basic_wallet_account.code_interface(),
+        slice::from_ref(&partial_note),
+    )?);
+
+    let executed_transaction = mock_chain
+        .build_tx_context(sender_basic_wallet_account.id(), &[], &[])
+        .expect("failed to build tx context")
+        .tx_script(send_note_transaction_script)
+        .extend_expected_output_notes(vec![RawOutputNote::Full(assetless_note.clone())])
+        .build()?
+        .execute()
+        .await?;
+
+    assert_eq!(
+        executed_transaction.output_notes().get_note(0),
+        &RawOutputNote::Full(assetless_note)
+    );
+
+    Ok(())
+}
+
+/// Tests that the faucet path still rejects assetless notes at script-build time.
+#[tokio::test]
+async fn test_send_note_script_fungible_faucet_without_assets() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let sender_fungible_faucet_account = builder.add_existing_basic_faucet(
+        Auth::BasicAuth {
+            auth_scheme: AuthScheme::Falcon512Poseidon2,
+        },
+        "POL",
+        200,
+        None,
+    )?;
+    builder.build()?;
+
+    let assetless_note = create_assetless_note(sender_fungible_faucet_account.id())?;
+    let partial_note = PartialNote::from(assetless_note);
+
+    let result = SendNotesTransactionScript::new(
+        &sender_fungible_faucet_account.code_interface(),
+        slice::from_ref(&partial_note),
+    );
+
+    assert!(matches!(result, Err(SendNotesTransactionScriptError::FaucetNoteWithoutAsset)));
 
     Ok(())
 }


### PR DESCRIPTION
While upgrading the client to the latest version of protocol, we came across a failing test:`consume_note_with_custom_script`, which failed with the vm error `InvalidStackDepthOnReturn { depth: 21 }`.

[#3204](https://github.com/0xMiden/protocol/pull/3204) moved `output_note::create` behind the account context, so `SendNotesTransactionScript` now creates notes through the wallet's `create_note` via `call` instead of `exec`. As a `call` is a context boundary, the caller's 6 overflow elements are restored on return, so the script comes back with `[note_idx, pad(21)]` (depth 22) instead of the previous `[note_idx, pad(16)]` (depth 17). The compensating cleanup that drops the 5 extra pads was placed inside the per-asset loop, so for a zero asset output note (like basic wallets may produce) the loop never runs, the script then returns at depth 21.

The fix normalizes the stack unconditionally right after `call create_note`. This makes note creation, the asset loop, attachments, and `finalize_note` all operate on the same depth-17 baseline regardless of how many assets the note carries.

Two regression tests are added: one executes a full transaction sending a zero asset note from a basic wallet (would fail with `InvalidStackDepthOnReturn` without the fix), and the other asserts the faucet path still rejects assetless notes with `FaucetNoteWithoutAsset` at script-build time.