### PR TITLE
feat: replace `AccountBuilder::with_auth_component`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [BREAKING] Migrated the `miden-agglayer` library, components and note scripts to `miden-project.toml` projects ([#3306](https://github.com/0xMiden/protocol/pull/3306)). 
 - [BREAKING] Renamed the BATCH_FEE standard note to TX_FEE: `BatchFeeNote` is now `TxFeeNote`, `miden::standards::notes::batch_fee` is now `miden::standards::notes::tx_fee`, and `StandardNote::BATCH_FEE` is now `StandardNote::TX_FEE`. The `0xFEE` note tag value is unchanged ([#3314](https://github.com/0xMiden/protocol/pull/3314)).
 - [BREAKING] Network accounts (`AuthNetworkAccount`) and no-auth accounts (`NoAuth`) now pay the transaction fee in the native fee asset at rate 1/1, funded from the account's vault ([#2899](https://github.com/0xMiden/protocol/discussions/2899)).
+- [BREAKING] Removed `AccountBuilder::with_auth_component`; the authentication component is now passed like any other component via `with_component` or `with_components` ([#3378](https://github.com/0xMiden/protocol/issues/3378)).
 
 ## v0.16.0-alpha.4 (2026-07-16)
 

--- a/crates/miden-protocol/src/account/builder/mod.rs
+++ b/crates/miden-protocol/src/account/builder/mod.rs
@@ -29,10 +29,21 @@ use crate::{Felt, Word};
 /// - The `account_type` set to [`AccountType::Private`].
 /// - The `version` set to [`AccountIdVersion::Version1`].
 ///
-/// The methods that are required to be called are:
+/// [`AccountBuilder::with_component`] (or [`AccountBuilder::with_components`]) must be called at
+/// least once, and exactly one of the added components must be an authentication component (i.e. a
+/// component exporting a procedure marked with the `@auth_script` attribute). The auth component is
+/// identified and extracted automatically when [`AccountBuilder::build`] is called.
 ///
-/// - [`AccountBuilder::with_auth_component`],
-/// - [`AccountBuilder::with_component`], which must be called at least once.
+/// # Security
+///
+/// The builder only enforces the structural requirement of exactly one auth component; it does not
+/// check that the auth component is a sensible choice for the other components on the account. In
+/// particular, an auth component that performs no authentication makes the account permissionless:
+/// every state-changing procedure it exposes can be called by anyone. This is especially dangerous
+/// when combined with components that rely on the auth component as their sole access gate (such as
+/// authority-controlled setters), which then become permissionless as well. Higher-level factory
+/// functions vet these combinations; when building an account directly, the caller is responsible
+/// for pairing a suitable auth component with the account's other components.
 ///
 /// Under the `testing` feature, it is possible to:
 /// - Build an existing account using `AccountBuilder::build_existing`, which will set the account's
@@ -53,7 +64,6 @@ pub struct AccountBuilder {
     #[cfg(any(feature = "testing", test))]
     nonce: Option<Felt>,
     components: Vec<AccountComponent>,
-    auth_component: Option<AccountComponent>,
     account_type: AccountType,
     asset_callbacks: AssetCallbackFlag,
     init_seed: [u8; 32],
@@ -72,7 +82,6 @@ impl AccountBuilder {
             #[cfg(any(feature = "testing", test))]
             nonce: None,
             components: vec![],
-            auth_component: None,
             init_seed,
             account_type: AccountType::Private,
             asset_callbacks: AssetCallbackFlag::Disabled,
@@ -107,6 +116,9 @@ impl AccountBuilder {
     /// **must be called at least once** since an account must export at least one procedure.
     ///
     /// All components will be merged to form the final code and storage of the built account.
+    /// Exactly one of the added components must be an authentication component (see
+    /// [`AccountComponent::is_auth_component`]); it is identified and moved to the front of the
+    /// procedure list automatically when [`Self::build`] is called.
     ///
     /// For composite configurations that expand into multiple components (such as
     /// `AccessControl` or `TokenPolicyManager`), use [`Self::with_components`].
@@ -132,37 +144,9 @@ impl AccountBuilder {
         self
     }
 
-    /// Adds a designated authentication [`AccountComponent`] to the builder.
-    ///
-    /// This component may contain multiple procedures, but is expected to contain exactly one
-    /// authentication procedure (marked with the `@auth_script` attribute).
-    /// Calling this method multiple times will override the previous auth component.
-    ///
-    /// Procedures from this component will be placed at the beginning of the account procedure
-    /// list.
-    ///
-    /// # Security
-    ///
-    /// This only enforces the structural requirement above; it does not check that the auth
-    /// component is a sensible choice for the other components on the account. In particular, an
-    /// auth component that performs no authentication makes the account permissionless: every
-    /// state-changing procedure it exposes can be called by anyone. This is especially dangerous
-    /// when combined with components that rely on the auth component as their sole access gate
-    /// (such as authority-controlled setters), which then become permissionless as well.
-    /// Higher-level factory functions vet these combinations; when building an account
-    /// directly, the caller is responsible for pairing a suitable auth component with the
-    /// account's other components.
-    pub fn with_auth_component(mut self, account_component: impl Into<AccountComponent>) -> Self {
-        self.auth_component = Some(account_component.into());
-        self
-    }
-
     /// Returns an iterator of storage schemas attached to the builder's components.
     pub fn storage_schemas(&self) -> impl Iterator<Item = &StorageSchema> + '_ {
-        self.auth_component
-            .iter()
-            .chain(self.components.iter())
-            .map(|component| component.storage_schema())
+        self.components.iter().map(|component| component.storage_schema())
     }
 
     /// Builds the common parts of testing and non-testing code.
@@ -175,14 +159,8 @@ impl AccountBuilder {
         #[cfg(all(not(feature = "testing"), not(test)))]
         let vault = AssetVault::default();
 
-        let auth_component = self
-            .auth_component
-            .take()
-            .ok_or(AccountError::BuildError("auth component must be set".into(), None))?;
-
-        let mut components = vec![auth_component];
-        components.append(&mut self.components);
-
+        // The build method does not access components, so it is safe to `take` them out.
+        let components = core::mem::take(&mut self.components);
         let (code, storage) = Account::initialize_from_components(components).map_err(|err| {
             AccountError::BuildError(
                 "account components failed to build".into(),
@@ -415,7 +393,7 @@ mod tests {
         let storage_slot2 = 42;
 
         let account = Account::builder([5; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(CustomComponent1 { slot0: storage_slot0 })
             .with_component(CustomComponent2 {
                 slot0: storage_slot1,
@@ -479,7 +457,7 @@ mod tests {
         ];
 
         let account = Account::builder([5; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_components(components)
             .build()
             .unwrap();
@@ -487,7 +465,7 @@ mod tests {
         // The account built via `with_components` should be identical to one built via
         // chained `with_component` calls in the same order.
         let expected = Account::builder([5; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(CustomComponent1 { slot0: storage_slot0 })
             .with_component(CustomComponent2 {
                 slot0: storage_slot1,
@@ -502,14 +480,14 @@ mod tests {
 
         // Empty iterators are accepted and behave as a no-op.
         let account_no_extra = Account::builder([6; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(CustomComponent1 { slot0: storage_slot0 })
             .with_components(core::iter::empty::<CustomComponent2>())
             .build()
             .unwrap();
 
         let expected_no_extra = Account::builder([6; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(CustomComponent1 { slot0: storage_slot0 })
             .build()
             .unwrap();
@@ -518,11 +496,59 @@ mod tests {
     }
 
     #[test]
+    fn account_builder_auth_component_position_is_irrelevant() {
+        let component1 = CustomComponent1 { slot0: 25 };
+        let component2 = CustomComponent2 { slot0: 12, slot1: 42 };
+        let common_components =
+            vec![AccountComponent::from(component1), AccountComponent::from(component2)];
+
+        let mut components_auth_1st = common_components.clone();
+        components_auth_1st.insert(0, AccountComponent::from(NoopAuthComponent));
+
+        let mut components_auth_2nd = common_components.clone();
+        components_auth_2nd.insert(1, AccountComponent::from(NoopAuthComponent));
+
+        let seed = [5; 32];
+        let auth_1st = Account::builder(seed).with_components(components_auth_1st).build().unwrap();
+        let auth_2nd = Account::builder(seed).with_components(components_auth_2nd).build().unwrap();
+
+        assert_eq!(auth_1st.id(), auth_2nd.id());
+        assert_eq!(auth_1st.code().commitment(), auth_2nd.code().commitment());
+        assert_eq!(auth_1st.storage().to_commitment(), auth_2nd.storage().to_commitment());
+    }
+
+    #[test]
+    fn account_builder_without_auth_component_fails() {
+        let build_error = Account::builder([5; 32])
+            .with_component(CustomComponent1 { slot0: 25 })
+            .build()
+            .unwrap_err();
+
+        assert_matches!(build_error, AccountError::BuildError(_, Some(source)) => {
+            assert_matches!(*source, AccountError::AccountCodeNoAuthComponent);
+        });
+    }
+
+    #[test]
+    fn account_builder_with_multiple_auth_components_fails() {
+        let build_error = Account::builder([5; 32])
+            .with_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
+            .with_component(CustomComponent1 { slot0: 25 })
+            .build()
+            .unwrap_err();
+
+        assert_matches!(build_error, AccountError::BuildError(_, Some(source)) => {
+            assert_matches!(*source, AccountError::AccountCodeMultipleAuthComponents);
+        });
+    }
+
+    #[test]
     fn account_builder_non_empty_vault_on_new_account() {
         let storage_slot0 = 25;
 
         let build_error = Account::builder([0xff; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(CustomComponent1 { slot0: storage_slot0 })
             .with_assets(AssetVault::mock().assets())
             .build()

--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -141,14 +141,21 @@ impl AccountCode {
         let package_debug_info = merge_component_debug_info(components, &root_map)?;
 
         let mut builder = AccountProcedureBuilder::new();
-        let mut components_iter = components.iter();
+        let mut num_auth_components = 0;
 
-        let first_component =
-            components_iter.next().ok_or(AccountError::AccountCodeNoAuthComponent)?;
-        builder.add_auth_component(first_component)?;
+        for component in components {
+            if component.is_auth_component() {
+                num_auth_components += 1;
+                builder.add_auth_component(component)?
+            } else {
+                builder.add_component(component)?;
+            }
+        }
 
-        for component in components_iter {
-            builder.add_component(component)?;
+        if num_auth_components == 0 {
+            return Err(AccountError::AccountCodeNoAuthComponent);
+        } else if num_auth_components > 1 {
+            return Err(AccountError::AccountCodeMultipleAuthComponents);
         }
 
         let procedures = builder.build()?;

--- a/crates/miden-protocol/src/account/component/mod.rs
+++ b/crates/miden-protocol/src/account/component/mod.rs
@@ -209,6 +209,12 @@ impl AccountComponent {
     pub fn has_procedure(&self, root: AccountProcedureRoot) -> bool {
         self.procedures().any(|(proc_root, _)| proc_root == root)
     }
+
+    /// Returns `true` if this component exports an authentication procedure (a procedure marked
+    /// with the `@auth_script` attribute).
+    pub fn is_auth_component(&self) -> bool {
+        self.procedures().any(|(_, is_auth)| is_auth)
+    }
 }
 
 impl From<AccountComponent> for AccountComponentCode {

--- a/crates/miden-protocol/src/account/interface/code_interface.rs
+++ b/crates/miden-protocol/src/account/interface/code_interface.rs
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn account_code_interface_matches_code_procedures() -> anyhow::Result<()> {
         let account = AccountBuilder::new([7; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(AddComponent)
             .build()?;
 
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn partial_account_code_interface_matches_code_procedures() -> anyhow::Result<()> {
         let account = AccountBuilder::new([8; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(AddComponent)
             .build()?;
         let partial = PartialAccount::from(&account);

--- a/crates/miden-protocol/src/account/mod.rs
+++ b/crates/miden-protocol/src/account/mod.rs
@@ -860,7 +860,7 @@ mod tests {
     #[test]
     fn seed_validation() -> anyhow::Result<()> {
         let account = AccountBuilder::new([5; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(AddComponent)
             .build()?;
         let (id, vault, storage, code, _nonce, seed) = account.into_parts();
@@ -925,7 +925,7 @@ mod tests {
     #[test]
     fn incrementing_nonce_should_remove_seed() -> anyhow::Result<()> {
         let mut account = AccountBuilder::new([5; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(AddComponent)
             .build()?;
         account.increment_nonce(Felt::ONE)?;

--- a/crates/miden-protocol/src/transaction/proven_tx.rs
+++ b/crates/miden-protocol/src/transaction/proven_tx.rs
@@ -630,7 +630,7 @@ mod tests {
         // A small account's delta does not exceed the limit.
         let account = Account::builder([9; 32])
             .account_type(AccountType::Public)
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(AddComponent)
             .build_existing()?;
         let patch = AccountPatch::try_from(account.clone())?;
@@ -697,7 +697,7 @@ mod tests {
     fn account_update_id_mismatch_between_account_id_and_patch() -> anyhow::Result<()> {
         let patch_account = Account::builder([9; 32])
             .account_type(AccountType::Public)
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(AddComponent)
             .build_existing()?;
         let patch = AccountPatch::try_from(patch_account.clone())?;

--- a/crates/miden-standards/src/account/auth/guarded_multisig.rs
+++ b/crates/miden-standards/src/account/auth/guarded_multisig.rs
@@ -404,7 +404,7 @@ mod tests {
 
         // Build account with guarded multisig component.
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(multisig_component)
+            .with_component(multisig_component)
             .with_component(BasicWallet)
             .build()
             .expect("account building failed");
@@ -481,7 +481,7 @@ mod tests {
         .expect("guarded multisig component creation failed");
 
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(multisig_component)
+            .with_component(multisig_component)
             .with_component(BasicWallet)
             .build()
             .expect("account building failed");

--- a/crates/miden-standards/src/account/auth/multisig.rs
+++ b/crates/miden-standards/src/account/auth/multisig.rs
@@ -484,7 +484,7 @@ mod tests {
 
         // Build account with multisig component
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(multisig_component)
+            .with_component(multisig_component)
             .with_component(BasicWallet)
             .build()
             .expect("account building failed");
@@ -534,7 +534,7 @@ mod tests {
             .expect("multisig component creation failed");
 
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(multisig_component)
+            .with_component(multisig_component)
             .with_component(BasicWallet)
             .build()
             .expect("account building failed");

--- a/crates/miden-standards/src/account/auth/multisig_smart/component.rs
+++ b/crates/miden-standards/src/account/auth/multisig_smart/component.rs
@@ -299,7 +299,7 @@ mod tests {
             AuthMultisigSmart::new(config).expect("multisig smart component creation failed");
 
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(component)
+            .with_component(component)
             .with_component(BasicWallet)
             .build()
             .expect("account building failed");

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -278,7 +278,7 @@ mod tests {
         let root_b = NoteScriptRoot::from_array([5, 6, 7, 8]);
 
         let _account = AccountBuilder::new([0; 32])
-            .with_auth_component(
+            .with_component(
                 AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([root_a, root_b]))
                     .expect("non-empty allowlist should construct"),
             )
@@ -290,7 +290,7 @@ mod tests {
     #[test]
     fn auth_network_account_with_empty_input_allowlists_only_config_note() {
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(
+            .with_component(
                 AuthNetworkAccount::with_allowed_notes(BTreeSet::new())
                     .expect("config note root makes the allowlist non-empty"),
             )
@@ -332,7 +332,7 @@ mod tests {
     fn auth_network_account_always_allowlists_config_note() {
         let root_a = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(
+            .with_component(
                 AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([root_a]))
                     .expect("config note root makes the allowlist non-empty"),
             )

--- a/crates/miden-standards/src/account/auth/network_account/network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/network_account.rs
@@ -106,7 +106,7 @@ impl NetworkAccount {
 
         Ok(AccountBuilder::new(init_seed)
             .account_type(AccountType::Public)
-            .with_auth_component(auth_component))
+            .with_component(auth_component))
     }
 
     /// Consumes `self` and returns the underlying [`Account`].
@@ -194,7 +194,7 @@ mod tests {
     fn build_account(account_type: AccountType, roots: BTreeSet<NoteScriptRoot>) -> Account {
         AccountBuilder::new([0; 32])
             .account_type(account_type)
-            .with_auth_component(
+            .with_component(
                 AuthNetworkAccount::with_allowed_notes(roots)
                     .expect("non-empty allowlist")
                     .with_allowed_tx_scripts(
@@ -238,7 +238,7 @@ mod tests {
     fn public_account_without_allowlist_is_not_a_network_account() {
         let account = AccountBuilder::new([0; 32])
             .account_type(AccountType::Public)
-            .with_auth_component(crate::account::auth::NoAuth)
+            .with_component(crate::account::auth::NoAuth)
             .with_component(BasicWallet)
             .build()
             .expect("account building should succeed");
@@ -257,7 +257,7 @@ mod tests {
         let note_root = NoteScriptRoot::from_array([1, 2, 3, 4]);
         let account = AccountBuilder::new([0; 32])
             .account_type(AccountType::Public)
-            .with_auth_component(
+            .with_component(
                 AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([note_root]))
                     .expect("non-empty allowlist"),
             )

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -232,7 +232,7 @@ mod tests {
         let original_roots = BTreeSet::from_iter([root_a, root_b, root_c]);
 
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(
+            .with_component(
                 AuthNetworkAccount::with_allowed_notes(original_roots.clone())
                     .expect("non-empty allowlist should construct"),
             )

--- a/crates/miden-standards/src/account/auth/network_account/tx_script_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/tx_script_allowlist.rs
@@ -205,7 +205,7 @@ mod tests {
         let original_roots = BTreeSet::from_iter([root_a, root_b]);
 
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(
+            .with_component(
                 AuthNetworkAccount::with_allowed_notes(BTreeSet::from_iter([
                     miden_protocol::note::NoteScriptRoot::from_array([9, 9, 9, 9]),
                 ]))

--- a/crates/miden-standards/src/account/auth/no_auth.rs
+++ b/crates/miden-standards/src/account/auth/no_auth.rs
@@ -77,7 +77,7 @@ mod tests {
     fn test_no_auth_component() {
         // Create an account using the NoAuth component
         let _account = AccountBuilder::new([0; 32])
-            .with_auth_component(NoAuth)
+            .with_component(NoAuth)
             .with_component(BasicWallet)
             .build()
             .expect("account building failed");

--- a/crates/miden-standards/src/account/auth/singlesig_acl.rs
+++ b/crates/miden-standards/src/account/auth/singlesig_acl.rs
@@ -291,7 +291,7 @@ mod tests {
         let component = AuthSingleSigAcl::new(Approver::new(public_key, auth_scheme), acl_config);
 
         let account = AccountBuilder::new([0; 32])
-            .with_auth_component(component)
+            .with_component(component)
             .with_component(BasicWallet)
             .build()
             .expect("account building failed");

--- a/crates/miden-standards/src/account/faucets/fungible/mod.rs
+++ b/crates/miden-standards/src/account/faucets/fungible/mod.rs
@@ -573,7 +573,7 @@ pub fn create_singlesig_user_fungible_faucet(
     AccountBuilder::new(init_seed)
         .account_type(account_type)
         .with_asset_callbacks(asset_callbacks)
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(faucet)
         .with_component(Authority::AuthControlled)
         .with_components(token_policy_manager)
@@ -593,7 +593,7 @@ pub fn create_multisig_user_fungible_faucet(
 ) -> Result<Account, FungibleFaucetError> {
     AccountBuilder::new(init_seed)
         .account_type(account_type)
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(faucet)
         .with_component(Authority::AuthControlled)
         .with_components(token_policy_manager)
@@ -613,7 +613,7 @@ pub fn create_guarded_user_fungible_faucet(
 ) -> Result<Account, FungibleFaucetError> {
     AccountBuilder::new(init_seed)
         .account_type(account_type)
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(faucet)
         .with_component(Authority::AuthControlled)
         .with_components(token_policy_manager)

--- a/crates/miden-standards/src/account/faucets/fungible/tests.rs
+++ b/crates/miden-standards/src/account/faucets/fungible/tests.rs
@@ -271,7 +271,7 @@ fn faucet_create_from_account() {
 
     let faucet_account = AccountBuilder::new(mock_seed)
         .with_component(faucet)
-        .with_auth_component(AuthSingleSig::new(Approver::new(
+        .with_component(AuthSingleSig::new(Approver::new(
             mock_public_key,
             AuthScheme::Falcon512Poseidon2,
         )))
@@ -283,7 +283,7 @@ fn faucet_create_from_account() {
 
     // invalid account: fungible faucet component is missing
     let invalid_faucet_account = AccountBuilder::new(mock_seed)
-        .with_auth_component(AuthSingleSig::new(Approver::new(
+        .with_component(AuthSingleSig::new(Approver::new(
             mock_public_key,
             AuthScheme::Falcon512Poseidon2,
         )))

--- a/crates/miden-standards/src/account/faucets/non_fungible/mod.rs
+++ b/crates/miden-standards/src/account/faucets/non_fungible/mod.rs
@@ -493,7 +493,7 @@ pub fn create_user_non_fungible_faucet(
 ) -> Result<Account, NonFungibleFaucetError> {
     AccountBuilder::new(init_seed)
         .account_type(account_type)
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(faucet)
         .with_component(Authority::AuthControlled)
         .with_components(token_policy_manager)

--- a/crates/miden-standards/src/account/fees/policies/constant_fee.rs
+++ b/crates/miden-standards/src/account/fees/policies/constant_fee.rs
@@ -214,7 +214,7 @@ mod tests {
 
         let account = AccountBuilder::new([1; 32])
             .account_type(AccountType::Public)
-            .with_auth_component(NoAuth)
+            .with_component(NoAuth)
             .with_components(fee_manager)
             .build_existing()?;
 

--- a/crates/miden-standards/src/account/inspection/code_inspection.rs
+++ b/crates/miden-standards/src/account/inspection/code_inspection.rs
@@ -147,7 +147,7 @@ mod tests {
     fn account_exposes_code_inspection_procedures() -> anyhow::Result<()> {
         let account = AccountBuilder::new([1; 32])
             .account_type(AccountType::Public)
-            .with_auth_component(NoAuth)
+            .with_component(NoAuth)
             .with_component(CodeInspection)
             .build_existing()?;
 

--- a/crates/miden-standards/src/account/inspection/schema_commitment.rs
+++ b/crates/miden-standards/src/account/inspection/schema_commitment.rs
@@ -243,13 +243,13 @@ mod tests {
         let component_b = AccountSchemaCommitment::new(&[schema_b, schema_a]).unwrap();
 
         let account_a = AccountBuilder::new([1u8; 32])
-            .with_auth_component(NoAuth)
+            .with_component(NoAuth)
             .with_component(component_a)
             .build()
             .unwrap();
 
         let account_b = AccountBuilder::new([2u8; 32])
-            .with_auth_component(NoAuth)
+            .with_component(NoAuth)
             .with_component(component_b)
             .build()
             .unwrap();
@@ -276,7 +276,7 @@ mod tests {
         ));
 
         let account = AccountBuilder::new([1u8; 32])
-            .with_auth_component(auth_component)
+            .with_component(auth_component)
             .build_with_schema_commitment()
             .unwrap();
 

--- a/crates/miden-standards/src/account/interface/test.rs
+++ b/crates/miden-standards/src/account/interface/test.rs
@@ -57,7 +57,7 @@ fn get_mock_falcon_auth_component() -> AuthSingleSig {
 fn test_account_interface_identifies_single_sig_auth() {
     let mock_seed = Word::from([0, 1, 2, 3u32]).as_bytes();
     let wallet_account = AccountBuilder::new(mock_seed)
-        .with_auth_component(get_mock_falcon_auth_component())
+        .with_component(get_mock_falcon_auth_component())
         .with_component(BasicWallet)
         .build_existing()
         .expect("failed to create wallet account");
@@ -74,7 +74,7 @@ fn test_account_interface_identifies_single_sig_auth() {
 fn test_account_interface_identifies_no_auth() {
     let mock_seed = Word::from([0, 1, 2, 3u32]).as_bytes();
     let no_auth_account = AccountBuilder::new(mock_seed)
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(BasicWallet)
         .build_existing()
         .expect("failed to create no-auth account");
@@ -98,7 +98,7 @@ fn test_basic_wallet_is_not_an_auth_component() {
 fn test_public_key_extraction_regular_account() {
     let mock_seed = Word::from([0, 1, 2, 3u32]).as_bytes();
     let wallet_account = AccountBuilder::new(mock_seed)
-        .with_auth_component(get_mock_falcon_auth_component())
+        .with_component(get_mock_falcon_auth_component())
         .with_component(BasicWallet)
         .build_existing()
         .expect("failed to create wallet account");
@@ -132,7 +132,7 @@ fn test_public_key_extraction_multisig_account() {
 
     let mock_seed = Word::from([0, 1, 2, 3u32]).as_bytes();
     let multisig_account = AccountBuilder::new(mock_seed)
-        .with_auth_component(multisig_component)
+        .with_component(multisig_component)
         .with_component(BasicWallet)
         .build_existing()
         .expect("failed to create multisig account");
@@ -149,7 +149,7 @@ fn test_public_key_extraction_multisig_account() {
 fn test_public_key_extraction_no_auth_account() {
     let mock_seed = Word::from([0, 1, 2, 3u32]).as_bytes();
     let no_auth_account = AccountBuilder::new(mock_seed)
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(BasicWallet)
         .build_existing()
         .expect("failed to create no-auth account");

--- a/crates/miden-standards/src/account/wallets/mod.rs
+++ b/crates/miden-standards/src/account/wallets/mod.rs
@@ -219,7 +219,7 @@ fn create_wallet(
 ) -> Result<Account, AccountError> {
     AccountBuilder::new(init_seed)
         .account_type(account_type)
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(BasicWallet)
         .build()
 }

--- a/crates/miden-standards/src/testing/mock_account.rs
+++ b/crates/miden-standards/src/testing/mock_account.rs
@@ -19,7 +19,7 @@ pub trait MockAccountExt {
     fn mock(account_id: u128, auth: impl Into<AccountComponent>) -> Account {
         let account_id = AccountId::try_from(account_id).unwrap();
         let account = AccountBuilder::new([1; 32])
-            .with_auth_component(auth)
+            .with_component(auth)
             .with_component(MockAccountComponent::with_slots(AccountStorage::mock_storage_slots()))
             .with_assets(AssetVault::mock().assets())
             .build_existing()
@@ -34,7 +34,7 @@ pub trait MockAccountExt {
         let account_id = AccountId::try_from(account_id).unwrap();
 
         let account = AccountBuilder::new([1; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(MockFaucetComponent)
             .build_existing()
             .expect("account should be valid");
@@ -48,7 +48,7 @@ pub trait MockAccountExt {
         let account_id = AccountId::try_from(account_id).unwrap();
 
         let account = AccountBuilder::new([1; 32])
-            .with_auth_component(NoopAuthComponent)
+            .with_component(NoopAuthComponent)
             .with_component(MockFaucetComponent)
             .build_existing()
             .expect("account should be valid");

--- a/crates/miden-testing/src/kernel_tests/block/header_errors.rs
+++ b/crates/miden-testing/src/kernel_tests/block/header_errors.rs
@@ -263,7 +263,7 @@ async fn block_building_fails_on_creating_account_with_existing_account_id_prefi
     let auth_component: AccountComponent = IncrNonceAuthComponent.into();
 
     let account = AccountBuilder::new([5; 32])
-        .with_auth_component(auth_component.clone())
+        .with_component(auth_component.clone())
         .with_component(MockAccountComponent::with_slots(vec![StorageSlot::with_value(
             StorageSlotName::new("miden::test_slot")?,
             Word::from([5u32; 4]),
@@ -354,7 +354,7 @@ async fn block_building_fails_on_creating_account_with_duplicate_account_id_pref
     // --------------------------------------------------------------------------------------------
     let mock_chain = MockChain::new();
     let account = AccountBuilder::new([5; 32])
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![StorageSlot::with_value(
             StorageSlotName::new("miden::test_slot")?,
             Word::from([5u32; 4]),

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -490,7 +490,7 @@ async fn test_get_item() -> anyhow::Result<()> {
 async fn test_get_map_item() -> anyhow::Result<()> {
     let slot = AccountStorage::mock_map_slot();
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![slot.clone()]))
         .build_existing()
         .unwrap();
@@ -755,7 +755,7 @@ async fn test_set_map_item() -> anyhow::Result<()> {
 
     let slot = AccountStorage::mock_map_slot();
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![slot.clone()]))
         .build_existing()
         .unwrap();
@@ -831,7 +831,7 @@ async fn test_set_map_item() -> anyhow::Result<()> {
 #[tokio::test]
 async fn create_account_with_empty_storage_slots() -> anyhow::Result<()> {
     let account = AccountBuilder::new([5; 32])
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .build()
         .context("failed to build account")?;
@@ -1020,7 +1020,7 @@ async fn prove_account_creation_with_non_empty_storage() -> anyhow::Result<()> {
 
     let account = AccountBuilder::new([6; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![
             slot0.clone(),
             slot1.clone(),
@@ -1561,7 +1561,7 @@ async fn test_was_procedure_called() -> anyhow::Result<()> {
     // Create a standard account using the mock component
     let mock_component = MockAccountComponent::with_slots(AccountStorage::mock_storage_slots());
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(mock_component)
         .build_existing()
         .unwrap();
@@ -1706,7 +1706,7 @@ async fn transaction_executor_account_code_using_custom_library() -> anyhow::Res
 
     // Build an existing account with nonce 1.
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(account_component)
         .build_existing()?;
 
@@ -1757,7 +1757,7 @@ async fn incrementing_nonce_twice_fails() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("test::faulty_auth"),
     )?;
     let account = AccountBuilder::new([5; 32])
-        .with_auth_component(faulty_auth_component)
+        .with_component(faulty_auth_component)
         .with_component(MockAccountComponent::with_empty_slots())
         .build()
         .context("failed to build account")?;
@@ -1774,7 +1774,7 @@ async fn test_has_procedure() -> anyhow::Result<()> {
     // Create a standard account using the mock component
     let mock_component = MockAccountComponent::with_slots(AccountStorage::mock_storage_slots());
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(mock_component)
         .build_existing()
         .unwrap();
@@ -1930,7 +1930,7 @@ async fn test_get_initial_item() -> anyhow::Result<()> {
 async fn test_get_initial_map_item() -> anyhow::Result<()> {
     let map_slot = AccountStorage::mock_map_slot();
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![map_slot.clone()]))
         .build_existing()
         .unwrap();
@@ -2020,7 +2020,7 @@ async fn test_get_item_and_get_initial_item_for_all_slots() -> anyhow::Result<()
         .collect();
 
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(slots.clone()))
         .build_existing()
         .unwrap();
@@ -2089,7 +2089,7 @@ async fn test_get_item_and_get_initial_item_for_all_slots() -> anyhow::Result<()
 #[tokio::test]
 async fn incrementing_nonce_overflow_fails() -> anyhow::Result<()> {
     let mut account = AccountBuilder::new([42; 32])
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .build_existing()
         .context("failed to build account")?;
@@ -2207,7 +2207,7 @@ async fn merging_components_with_same_mast_root_succeeds() -> anyhow::Result<()>
     let slot = StorageSlot::with_value(TEST_SLOT_NAME.clone(), slot_content1);
 
     let account = AccountBuilder::new([42; 32])
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(CustomComponent1 { slot: slot.clone() })
         .with_component(CustomComponent2)
         .build()

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
@@ -712,7 +712,7 @@ async fn proven_tx_storage_maps_matches_executed_tx_for_new_account() -> anyhow:
     // Build a public account so the proven transaction includes the account update.
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(delta_check_auth_component())
+        .with_component(delta_check_auth_component())
         .with_component(MockAccountComponent::with_slots(vec![
             AccountStorage::mock_value_slot0(),
             StorageSlot::with_map(map0_slot_name.clone(), map0.clone()),
@@ -838,7 +838,7 @@ async fn patch_for_new_account_retains_empty_value_storage_slots() -> anyhow::Re
             StorageSlot::with_empty_value(slot_name0.clone()),
             StorageSlot::with_value(slot_name1.clone(), slot_value2),
         ]))
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .build()?;
 
     let tx = TestTransactionBuilder::new(account.clone()).build()?.execute().await?;
@@ -886,7 +886,7 @@ async fn patch_for_new_account_retains_empty_map_storage_slots() -> anyhow::Resu
             StorageSlot::with_empty_map(slot_name0.clone()),
             StorageSlot::with_empty_map(slot_name1.clone()),
         ]))
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .build()?;
 
     let map_key = StorageMapKey::from_array([1, 2, 3, 4u32]);
@@ -1068,7 +1068,7 @@ async fn recomputing_delta_resets_host_delta() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let account = Account::builder(builder.rng_mut().random())
         .account_type(AccountType::Public)
-        .with_auth_component(AccountComponent::new(
+        .with_component(AccountComponent::new(
             auth_component_code,
             vec![],
             AccountComponentMetadata::new("test::account"),
@@ -1271,7 +1271,7 @@ impl AccountUpdateTest {
         let mut builder = MockChain::builder();
         let account = Account::builder(builder.rng_mut().random())
             .account_type(AccountType::Public)
-            .with_auth_component(delta_check_auth_component())
+            .with_component(delta_check_auth_component())
             .with_component(MockAccountComponent::with_slots(initial_storage_slots))
             .with_assets(initial_vault_assets)
             .build_existing()?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_array.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_array.rs
@@ -74,7 +74,7 @@ async fn test_array_get_and_set() -> anyhow::Result<()> {
 
     // Build an account with the wrapper component that uses the array utility
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(wrapper_component)
         .build_existing()?;
 
@@ -194,7 +194,7 @@ async fn test_double_word_array_get_and_set() -> anyhow::Result<()> {
     )?;
 
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(wrapper_component)
         .build_existing()?;
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_auth.rs
@@ -74,7 +74,7 @@ async fn test_auth_procedure_called_from_wrong_context() -> anyhow::Result<()> {
     let (auth_component, _) = Auth::IncrNonce.build_component();
 
     let account = AccountBuilder::new([42; 32])
-        .with_auth_component(auth_component.clone())
+        .with_component(auth_component.clone())
         .with_component(BasicWallet)
         .build_existing()?;
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -701,7 +701,7 @@ fn setup_non_faucet_account() -> anyhow::Result<Account> {
     let metadata = AccountComponentMetadata::new("test::non_faucet_component");
     let faucet_component = AccountComponent::new(faucet_code, vec![], metadata)?;
     Ok(AccountBuilder::new([4; 32])
-        .with_auth_component(NoopAuthComponent)
+        .with_component(NoopAuthComponent)
         .with_component(faucet_component)
         .build_existing()?)
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -101,12 +101,12 @@ async fn test_fpi_memory_single_account() -> anyhow::Result<()> {
     )?;
 
     let foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component)
         .build_existing()?;
 
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![AccountStorage::mock_map_slot()]))
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -373,17 +373,17 @@ async fn test_fpi_memory_two_accounts() -> anyhow::Result<()> {
     )?;
 
     let foreign_account_1 = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component_1)
         .build_existing()?;
 
     let foreign_account_2 = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component_2)
         .build_existing()?;
 
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -608,12 +608,12 @@ async fn test_fpi_execute_foreign_procedure() -> anyhow::Result<()> {
     )?;
 
     let foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;
 
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -797,13 +797,13 @@ async fn foreign_account_can_get_balance_and_presence_of_asset() -> anyhow::Resu
     )?;
 
     let foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .with_assets(vec![fungible_asset, non_fungible_asset])
         .build_existing()?;
 
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -943,7 +943,7 @@ async fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
     )?;
 
     let second_foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(second_foreign_account_component)
         .build_existing()?;
 
@@ -1007,13 +1007,13 @@ async fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
     )?;
 
     let first_foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(first_foreign_account_component.clone())
         .build_existing()?;
 
     // ------ NATIVE ACCOUNT ---------------------------------------------------------------
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -1140,7 +1140,7 @@ async fn test_prove_fpi_two_foreign_accounts_chain() -> anyhow::Result<()> {
     )?;
 
     let second_foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(second_foreign_account_component.clone())
         .build_existing()?;
 
@@ -1187,13 +1187,13 @@ async fn test_prove_fpi_two_foreign_accounts_chain() -> anyhow::Result<()> {
     )?;
 
     let first_foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(first_foreign_account_component.clone())
         .build_existing()?;
 
     // ------ NATIVE ACCOUNT ---------------------------------------------------------------
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -1316,7 +1316,7 @@ async fn test_nested_fpi_stack_overflow() -> anyhow::Result<()> {
     .unwrap();
 
     let last_foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(last_foreign_account_component)
         .build_existing()
         .unwrap();
@@ -1369,7 +1369,7 @@ async fn test_nested_fpi_stack_overflow() -> anyhow::Result<()> {
         .unwrap();
 
         let foreign_account = AccountBuilder::new(rand::random())
-            .with_auth_component(Auth::IncrNonce)
+            .with_component(Auth::IncrNonce)
             .with_component(foreign_account_component)
             .build_existing()
             .unwrap();
@@ -1379,7 +1379,7 @@ async fn test_nested_fpi_stack_overflow() -> anyhow::Result<()> {
 
     // ------ NATIVE ACCOUNT ---------------------------------------------------------------
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()
@@ -1485,13 +1485,13 @@ async fn test_nested_fpi_native_account_invocation() -> anyhow::Result<()> {
     )?;
 
     let foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;
 
     // ------ NATIVE ACCOUNT ---------------------------------------------------------------
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -1586,12 +1586,12 @@ async fn test_fpi_stale_account() -> anyhow::Result<()> {
     )?;
 
     let mut foreign_account = AccountBuilder::new([5; 32])
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component)
         .build_existing()?;
 
     let native_account = AccountBuilder::new([4; 32])
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![AccountStorage::mock_map_slot()]))
         .build_existing()?;
 
@@ -1695,12 +1695,12 @@ async fn test_fpi_get_account_id() -> anyhow::Result<()> {
     )?;
 
     let foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;
 
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -1784,7 +1784,7 @@ async fn test_fpi_get_account_id() -> anyhow::Result<()> {
 #[tokio::test]
 async fn get_initial_item_fails_for_foreign_account() -> anyhow::Result<()> {
     let native_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -1817,7 +1817,7 @@ async fn get_initial_item_fails_for_foreign_account() -> anyhow::Result<()> {
     )?;
 
     let foreign_account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(foreign_account_component.clone())
         .build_existing()?;
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -534,7 +534,7 @@ fn input_notes_memory_assertions(
 async fn create_simple_account() -> anyhow::Result<()> {
     let account = AccountBuilder::new([6; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_empty_slots())
         .build()?;
 
@@ -568,7 +568,7 @@ pub async fn create_multiple_accounts_test(account_type: AccountType) -> anyhow:
 
     let account = AccountBuilder::new(rand::random())
         .account_type(account_type)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(MockAccountComponent::with_slots(vec![StorageSlot::with_value(
             StorageSlotName::mock(0),
             Word::from([255u32; WORD_SIZE]),
@@ -602,7 +602,7 @@ pub async fn create_account_invalid_seed() -> anyhow::Result<()> {
     mock_chain.prove_next_block()?;
 
     let account = AccountBuilder::new(rand::random())
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .build()?;
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -484,7 +484,7 @@ async fn user_code_can_abort_transaction_with_summary() -> anyhow::Result<()> {
 
     let account = AccountBuilder::new([42; 32])
         .account_type(AccountType::Private)
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(BasicWallet)
         .build_existing()
         .context("failed to build account")?;

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -643,7 +643,7 @@ impl MockChainBuilder {
         account_state: AccountState,
     ) -> anyhow::Result<Account> {
         let (auth_component, authenticator) = auth_method.build_component();
-        account_builder = account_builder.with_auth_component(auth_component);
+        account_builder = account_builder.with_component(auth_component);
 
         let account = if let AccountState::New = account_state {
             account_builder.build().context("failed to build account from builder")?

--- a/crates/miden-testing/src/standards/account_upgrade.rs
+++ b/crates/miden-testing/src/standards/account_upgrade.rs
@@ -33,7 +33,7 @@ async fn test_upgrade_manager_stores_commitments_when_authorized() -> anyhow::Re
     // procedure, plus the network-account auth component (unused by `execute_code`, but
     // representative).
     let account = AccountBuilder::new([42; 32])
-        .with_auth_component(AuthNetworkAccount::with_allowed_notes(
+        .with_component(AuthNetworkAccount::with_allowed_notes(
             [placeholder_script_root()].into_iter().collect(),
         )?)
         .with_components(AccessControl::Ownable2Step { owner })

--- a/crates/miden-testing/src/standards/token_metadata.rs
+++ b/crates/miden-testing/src/standards/token_metadata.rs
@@ -157,7 +157,7 @@ fn build_pol_faucet_metadata() -> FungibleFaucet {
 fn build_pol_faucet_account() -> Account {
     AccountBuilder::new([4u8; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(build_pol_faucet_metadata())
         .build()
         .unwrap()
@@ -212,7 +212,7 @@ async fn get_name_from_masm() -> anyhow::Result<()> {
         .unwrap();
 
     let account = AccountBuilder::new([1u8; 32])
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(faucet)
         .with_component(Pausable::unpaused())
         .build()?;
@@ -249,7 +249,7 @@ async fn get_name_zeros_returns_empty() -> anyhow::Result<()> {
         .unwrap();
 
     let account = AccountBuilder::new([1u8; 32])
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(faucet)
         .with_component(Pausable::unpaused())
         .build()?;
@@ -414,7 +414,7 @@ async fn get_mutability_config() -> anyhow::Result<()> {
         .unwrap();
 
     let account = AccountBuilder::new([1u8; 32])
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(faucet)
         .with_component(Pausable::unpaused())
         .build()?;
@@ -458,7 +458,7 @@ async fn is_field_mutable_checks(
     #[case] expected: u8,
 ) -> anyhow::Result<()> {
     let account = AccountBuilder::new([1u8; 32])
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(faucet)
         .with_component(Pausable::unpaused())
         .build()?;
@@ -498,7 +498,7 @@ fn faucet_with_metadata_storage_layout() {
 
     let account = AccountBuilder::new([1u8; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(faucet)
         .build()
         .unwrap();
@@ -538,7 +538,7 @@ fn verify_faucet_with_max_name_and_description(
 
     let mut builder = AccountBuilder::new(seed)
         .account_type(account_type)
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(faucet)
         .with_component(Pausable::unpaused());
 

--- a/crates/miden-testing/tests/auth/fee_payment/network.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/network.rs
@@ -50,7 +50,7 @@ async fn execute_network_account_tx(
         .build();
 
     let account = AccountBuilder::new([9; 32])
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(BasicWallet)
         .with_components(fee_manager)
         .with_assets(assets)

--- a/crates/miden-testing/tests/auth/fee_payment/no_auth.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/no_auth.rs
@@ -25,7 +25,7 @@ async fn execute_no_auth_tx(
     input_note: Option<Note>,
 ) -> anyhow::Result<(Account, Result<ExecutedTransaction, miden_tx::TransactionExecutorError>)> {
     let account = AccountBuilder::new([11; 32])
-        .with_auth_component(NoAuth)
+        .with_component(NoAuth)
         .with_component(BasicWallet)
         .with_assets(assets)
         .account_type(AccountType::Public)

--- a/crates/miden-testing/tests/auth/fee_payment/singlesig_acl.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/singlesig_acl.rs
@@ -104,7 +104,7 @@ async fn acl_exempt_branch_pays_native_fee_note() -> anyhow::Result<()> {
     .build_component();
 
     let account = AccountBuilder::new([0; 32])
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(component)
         .account_type(AccountType::Public)
         .with_assets([fee_asset.into()])

--- a/crates/miden-testing/tests/auth/fee_payment/sponsorship.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/sponsorship.rs
@@ -69,7 +69,7 @@ fn network_account(
 
     Ok(AccountBuilder::new(seed)
         .account_type(AccountType::Public)
-        .with_auth_component(auth)
+        .with_component(auth)
         .with_component(BasicWallet)
         .with_components(fee_manager)
         .with_assets(assets)

--- a/crates/miden-testing/tests/auth/guarded_multisig.rs
+++ b/crates/miden-testing/tests/auth/guarded_multisig.rs
@@ -155,7 +155,7 @@ fn create_guarded_multisig_account(
 
     let multisig_account = AccountBuilder::new([0; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(AuthGuardedMultisig::new(config)?)
+        .with_component(AuthGuardedMultisig::new(config)?)
         .with_component(BasicWallet)
         .with_assets(vec![FungibleAsset::mock(asset_amount)])
         .build_existing()?;

--- a/crates/miden-testing/tests/auth/hybrid_multisig.rs
+++ b/crates/miden-testing/tests/auth/hybrid_multisig.rs
@@ -87,7 +87,7 @@ fn create_multisig_account(
     let approver_set = ApproverSet::new(approvers, threshold)?;
 
     let multisig_account = AccountBuilder::new([0; 32])
-        .with_auth_component(Auth::Multisig { approver_set, proc_threshold_map })
+        .with_component(Auth::Multisig { approver_set, proc_threshold_map })
         .with_component(BasicWallet)
         .account_type(AccountType::Public)
         .with_assets(vec![FungibleAsset::mock(asset_amount)])

--- a/crates/miden-testing/tests/auth/multisig.rs
+++ b/crates/miden-testing/tests/auth/multisig.rs
@@ -124,7 +124,7 @@ fn create_multisig_account(
     let approver_set = ApproverSet::new(approvers, threshold)?;
 
     let multisig_account = AccountBuilder::new([0; 32])
-        .with_auth_component(Auth::Multisig { approver_set, proc_threshold_map })
+        .with_component(Auth::Multisig { approver_set, proc_threshold_map })
         .with_component(BasicWallet)
         .account_type(AccountType::Public)
         .with_assets(vec![FungibleAsset::mock(asset_amount)])

--- a/crates/miden-testing/tests/auth/multisig_smart.rs
+++ b/crates/miden-testing/tests/auth/multisig_smart.rs
@@ -56,7 +56,7 @@ fn create_multisig_smart_account(
     )?;
 
     let multisig_account = AccountBuilder::new([0; 32])
-        .with_auth_component(AuthMultisigSmart::new(config)?)
+        .with_component(AuthMultisigSmart::new(config)?)
         .with_component(BasicWallet)
         .account_type(AccountType::Public)
         .with_assets(core::iter::once(asset.into()))

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -75,7 +75,7 @@ fn build_account_with_allowlists(
         zero_fee_manager(auth_component.allowed_notes().allowed_script_roots().iter().copied())?;
 
     Ok(AccountBuilder::new([0; 32])
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(BasicWallet)
         .with_components(fee_manager)
         .account_type(AccountType::Public)
@@ -371,7 +371,7 @@ fn build_owner_controlled_account(
     let fee_manager = zero_fee_manager(scheduled_roots)?;
 
     Ok(AccountBuilder::new([7; 32])
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_components(AccessControl::Ownable2Step { owner })
         .with_component(BasicWallet)
         .with_components(fee_manager)
@@ -697,7 +697,7 @@ fn build_upgradeable_network_account(
         zero_fee_manager(auth_component.allowed_notes().allowed_script_roots().iter().copied())?;
 
     Ok(AccountBuilder::new([7; 32])
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_components(AccessControl::Ownable2Step { owner })
         .with_component(UpgradeManager)
         .with_component(BasicWallet)

--- a/crates/miden-testing/tests/auth/singlesig.rs
+++ b/crates/miden-testing/tests/auth/singlesig.rs
@@ -39,7 +39,7 @@ fn setup_singlesig_with_mock_component(
     let (auth_component, authenticator) = Auth::BasicAuth { auth_scheme }.build_component();
 
     let account = AccountBuilder::new([0; 32])
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(mock_component)
         .account_type(AccountType::Public)
         .build_existing()?;

--- a/crates/miden-testing/tests/auth/singlesig_acl.rs
+++ b/crates/miden-testing/tests/auth/singlesig_acl.rs
@@ -373,7 +373,7 @@ async fn test_acl_burn_note_against_user_faucet_runs_without_signature(
 
     let faucet_account = AccountBuilder::new([42u8; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(faucet)
         .with_component(Authority::AuthControlled)
         .with_components(policy_manager)
@@ -455,7 +455,7 @@ async fn test_acl_non_binary_exempt_marker_requires_auth_instead_of_bricking(
         MockAccountComponent::with_slots(AccountStorage::mock_storage_slots()).into();
 
     let account = AccountBuilder::new([0; 32])
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(mock_component)
         .account_type(AccountType::Public)
         .build_existing()?;
@@ -527,7 +527,7 @@ fn setup_acl_test(
         Auth::Acl { exempt_procedures, auth_scheme }.build_component();
 
     let account = AccountBuilder::new([0; 32])
-        .with_auth_component(auth_component)
+        .with_component(auth_component)
         .with_component(component)
         .account_type(AccountType::Public)
         .build_existing()

--- a/crates/miden-testing/tests/scripts/code_inspection.rs
+++ b/crates/miden-testing/tests/scripts/code_inspection.rs
@@ -14,7 +14,7 @@ use miden_testing::{Auth, MockChain};
 fn create_inspectable_account() -> anyhow::Result<Account> {
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_component(CodeInspection)
         .build_existing()?;

--- a/crates/miden-testing/tests/scripts/fee_collection.rs
+++ b/crates/miden-testing/tests/scripts/fee_collection.rs
@@ -119,7 +119,7 @@ fn network_account(fee_entry: Option<(NoteScriptRoot, AssetAmount)>) -> anyhow::
 
     Ok(AccountBuilder::new([7; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(fee_manager)
         .with_component(fee_collector_component()?)
@@ -721,7 +721,7 @@ async fn feature_notes_priced_in_different_assets_are_rejected() -> anyhow::Resu
     )?;
     let network_account = AccountBuilder::new([7; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(
             FeeManager::builder()
@@ -859,7 +859,7 @@ fn build_create_test(target_fee_faucet: AccountId) -> anyhow::Result<CreateTest>
         .build();
     let sponsor = AccountBuilder::new([8; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(sponsor_fee_manager)
         .with_component(sponsorship_creator_component()?)
@@ -874,7 +874,7 @@ fn build_create_test(target_fee_faucet: AccountId) -> anyhow::Result<CreateTest>
         .build();
     let target = AccountBuilder::new([9; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(target_fee_manager)
         .build_existing()?;

--- a/crates/miden-testing/tests/scripts/fee_manager.rs
+++ b/crates/miden-testing/tests/scripts/fee_manager.rs
@@ -160,7 +160,7 @@ pub(super) fn custom_fee_policy() -> anyhow::Result<FeePolicy> {
 pub(super) fn build_fee_account_with_switching(owner: AccountId) -> anyhow::Result<Account> {
     Ok(AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_component(Ownable2Step::new(owner))
         .with_component(Authority::OwnerControlled)
@@ -259,7 +259,7 @@ async fn estimate_note_fee_returns_scheduled_fee(
 ) -> anyhow::Result<()> {
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(fee_manager()?)
         .build_existing()?;
@@ -301,7 +301,7 @@ async fn estimate_note_fee_rejects_non_u32_timeframe_or_priority(
 ) -> anyhow::Result<()> {
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(fee_manager()?)
         .build_existing()?;
@@ -348,7 +348,7 @@ async fn estimate_note_fee_rejects_non_u32_timeframe_or_priority(
 async fn estimate_note_fee_aborts_for_unscheduled_root() -> anyhow::Result<()> {
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(fee_manager()?)
         .build_existing()?;
@@ -394,14 +394,14 @@ async fn estimate_note_fee_dispatches_to_custom_policy_via_fpi() -> anyhow::Resu
 
     let foreign_account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(fee_manager)
         .build_existing()?;
 
     let native_account = AccountBuilder::new([2; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .build_existing()?;
 
@@ -498,14 +498,14 @@ async fn estimate_note_fee_dispatches_to_custom_policy_via_fpi() -> anyhow::Resu
 async fn get_fee_asset_id_returns_configured_fee_asset_via_fpi() -> anyhow::Result<()> {
     let foreign_account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .with_components(fee_manager()?)
         .build_existing()?;
 
     let native_account = AccountBuilder::new([2; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(BasicWallet)
         .build_existing()?;
 

--- a/crates/miden-testing/tests/scripts/ownable2step.rs
+++ b/crates/miden-testing/tests/scripts/ownable2step.rs
@@ -28,7 +28,7 @@ use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
 pub(super) fn create_ownable_account(owner: AccountId) -> anyhow::Result<Account> {
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(Ownable2Step::new(owner))
         .build_existing()?;
     Ok(account)

--- a/crates/miden-testing/tests/scripts/pause_action.rs
+++ b/crates/miden-testing/tests/scripts/pause_action.rs
@@ -26,7 +26,7 @@ use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
 fn create_pausable_account(owner: AccountId) -> anyhow::Result<Account> {
     let account = AccountBuilder::new([43; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_components(AccessControl::Ownable2Step { owner })
         .with_component(Pausable::unpaused())
         .with_component(PausableManager)

--- a/crates/miden-testing/tests/scripts/rbac.rs
+++ b/crates/miden-testing/tests/scripts/rbac.rs
@@ -31,7 +31,7 @@ use rstest::rstest;
 fn create_rbac_account_with_admin(admin: AccountId) -> anyhow::Result<Account> {
     let account = AccountBuilder::new([9; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_components(AccessControl::Rbac { admin, procedure_roles: BTreeMap::new() })
         .build_existing()?;
 
@@ -927,7 +927,7 @@ fn test_rbac_with_role_members_seeds_admin_and_operator_roles() -> anyhow::Resul
 
     let account = AccountBuilder::new([9; 32])
         .account_type(AccountType::Public)
-        .with_auth_component(Auth::IncrNonce)
+        .with_component(Auth::IncrNonce)
         .with_component(RoleBasedAccessControl::new(
             BTreeSet::from([admin]),
             BTreeMap::from([


### PR DESCRIPTION
Closes https://github.com/0xMiden/protocol/issues/3378

For the motivation, see the issue description.

Required for https://github.com/0xMiden/protocol/pull/3353 to proceed.