### PR TITLE
chore: use `AuthNetworkAccount` in tests

### DIFF
--- a/crates/miden-testing/tests/scripts/fee_collection.rs
+++ b/crates/miden-testing/tests/scripts/fee_collection.rs
@@ -311,7 +311,7 @@ async fn set_fee_policy_switches_to_custom_policy() -> anyhow::Result<()> {
         AccountId::builder().account_type(AccountType::Private).build_with_seed([4; 32]);
 
     let set_policy_note_script =
-        &create_fee_manager_note_script("set_fee_policy", custom_fee_policy()?.root().as_word());
+        create_fee_manager_note_script("set_fee_policy", custom_fee_policy()?.root().as_word());
     let mut rng = RandomCoin::new([Felt::from(600u32); 4].into());
     let set_policy_note = NoteBuilder::new(owner_account_id, &mut rng)
         .note_type(NoteType::Private)

--- a/crates/miden-testing/tests/scripts/fee_collection.rs
+++ b/crates/miden-testing/tests/scripts/fee_collection.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use std::collections::BTreeSet;
 use std::sync::LazyLock;
 
 use miden_processor::crypto::random::RandomCoin;
@@ -6,13 +7,16 @@ use miden_protocol::account::component::{AccountComponentCode, AccountComponentM
 use miden_protocol::account::{Account, AccountBuilder, AccountComponent, AccountId, AccountType};
 use miden_protocol::assembly::DefaultSourceManager;
 use miden_protocol::asset::{Asset, AssetAmount, AssetId, FungibleAsset};
-use miden_protocol::note::{Note, NoteId, NoteScriptRoot, NoteType};
-use miden_protocol::testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1;
+use miden_protocol::note::{Note, NoteAssets, NoteId, NoteScriptRoot, NoteType};
+use miden_protocol::testing::account_id::{
+    ACCOUNT_ID_FEE_FAUCET,
+    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
+};
 use miden_protocol::transaction::{RawOutputNote, TransactionScript};
 use miden_protocol::{Felt, Word};
 use miden_standards::account::auth::AuthNetworkAccount;
 use miden_standards::account::fees::{ConstantFeePolicy, FeePolicy, FeePolicyManager};
-use miden_standards::account::wallets::BasicWallet;
+use miden_standards::account::wallets::{BasicWallet, NoteCreator};
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::errors::standards::{
     ERR_FEE_MANAGER_EXPECTED_FEE_ASSET_MISMATCH,
@@ -27,7 +31,12 @@ use miden_standards::errors::standards::{
     ERR_NOTE_SCRIPT_NOT_IN_FEE_SCHEDULE,
     ERR_SENDER_NOT_OWNER,
 };
-use miden_standards::note::{FeeSponsorshipNote, P2idNote};
+use miden_standards::note::{
+    FeeSponsorshipNote,
+    FeeSponsorshipNoteStorage,
+    NetworkAccountTarget,
+    P2idNote,
+};
 use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
 use rstest::rstest;
@@ -38,10 +47,7 @@ use crate::scripts::fee_manager::{
     create_fee_manager_note_script,
     custom_fee_amount_for,
     custom_fee_policy,
-    estimate_note_fee_tx_script_code,
     fee_faucet_id,
-    fee_policy_manager_with_storage,
-    priced_root,
 };
 
 // COLLECT SPONSORED FEES
@@ -61,26 +67,27 @@ fn other_asset(amount: u64) -> anyhow::Result<Asset> {
     )
 }
 
-// `collect_sponsored_fees` is `exec`-only and reads the active account's storage, so it must run
-// inside a registered account procedure. This test-only component wraps it in an
-// `@account_procedure` that the transaction scripts below `call` into, mirroring how a network
-// account's own auth procedure would `exec` it.
+/// The faucet issuing the chain's native fee asset, which the auth procedure's `pay_fee` funds
+/// network-note sponsorships in (via `tx::get_fee_faucet_id`, not the account's configured asset).
+fn native_fee_faucet_id() -> anyhow::Result<AccountId> {
+    Ok(ACCOUNT_ID_FEE_FAUCET.try_into()?)
+}
+
+/// Returns a fungible asset of `amount` units of the native fee asset.
+fn native_fee_asset(amount: u64) -> anyhow::Result<Asset> {
+    Ok(FungibleAsset::new(native_fee_faucet_id()?, amount)?.into())
+}
+
+// In a real deployment `collect_sponsored_fees` runs inside the `AuthNetworkAccount` auth
+// procedure, always priced in the fee manager's configured asset. This test-only component exposes
+// a variant that deliberately passes a wrong expected fee asset, letting
+// `collect_rejects_expected_fee_asset_mismatch` exercise the mismatch guard - a case the auth flow
+// cannot reach.
 const FEE_COLLECTOR_NAME: &str = "test::fee_collector";
 
 static FEE_COLLECTOR_CODE: LazyLock<AccountComponentCode> = LazyLock::new(|| {
     let src = r#"
         use miden::standards::fees
-        use miden::standards::fees::fee_manager
-
-        @account_procedure
-        pub proc collect_sponsored_fees
-            # collect fees in the asset the fee manager is configured with
-            exec.fee_manager::read_fee_asset_id
-            # => [FEE_ASSET_ID, pad(16)]
-
-            exec.fees::collect_sponsored_fees drop
-            # => [pad(16)]
-        end
 
         @account_procedure
         pub proc collect_sponsored_fees_wrong_asset
@@ -97,7 +104,7 @@ static FEE_COLLECTOR_CODE: LazyLock<AccountComponentCode> = LazyLock::new(|| {
         .expect("fee collector component should compile")
 });
 
-/// The test-only account component exposing `collect_sponsored_fees` as an account procedure.
+/// The test-only account component exposing the wrong-asset `collect_sponsored_fees` variant.
 fn fee_collector_component() -> anyhow::Result<AccountComponent> {
     Ok(AccountComponent::new(
         FEE_COLLECTOR_CODE.clone(),
@@ -106,10 +113,13 @@ fn fee_collector_component() -> anyhow::Result<AccountComponent> {
     )?)
 }
 
-/// Builds a network account with a `BasicWallet`, a `FeePolicyManager`, and the test fee-collector
-/// component. When `fee_entry` is provided, the fee policy manager schedules the given fee for that
-/// note script root.
-fn network_account(fee_entry: Option<(NoteScriptRoot, AssetAmount)>) -> anyhow::Result<Account> {
+/// Builds an `AuthNetworkAccount`-authenticated network account with a `BasicWallet` and a
+/// `FeePolicyManager`. When `fee_entry` is provided, the fee policy manager schedules the
+/// given fee for that note script root; `allowed_note_roots` seeds the note-script allowlist.
+fn network_account(
+    fee_entry: Option<(NoteScriptRoot, AssetAmount)>,
+    allowed_note_roots: BTreeSet<NoteScriptRoot>,
+) -> anyhow::Result<Account> {
     let mut policy = ConstantFeePolicy::new();
     if let Some((root, fee)) = fee_entry {
         policy = policy.with_fee(root, fee);
@@ -121,10 +131,12 @@ fn network_account(fee_entry: Option<(NoteScriptRoot, AssetAmount)>) -> anyhow::
 
     Ok(AccountBuilder::new([7; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: allowed_note_roots,
+            allowed_tx_script_roots: BTreeSet::new(),
+            fee_policy_manager,
+        })
         .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(fee_policy_manager)?)
-        .with_component(fee_collector_component()?)
         .build_existing()?)
 }
 
@@ -156,7 +168,14 @@ fn build_test(
         .collect::<anyhow::Result<_>>()?;
 
     let fee_entry = feature_note_fee.map(|fee| (feature_notes[0].script().root(), fee));
-    let network_account = network_account(fee_entry)?;
+
+    // The account consumes the feature notes (all sharing one P2ANY root) and their FEE_SPONSORSHIP
+    // notes, so both roots must be allowlisted for the auth procedure to reach fee collection.
+    let mut allowed_note_roots = BTreeSet::from([FeeSponsorshipNote::script_root()]);
+    if let Some(feature_note) = feature_notes.first() {
+        allowed_note_roots.insert(feature_note.script().root());
+    }
+    let network_account = network_account(fee_entry, allowed_note_roots)?;
     builder.add_account(network_account.clone())?;
 
     let mut sponsorship_notes = Vec::new();
@@ -186,27 +205,8 @@ fn build_test(
     })
 }
 
-/// A transaction script that runs `collect_sponsored_fees`.
-fn collect_tx_script() -> anyhow::Result<TransactionScript> {
-    let src = r#"
-        use test::fee_collector
-
-        @transaction_script
-        pub proc main
-            call.fee_collector::collect_sponsored_fees
-            # => [pad(16)]
-
-            dropw dropw dropw dropw
-        end
-        "#;
-
-    Ok(CodeBuilder::default()
-        .with_dynamically_linked_package(&*FEE_COLLECTOR_CODE)?
-        .compile_tx_script(src)?)
-}
-
-/// Runs `collect_sponsored_fees` for the given input notes against the network account and returns
-/// the account's fee-asset balance after the transaction.
+/// Consumes the given input notes against the network account - triggering the auth procedure's
+/// fee collection - and returns the account's fee-asset balance after the transaction.
 async fn collect_fee_balance(
     mock_chain: MockChain,
     mut network_account: Account,
@@ -216,7 +216,7 @@ async fn collect_fee_balance(
     for note_id in input_notes {
         builder = builder.authenticated_input_note(*note_id);
     }
-    let executed = builder.tx_script(collect_tx_script()?).build()?.execute().await?;
+    let executed = builder.build()?.execute().await?;
 
     network_account.apply_patch(executed.account_patch())?;
     Ok(network_account
@@ -256,7 +256,20 @@ async fn collects_sponsored_fee_for_a_pair(#[case] sponsored_amount: u64) -> any
 /// sponsorship payments in another.
 #[tokio::test]
 async fn collect_rejects_expected_fee_asset_mismatch() -> anyhow::Result<()> {
-    let Test { mock_chain, network_account, .. } = build_test(None, vec![])?;
+    let account = AccountBuilder::new([7; 32])
+        .account_type(AccountType::Public)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::new(),
+            allowed_tx_script_roots: BTreeSet::new(),
+            fee_policy_manager: FeePolicyManager::mock(fee_faucet_id()?),
+        })
+        .with_component(BasicWallet)
+        .with_component(fee_collector_component()?)
+        .build_existing()?;
+
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+    let mock_chain = builder.build()?;
 
     let src = r#"
         use test::fee_collector
@@ -274,7 +287,7 @@ async fn collect_rejects_expected_fee_asset_mismatch() -> anyhow::Result<()> {
         .compile_tx_script(src)?;
 
     let result = mock_chain
-        .build_transaction(network_account.id())
+        .build_transaction(account.id())
         .tx_script(tx_script)
         .build()?
         .execute()
@@ -285,60 +298,63 @@ async fn collect_rejects_expected_fee_asset_mismatch() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The owner switches the active fee policy from the constant fee policy to the user-defined
-/// custom policy via `set_fee_policy`, after which `estimate_note_fee` prices the previously
-/// priced root with the custom policy's logic instead of the schedule.
+/// The owner switches the active fee policy from the constant fee policy to the user-defined custom
+/// policy via `set_fee_policy`. Under the network auth procedure the same transaction then prices
+/// the consumed `set_fee_policy` note through the just-activated custom policy, so it must be
+/// paired with a FEE_SPONSORSHIP note funded with exactly that custom fee. The transaction
+/// succeeding proves the switch took effect and that the custom policy - not the constant fee
+/// schedule - priced the note: had the switch not happened, the constant policy prices the note at
+/// 0 and the sponsorship note would be rejected as unpaired.
 #[tokio::test]
 async fn set_fee_policy_switches_to_custom_policy() -> anyhow::Result<()> {
     let owner_account_id =
         AccountId::builder().account_type(AccountType::Private).build_with_seed([4; 32]);
 
-    let account = build_fee_account_with_switching(owner_account_id)?;
-
     let set_policy_note_script =
-        create_fee_manager_note_script("set_fee_policy", custom_fee_policy()?.root().as_word());
+        &create_fee_manager_note_script("set_fee_policy", custom_fee_policy()?.root().as_word());
     let mut rng = RandomCoin::new([Felt::from(600u32); 4].into());
     let set_policy_note = NoteBuilder::new(owner_account_id, &mut rng)
         .note_type(NoteType::Private)
         .code(set_policy_note_script.as_str())
         .build()?;
 
+    // The custom policy prices the set_fee_policy note on its (empty) storage commitment with a
+    // timeframe and priority of 0 - the values fee collection passes - so the fee is known ahead of
+    // time and the sponsorship can cover it exactly.
+    let custom_fee =
+        custom_fee_amount_for(set_policy_note.recipient().storage().commitment(), 0, 0);
+
+    // Allowlist both the set_fee_policy note and the FEE_SPONSORSHIP note that pays its fee.
+    let account = build_fee_account_with_switching(
+        owner_account_id,
+        BTreeSet::from([set_policy_note.script().root(), FeeSponsorshipNote::script_root()]),
+        BTreeSet::new(),
+    )?;
+
+    let sponsorship_note = Note::from(
+        FeeSponsorshipNote::builder()
+            .sender(owner_account_id)
+            .target_account(account.id())
+            .feature_note_id(set_policy_note.id())
+            .asset(fee_asset(custom_fee.as_u64())?)
+            .generate_serial_number(&mut rng)
+            .build()?,
+    );
+
     let mut builder = MockChain::builder();
     builder.add_account(account.clone())?;
     builder.add_output_note(RawOutputNote::Full(set_policy_note.clone()));
+    builder.add_output_note(RawOutputNote::Full(sponsorship_note.clone()));
     let mut mock_chain = builder.build()?;
     mock_chain.prove_next_block()?;
 
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let mock_tx = mock_chain
-        .build_transaction(account.id())
-        .authenticated_input_note(set_policy_note.id())
-        .with_source_manager(source_manager)
-        .build()?;
-    let executed_transaction = mock_tx.execute().await?;
-    mock_chain.add_pending_executed_transaction(&executed_transaction)?;
-    mock_chain.prove_next_block()?;
-
-    // With the custom policy active, the previously priced root is priced by the custom logic:
-    // the amount is derived from the base custom fee, the storage commitment supplied to the
-    // estimate script, and the supplied timeframe and priority, while the fee asset ID still
-    // comes from the manager's storage.
-    let storage_commitment = Word::from([11u32, 12, 13, 14]);
-    let timeframe = 25u64;
-    let priority = 3u64;
-    let tx_script_code = estimate_note_fee_tx_script_code(
-        storage_commitment,
-        timeframe,
-        priority,
-        AssetId::new_fungible(fee_faucet_id()?).to_word(),
-        AssetAmount::new(custom_fee_amount_for(storage_commitment, timeframe, priority))?.to_word(),
-    );
-    let tx_script = CodeBuilder::default().compile_tx_script(tx_script_code)?;
-
+    // Consuming the switch note (which activates the custom policy) followed by its sponsorship
+    // note succeeds only if the custom policy is active and prices the note at the sponsored
+    // fee.
     mock_chain
         .build_transaction(account.id())
-        .tx_script(tx_script)
-        .tx_script_args(priced_root().as_word())
+        .authenticated_input_note(set_policy_note.id())
+        .authenticated_input_note(sponsorship_note.id())
         .build()?
         .execute()
         .await?;
@@ -383,7 +399,10 @@ async fn set_fee_policy_rejects_non_allowed_root() -> anyhow::Result<()> {
     let owner_account_id =
         AccountId::builder().account_type(AccountType::Private).build_with_seed([4; 32]);
 
-    let account = build_fee_account_with_switching(owner_account_id)?;
+    // The set_fee_policy note aborts inside its note script, before the auth allowlist check runs,
+    // so the allowlists can stay empty.
+    let account =
+        build_fee_account_with_switching(owner_account_id, BTreeSet::new(), BTreeSet::new())?;
 
     // This root exists in the account code, but is not in the fee policy allowlist.
     let invalid_policy_root = AuthNetworkAccount::get_fee_policy_root().as_word();
@@ -429,7 +448,6 @@ async fn unscheduled_feature_note_aborts_fee_collection() -> anyhow::Result<()> 
     let result = mock_chain
         .build_transaction(network_account.id())
         .authenticated_input_note(feature_notes[0].id())
-        .tx_script(collect_tx_script()?)
         .build()?
         .execute()
         .await;
@@ -466,7 +484,10 @@ async fn non_owner_cannot_set_fee_policy() -> anyhow::Result<()> {
     let non_owner_account_id =
         AccountId::builder().account_type(AccountType::Private).build_with_seed([5; 32]);
 
-    let account = build_fee_account_with_switching(owner_account_id)?;
+    // The set_fee_policy note aborts inside its note script, before the auth allowlist check runs,
+    // so the allowlists can stay empty.
+    let account =
+        build_fee_account_with_switching(owner_account_id, BTreeSet::new(), BTreeSet::new())?;
 
     let set_policy_note_script =
         create_fee_manager_note_script("set_fee_policy", custom_fee_policy()?.root().as_word());
@@ -509,7 +530,6 @@ async fn priced_feature_note_without_sponsorship_is_rejected() -> anyhow::Result
     let result = mock_chain
         .build_transaction(network_account.id())
         .authenticated_input_note(feature_notes[0].id())
-        .tx_script(collect_tx_script()?)
         .build()?
         .execute()
         .await;
@@ -534,7 +554,6 @@ async fn sponsorship_note_as_current_note_is_rejected() -> anyhow::Result<()> {
         .build_transaction(network_account.id())
         .authenticated_input_note(sponsorship_notes[0].id())
         .authenticated_input_note(feature_notes[0].id())
-        .tx_script(collect_tx_script()?)
         .build()?
         .execute()
         .await;
@@ -559,7 +578,6 @@ async fn sponsorship_below_required_fee_is_rejected() -> anyhow::Result<()> {
         .build_transaction(network_account.id())
         .authenticated_input_note(feature_notes[0].id())
         .authenticated_input_note(sponsorship_notes[0].id())
-        .tx_script(collect_tx_script()?)
         .build()?
         .execute()
         .await;
@@ -583,7 +601,6 @@ async fn sponsorship_with_wrong_asset_is_rejected() -> anyhow::Result<()> {
         .build_transaction(network_account.id())
         .authenticated_input_note(feature_notes[0].id())
         .authenticated_input_note(sponsorship_notes[0].id())
-        .tx_script(collect_tx_script()?)
         .build()?
         .execute()
         .await;
@@ -607,8 +624,12 @@ async fn sponsorship_for_wrong_feature_note_is_rejected() -> anyhow::Result<()> 
     let feature_note = builder.add_p2any_note(sponsor.id(), NoteType::Public, [])?;
     let other_feature_note = builder.add_p2any_note(sponsor.id(), NoteType::Public, [])?;
 
-    let network_account =
-        network_account(Some((feature_note.script().root(), AssetAmount::new(FEE_AMOUNT)?)))?;
+    // Both feature notes are P2ANY notes and so share one script root; allowlist it and the
+    // FEE_SPONSORSHIP root.
+    let network_account = network_account(
+        Some((feature_note.script().root(), AssetAmount::new(FEE_AMOUNT)?)),
+        BTreeSet::from([feature_note.script().root(), FeeSponsorshipNote::script_root()]),
+    )?;
     builder.add_account(network_account.clone())?;
 
     // The sponsorship note sponsors `other_feature_note`, yet below it is consumed right after
@@ -634,7 +655,6 @@ async fn sponsorship_for_wrong_feature_note_is_rejected() -> anyhow::Result<()> 
         .authenticated_input_note(feature_note.id())
         .authenticated_input_note(sponsorship_note.id())
         .authenticated_input_note(other_feature_note.id())
-        .tx_script(collect_tx_script()?)
         .build()?
         .execute()
         .await;
@@ -701,8 +721,8 @@ fn asset_commitment_fee_policy(
 }
 
 /// Two priced feature notes whose fees are charged in different assets cannot be collected in the
-/// same transaction. A custom fee policy prices the first feature note (no assets) in the fee
-/// faucet's asset and the second (which carries an asset, so its assets commitment differs) in a
+/// same transaction. A custom fee policy prices the first feature note in the fee faucet's asset
+/// and the second (which carries a different asset, so its assets commitment differs) in a
 /// different faucet's asset. The first pair is collected; pricing the second feature note in an
 /// asset other than the manager's configured fee asset is rejected by the manager's fee asset
 /// consistency check before the second note's own sponsor is sought.
@@ -712,33 +732,54 @@ async fn feature_notes_priced_in_different_assets_are_rejected() -> anyhow::Resu
     let mut builder = MockChain::builder();
     let sponsor = builder.add_existing_wallet(Auth::IncrNonce)?;
 
-    let feature_note_a = builder.add_p2any_note(sponsor.id(), NoteType::Public, [])?;
-    let feature_note_b =
-        builder.add_p2any_note(sponsor.id(), NoteType::Public, [other_asset(1)?])?;
-
     let fee_asset_id = AssetId::new_fungible(fee_faucet_id()?).to_word();
     let other_fee_asset_id =
         AssetId::new_fungible(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1)?).to_word();
 
+    // The two feature notes carry different assets, so the P2ID notes (which share one script root)
+    // have distinct assets commitments. The policy keys on those commitments to price the first in
+    // the fee asset and the second in a different asset.
+    let feature_note_a_asset = fee_asset(1)?;
+    let feature_note_b_asset = other_asset(1)?;
     let policy = asset_commitment_fee_policy(
-        feature_note_a.assets().commitment(),
+        NoteAssets::new(vec![feature_note_a_asset])?.commitment(),
         fee_asset_id,
         other_fee_asset_id,
     )?;
+
+    // Both feature notes are P2ID notes sharing one script root; allowlist it and the
+    // FEE_SPONSORSHIP root.
     let network_account = AccountBuilder::new([7; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
-        .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(
-            FeePolicyManager::builder()
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::from([
+                P2idNote::script_root(),
+                FeeSponsorshipNote::script_root(),
+            ]),
+            allowed_tx_script_roots: BTreeSet::new(),
+            fee_policy_manager: FeePolicyManager::builder()
                 .fee_faucet_id(fee_faucet_id()?)
                 .active_fee_policy(policy)
                 .build(),
-        )?)
-        .with_component(fee_collector_component()?)
+        })
+        .with_component(BasicWallet)
         .build_existing()?;
 
     builder.add_account(network_account.clone())?;
+
+    // The P2ID feature notes target the network account so it can consume them.
+    let feature_note_a = builder.add_p2id_note(
+        sponsor.id(),
+        network_account.id(),
+        &[feature_note_a_asset],
+        NoteType::Public,
+    )?;
+    let feature_note_b = builder.add_p2id_note(
+        sponsor.id(),
+        network_account.id(),
+        &[feature_note_b_asset],
+        NoteType::Public,
+    )?;
 
     // Only the first feature note is sponsored; the second is rejected before its sponsor is
     // sought.
@@ -761,7 +802,6 @@ async fn feature_notes_priced_in_different_assets_are_rejected() -> anyhow::Resu
         .authenticated_input_note(feature_note_a.id())
         .authenticated_input_note(sponsorship_note.id())
         .authenticated_input_note(feature_note_b.id())
-        .tx_script(collect_tx_script()?)
         .build()?
         .execute()
         .await;
@@ -774,79 +814,15 @@ async fn feature_notes_priced_in_different_assets_are_rejected() -> anyhow::Resu
 // CREATE NETWORK NOTE SPONSORSHIPS
 // ================================================================================================
 
-// `create_network_note_sponsorships` is `exec`-only and must run while the native account is the
-// active account, so this test-only component wraps it in an `@account_procedure`. The wrapper
-// first creates a storage-less output note targeted at a network account (carrying a
-// `NetworkAccountTarget` attachment) and then sponsors the transaction's network notes.
-const SPONSORSHIP_CREATOR_NAME: &str = "test::sponsorship_creator";
-
-static SPONSORSHIP_CREATOR_CODE: LazyLock<AccountComponentCode> = LazyLock::new(|| {
-    let src = r#"
-        use {NOTE_TYPE_PUBLIC} from miden::protocol::note
-        use miden::protocol::note
-        use miden::protocol::output_note
-
-        use miden::standards::attachments::network_account_target
-        use miden::standards::fees
-        use miden::standards::fees::fee_manager
-        use miden::standards::note_tag
-
-        #! Creates a storage-less output note targeted at the given network account, then runs
-        #! `create_network_note_sponsorships` to sponsor it.
-        #!
-        #! Inputs:  [SERIAL_NUM, SCRIPT_ROOT, target_id_suffix, target_id_prefix, pad(6)]
-        #! Outputs: [pad(16)]
-        #!
-        #! Invocation: call
-        @account_procedure
-        pub proc create_note_and_sponsorships
-            push.0.0
-            # => [storage_ptr = 0, num_storage_items = 0, SERIAL_NUM, SCRIPT_ROOT,
-            #     target_id_suffix, target_id_prefix, pad(6)]
-
-            exec.note::compute_and_store_recipient
-            # => [RECIPIENT, target_id_suffix, target_id_prefix, pad(6)]
-
-            push.NOTE_TYPE_PUBLIC dup.6 exec.note_tag::create_account_target
-            # => [tag, note_type, RECIPIENT, target_id_suffix, target_id_prefix, pad(6)]
-
-            exec.output_note::create
-            # => [note_idx, target_id_suffix, target_id_prefix, pad(6)]
-
-            movdn.2 push.0 movdn.2
-            # => [target_id_suffix, target_id_prefix, exec_hint_tag = 0, note_idx, pad(6)]
-
-            exec.network_account_target::new
-            # => [attachment_scheme, NOTE_ATTACHMENT, note_idx, pad(6)]
-
-            exec.output_note::add_word_attachment
-            # => [pad(16)]
-
-            # fund sponsorship notes with the asset the fee manager is configured with
-            exec.fee_manager::read_fee_asset_id
-            # => [FEE_ASSET_ID, pad(16)]
-
-            exec.fees::create_network_note_sponsorships
-            # => [pad(16)]
-        end
-        "#;
-    CodeBuilder::default()
-        .compile_component_code(SPONSORSHIP_CREATOR_NAME, src)
-        .expect("sponsorship creator component should compile")
-});
-
-/// The test-only account component exposing the creator wrapper as an account procedure.
-fn sponsorship_creator_component() -> anyhow::Result<AccountComponent> {
-    Ok(AccountComponent::new(
-        SPONSORSHIP_CREATOR_CODE.clone(),
-        vec![],
-        AccountComponentMetadata::mock(SPONSORSHIP_CREATOR_NAME),
-    )?)
-}
+// A network account's own auth procedure sponsors every network output note automatically (via
+// `pay_fee` -> `create_network_note_sponsorships`), so the sponsor only needs to create the note.
+// Note creation goes through the standard `NoteCreator` component's `create_note` procedure (the
+// only note operation restricted to the account context); the sponsor's tx script computes the
+// recipient and tag, calls into it, and adds the network account target attachment itself.
 
 /// A sponsor account (funded with [`FEE_AMOUNT`] of the fee asset) and a target network account
 /// whose fee policy manager charges [`FEE_AMOUNT`] in the asset of the given faucet, plus the
-/// script creating and sponsoring a network note targeted at it.
+/// script creating a network note targeted at it; the sponsor's auth procedure sponsors the note.
 struct CreateTest {
     mock_chain: MockChain,
     sponsor: Account,
@@ -859,16 +835,9 @@ fn build_create_test(target_fee_faucet: AccountId) -> anyhow::Result<CreateTest>
     let script_root = P2idNote::script_root();
     let serial_num = Word::from([21u32, 22, 23, 24]);
 
-    let sponsor_fee_policy_manager = FeePolicyManager::mock(fee_faucet_id()?);
-    let sponsor = AccountBuilder::new([8; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
-        .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(sponsor_fee_policy_manager)?)
-        .with_component(sponsorship_creator_component()?)
-        .with_assets([fee_asset(FEE_AMOUNT)?])
-        .build_existing()?;
-
+    // The target is only queried for its fee policy via FPI, so its auth never runs and its
+    // allowlists can stay empty. It is built first because its ID is embedded in the creator tx
+    // script, whose root the sponsor must in turn allowlist.
     let target_policy =
         ConstantFeePolicy::new().with_fee(script_root, AssetAmount::new(FEE_AMOUNT)?);
     let target_fee_policy_manager = FeePolicyManager::builder()
@@ -877,35 +846,56 @@ fn build_create_test(target_fee_faucet: AccountId) -> anyhow::Result<CreateTest>
         .build();
     let target = AccountBuilder::new([9; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::new(),
+            allowed_tx_script_roots: BTreeSet::new(),
+            fee_policy_manager: target_fee_policy_manager,
+        })
         .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(target_fee_policy_manager)?)
         .build_existing()?;
-
-    let mut builder = MockChain::builder();
-    builder.add_account(sponsor.clone())?;
-    builder.add_account(target.clone())?;
-    let mut mock_chain = builder.build()?;
-    mock_chain.prove_next_block()?;
 
     let tx_script_src = format!(
         r#"
-        use test::sponsorship_creator
+        use miden::protocol::note
+        use miden::protocol::output_note
+
+        use miden::standards::attachments::network_account_target
+        use miden::standards::note_tag
+
+        use {{NOTE_TYPE_PUBLIC}} from miden::protocol::note
 
         @transaction_script
         pub proc main
             # => [pad(16)]
 
-            push.{target_prefix} push.{target_suffix}
+            # compute the recipient of the storage-less network note
             push.{script_root}
             push.{serial_num}
-            # => [SERIAL_NUM, SCRIPT_ROOT, target_id_suffix, target_id_prefix, pad(16)]
+            push.0.0
+            # => [storage_ptr = 0, num_storage_items = 0, SERIAL_NUM, SCRIPT_ROOT, pad(16)]
 
-            call.sponsorship_creator::create_note_and_sponsorships
-            # => [pad(16), pad(10)]
+            exec.note::compute_and_store_recipient
+            # => [RECIPIENT, pad(16)]
 
-            dropw dropw drop drop
-            # => [pad(16)]
+            # tag the note for the target network account, then create it via the NoteCreator
+            push.NOTE_TYPE_PUBLIC push.{target_prefix} exec.note_tag::create_account_target
+            # => [tag, note_type, RECIPIENT, pad(16)]
+
+            call.::miden::standards::note::note_creator::create_note
+            # => [note_idx, pad(21)]
+
+            movdn.15 dropw dropw dropw drop drop drop
+            # => [note_idx, pad(6)]
+
+            # attach the network account target so the auth procedure sponsors the note
+            push.0 push.{target_prefix} push.{target_suffix}
+            # => [target_id_suffix, target_id_prefix, exec_hint_tag = 0, note_idx, pad(6)]
+
+            exec.network_account_target::new
+            # => [attachment_scheme, NOTE_ATTACHMENT, note_idx, pad(6)]
+
+            exec.output_note::add_word_attachment
+            # => [pad(6)]
         end
         "#,
         target_prefix = target.id().prefix().as_felt(),
@@ -913,9 +903,26 @@ fn build_create_test(target_fee_faucet: AccountId) -> anyhow::Result<CreateTest>
         script_root = script_root.as_word(),
         serial_num = serial_num,
     );
-    let tx_script = CodeBuilder::default()
-        .with_dynamically_linked_package(&*SPONSORSHIP_CREATOR_CODE)?
-        .compile_tx_script(tx_script_src)?;
+    let tx_script = CodeBuilder::default().compile_tx_script(tx_script_src)?;
+
+    // The sponsor runs the tx script that creates a network note, so its root must be allowlisted.
+    let sponsor_fee_policy_manager = FeePolicyManager::mock(fee_faucet_id()?);
+    let sponsor = AccountBuilder::new([8; 32])
+        .account_type(AccountType::Public)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::new(),
+            allowed_tx_script_roots: BTreeSet::from([tx_script.root()]),
+            fee_policy_manager: sponsor_fee_policy_manager,
+        })
+        .with_component(NoteCreator)
+        .with_assets([native_fee_asset(FEE_AMOUNT)?])
+        .build_existing()?;
+
+    let mut builder = MockChain::builder();
+    builder.add_account(sponsor.clone())?;
+    builder.add_account(target.clone())?;
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
 
     let foreign_inputs = mock_chain.get_foreign_account_inputs(target.id())?;
 
@@ -927,16 +934,17 @@ fn build_create_test(target_fee_faucet: AccountId) -> anyhow::Result<CreateTest>
     })
 }
 
-/// A network note whose target charges its fee in the sponsor's configured fee asset is
-/// sponsored: the sponsorship note is funded with the fee from the sponsor's vault.
+/// A network note whose target charges its fee in the native fee asset is sponsored by the auth
+/// procedure: the sponsorship note is funded with the fee from the sponsor's vault.
 #[tokio::test]
-async fn create_sponsorships_funds_note_in_configured_fee_asset() -> anyhow::Result<()> {
+async fn create_sponsorships_funds_note_in_native_fee_asset() -> anyhow::Result<()> {
     let CreateTest {
         mock_chain,
         mut sponsor,
         tx_script,
         foreign_inputs,
-    } = build_create_test(fee_faucet_id()?)?;
+    } = build_create_test(native_fee_faucet_id()?)?;
+    let target_id = foreign_inputs.0.id();
 
     let executed = mock_chain
         .build_transaction(sponsor.id())
@@ -946,9 +954,64 @@ async fn create_sponsorships_funds_note_in_configured_fee_asset() -> anyhow::Res
         .execute()
         .await?;
 
+    // The tx creates the feature note, which the auth procedure pairs with a sponsorship note.
+    let output_notes = executed.output_notes();
+    assert_eq!(
+        output_notes.num_notes(),
+        2,
+        "the transaction should create the feature note and its sponsorship note"
+    );
+    let feature_note = output_notes
+        .iter()
+        .find(|note| {
+            note.recipient()
+                .is_some_and(|recipient| recipient.script().root() == P2idNote::script_root())
+        })
+        .expect("the P2ID feature note should be created");
+    let sponsorship_note = output_notes
+        .iter()
+        .find(|note| {
+            note.recipient().is_some_and(|recipient| {
+                recipient.script().root() == FeeSponsorshipNote::script_root()
+            })
+        })
+        .expect("the sponsorship note should be created");
+
+    // The sponsorship note names the feature note it pays for.
+    let sponsorship_storage = FeeSponsorshipNoteStorage::try_from(
+        sponsorship_note
+            .recipient()
+            .expect("a public sponsorship note has recipient details")
+            .storage()
+            .items(),
+    )?;
+    assert_eq!(
+        sponsorship_storage.feature_note_id(),
+        feature_note.id(),
+        "the sponsorship note should sponsor the feature note"
+    );
+
+    // It carries exactly the target's fee in the native fee asset.
+    assert_eq!(
+        sponsorship_note.assets().iter().copied().collect::<Vec<_>>(),
+        vec![native_fee_asset(FEE_AMOUNT)?],
+        "the sponsorship note should carry the target's fee in the native fee asset"
+    );
+
+    // The feature note is tagged for the target network account via its attachment.
+    let network_target = NetworkAccountTarget::try_from(feature_note.attachments())?;
+    assert_eq!(
+        network_target.target_id(),
+        target_id,
+        "the feature note should target the network account"
+    );
+
     sponsor.apply_patch(executed.account_patch())?;
     assert_eq!(
-        sponsor.vault().get_balance(AssetId::new_fungible(fee_faucet_id()?))?.as_u64(),
+        sponsor
+            .vault()
+            .get_balance(AssetId::new_fungible(native_fee_faucet_id()?))?
+            .as_u64(),
         0,
         "the sponsorship note should be funded with the fee from the sponsor's vault"
     );
@@ -956,8 +1019,8 @@ async fn create_sponsorships_funds_note_in_configured_fee_asset() -> anyhow::Res
     Ok(())
 }
 
-/// A network note whose target charges a non-zero fee in an asset other than the sponsor's
-/// configured fee asset is rejected: fee asset conversion is not supported yet.
+/// A network note whose target charges a non-zero fee in an asset other than the native fee asset
+/// is rejected: fee asset conversion is not supported yet.
 #[tokio::test]
 async fn create_sponsorships_reject_target_with_different_fee_asset() -> anyhow::Result<()> {
     let CreateTest {

--- a/crates/miden-testing/tests/scripts/fee_manager.rs
+++ b/crates/miden-testing/tests/scripts/fee_manager.rs
@@ -139,7 +139,7 @@ pub(super) fn custom_fee_policy() -> anyhow::Result<FeePolicy> {
 
             # drop the script root and reduce the storage commitment to the low 32 bits of the sum
             # of its elements. The commitment's raw sum could exceed a valid asset amount so we
-            # take the the low 32 bits.
+            # take the low 32 bits.
             dropw add add add u32split swap drop
             # => [storage_commitment_term, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT, timeframe,
             #     priority, pad(2)]

--- a/crates/miden-testing/tests/scripts/fee_manager.rs
+++ b/crates/miden-testing/tests/scripts/fee_manager.rs
@@ -1,4 +1,5 @@
 use alloc::sync::Arc;
+use std::collections::BTreeSet;
 
 use miden_processor::ExecutionError;
 use miden_processor::crypto::random::RandomCoin;
@@ -6,11 +7,11 @@ use miden_processor::operation::OperationError;
 use miden_protocol::account::component::AccountComponentMetadata;
 use miden_protocol::account::{Account, AccountBuilder, AccountComponent, AccountId, AccountType};
 use miden_protocol::assembly::DefaultSourceManager;
-use miden_protocol::asset::{AssetAmount, AssetId};
+use miden_protocol::asset::{AssetAmount, AssetId, FungibleAsset};
 use miden_protocol::errors::MasmError;
 use miden_protocol::note::{Note, NoteScriptRoot, NoteType};
 use miden_protocol::testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET;
-use miden_protocol::transaction::RawOutputNote;
+use miden_protocol::transaction::{RawOutputNote, TransactionScriptRoot};
 use miden_protocol::{Felt, Word};
 use miden_standards::account::access::{Authority, Ownable2Step};
 use miden_standards::account::auth::AuthNetworkAccount;
@@ -24,7 +25,7 @@ use miden_standards::errors::standards::{
     ERR_SENDER_NOT_OWNER,
     ERR_TIMEFRAME_OR_PRIORITY_NOT_U32,
 };
-use miden_standards::testing::account_component::MockAccountComponent;
+use miden_standards::note::FeeSponsorshipNote;
 use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{Auth, MockChain, MockChainBuilder, assert_transaction_executor_error};
 use rstest::rstest;
@@ -53,45 +54,23 @@ fn free_root() -> NoteScriptRoot {
 /// (in the test faucet's asset) for notes with the [`priced_root`] script root and an explicit
 /// 0 fee for the [`free_root`] script root, and whose allowed-policies map additionally
 /// registers the user-defined [`custom_fee_policy`] for runtime switching.
-fn fee_policy_manager() -> anyhow::Result<FeePolicyManager> {
-    let constant_fee_policy = ConstantFeePolicy::new()
+///
+/// Each root in `zero_fee_note_roots` is additionally scheduled at a 0 fee.
+fn fee_policy_manager(
+    zero_fee_note_roots: &BTreeSet<NoteScriptRoot>,
+) -> anyhow::Result<FeePolicyManager> {
+    let mut constant_fee_policy = ConstantFeePolicy::new()
         .with_fee(priced_root(), AssetAmount::new(FEE_AMOUNT)?)
         .with_fee(free_root(), AssetAmount::ZERO);
+    for note_root in zero_fee_note_roots {
+        constant_fee_policy = constant_fee_policy.with_fee(*note_root, AssetAmount::ZERO);
+    }
 
     Ok(FeePolicyManager::builder()
         .fee_faucet_id(fee_faucet_id()?)
         .active_fee_policy(constant_fee_policy.into())
         .allowed_fee_policy(custom_fee_policy()?)
         .build())
-}
-
-/// Installs a `FeePolicyManager`'s policy components together with the fee-policy storage and
-/// procedures that, in a real deployment, the `AuthNetworkAccount` component owns.
-pub(super) fn fee_policy_manager_with_storage(
-    manager: FeePolicyManager,
-) -> anyhow::Result<Vec<AccountComponent>> {
-    let storage: AccountComponent =
-        MockAccountComponent::with_slots(manager.to_storage_slots().to_vec()).into();
-    Ok([storage, fee_procedures_component()?]
-        .into_iter()
-        .chain(manager.into_fee_policy_components())
-        .collect())
-}
-
-/// Compiles a minimal account component re-exporting the fee-policy procedures, standing in for
-/// the `AuthNetworkAccount` component that exposes them in a real deployment.
-fn fee_procedures_component() -> anyhow::Result<AccountComponent> {
-    const NAME: &str = "test::fees::fee_procedure_exposer";
-    let code = CodeBuilder::default().compile_component_code(
-        NAME,
-        "pub use {estimate_note_fee} from miden::standards::fees::fee_manager
-         pub use {get_fee_asset_id} from miden::standards::fees::fee_manager
-         pub use {get_fee_policy} from miden::standards::fees::fee_manager
-         pub use {set_fee_policy} from miden::standards::fees::fee_manager
-         pub use {add_allowed_fee_policy} from miden::standards::fees::fee_manager
-         pub use {remove_allowed_fee_policy} from miden::standards::fees::fee_manager\n",
-    )?;
-    Ok(AccountComponent::new(code, vec![], AccountComponentMetadata::mock(NAME))?)
 }
 
 /// The base fee charged by the user-defined test policy in [`custom_fee_policy`].
@@ -101,13 +80,19 @@ pub(super) const CUSTOM_FEE_AMOUNT: u64 = 777;
 /// commitment, timeframe, and priority. The distinct timeframe and priority weights make a
 /// transposition of the two parameters detectable; the storage-commitment term proves the
 /// policy recovered the commitment from the recipient.
+///
+/// The commitment elements are field-summed and reduced to their low 32 bits, keeping the fee
+/// within a valid asset amount for any (hash-derived) commitment.
 pub(super) fn custom_fee_amount_for(
     storage_commitment: Word,
     timeframe: u64,
     priority: u64,
-) -> u64 {
-    let commitment_sum = (0..4).map(|idx| storage_commitment[idx].as_canonical_u64()).sum::<u64>();
-    CUSTOM_FEE_AMOUNT + 2 * timeframe + priority + commitment_sum
+) -> AssetAmount {
+    let elements = storage_commitment.as_elements();
+    let commitment_sum = elements[0] + elements[1] + elements[2] + elements[3];
+    let commitment_term = commitment_sum.as_canonical_u64() & u64::from(u32::MAX);
+    let amount = CUSTOM_FEE_AMOUNT + 2 * timeframe + priority + commitment_term;
+    AssetAmount::new(amount).expect("custom fee amount should not exceed the maximum asset amount")
 }
 
 /// The namespace under which the user-defined test policy is compiled.
@@ -131,8 +116,9 @@ pub(super) fn custom_fee_policy() -> anyhow::Result<FeePolicy> {
         use {{Asset, NoteRecipient}} from miden::protocol::types
 
         #! Fee policy charging a fixed amount plus twice the timeframe plus the priority plus the
-        #! sum of the storage commitment elements (recovered from the recipient via the advice
-        #! provider), in the fee asset the manager is configured with.
+        #! low 32 bits of the sum of the storage commitment elements, in the fee asset the manager
+        #! is configured with. The commitment term is bounded so the fee is always a valid asset
+        #! amount.
         #!
         #! Inputs:  [RECIPIENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT, timeframe, priority, pad(2)]
         #! Outputs: [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(8)]
@@ -150,18 +136,19 @@ pub(super) fn custom_fee_policy() -> anyhow::Result<FeePolicy> {
             # => [NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT,
             #     timeframe, priority, pad(2)]
 
-            # drop the script root and reduce the storage commitment to the sum of its elements
-            dropw add add add
-            # => [storage_commitment_sum, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT, timeframe,
+            # drop the script root and reduce the storage commitment to the low 32 bits of the sum
+            # of its elements. The commitment's raw sum could exceed a valid asset amount so we
+            # take the the low 32 bits.
+            dropw add add add u32split swap drop
+            # => [storage_commitment_term, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT, timeframe,
             #     priority, pad(2)]
 
-            # keep the sum and the timeframe and priority as pricing inputs, dropping the
-            # remaining note parameters
+            # drop the remaining note parameters
             movdn.8 dropw dropw
-            # => [storage_commitment_sum, timeframe, priority, pad(10)]
+            # => [storage_commitment_term, timeframe, priority, pad(10)]
 
-            # charge the base amount plus twice the timeframe plus the priority plus the storage
-            # commitment sum
+            # charge the base amount plus twice the timeframe plus the priority plus the bounded
+            # storage commitment term
             swap mul.2 add add push.{CUSTOM_FEE_AMOUNT} add
             # => [fee_amount, pad(12)]
 
@@ -197,17 +184,28 @@ pub(super) fn custom_fee_policy() -> anyhow::Result<FeePolicy> {
     Ok(FeePolicy::custom(root, [component])?)
 }
 
-/// Builds an account exposing the fee policy manager procedures, owned by `owner` via
-/// `Ownable2Step` with an owner-controlled `Authority` so the owner-gated `set_fee_policy` can be
-/// exercised.
-pub(super) fn build_fee_account_with_switching(owner: AccountId) -> anyhow::Result<Account> {
+/// Builds an `AuthNetworkAccount`-authenticated account exposing the fee policy manager procedures,
+/// owned by `owner` via `Ownable2Step` with an owner-controlled `Authority` so the owner-gated
+/// `set_fee_policy` can be exercised.
+///
+/// `allowed_note_roots` and `allowed_tx_script_roots` seed the network-auth allowlists, so callers
+/// must register the roots of any note they consume or transaction script they run against the
+/// account (the auth procedure rejects a transaction touching a non-allowlisted root).
+pub(super) fn build_fee_account_with_switching(
+    owner: AccountId,
+    allowed_note_roots: BTreeSet<NoteScriptRoot>,
+    allowed_tx_script_roots: BTreeSet<TransactionScriptRoot>,
+) -> anyhow::Result<Account> {
     Ok(AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
+        .with_components(Auth::NetworkAccount {
+            fee_policy_manager: fee_policy_manager(&allowed_note_roots)?,
+            allowed_script_roots: allowed_note_roots,
+            allowed_tx_script_roots,
+        })
         .with_component(BasicWallet)
         .with_component(Ownable2Step::new(owner))
         .with_component(Authority::OwnerControlled)
-        .with_components(fee_policy_manager_with_storage(fee_policy_manager()?)?)
         .build_existing()?)
 }
 
@@ -318,27 +316,6 @@ fn build_sender_note(sender: AccountId, seed: u32, note_script: &str) -> anyhow:
         .build()?)
 }
 
-/// Consumes `note` with `account_id`, commits the resulting transaction, and advances the chain so
-/// the account's storage mutation takes effect for subsequent transactions. Panics if the
-/// transaction fails.
-async fn consume_note(
-    mock_chain: &mut MockChain,
-    account_id: AccountId,
-    note: &Note,
-) -> anyhow::Result<()> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let executed_transaction = mock_chain
-        .build_transaction(account_id)
-        .authenticated_input_note(note.id())
-        .with_source_manager(source_manager)
-        .build()?
-        .execute()
-        .await?;
-    mock_chain.add_pending_executed_transaction(&executed_transaction)?;
-    mock_chain.prove_next_block()?;
-    Ok(())
-}
-
 // TESTS
 // ================================================================================================
 
@@ -354,17 +331,6 @@ async fn estimate_note_fee_returns_scheduled_fee(
     #[case] queried_root: NoteScriptRoot,
     #[case] expected_amount: u64,
 ) -> anyhow::Result<()> {
-    let account = AccountBuilder::new([1; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
-        .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(fee_policy_manager()?)?)
-        .build_existing()?;
-
-    let mut builder = MockChain::builder();
-    builder.add_account(account.clone())?;
-    let mock_chain = builder.build()?;
-
     // The constant fee policy ignores the storage commitment, timeframe, and priority, so an
     // all-zero commitment and arbitrary non-zero timeframe and priority are passed.
     let tx_script_code = estimate_note_fee_tx_script_code(
@@ -376,8 +342,33 @@ async fn estimate_note_fee_returns_scheduled_fee(
     );
     let tx_script = CodeBuilder::default().compile_tx_script(tx_script_code)?;
 
+    let mut builder = MockChain::builder();
+    let sender = builder.add_existing_wallet(Auth::IncrNonce)?;
+
+    // A note-less query transaction would be rejected as an empty no-op, so the account consumes a
+    // note. Its root is allowlisted and scheduled at a 0 fee so the auth procedure's fee collection
+    // stays a no-op.
+    let consumed_note = builder.add_p2any_note(sender.id(), NoteType::Public, [])?;
+    let consumed_root = consumed_note.script().root();
+
+    // The network auth procedure runs after the tx script and rejects any non-allowlisted tx script
+    // or input note, so allowlist both the estimate script and the consumed note.
+    let account = AccountBuilder::new([1; 32])
+        .account_type(AccountType::Public)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::from([consumed_root]),
+            allowed_tx_script_roots: BTreeSet::from([tx_script.root()]),
+            fee_policy_manager: fee_policy_manager(&BTreeSet::from([consumed_root]))?,
+        })
+        .with_component(BasicWallet)
+        .build_existing()?;
+
+    builder.add_account(account.clone())?;
+    let mock_chain = builder.build()?;
+
     mock_chain
         .build_transaction(account.id())
+        .authenticated_input_note(consumed_note.id())
         .tx_script(tx_script)
         .tx_script_args(queried_root.as_word())
         .build()?
@@ -396,17 +387,6 @@ async fn estimate_note_fee_rejects_non_u32_timeframe_or_priority(
     #[case] timeframe: u64,
     #[case] priority: u64,
 ) -> anyhow::Result<()> {
-    let account = AccountBuilder::new([1; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
-        .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(fee_policy_manager()?)?)
-        .build_existing()?;
-
-    let mut builder = MockChain::builder();
-    builder.add_account(account.clone())?;
-    let mock_chain = builder.build()?;
-
     // The expected fee asset is irrelevant since the call aborts before the assertions.
     let tx_script_code = estimate_note_fee_tx_script_code(
         Word::empty(),
@@ -416,6 +396,20 @@ async fn estimate_note_fee_rejects_non_u32_timeframe_or_priority(
         Word::empty(),
     );
     let tx_script = CodeBuilder::default().compile_tx_script(tx_script_code)?;
+
+    let account = AccountBuilder::new([1; 32])
+        .account_type(AccountType::Public)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::new(),
+            allowed_tx_script_roots: BTreeSet::from([tx_script.root()]),
+            fee_policy_manager: fee_policy_manager(&BTreeSet::new())?,
+        })
+        .with_component(BasicWallet)
+        .build_existing()?;
+
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+    let mock_chain = builder.build()?;
 
     let result = mock_chain
         .build_transaction(account.id())
@@ -443,22 +437,25 @@ async fn estimate_note_fee_rejects_non_u32_timeframe_or_priority(
 /// of 0.
 #[tokio::test]
 async fn estimate_note_fee_aborts_for_unscheduled_root() -> anyhow::Result<()> {
-    let account = AccountBuilder::new([1; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
-        .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(fee_policy_manager()?)?)
-        .build_existing()?;
-
-    let mut builder = MockChain::builder();
-    builder.add_account(account.clone())?;
-    let mock_chain = builder.build()?;
-
     // The expected fee asset words are irrelevant: execution aborts in `compute_note_fee`
     // before the tx script's assertions are reached.
     let tx_script_code =
         estimate_note_fee_tx_script_code(Word::empty(), 0, 0, Word::empty(), Word::empty());
     let tx_script = CodeBuilder::default().compile_tx_script(tx_script_code)?;
+
+    let account = AccountBuilder::new([1; 32])
+        .account_type(AccountType::Public)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::new(),
+            allowed_tx_script_roots: BTreeSet::from([tx_script.root()]),
+            fee_policy_manager: fee_policy_manager(&BTreeSet::new())?,
+        })
+        .with_component(BasicWallet)
+        .build_existing()?;
+
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+    let mock_chain = builder.build()?;
 
     let result = mock_chain
         .build_transaction(account.id())
@@ -489,11 +486,15 @@ async fn estimate_note_fee_dispatches_to_custom_policy_via_fpi() -> anyhow::Resu
         .active_fee_policy(custom_fee_policy()?)
         .build();
 
+    // The foreign account's auth never runs under FPI, so its allowlists can stay empty.
     let foreign_account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::new(),
+            allowed_tx_script_roots: BTreeSet::new(),
+            fee_policy_manager,
+        })
         .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(fee_policy_manager)?)
         .build_existing()?;
 
     let native_account = AccountBuilder::new([2; 32])
@@ -569,8 +570,7 @@ async fn estimate_note_fee_dispatches_to_custom_policy_via_fpi() -> anyhow::Resu
         foreign_suffix = foreign_account.id().suffix(),
         expected_fee_asset_id = AssetId::new_fungible(fee_faucet_id()?).to_word(),
         expected_fee_value =
-            AssetAmount::new(custom_fee_amount_for(storage_commitment, timeframe, priority))?
-                .to_word(),
+            custom_fee_amount_for(storage_commitment, timeframe, priority).to_word(),
     );
 
     let tx_script = CodeBuilder::default().compile_tx_script(tx_script_code)?;
@@ -594,8 +594,6 @@ async fn get_fee_policy_returns_active_policy_root_via_note() -> anyhow::Result<
     let owner_account_id =
         AccountId::builder().account_type(AccountType::Private).build_with_seed([4; 32]);
 
-    let account = build_fee_account_with_switching(owner_account_id)?;
-
     // The active policy is the constant fee policy the manager is built with.
     let get_policy_note_script =
         create_get_fee_policy_note_script(ConstantFeePolicy::root().as_word());
@@ -604,6 +602,14 @@ async fn get_fee_policy_returns_active_policy_root_via_note() -> anyhow::Result<
         .note_type(NoteType::Private)
         .code(get_policy_note_script)
         .build()?;
+
+    // The account only consumes the get-policy note, so allowlist just its script root (the auth
+    // procedure also prices it, which the helper schedules at a 0 fee).
+    let account = build_fee_account_with_switching(
+        owner_account_id,
+        BTreeSet::from([get_policy_note.script().root()]),
+        BTreeSet::new(),
+    )?;
 
     let mut builder = MockChain::builder();
     builder.add_account(account.clone())?;
@@ -626,11 +632,15 @@ async fn get_fee_policy_returns_active_policy_root_via_note() -> anyhow::Result<
 /// returned fee asset ID.
 #[tokio::test]
 async fn get_fee_asset_id_returns_configured_fee_asset_via_fpi() -> anyhow::Result<()> {
+    // The foreign account's auth never runs under FPI, so its allowlists can stay empty.
     let foreign_account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::IncrNonce)
+        .with_components(Auth::NetworkAccount {
+            allowed_script_roots: BTreeSet::new(),
+            allowed_tx_script_roots: BTreeSet::new(),
+            fee_policy_manager: fee_policy_manager(&BTreeSet::new())?,
+        })
         .with_component(BasicWallet)
-        .with_components(fee_policy_manager_with_storage(fee_policy_manager()?)?)
         .build_existing()?;
 
     let native_account = AccountBuilder::new([2; 32])
@@ -684,32 +694,90 @@ async fn get_fee_asset_id_returns_configured_fee_asset_via_fpi() -> anyhow::Resu
     Ok(())
 }
 
-/// The owner mutates the allowed-policies map after deployment, and a follow-up `set_fee_policy` to
-/// the mutated root reflects the change: an added root becomes switchable, while a removed root can
-/// no longer be switched to (`ERR_FEE_POLICY_ROOT_NOT_ALLOWED`). This proves the allowlist can be
-/// both extended and narrowed post-deployment.
+/// Builds the owner-gated network account for [`owner_can_mutate_allowed_fee_policy_roots`],
+/// scheduling each root in `allowed_note_roots` at a 0 fee.
 ///
-/// - `add`: `FeeManager::get_fee_policy_root` is a procedure of the account but not in the initial
-///   allowlist, so `set_fee_policy` rejects it before the add and accepts it after.
-/// - `remove`: the reserved `custom_fee_policy` root is allowlisted at deployment, so
-///   `set_fee_policy` accepts it before the remove and rejects it after.
+/// When `custom_policy_allowed` is set, [`custom_fee_policy`] starts in the allowed-policies map.
+/// Otherwise it is left off the initial allowlist but its component is still installed, so it only
+/// becomes switchable once the owner adds its root at runtime. That test needs both starting states
+/// so it can exercise a meaningful add (root starts disallowed) and remove (root starts allowed);
+/// it therefore builds its account here rather than through [`build_fee_account_with_switching`],
+/// which always registers the custom policy.
+fn build_mutation_test_account(
+    owner: AccountId,
+    allowed_note_roots: BTreeSet<NoteScriptRoot>,
+    custom_policy_allowed: bool,
+) -> anyhow::Result<Account> {
+    let mut constant_fee_policy = ConstantFeePolicy::new()
+        .with_fee(priced_root(), AssetAmount::new(FEE_AMOUNT)?)
+        .with_fee(free_root(), AssetAmount::ZERO);
+    for note_root in &allowed_note_roots {
+        constant_fee_policy = constant_fee_policy.with_fee(*note_root, AssetAmount::ZERO);
+    }
+
+    let mut manager_builder = FeePolicyManager::builder()
+        .fee_faucet_id(fee_faucet_id()?)
+        .active_fee_policy(constant_fee_policy.into());
+    if custom_policy_allowed {
+        manager_builder = manager_builder.allowed_fee_policy(custom_fee_policy()?);
+    }
+
+    let mut account_builder = AccountBuilder::new([1; 32])
+        .account_type(AccountType::Public)
+        .with_components(Auth::NetworkAccount {
+            fee_policy_manager: manager_builder.build(),
+            allowed_script_roots: allowed_note_roots,
+            allowed_tx_script_roots: BTreeSet::new(),
+        })
+        .with_component(BasicWallet)
+        .with_component(Ownable2Step::new(owner))
+        .with_component(Authority::OwnerControlled);
+
+    // The manager only installs components for the policies it registers, so when the custom policy
+    // is left off the initial allowlist its component must be installed separately to keep it
+    // dispatchable once the owner adds its root at runtime.
+    if !custom_policy_allowed {
+        for component in custom_fee_policy()? {
+            account_builder = account_builder.with_component(component);
+        }
+    }
+
+    Ok(account_builder.build_existing()?)
+}
+
+/// The owner mutates the allowed-policies map after deployment, then a follow-up transaction whose
+/// note switches the active policy to the `custom_fee_policy` root observes the mutation. Each case
+/// starts from the initial allowlist state that makes its mutation meaningful.
+///
+/// - `add`: the custom policy starts off the allowlist, so `add_allowed_fee_policy` is what makes
+///   it switchable. Switching then succeeds; the network auth procedure prices the switch note
+///   through the now-active custom policy, so the note is paired with a FEE_SPONSORSHIP note
+///   covering that fee and the transaction succeeds.
+/// - `remove`: the custom policy starts on the allowlist, so `remove_allowed_fee_policy` is what
+///   makes it non-switchable. Switching then is rejected with `ERR_FEE_POLICY_ROOT_NOT_ALLOWED`
+///   before fee collection, leaving the sponsorship note unused.
 #[rstest]
-#[case::add("add_allowed_fee_policy", AuthNetworkAccount::get_fee_policy_root().as_word(), None)]
+#[case::add(
+    "add_allowed_fee_policy",
+    custom_fee_policy().unwrap().root().as_word(),
+    false,
+    None
+)]
 #[case::remove(
     "remove_allowed_fee_policy",
     custom_fee_policy().unwrap().root().as_word(),
+    true,
     Some(ERR_FEE_POLICY_ROOT_NOT_ALLOWED)
 )]
 #[tokio::test]
 async fn owner_can_mutate_allowed_fee_policy_roots(
     #[case] mutator_proc: &str,
     #[case] target_root: Word,
+    #[case] custom_policy_initially_allowed: bool,
     #[case] set_fee_policy_error: Option<MasmError>,
 ) -> anyhow::Result<()> {
     let owner_account_id =
         AccountId::builder().account_type(AccountType::Private).build_with_seed([4; 32]);
-
-    let account = build_fee_account_with_switching(owner_account_id)?;
 
     let mutation_note = build_sender_note(
         owner_account_id,
@@ -722,23 +790,62 @@ async fn owner_can_mutate_allowed_fee_policy_roots(
         &create_fee_manager_note_script("set_fee_policy", target_root),
     )?;
 
+    // The account consumes the mutation note, the switch note, and the switch note's sponsorship
+    // note, so allowlist all three roots. The helper schedules the mutation and switch note roots
+    // at a 0 fee, so the still-active constant policy prices them for free.
+    let account = build_mutation_test_account(
+        owner_account_id,
+        BTreeSet::from([
+            mutation_note.script().root(),
+            set_note.script().root(),
+            FeeSponsorshipNote::script_root(),
+        ]),
+        custom_policy_initially_allowed,
+    )?;
+
+    // In the `add` case the switch note activates the custom policy, which fee collection then
+    // prices the switch note through (on its storage commitment, with a timeframe and priority
+    // of 0), so pair it with a sponsorship note covering exactly that fee. The `remove` case
+    // aborts in the switch note's script before fee collection, leaving the sponsorship note
+    // unused.
+    let custom_fee = custom_fee_amount_for(set_note.recipient().storage().commitment(), 0, 0);
+    let sponsorship_note = Note::from(
+        FeeSponsorshipNote::builder()
+            .sender(owner_account_id)
+            .target_account(account.id())
+            .feature_note_id(set_note.id())
+            .asset(FungibleAsset::new(fee_faucet_id()?, custom_fee.as_u64())?)
+            .serial_number(Word::from([1, 2, 3, 4u32]))
+            .build()?,
+    );
+
     let mut builder = MockChain::builder();
     builder.add_account(account.clone())?;
     builder.add_output_note(RawOutputNote::Full(mutation_note.clone()));
     builder.add_output_note(RawOutputNote::Full(set_note.clone()));
+    builder.add_output_note(RawOutputNote::Full(sponsorship_note.clone()));
     let mut mock_chain = builder.build()?;
     mock_chain.prove_next_block()?;
 
-    // Apply the allowlist mutation; it takes effect from the next block.
-    consume_note(&mut mock_chain, account.id(), &mutation_note).await?;
+    // Apply the allowlist mutation; it takes effect from the next block. The mutation note is
+    // priced by the still-active constant policy at 0, so it needs no sponsorship.
+    let executed_transaction = mock_chain
+        .build_transaction(account.id())
+        .authenticated_input_note(mutation_note.id())
+        .build()?
+        .execute()
+        .await?;
+    mock_chain.add_pending_executed_transaction(&executed_transaction)?;
+    mock_chain.prove_next_block()?;
 
-    // Switching to the mutated root now behaves per the mutation: an added root is accepted, a
-    // removed root aborts with `ERR_FEE_POLICY_ROOT_NOT_ALLOWED`.
-    let source_manager = Arc::new(DefaultSourceManager::default());
+    // Switch to the mutated root, consuming the switch note followed immediately by its sponsorship
+    // note. In the `add` case the switch succeeds and fee collection prices the switch note through
+    // the now-active custom policy, covered by the sponsorship; in the `remove` case the switch
+    // note aborts with `ERR_FEE_POLICY_ROOT_NOT_ALLOWED`.
     let result = mock_chain
         .build_transaction(account.id())
         .authenticated_input_note(set_note.id())
-        .with_source_manager(source_manager)
+        .authenticated_input_note(sponsorship_note.id())
         .build()?
         .execute()
         .await;
@@ -762,13 +869,20 @@ async fn non_owner_cannot_add_allowed_fee_policy_root() -> anyhow::Result<()> {
     let non_owner_account_id =
         AccountId::builder().account_type(AccountType::Private).build_with_seed([5; 32]);
 
-    let account = build_fee_account_with_switching(owner_account_id)?;
-
     let new_root = AuthNetworkAccount::get_fee_policy_root().as_word();
     let add_note = build_sender_note(
         non_owner_account_id,
         702,
         &create_fee_manager_note_script("add_allowed_fee_policy", new_root),
+    )?;
+
+    // Allowlist the consumed note's root so execution reaches the gated `add_allowed_fee_policy`
+    // (which aborts because the sender is not the owner) instead of being rejected by the auth
+    // procedure's allowlist check.
+    let account = build_fee_account_with_switching(
+        owner_account_id,
+        BTreeSet::from([add_note.script().root()]),
+        BTreeSet::new(),
     )?;
 
     let mut builder = MockChain::builder();
@@ -799,8 +913,6 @@ async fn removing_active_policy_root_is_rejected() -> anyhow::Result<()> {
     let owner_account_id =
         AccountId::builder().account_type(AccountType::Private).build_with_seed([4; 32]);
 
-    let account = build_fee_account_with_switching(owner_account_id)?;
-
     // The active policy is the `ConstantFeePolicy`; its root is registered in the allowlist at
     // deployment.
     let active_root = ConstantFeePolicy::root().as_word();
@@ -809,6 +921,14 @@ async fn removing_active_policy_root_is_rejected() -> anyhow::Result<()> {
         owner_account_id,
         720,
         &create_fee_manager_note_script("remove_allowed_fee_policy", active_root),
+    )?;
+
+    // Allowlist the consumed note's root so execution reaches the gated `remove_allowed_fee_policy`
+    // (which aborts because the target is the active policy's root).
+    let account = build_fee_account_with_switching(
+        owner_account_id,
+        BTreeSet::from([remove_note.script().root()]),
+        BTreeSet::new(),
     )?;
 
     let mut builder = MockChain::builder();


### PR DESCRIPTION

## Summary

Test-only changes. Switches the fee-collection and fee-manager tests from `Auth::IncrNonce` plus test-only scaffolding to the real `AuthNetworkAccount`, so fee collection and network-note sponsorship run through the actual auth procedure instead of hand-written wrappers. This simplifies tests and makes them assert the real code instead of ad-hoc test-only components.

## Changes

- Accounts in `fee_collection.rs` and `fee_manager.rs` now build with `Auth::NetworkAccount`.
- Removed test-only scaffolding now provided by the auth procedure:
  - `collect_sponsored_fees` `@account_procedure` wrapper + `collect_tx_script` - fee collection now fires automatically on note consumption.
  - `sponsorship_creator_component` - sponsoring network notes now happens in the auth procedure; the sponsor tx script only creates the note (via the real `NoteCreator::create_note`) and attaches the `NetworkAccountTarget`.
  - `fee_policy_manager_with_storage` / `fee_procedures_component` - the `AuthNetworkAccount` component owns the fee-policy storage and procedures.
- Sponsorships are now funded in the native fee asset rather than the manager's configured asset.
- Added assertions on the created feature/sponsorship notes in one of the tests.
- `custom_fee_amount_for` bounds the commitment term to its low 32 bits, keeping the fee a valid asset amount for any hash-derived commitment.
- The wrong-asset mismatch case keeps a minimal test-only component, since the real auth flow can never pass a mismatched expected fee asset.

One thing I think we should do separately is add the `FeeSponsorshipNote` to the network account allowlist by default.