### PR TITLE
packaging: ensure miden-tx-kernel is shipped with miden-protocol

### DIFF
--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -66,18 +66,20 @@ jobs:
       - name: Prepare artifacts
         run: |
           set -euo pipefail
-          cp target/release/miden-protocol.masp protocol.masp
-          cp target/release/miden-standards.masp standards.masp
+          cp target/release/miden-tx-kernel.masp miden-tx-kernel.masp
+          cp target/release/miden-protocol.masp miden-protocol.masp
+          cp target/release/miden-standards.masp miden-standards.masp
       - name: Attest packages
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
         with:
           subject-path: |
-            protocol.masp
-            standards.masp
+            miden-tx-kernel.masp
+            miden-protocol.masp
+            miden-standards.masp
       - name: Upload packages
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          gh release upload ${RELEASE_TAG} protocol.masp standards.masp --clobber
+          gh release upload ${RELEASE_TAG} miden-tx-kernel.masp miden-protocol.masp miden-tx-kernel.masp miden-standards.masp --clobber

--- a/crates/miden-protocol/build.rs
+++ b/crates/miden-protocol/build.rs
@@ -169,6 +169,8 @@ fn compile_tx_kernel(
         project_assembler.assemble(ProjectTargetSelector::Library, BUILD_PROFILE)?;
     kernel_package.write_masp_file(target_dir).into_diagnostic()?;
 
+    write_release_package(&kernel_package)?;
+
     // generate kernel `procedures.rs` file
     generate_kernel_proc_hash_file(&kernel_package, build_dir)?;
 


### PR DESCRIPTION
This PR does two things:

1. Ensures that `miden-tx-kernel` is shipped alongside `ProtocolLib` so that downstream users can satisfy the implicit dependency of the `miden-protocol` package on `miden-tx-kernel`
2. Uses the canonical filename format for the package release artifacts uploaded to the GitHub release (i.e. the full name of the package, which includes the `miden-` prefix).

Currently, downstream dependents on the protocol packages cannot satisfy the dependency of the protocol on the kernel to execute their programs, so consider this a blocker until the next patch release of the protocol ships with this fix.