### PR TITLE
feat: add `non_fungible_asset::validate` to the standards library

### DIFF
--- a/.claude/skills/masm-inline-comments/SKILL.md
+++ b/.claude/skills/masm-inline-comments/SKILL.md
@@ -90,6 +90,18 @@ Use the vocabulary already established in the surrounding code and doc comments.
 
 Inline comments explain what the code does for a future reader, not why a particular PR made a change. Avoid PR narrative and framing such as "this is the X that prevents Y"; describe the operation and its purpose as the code stands.
 
+### 7. Accessing a word's individual elements
+
+When accessing individual elements of a word, show the word destructured into elements, grouped with brackets, e.g.:
+
+```
+# => [ASSET_ID, ASSET_VALUE]
+# => [[asset_class_suffix, asset_class_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix], ASSET_VALUE]
+
+dup
+# => [asset_class_suffix, ASSET_ID, ASSET_VALUE]
+```
+
 ## Examples
 
 **Good:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.16.0 (TBD)
 
+### Features
+
+- Added the `miden::standards::assets::non_fungible_asset::validate` MASM procedure, which validates a non-fungible asset's composition and the binding of its value to the asset class, and used it in the `NonFungibleFaucet` burn procedure ([#3308](https://github.com/0xMiden/protocol/pull/3308)).
+
 ### Changes
 
 - [BREAKING] Replaced the owner-only transfer allowlist/blocklist admin components (`AllowlistOwnerControlled` / `BlocklistOwnerControlled`) with authority-gated `AllowlistManager` / `BlocklistManager` ([#3277](https://github.com/0xMiden/protocol/pull/3277)).

--- a/crates/miden-standards/asm/standards/assets/non_fungible_asset.masm
+++ b/crates/miden-standards/asm/standards/assets/non_fungible_asset.masm
@@ -2,7 +2,17 @@
 #!
 #! Provides procedures for creating non-fungible assets.
 
+use miden::protocol::asset
 use {COMPOSITION_NONE} from miden::protocol::asset
+
+# ERRORS
+# ================================================================================================
+
+const ERR_NON_FUNGIBLE_ASSET_ID_COMPOSITION_MUST_BE_NON_FUNGIBLE = "non-fungible asset ID's composition must be non-fungible"
+
+const ERR_NON_FUNGIBLE_ASSET_CLASS_SUFFIX_MUST_MATCH_HASH0 = "the asset class suffix in a non-fungible asset ID must match hash0 of the asset value"
+
+const ERR_NON_FUNGIBLE_ASSET_CLASS_PREFIX_MUST_MATCH_HASH1 = "the asset class prefix in a non-fungible asset ID must match hash1 of the asset value"
 
 # PROCEDURES
 # ================================================================================================
@@ -36,6 +46,38 @@ pub proc create
     # word
     dup.3 dup.3
     # => [hash0, hash1, faucet_id_suffix_and_metadata, faucet_id_prefix, ASSET_VALUE]
+    # => [ASSET_ID, ASSET_VALUE]
+end
+
+#! Validates that a non-fungible asset is well formed.
+#!
+#! Only the value's binding to the asset ID and the composition are checked; the structure of
+#! the asset ID's account ID is validated by the kernel and not re-checked here.
+#!
+#! Inputs:  [ASSET_ID, ASSET_VALUE]
+#! Outputs: [ASSET_ID, ASSET_VALUE]
+#!
+#! Where:
+#! - ASSET_ID is the asset ID of the asset to validate.
+#! - ASSET_VALUE is the value (data commitment) of the asset to validate.
+#!
+#! Panics if:
+#! - the asset ID's composition is not non-fungible (None).
+#! - the asset class suffix of the asset ID does not match hash0 of the value.
+#! - the asset class prefix of the asset ID does not match hash1 of the value.
+#!
+#! Invocation: exec
+pub proc validate
+    # assert the asset composition is non-fungible (None)
+    exec.asset::id_to_composition
+    eq.COMPOSITION_NONE
+    assert.err=ERR_NON_FUNGIBLE_ASSET_ID_COMPOSITION_MUST_BE_NON_FUNGIBLE
+    # => [ASSET_ID, ASSET_VALUE]
+    # => [[asset_class_suffix, asset_class_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix], [hash0, hash1, hash2, hash3]]
+
+    # assert that hash0 matches asset_class_suffix and hash1 matches asset_class_prefix
+    dup.4 dup.1 assert_eq.err=ERR_NON_FUNGIBLE_ASSET_CLASS_SUFFIX_MUST_MATCH_HASH0
+    dup.5 dup.2 assert_eq.err=ERR_NON_FUNGIBLE_ASSET_CLASS_PREFIX_MUST_MATCH_HASH1
     # => [ASSET_ID, ASSET_VALUE]
 end
 

--- a/crates/miden-standards/asm/standards/faucets/non_fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/non_fungible.masm
@@ -227,6 +227,9 @@ pub proc mint_and_send
     exec.active_account::get_id
     # => [id_suffix, id_prefix, ASSET_VALUE, note_idx, note_idx, pad(15)]
 
+    # the asset ID is derived from the value here (composition None, asset class copied from
+    # the value's hash0/hash1), so the minted asset is well formed by construction and
+    # non_fungible_asset::validate is deliberately skipped
     exec.non_fungible_asset::create
     # => [ASSET_ID, ASSET_VALUE, note_idx, note_idx, pad(15)]
 
@@ -271,6 +274,11 @@ pub proc receive_and_burn
     # => [pad(16)]
 
     push.ASSET_PTR exec.asset::load
+    # => [ASSET_ID, ASSET_VALUE, pad(16)]
+
+    # validate the asset to burn is well-formed before processing it
+    # note that the asset's origin is validated by the kernel
+    exec.non_fungible_asset::validate
     # => [ASSET_ID, ASSET_VALUE, pad(16)]
 
     # run the active burn policy on a copy of the asset

--- a/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_asset.rs
@@ -116,10 +116,16 @@ fn key_suffix_with_metadata(account_id: AccountId, metadata_byte: u64) -> Felt {
         .expect("metadata byte only occupies the lower 8 bits")
 }
 
+/// The kernel and standards `validate` procedures reject the same malformed non-fungible assets.
+///
+/// Both are exercised via the `namespace` matrix. The two procedures deliberately share the same
+/// error wording, so a single expectation matches both. The kernel proc additionally validates
+/// the account ID structure (which the standards proc leaves to the kernel); that difference is
+/// not covered by these shared cases.
 #[rstest::rstest]
-#[case::account_is_not_non_fungible_faucet(
-    ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE.try_into()?,
-    AssetClass::default(),
+#[case::composition_is_not_non_fungible(
+    ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET.try_into()?,
+    AssetClass::new(Felt::from(2u32), Felt::from(3u32)),
     METADATA_BYTE_FUNGIBLE,
     ERR_NON_FUNGIBLE_ASSET_ID_COMPOSITION_MUST_BE_NON_FUNGIBLE
 )]
@@ -141,10 +147,11 @@ async fn test_validate_non_fungible_asset(
     #[case] asset_class: AssetClass,
     #[case] metadata_byte: u64,
     #[case] expected_err: MasmError,
+    #[values("miden::tx_kernel_core", "miden::standards::assets")] namespace: &str,
 ) -> anyhow::Result<()> {
     let code = format!(
         "
-        use miden::tx_kernel_core::non_fungible_asset
+        use {namespace}::non_fungible_asset
 
         begin
             # a random asset value
@@ -172,6 +179,43 @@ async fn test_validate_non_fungible_asset(
     let exec_result = CodeExecutor::with_default_host().run(&code).await;
 
     assert_execution_error!(exec_result, expected_err);
+
+    Ok(())
+}
+
+/// A well-formed non-fungible asset passes the standards-side `validate` and leaves the asset ID
+/// and value on the stack unchanged.
+#[tokio::test]
+async fn test_validate_non_fungible_asset_standards_succeeds() -> anyhow::Result<()> {
+    let non_fungible_asset_details = NonFungibleAssetDetails::new(
+        NonFungibleAsset::mock_issuer(),
+        NON_FUNGIBLE_ASSET_DATA.to_vec(),
+    );
+    let non_fungible_asset = NonFungibleAsset::new(&non_fungible_asset_details);
+
+    let code = format!(
+        "
+        use miden::standards::assets::non_fungible_asset
+
+        begin
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
+            # => [ASSET_ID, ASSET_VALUE]
+
+            exec.non_fungible_asset::validate
+
+            # truncate the stack
+            swapdw dropw dropw
+        end
+        ",
+        ASSET_VALUE = non_fungible_asset.to_value_word(),
+        ASSET_ID = non_fungible_asset.to_id_word(),
+    );
+
+    let exec_output = CodeExecutor::with_default_host().run(&code).await?;
+
+    assert_eq!(exec_output.get_stack_word(0), non_fungible_asset.to_id_word());
+    assert_eq!(exec_output.get_stack_word(4), non_fungible_asset.to_value_word());
 
     Ok(())
 }


### PR DESCRIPTION


## Summary

This PR adds a `miden::standards::assets::non_fungible_asset::validate` MASM procedure that validates a non-fungible asset is well formed: it asserts the asset ID's composition is non-fungible (`COMPOSITION_NONE`) and that the value's `hash0`/`hash1` match the asset class suffix/prefix in the ID. It intentionally does not re-validate the structure of the asset ID's account ID, since the kernel already does that.

## Motivation

The kernel's non-fungible asset **structural** validation is slated for removal, so it moves to standards. This allows custom assets to use `AssetComposition::None` in the future. For now, the kernel still validates the structure but eventually it will only validate the asset ID. Until then this deliberate double validation is intended.

## Changes

- Added `miden::standards::assets::non_fungible_asset::validate`.
- Wired `validate` into the `NonFungibleFaucet` burn procedure (`receive_and_burn`), which processes an asset that originates from a note rather than being constructed locally.
- Left `mint_and_send` unvalidated with a comment: the asset ID is derived from the value there, so the minted asset is well formed by construction and validation would always pass.

half of https://github.com/0xMiden/protocol/issues/3168