### PR TITLE
Make script of `NetworkAccountConfigNote` default to `AuthNetworkAccount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added the `create_sponsorship_notes` procedure to the `FeeManager` to create sponsorship notes for all created network notes ([#3321](https://github.com/0xMiden/protocol/pull/3321)).
 - Added the `miden::standards::assets::non_fungible_asset::validate` MASM procedure, which validates a non-fungible asset's composition and the binding of its value to the asset class, and used it in the `NonFungibleFaucet` burn procedure ([#3308](https://github.com/0xMiden/protocol/pull/3308)).
 - Added post-deployment management of `AuthNetworkAccount` allowlists: authority-gated `add_allowed_note_script` / `remove_allowed_note_script` / `add_allowed_tx_script` / `remove_allowed_tx_script` procedures (composed with an `Authority` component in `OwnerControlled` or `RbacControlled` mode), a standardized `NetworkAccountConfigNote` to invoke them, and an `AuthNetworkAccount::with_allowlist_management` constructor that allowlists that note ([#3330](https://github.com/0xMiden/protocol/pull/3330)).
+- Made `AuthNetworkAccount` allowlist management enabled by default: every account now allowlists the standardized `NetworkAccountConfigNote` script root at construction (folded into `with_allowed_notes`), replacing the dedicated `with_allowlist_management` constructor ([#](https://github.com/0xMiden/protocol/pull/)).
 
 ### Changes
 

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -125,34 +125,20 @@ impl AuthNetworkAccount {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Creates a new [`AuthNetworkAccount`] component that allows `allowed_script_roots` plus the
-    /// standardized [`NetworkAccountConfigNote`] script root, so the allowlists can be updated
-    /// after deployment by sending that note.
+    /// Creates a new [`AuthNetworkAccount`] component that allows the provided input-note script
+    /// roots.
     ///
-    /// To authorize those updates, the account must also install an
+    /// The standardized [`NetworkAccountConfigNote`] script root is always added to the allowlist,
+    /// so the account's allowlists can be updated after deployment by sending that note. To
+    /// authorize those updates, the account must also install an
     /// [`Authority`](crate::account::access::Authority) component in
     /// [`OwnerControlled`](crate::account::access::Authority::OwnerControlled) or
     /// [`RbacControlled`](crate::account::access::Authority::RbacControlled) mode: the note sender
     /// is checked against it.
-    pub fn with_allowlist_management(mut allowed_script_roots: BTreeSet<NoteScriptRoot>) -> Self {
-        allowed_script_roots.insert(NetworkAccountConfigNote::script_root());
-        Self {
-            allowed_notes: NetworkAccountNoteAllowlist::new(allowed_script_roots)
-                .expect("allowlist contains at least the config note root"),
-            allowed_tx_scripts: NetworkAccountTxScriptAllowlist::default(),
-        }
-    }
-
-    /// Creates a new [`AuthNetworkAccount`] component with the provided list of allowed
-    /// input-note script roots.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `allowed_script_roots` is empty since the account could not consume any
-    /// notes.
     pub fn with_allowed_notes(
-        allowed_script_roots: BTreeSet<NoteScriptRoot>,
+        mut allowed_script_roots: BTreeSet<NoteScriptRoot>,
     ) -> Result<Self, NetworkAccountNoteAllowlistError> {
+        allowed_script_roots.insert(NetworkAccountConfigNote::script_root());
         Ok(Self {
             allowed_notes: NetworkAccountNoteAllowlist::new(allowed_script_roots)?,
             allowed_tx_scripts: NetworkAccountTxScriptAllowlist::default(),
@@ -274,6 +260,7 @@ mod tests {
 
     use super::*;
     use crate::account::wallets::BasicWallet;
+    use crate::note::NetworkAccountConfigNote;
 
     #[test]
     fn auth_network_account_component_builds() {
@@ -291,9 +278,24 @@ mod tests {
     }
 
     #[test]
-    fn auth_network_account_with_empty_allowlist_is_rejected() {
-        let result = AuthNetworkAccount::with_allowed_notes(BTreeSet::new());
-        assert!(matches!(result, Err(NetworkAccountNoteAllowlistError::EmptyAllowlist)));
+    fn auth_network_account_with_empty_input_allowlists_only_config_note() {
+        let account = AccountBuilder::new([0; 32])
+            .with_auth_component(
+                AuthNetworkAccount::with_allowed_notes(BTreeSet::new())
+                    .expect("config note root makes the allowlist non-empty"),
+            )
+            .with_component(BasicWallet)
+            .build()
+            .expect("account building with AuthNetworkAccount failed");
+
+        let allowlist = NetworkAccountNoteAllowlist::try_from(account.storage())
+            .expect("allowlist should be reconstructable from account storage");
+
+        assert_eq!(
+            allowlist.allowed_script_roots(),
+            &BTreeSet::from_iter([NetworkAccountConfigNote::script_root()]),
+            "an empty input should yield an allowlist containing only the config note root",
+        );
     }
 
     #[test]
@@ -317,14 +319,13 @@ mod tests {
     }
 
     #[test]
-    fn with_allowlist_management_allowlists_action_note() {
-        use crate::note::NetworkAccountConfigNote;
-
+    fn auth_network_account_always_allowlists_config_note() {
         let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(AuthNetworkAccount::with_allowlist_management(
-                BTreeSet::from_iter([root_a]),
-            ))
+            .with_auth_component(
+                AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([root_a]))
+                    .expect("config note root makes the allowlist non-empty"),
+            )
             .with_component(BasicWallet)
             .build()
             .expect("account building with AuthNetworkAccount failed");
@@ -336,11 +337,11 @@ mod tests {
             allowlist
                 .allowed_script_roots()
                 .contains(&NetworkAccountConfigNote::script_root()),
-            "with_allowlist_management should allowlist the config note root",
+            "with_allowed_notes should always allowlist the config note root",
         );
         assert!(
             allowlist.allowed_script_roots().contains(&root_a),
-            "with_allowlist_management should preserve the existing allowlist entries",
+            "with_allowed_notes should preserve the provided allowlist entries",
         );
     }
 }

--- a/crates/miden-standards/src/account/auth/network_account/network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/network_account.rs
@@ -117,7 +117,10 @@ mod tests {
         let network_account = NetworkAccount::new(account).expect("should be a network account");
         let actual: BTreeSet<NoteScriptRoot> =
             network_account.allowed_notes().allowed_script_roots().iter().copied().collect();
-        assert_eq!(actual, roots);
+        // Every network account also allowlists the config note root by default.
+        let mut expected = roots;
+        expected.insert(crate::note::NetworkAccountConfigNote::script_root());
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/miden-standards/src/account/auth/network_account/network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/network_account.rs
@@ -117,7 +117,7 @@ mod tests {
         let network_account = NetworkAccount::new(account).expect("should be a network account");
         let actual: BTreeSet<NoteScriptRoot> =
             network_account.allowed_notes().allowed_script_roots().iter().copied().collect();
-        // Every network account also allowlists the config note root by default.
+
         let mut expected = roots;
         expected.insert(crate::note::NetworkAccountConfigNote::script_root());
         assert_eq!(actual, expected);

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -246,8 +246,10 @@ mod tests {
         let allowlist = NetworkAccountNoteAllowlist::try_from(account.storage())
             .expect("allowlist should be reconstructable from account storage");
 
-        // The map's ordering is determined by the StorageMapKey, so compare as sets.
-        let expected: BTreeSet<NoteScriptRoot> = original_roots.into_iter().collect();
+        // The map's ordering is determined by the StorageMapKey, so compare as sets. Every network
+        // account also allowlists the config note root by default.
+        let mut expected: BTreeSet<NoteScriptRoot> = original_roots.into_iter().collect();
+        expected.insert(crate::note::NetworkAccountConfigNote::script_root());
         let actual: BTreeSet<NoteScriptRoot> =
             allowlist.allowed_script_roots().iter().copied().collect();
 

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -246,8 +246,7 @@ mod tests {
         let allowlist = NetworkAccountNoteAllowlist::try_from(account.storage())
             .expect("allowlist should be reconstructable from account storage");
 
-        // The map's ordering is determined by the StorageMapKey, so compare as sets. Every network
-        // account also allowlists the config note root by default.
+        // The map's ordering is determined by the StorageMapKey, so compare as sets.
         let mut expected: BTreeSet<NoteScriptRoot> = original_roots.into_iter().collect();
         expected.insert(crate::note::NetworkAccountConfigNote::script_root());
         let actual: BTreeSet<NoteScriptRoot> =

--- a/crates/miden-standards/src/note/network_account_config.rs
+++ b/crates/miden-standards/src/note/network_account_config.rs
@@ -123,9 +123,9 @@ impl From<NetworkAccountConfig> for NoteStorage {
 /// component against the note sender.
 ///
 /// For the consuming network account to accept this note, its own script root must be in the
-/// account's note script allowlist; the
-/// [`AuthNetworkAccount::with_allowlist_management`](crate::account::auth::AuthNetworkAccount::with_allowlist_management)
-/// constructor allowlists it automatically.
+/// account's note script allowlist. Every
+/// [`AuthNetworkAccount`](crate::account::auth::AuthNetworkAccount) allowlists it by default at
+/// construction, so no extra setup is required.
 ///
 /// Construct one with the [builder](NetworkAccountConfigNote::builder); convert it into a
 /// protocol [`Note`] infallibly via `Note::from`.

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -326,12 +326,12 @@ fn build_owner_controlled_account(
     allowed_tx_script_roots: Vec<TransactionScriptRoot>,
     owner: AccountId,
 ) -> anyhow::Result<Account> {
-    // Enable allowlist management (allowlists the standardized config note so admin notes can be
-    // consumed) plus any extra note roots.
+    // `with_allowed_notes` always allowlists the standardized config note (so admin notes can be
+    // consumed) in addition to any extra note roots.
     let note_roots: BTreeSet<NoteScriptRoot> =
         extra_allowed_note_roots.into_iter().map(NoteScriptRoot::from_raw).collect();
 
-    let auth_component = AuthNetworkAccount::with_allowlist_management(note_roots)
+    let auth_component = AuthNetworkAccount::with_allowed_notes(note_roots)?
         .with_allowed_tx_scripts(BTreeSet::from_iter(allowed_tx_script_roots));
 
     Ok(AccountBuilder::new([7; 32])

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -326,8 +326,6 @@ fn build_owner_controlled_account(
     allowed_tx_script_roots: Vec<TransactionScriptRoot>,
     owner: AccountId,
 ) -> anyhow::Result<Account> {
-    // `with_allowed_notes` always allowlists the standardized config note (so admin notes can be
-    // consumed) in addition to any extra note roots.
     let note_roots: BTreeSet<NoteScriptRoot> =
         extra_allowed_note_roots.into_iter().map(NoteScriptRoot::from_raw).collect();
 


### PR DESCRIPTION
## Summary

Follow-up to [#3330](https://github.com/0xMiden/protocol/pull/3330) addressing review feedback that network accounts should come with allowlist management enabled **by default** rather than as an opt-in.

Every `AuthNetworkAccount` now allowlists the standardized `NetworkAccountConfigNote` script root at construction, so any network account can be managed post-deployment (adding/removing allowed note and tx script roots) without extra setup — provided it also composes an `Authority` component.

## Changes

- Folded the config-note default into the existing `AuthNetworkAccount::with_allowed_notes` constructor: it now inserts `NetworkAccountConfigNote::script_root()` into the provided set before building the allowlist.
- Removed the dedicated `with_allowlist_management` constructor (no longer needed).
- Kept `with_allowed_notes`' `-> Result<Self>` signature, so **no production caller changes** are required (faucets and the AggLayer bridge/faucet are untouched). It is now effectively infallible, since the config note root guarantees a non-empty allowlist.
- Updated docs and the tests that assert exact allowlist contents to account for the always-present config note root.

## Behavior note

Because faucets and the AggLayer bridge/faucet build their auth via `with_allowed_notes`, they now allowlist the config note too. This means:

- Their note allowlist (and therefore storage commitment / derived account ID) changes.
- An owner/RBAC admin on those accounts can now mutate the allowlist by sending a config note.

This is the intended effect of "management by default". On accounts without an `Authority` component, a config note is simply unusable (the gated mutation procedure panics), so it is harmless.

## Testing

- `miden-standards` lib: all pass (191).
- `miden-agglayer`: all pass (7).
- Full `miden-testing` integration suite: all pass (470) — including every AggLayer bridge/faucet test, confirming no deterministic account-ID or golden-value assertions broke.
- `clippy`, `cargo doc -D warnings`, and `cargo +nightly fmt --check` clean.