### PR TITLE
feat: make link map events unprivileged

### DIFF
--- a/crates/miden-protocol/src/transaction/kernel/tx_event_id.rs
+++ b/crates/miden-protocol/src/transaction/kernel/tx_event_id.rs
@@ -85,10 +85,7 @@ impl TransactionEventId {
     ///
     /// The host enforces this: a privileged event emitted from a non-root context is rejected.
     pub fn is_privileged(&self) -> bool {
-        let is_unprivileged = matches!(
-            self,
-            Self::AuthRequest | Self::Unauthorized | Self::LinkMapSet | Self::LinkMapGet
-        );
+        let is_unprivileged = matches!(self, Self::AuthRequest | Self::Unauthorized);
         !is_unprivileged
     }
 


### PR DESCRIPTION
closes https://github.com/0xMiden/protocol/issues/3389

After looking into it more, making the link map code not panic is a larger refactor, and making the event privileged should root out any malicious panic, so this seems good enough for now.