### PR TITLE
feat(standards): add minimal FeeManager component exposing estimate_note_fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.16.0 (TBD)
 
+### Features
+
+- Added a minimal `FeeManager` account component exposing the FPI-callable `estimate_note_fee` procedure over a fixed per-note-script fee schedule ([#3307](https://github.com/0xMiden/protocol/pull/3307)).
+
 ### Changes
 
 - [BREAKING] Replaced the owner-only transfer allowlist/blocklist admin components (`AllowlistOwnerControlled` / `BlocklistOwnerControlled`) with authority-gated `AllowlistManager` / `BlocklistManager` ([#3277](https://github.com/0xMiden/protocol/pull/3277)).

--- a/crates/miden-standards/asm/components/fees/fee_manager/fee_manager.masm
+++ b/crates/miden-standards/asm/components/fees/fee_manager/fee_manager.masm
@@ -1,0 +1,5 @@
+# The MASM code of the Fee Manager Account Component.
+#
+# See the `FeeManager` Rust type's documentation for more details.
+
+pub use {estimate_note_fee} from miden::standards::fees::fee_manager

--- a/crates/miden-standards/asm/components/fees/fee_manager/miden-project.toml
+++ b/crates/miden-standards/asm/components/fees/fee_manager/miden-project.toml
@@ -1,0 +1,13 @@
+[package]
+name              = "miden-standards-fees-fee-manager"
+version.workspace = true
+
+[lib]
+kind      = "account-component"
+namespace = "miden::standards::components::fees::fee_manager"
+path      = "fee_manager.masm"
+
+[dependencies]
+miden-core.workspace      = true
+miden-protocol.workspace  = true
+miden-standards.workspace = true

--- a/crates/miden-standards/asm/components/miden-project.toml
+++ b/crates/miden-standards/asm/components/miden-project.toml
@@ -26,6 +26,7 @@ members = [
   "faucets/policies/transfer/basic_allowlist",
   "faucets/policies/transfer/basic_blocklist",
   "faucets/policies/transfer/blocklist/manager",
+  "fees/fee_manager",
   "inspection/code_inspection",
   "inspection/schema_commitment",
   "note/note_creator",

--- a/crates/miden-standards/asm/standards/fees/fee_manager.masm
+++ b/crates/miden-standards/asm/standards/fees/fee_manager.masm
@@ -1,0 +1,81 @@
+# miden::standards::fees::fee_manager
+#
+# Fee estimation over a fixed per-note-script fee schedule. External callers (typically an
+# authentication component on another account, via FPI) `call` into `estimate_note_fee` to learn
+# the fee this account charges for a note with the given parameters.
+#
+# Both storage slots are populated once at account creation (via the `FeeManager` Rust type) and
+# there are no on-chain setters.
+#
+# Storage layout:
+# - `fee_asset_id` word: the ID of the asset this account accepts fees in.
+# - `fee_schedule` map: NOTE_SCRIPT_ROOT => [fee_amount, 0, 0, 0]. The default (unset) entry is
+#   the zero word, so unpriced note scripts estimate to a fee amount of 0.
+
+use miden::protocol::active_account
+
+# CONSTANTS
+# ================================================================================================
+
+# Slot holding the ID of the asset this account accepts fees in.
+const FEE_ASSET_ID_SLOT = word("miden::standards::fees::fee_manager::fee_asset_id")
+
+# Slot holding the per-note-script fee schedule.
+# Map entries: NOTE_SCRIPT_ROOT => [fee_amount, 0, 0, 0]
+const FEE_SCHEDULE_SLOT = word("miden::standards::fees::fee_manager::fee_schedule")
+
+# PUBLIC INTERFACE
+# ================================================================================================
+
+#! Returns the estimated fee for a note with the given parameters.
+#!
+#! The fee amount is looked up in the fee schedule under a key built from the note parameters. In
+#! the current version the key is just NOTE_SCRIPT_ROOT; note scripts without a schedule entry
+#! estimate to a fee amount of 0.
+#!
+#! Inputs:  [NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT]
+#! Outputs: [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(8)]
+#!
+#! Where:
+#! - NOTE_SCRIPT_ROOT is the root of the script of the note whose fee is estimated.
+#! - STORAGE_COMMITMENT is the commitment to the note's storage (reserved, currently unused).
+#! - ASSETS_COMMITMENT is the commitment to the note's assets (reserved, currently unused).
+#! - ATTACHMENTS_COMMITMENT is the commitment to the note's attachments (reserved, currently
+#!   unused).
+#! - FEE_ASSET_ID is the ID of the asset this account accepts fees in.
+#! - FEE_ASSET_VALUE is the fee as an asset value word [fee_amount, 0, 0, 0].
+#!
+#! Invocation: call
+@account_procedure
+pub proc estimate_note_fee
+    exec.build_note_fee_lookup_key
+    # => [LOOKUP_KEY, pad(12)]
+
+    push.FEE_SCHEDULE_SLOT[0..2]
+    # => [slot_suffix, slot_prefix, LOOKUP_KEY, pad(12)]
+
+    exec.active_account::get_map_item
+    # => [FEE_ASSET_VALUE, pad(12)]
+
+    push.FEE_ASSET_ID_SLOT[0..2] exec.active_account::get_item
+    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(12)]
+
+    # drop the excess padding to restore the stack depth for the call boundary
+    movupw.3 dropw
+    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(8)]
+end
+
+# HELPER PROCEDURES
+# ================================================================================================
+
+#! Builds the fee schedule lookup key from the note parameters.
+#!
+#! In the current version the lookup key is just NOTE_SCRIPT_ROOT; the remaining parameters are
+#! reserved for future fee logic.
+#!
+#! Inputs:  [NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT]
+#! Outputs: [LOOKUP_KEY]
+proc build_note_fee_lookup_key
+    swapw.3 dropw dropw dropw
+    # => [LOOKUP_KEY]
+end

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -1,0 +1,1 @@
+pub mod fee_manager

--- a/crates/miden-standards/asm/standards/mod.masm
+++ b/crates/miden-standards/asm/standards/mod.masm
@@ -4,6 +4,7 @@ pub mod attachments
 pub mod auth
 pub mod data_structures
 pub mod faucets
+pub mod fees
 pub mod inspection
 pub mod note
 pub mod note_tag

--- a/crates/miden-standards/src/account/fees/fee_manager.rs
+++ b/crates/miden-standards/src/account/fees/fee_manager.rs
@@ -1,0 +1,264 @@
+use alloc::collections::BTreeMap;
+
+use miden_protocol::account::component::{
+    AccountComponentCode,
+    AccountComponentMetadata,
+    SchemaType,
+    StorageSchema,
+    StorageSlotSchema,
+    WordSchema,
+};
+use miden_protocol::account::{
+    AccountComponent,
+    AccountComponentName,
+    AccountId,
+    AccountProcedureRoot,
+    StorageMap,
+    StorageMapKey,
+    StorageSlot,
+    StorageSlotName,
+};
+use miden_protocol::asset::{AssetAmount, AssetId};
+use miden_protocol::note::NoteScriptRoot;
+use miden_protocol::utils::sync::LazyLock;
+use miden_protocol::{Felt, Word};
+
+use crate::account::account_component_code;
+use crate::procedure_root;
+
+// FEE MANAGER
+// ================================================================================================
+
+account_component_code!(FEE_MANAGER_CODE, "miden-standards-fees-fee-manager.masp");
+
+// Initialize the procedure root of the `estimate_note_fee` procedure only once.
+procedure_root!(
+    FEE_MANAGER_ESTIMATE_NOTE_FEE,
+    FeeManager::NAME,
+    FeeManager::ESTIMATE_NOTE_FEE_PROC_NAME,
+    FeeManager::code()
+);
+
+static FEE_ASSET_ID_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
+    StorageSlotName::new("miden::standards::fees::fee_manager::fee_asset_id")
+        .expect("storage slot name should be valid")
+});
+
+static FEE_SCHEDULE_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
+    StorageSlotName::new("miden::standards::fees::fee_manager::fee_schedule")
+        .expect("storage slot name should be valid")
+});
+
+/// An [`AccountComponent`] exposing fee estimation over a fixed per-note-script fee schedule.
+///
+/// The component's single procedure, `estimate_note_fee`, is designed to be `call`ed by external
+/// callers - typically via FPI from the authentication component of an account that creates a
+/// note targeted at this account. It returns the fee this account charges for a note with the
+/// given parameters as a fee asset (asset ID and value words): the amount is looked up in the fee
+/// schedule under the note's script root, and note scripts without a schedule entry estimate to
+/// an amount of 0.
+///
+/// Both storage slots are populated at account creation and there are no on-chain setters.
+///
+/// ## Storage Layout
+///
+/// - `fee_asset_id` value slot: the [`AssetId`] word of the fungible asset this account accepts
+///   fees in.
+/// - `fee_schedule` map slot: `NOTE_SCRIPT_ROOT => [fee_amount, 0, 0, 0]`.
+#[derive(Debug, Clone)]
+pub struct FeeManager {
+    /// The ID of the fungible asset this account accepts fees in.
+    fee_asset_id: AssetId,
+    /// The fee charged per note script root.
+    fee_schedule: BTreeMap<NoteScriptRoot, AssetAmount>,
+}
+
+impl FeeManager {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// The name of the component.
+    pub const NAME: &'static str = "miden::standards::components::fees::fee_manager";
+
+    const ESTIMATE_NOTE_FEE_PROC_NAME: &str = "estimate_note_fee";
+
+    /// Returns the canonical [`AccountComponentName`] of this component.
+    pub const fn name() -> AccountComponentName {
+        AccountComponentName::from_static_str(Self::NAME)
+    }
+
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new [`FeeManager`] with an empty fee schedule, accepting fees in the fungible
+    /// asset issued by the given faucet.
+    pub fn new(fee_faucet_id: AccountId) -> Self {
+        Self {
+            fee_asset_id: AssetId::new_fungible(fee_faucet_id),
+            fee_schedule: BTreeMap::new(),
+        }
+    }
+
+    /// Sets the fee for notes with the given script root, replacing any previous entry.
+    #[must_use]
+    pub fn with_fee(mut self, script_root: NoteScriptRoot, fee: AssetAmount) -> Self {
+        self.fee_schedule.insert(script_root, fee);
+        self
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the [`AccountComponentCode`] of this component.
+    pub fn code() -> &'static AccountComponentCode {
+        &FEE_MANAGER_CODE
+    }
+
+    /// Returns the procedure root of the `estimate_note_fee` procedure.
+    pub fn estimate_note_fee_root() -> AccountProcedureRoot {
+        *FEE_MANAGER_ESTIMATE_NOTE_FEE
+    }
+
+    /// Returns the [`StorageSlotName`] of the slot holding the fee asset ID.
+    pub fn fee_asset_id_slot_name() -> &'static StorageSlotName {
+        &FEE_ASSET_ID_SLOT_NAME
+    }
+
+    /// Returns the [`StorageSlotName`] of the slot holding the fee schedule map.
+    pub fn fee_schedule_slot_name() -> &'static StorageSlotName {
+        &FEE_SCHEDULE_SLOT_NAME
+    }
+
+    /// Returns the [`AssetId`] of the fungible asset this account accepts fees in.
+    pub fn fee_asset_id(&self) -> AssetId {
+        self.fee_asset_id
+    }
+
+    /// Returns the fee charged per note script root.
+    pub fn fee_schedule(&self) -> &BTreeMap<NoteScriptRoot, AssetAmount> {
+        &self.fee_schedule
+    }
+
+    /// Returns the [`AccountComponentMetadata`] for this component.
+    pub fn component_metadata() -> AccountComponentMetadata {
+        let storage_schema = StorageSchema::new([
+            (
+                Self::fee_asset_id_slot_name().clone(),
+                StorageSlotSchema::value(
+                    "ID of the fungible asset the account accepts fees in",
+                    WordSchema::new_simple(SchemaType::native_word()),
+                ),
+            ),
+            (
+                Self::fee_schedule_slot_name().clone(),
+                StorageSlotSchema::map(
+                    "Fee charged per note script root",
+                    SchemaType::native_word(),
+                    SchemaType::native_word(),
+                ),
+            ),
+        ])
+        .expect("storage schema should be valid");
+
+        AccountComponentMetadata::new(Self::NAME)
+            .with_description("Fee estimation over a fixed per-note-script fee schedule")
+            .with_storage_schema(storage_schema)
+    }
+}
+
+impl From<FeeManager> for AccountComponent {
+    fn from(fee_manager: FeeManager) -> Self {
+        let fee_asset_id_slot = StorageSlot::with_value(
+            FeeManager::fee_asset_id_slot_name().clone(),
+            fee_manager.fee_asset_id.to_word(),
+        );
+
+        // Each fee is stored as an asset value word so that `estimate_note_fee` can return the
+        // map entry as FEE_ASSET_VALUE unmodified.
+        let entries = fee_manager.fee_schedule.into_iter().map(|(root, fee)| {
+            (
+                StorageMapKey::new(root.as_word()),
+                Word::new([fee.into(), Felt::ZERO, Felt::ZERO, Felt::ZERO]),
+            )
+        });
+        let fee_schedule_map = StorageMap::with_entries(entries)
+            .expect("fee schedule entries should produce a valid storage map");
+        let fee_schedule_slot =
+            StorageSlot::with_map(FeeManager::fee_schedule_slot_name().clone(), fee_schedule_map);
+
+        let metadata = FeeManager::component_metadata();
+
+        AccountComponent::new(
+            FeeManager::code().clone(),
+            vec![fee_asset_id_slot, fee_schedule_slot],
+            metadata,
+        )
+        .expect(
+            "fee manager component should satisfy the requirements of a valid account component",
+        )
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::account::{AccountBuilder, AccountType, StorageSlotContent};
+    use miden_protocol::testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET;
+
+    use super::*;
+    use crate::account::auth::NoAuth;
+
+    fn fee_faucet_id() -> AccountId {
+        AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)
+            .expect("testing account ID should be valid")
+    }
+
+    /// Check that the component can be added to an account and that the resulting account exposes
+    /// the `estimate_note_fee` procedure.
+    #[test]
+    fn account_exposes_estimate_note_fee() -> anyhow::Result<()> {
+        let account = AccountBuilder::new([1; 32])
+            .account_type(AccountType::Public)
+            .with_auth_component(NoAuth)
+            .with_component(FeeManager::new(fee_faucet_id()))
+            .build_existing()?;
+
+        assert!(account.code().has_procedure(*FeeManager::estimate_note_fee_root().mast_root()));
+
+        Ok(())
+    }
+
+    /// Check that the component's storage slots contain the fee asset ID and the fee schedule
+    /// entries.
+    #[test]
+    fn storage_slots_contain_expected_entries() -> anyhow::Result<()> {
+        let script_root = NoteScriptRoot::from_array([1, 2, 3, 4]);
+        let fee = AssetAmount::new(500)?;
+
+        let account = AccountBuilder::new([1; 32])
+            .account_type(AccountType::Public)
+            .with_auth_component(NoAuth)
+            .with_component(FeeManager::new(fee_faucet_id()).with_fee(script_root, fee))
+            .build_existing()?;
+
+        let fee_asset_id_word = account.storage().get_item(FeeManager::fee_asset_id_slot_name())?;
+        assert_eq!(fee_asset_id_word, AssetId::new_fungible(fee_faucet_id()).to_word());
+
+        let slot = account
+            .storage()
+            .get(FeeManager::fee_schedule_slot_name())
+            .expect("fee schedule slot should exist");
+        let StorageSlotContent::Map(map) = slot.content() else {
+            panic!("fee schedule slot must be a map");
+        };
+        assert_eq!(
+            map.get(&StorageMapKey::new(script_root.as_word())),
+            Word::new([Felt::from(500u32), Felt::ZERO, Felt::ZERO, Felt::ZERO]),
+            "the fee entry should be stored as an asset value word"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/miden-standards/src/account/fees/mod.rs
+++ b/crates/miden-standards/src/account/fees/mod.rs
@@ -1,0 +1,3 @@
+mod fee_manager;
+
+pub use fee_manager::FeeManager;

--- a/crates/miden-standards/src/account/mod.rs
+++ b/crates/miden-standards/src/account/mod.rs
@@ -2,6 +2,7 @@ pub mod access;
 pub mod auth;
 pub mod components;
 pub mod faucets;
+pub mod fees;
 pub mod inspection;
 pub mod interface;
 pub mod policies;

--- a/crates/miden-testing/tests/scripts/fee_manager.rs
+++ b/crates/miden-testing/tests/scripts/fee_manager.rs
@@ -1,0 +1,186 @@
+extern crate alloc;
+
+use miden_protocol::account::{AccountBuilder, AccountId, AccountType};
+use miden_protocol::asset::{AssetAmount, AssetId};
+use miden_protocol::note::NoteScriptRoot;
+use miden_protocol::testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET;
+use miden_protocol::{Felt, Word};
+use miden_standards::account::fees::FeeManager;
+use miden_standards::account::wallets::BasicWallet;
+use miden_standards::code_builder::CodeBuilder;
+use miden_testing::{Auth, MockChain, MockChainBuilder};
+use rstest::rstest;
+
+// HELPERS
+// ================================================================================================
+
+/// The fee scheduled for [`priced_root`] in these tests.
+const FEE_AMOUNT: u64 = 500;
+
+fn fee_faucet_id() -> anyhow::Result<AccountId> {
+    Ok(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET)?)
+}
+
+/// The note script root priced in the fee schedule.
+fn priced_root() -> NoteScriptRoot {
+    NoteScriptRoot::from_array([1, 2, 3, 4])
+}
+
+/// Builds a `FeeManager` accepting fees in the test faucet's asset and charging [`FEE_AMOUNT`]
+/// for notes with the [`priced_root`] script root.
+fn fee_manager() -> anyhow::Result<FeeManager> {
+    Ok(FeeManager::new(fee_faucet_id()?).with_fee(priced_root(), AssetAmount::new(FEE_AMOUNT)?))
+}
+
+/// Returns the asset value word `[fee_amount, 0, 0, 0]` for the given amount.
+fn fee_value_word(amount: u64) -> anyhow::Result<Word> {
+    Ok(Word::new([
+        AssetAmount::new(amount)?.into(),
+        Felt::ZERO,
+        Felt::ZERO,
+        Felt::ZERO,
+    ]))
+}
+
+// TESTS
+// ================================================================================================
+
+/// `FeeManager::estimate_note_fee`, invoked via `call` from a transaction script, returns the
+/// account's fee asset ID and the fee amount scheduled for the queried note script root. Roots
+/// without a schedule entry estimate to an amount of 0. A wrong result aborts the transaction,
+/// so successful execution proves the returned fee asset.
+#[rstest]
+#[case::priced_root(priced_root(), FEE_AMOUNT)]
+#[case::unknown_root(NoteScriptRoot::from_array([5, 6, 7, 8]), 0)]
+#[tokio::test]
+async fn estimate_note_fee_returns_scheduled_fee(
+    #[case] queried_root: NoteScriptRoot,
+    #[case] expected_amount: u64,
+) -> anyhow::Result<()> {
+    let account = AccountBuilder::new([1; 32])
+        .account_type(AccountType::Public)
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(BasicWallet)
+        .with_component(fee_manager()?)
+        .build_existing()?;
+
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+    let mock_chain = builder.build()?;
+
+    // The tx script argument is placed on top of the initial operand stack, so the script starts
+    // with `[NOTE_SCRIPT_ROOT, pad(12)]` - exactly the `estimate_note_fee` inputs with the
+    // reserved commitments zeroed.
+    let tx_script_code = format!(
+        r#"
+        use miden::standards::components::fees::fee_manager
+
+        @transaction_script
+        pub proc main
+            # => [NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT]
+            call.fee_manager::estimate_note_fee
+            # => [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(8)]
+
+            push.{expected_fee_asset_id}
+            assert_eqw.err="estimate_note_fee should return the account's fee asset ID"
+            # => [FEE_ASSET_VALUE, pad(12)]
+
+            push.{expected_fee_value}
+            assert_eqw.err="estimate_note_fee should return the scheduled fee amount"
+            # => [pad(16)]
+        end
+        "#,
+        expected_fee_asset_id = AssetId::new_fungible(fee_faucet_id()?).to_word(),
+        expected_fee_value = fee_value_word(expected_amount)?,
+    );
+
+    let tx_script = CodeBuilder::default()
+        .with_dynamically_linked_library(FeeManager::code())?
+        .compile_tx_script(tx_script_code)?;
+
+    mock_chain
+        .build_tx_context(account.id(), &[], &[])?
+        .tx_script(tx_script)
+        .tx_script_args(queried_root.as_word())
+        .build()?
+        .execute()
+        .await?;
+
+    Ok(())
+}
+
+/// `FeeManager::estimate_note_fee` invoked on a foreign account via FPI
+/// (`tx::execute_foreign_procedure`), mirroring how the authentication component of an account
+/// that creates a note targeted at a network account estimates the note's fee.
+#[tokio::test]
+async fn estimate_note_fee_via_fpi() -> anyhow::Result<()> {
+    let foreign_account = AccountBuilder::new([1; 32])
+        .account_type(AccountType::Public)
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(BasicWallet)
+        .with_component(fee_manager()?)
+        .build_existing()?;
+
+    let native_account = AccountBuilder::new([2; 32])
+        .account_type(AccountType::Public)
+        .with_auth_component(Auth::IncrNonce)
+        .with_component(BasicWallet)
+        .build_existing()?;
+
+    let mut mock_chain =
+        MockChainBuilder::with_accounts([native_account.clone(), foreign_account.clone()])?
+            .build()?;
+    mock_chain.prove_next_block()?;
+
+    // The tx script argument supplies NOTE_SCRIPT_ROOT on top of the initial operand stack; the
+    // zeros below it serve as the reserved commitments, forming the full 16-felt
+    // `estimate_note_fee` inputs. The procedure root is interpolated directly so the foreign
+    // library does not need to be linked.
+    let tx_script_code = format!(
+        r#"
+        use miden::protocol::tx
+
+        @transaction_script
+        pub proc main
+            # => [NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT]
+
+            # push the estimate_note_fee procedure root and the foreign account ID
+            push.{estimate_note_fee_root}
+            push.{foreign_prefix} push.{foreign_suffix}
+            # => [foreign_account_id_suffix, foreign_account_id_prefix, FOREIGN_PROC_ROOT,
+            #     NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT]
+
+            exec.tx::execute_foreign_procedure
+            # => [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(8)]
+
+            push.{expected_fee_asset_id}
+            assert_eqw.err="foreign fee estimation should return the fee asset ID"
+            # => [FEE_ASSET_VALUE, pad(12)]
+
+            push.{expected_fee_value}
+            assert_eqw.err="foreign fee estimation should return the scheduled fee amount"
+            # => [pad(16)]
+        end
+        "#,
+        estimate_note_fee_root = FeeManager::estimate_note_fee_root().mast_root(),
+        foreign_prefix = foreign_account.id().prefix().as_felt(),
+        foreign_suffix = foreign_account.id().suffix(),
+        expected_fee_asset_id = AssetId::new_fungible(fee_faucet_id()?).to_word(),
+        expected_fee_value = fee_value_word(FEE_AMOUNT)?,
+    );
+
+    let tx_script = CodeBuilder::default().compile_tx_script(tx_script_code)?;
+
+    let foreign_account_inputs = mock_chain.get_foreign_account_inputs(foreign_account.id())?;
+
+    mock_chain
+        .build_tx_context(native_account.id(), &[], &[])?
+        .foreign_accounts([foreign_account_inputs])
+        .tx_script(tx_script)
+        .tx_script_args(priced_root().as_word())
+        .build()?
+        .execute()
+        .await?;
+
+    Ok(())
+}

--- a/crates/miden-testing/tests/scripts/mod.rs
+++ b/crates/miden-testing/tests/scripts/mod.rs
@@ -5,6 +5,7 @@ mod code_inspection;
 mod expiration;
 mod faucet;
 mod faucet_policy_action;
+mod fee_manager;
 mod non_fungible_faucet;
 mod ownable2step;
 mod owner_action;


### PR DESCRIPTION
Adds a minimal v0.1 `FeeManager` account component: estimation only, per the first-iteration scope agreed in [#3264](https://github.com/0xMiden/protocol/issues/3264). Addresses [#2901](https://github.com/0xMiden/protocol/issues/2901).

The component exposes a single FPI-callable procedure with the interface proposed in #3264:

```
#! Inputs:  [NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT]
#! Outputs: [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(8)]
```

- The fee amount is looked up in a storage map `NOTE_SCRIPT_ROOT => [fee_amount, 0, 0, 0]`; roots without an entry estimate to an amount of 0.
- The three commitments besides `NOTE_SCRIPT_ROOT` are accepted but unused (reserved for future fee logic). Internally the lookup key is built by `build_note_fee_lookup_key`, whose trivial v0.1 implementation returns `NOTE_SCRIPT_ROOT`.
- The fee asset (a fungible faucet ID) and the schedule are fixed at account creation via the `FeeManager` Rust builder; there are no on-chain setters.
- Tests cover the direct `call` path (priced and unknown roots, via `rstest`) and the FPI path via `tx::execute_foreign_procedure`, mirroring how an auth component would estimate a note's fee.

Deferred to follow-ups: sponsored fee collection in `auth_network_transaction`, on-chain schedule setters, `timeframe`/`priority` inputs (require collapsing the commitments), and pluggable fee policies.
