### PR TITLE
feat: add `FeeSponsorshipNote` to `NetworkAccount` allowlist by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [BREAKING] Made `MockTransaction::execute_code` and the `executor` module test-only, and removed `MockTransactionBuilder::disable_lazy_loading` ([#1919](https://github.com/0xMiden/protocol/issues/1919)).
 - [BREAKING] Renamed the `FeeManager` component to `FeePolicyManager` and turned it from an account component into the fee-policy configuration of the `AuthNetworkAccount` component ([#3353](https://github.com/0xMiden/protocol/pull/3353)).
 - [BREAKING] Renamed `ConstantFeePolicy` to `BasicConstantFeePolicy` ([#3391](https://github.com/0xMiden/protocol/issues/3391)).
+- [BREAKING] Moved the network-account default configuration into `AuthNetworkAccount::new`, which now allowlists the `NetworkAccountConfigNote` and `FeeSponsorshipNote` script roots and the canonical `ExpirationTransactionScript` tx-script root; added `AuthNetworkAccount::custom` to build a raw component with no default configuration for low-level use, and removed `AuthNetworkAccount::with_allowed_tx_scripts` ([#3392](https://github.com/0xMiden/protocol/pull/3392)).
 
 ## v0.16.0-beta.1 (2026-07-20)
 

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -23,8 +23,9 @@ use super::{
 };
 use crate::account::account_component_code;
 use crate::account::fees::FeePolicyManager;
-use crate::note::NetworkAccountConfigNote;
+use crate::note::{FeeSponsorshipNote, NetworkAccountConfigNote};
 use crate::procedure_root;
+use crate::tx_script::ExpirationTransactionScript;
 
 account_component_code!(NETWORK_ACCOUNT_AUTH_CODE, "miden-standards-auth-network-account.masp");
 
@@ -187,47 +188,63 @@ impl AuthNetworkAccount {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Creates a new [`AuthNetworkAccount`] component that allows the provided input-note script
-    /// roots and pays fees per the given [`FeePolicyManager`].
+    /// Creates a new [`AuthNetworkAccount`] component configured with the standard network-account
+    /// defaults on top of the provided input-note script roots, paying fees per the given
+    /// [`FeePolicyManager`].
+    ///
+    /// On top of `allowed_notes`, the following default configuration is always applied (use
+    /// [`custom`](Self::custom) for a variant that applies none of it):
+    /// - The standardized [`NetworkAccountConfigNote`] script root is added to the note allowlist,
+    ///   so the account's allowlists can be updated after deployment by sending that note.
+    /// - The [`FeeSponsorshipNote`] script root is added to the note allowlist. A network account
+    ///   collects prepaid fees by consuming these notes, so without it, fees could not be
+    ///   collected. Allowlisting it is safe: an unpaired sponsorship note is rejected during fee
+    ///   collection.
+    /// - The tx-script allowlist contains the [`ExpirationTransactionScript`] root, which the
+    ///   network transaction builder attaches to every network transaction, so the account is
+    ///   serviceable by the network.
     ///
     /// The active policy, allowed policies and fee asset of `fee_policy_manager` initialize the
     /// three fee-policy storage slots this component owns. The manager is carried by the component
     /// and the components of its registered policies are emitted alongside it when the component is
     /// expanded (see the [`IntoIterator`] impl), so the caller does not install them separately.
-    ///
-    /// The standardized [`NetworkAccountConfigNote`] script root is always added to the allowlist,
-    /// so the account's allowlists can be updated after deployment by sending that note. To
-    /// authorize those updates, the account must also install an
-    /// [`Authority`](crate::account::access::Authority) component in
-    /// [`OwnerControlled`](crate::account::access::Authority::OwnerControlled) or
-    /// [`RbacControlled`](crate::account::access::Authority::RbacControlled) mode: the note sender
-    /// is checked against it.
     pub fn new(
-        mut allowed_script_roots: BTreeSet<NoteScriptRoot>,
+        mut allowed_notes: BTreeSet<NoteScriptRoot>,
         fee_policy_manager: FeePolicyManager,
     ) -> Result<Self, NetworkAccountNoteAllowlistError> {
-        allowed_script_roots.insert(NetworkAccountConfigNote::script_root());
+        allowed_notes.insert(NetworkAccountConfigNote::script_root());
+        allowed_notes.insert(FeeSponsorshipNote::script_root());
+        Ok(Self::custom(allowed_notes, fee_policy_manager)?
+            .with_allowed_tx_scripts([ExpirationTransactionScript::script_root()]))
+    }
+
+    /// Creates a raw [`AuthNetworkAccount`] component from the given note-script allowlist, with an
+    /// empty tx-script allowlist and without any default configuration.
+    ///
+    /// Most callers should use [`Self::new`] to include the defaults.
+    pub fn custom(
+        allowed_notes: BTreeSet<NoteScriptRoot>,
+        fee_policy_manager: FeePolicyManager,
+    ) -> Result<Self, NetworkAccountNoteAllowlistError> {
         Ok(Self {
-            allowed_notes: NetworkAccountNoteAllowlist::new(allowed_script_roots)?,
+            allowed_notes: NetworkAccountNoteAllowlist::new(allowed_notes)?,
             allowed_tx_scripts: NetworkAccountTxScriptAllowlist::default(),
             policy_manager: fee_policy_manager,
         })
     }
 
-    /// Sets the allowlist of transaction script roots this account will execute, replacing any
-    /// previously configured tx-script allowlist.
+    /// Extends the tx-script allowlist with the given transaction script roots, keeping any that
+    /// are already allowlisted.
     ///
-    /// An empty set (the default) means the account permits no transaction scripts.
-    ///
-    /// Only scripts whose effect is safe for every possible input should be allowlisted: a root
-    /// pins the script's code but not its `TX_SCRIPT_ARGS` or advice inputs, which the
-    /// (arbitrary) transaction submitter controls. See the [`AuthNetworkAccount`] type docs for
-    /// the full rationale.
+    /// Only tx scripts whose effect is safe for every possible input should be allowlisted: a root
+    /// pins the script's code but not its `TX_SCRIPT_ARGS` or advice inputs, which the (arbitrary)
+    /// transaction submitter controls. See the [`AuthNetworkAccount`] type docs for the full
+    /// rationale.
     pub fn with_allowed_tx_scripts(
         mut self,
-        allowed_tx_script_roots: BTreeSet<TransactionScriptRoot>,
+        allowed_tx_script_roots: impl IntoIterator<Item = TransactionScriptRoot>,
     ) -> Self {
-        self.allowed_tx_scripts = NetworkAccountTxScriptAllowlist::new(allowed_tx_script_roots);
+        self.allowed_tx_scripts.extend_script_roots(allowed_tx_script_roots);
         self
     }
 
@@ -409,14 +426,14 @@ mod tests {
     }
 
     #[test]
-    fn auth_network_account_with_empty_input_allowlists_only_config_note() {
+    fn auth_network_account_with_empty_input_allowlists_default_notes() {
         let account = AccountBuilder::new([0; 32])
             .with_components(
                 AuthNetworkAccount::new(
                     BTreeSet::new(),
                     FeePolicyManager::mock(FungibleAsset::mock_issuer()),
                 )
-                .expect("config note root makes the allowlist non-empty"),
+                .expect("the default note roots make the allowlist non-empty"),
             )
             .with_component(BasicWallet)
             .build()
@@ -427,8 +444,11 @@ mod tests {
 
         assert_eq!(
             allowlist.allowed_script_roots(),
-            &BTreeSet::from_iter([NetworkAccountConfigNote::script_root()]),
-            "an empty input should yield an allowlist containing only the config note root",
+            &BTreeSet::from_iter([
+                NetworkAccountConfigNote::script_root(),
+                FeeSponsorshipNote::script_root(),
+            ]),
+            "an empty input should yield an allowlist containing only the default note roots",
         );
     }
 

--- a/crates/miden-standards/src/account/auth/network_account/network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/network_account.rs
@@ -81,35 +81,25 @@ impl NetworkAccount {
 
     /// Creates an [`AccountBuilder`] pre-configured as a network account.
     ///
-    /// The returned builder is set to [`AccountType::Public`] and has the [`AuthNetworkAccount`]
-    /// auth component installed with the provided note allowlist, its fee-policy slots initialized
-    /// from `fee_policy_manager`. The tx-script allowlist contains the canonical
-    /// [`ExpirationTransactionScript`], which the network transaction builder attaches to every
-    /// network transaction it executes, so the built account is serviceable by the network by
-    /// construction.
-    ///
-    /// The components of the fee policies registered with `fee_policy_manager` are installed as
-    /// part of the auth component's expansion, so the active policy is dispatchable without the
-    /// caller installing it separately.
+    /// The returned builder is set to [`AccountType::Public`] with the [`AuthNetworkAccount`] auth
+    /// component installed via [`AuthNetworkAccount::new`] (see it for the default note and
+    /// tx-script configuration applied on top of `allowed_notes`), its fee-policy slots initialized
+    /// from `fee_policy_manager`. The default configuration includes the canonical
+    /// [`ExpirationTransactionScript`] tx-script root, so the built account is serviceable by the
+    /// network by construction. The components of the fee policies registered with
+    /// `fee_policy_manager` are installed as part of the auth component's expansion, so the active
+    /// policy is dispatchable without the caller installing it separately.
     ///
     /// Callers add their functional components to the returned builder and finish with
     /// [`AccountBuilder::build`]; the built account satisfies the [`NetworkAccount`] specification.
-    /// Accounts that need to allowlist additional transaction scripts should construct the
-    /// [`AuthNetworkAccount`] component manually instead.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `allowed_notes` is empty since the account could not consume any
-    /// notes.
+    /// Accounts that need a different set of allowlisted transaction scripts should construct the
+    /// [`AuthNetworkAccount`] component via [`AuthNetworkAccount::custom`] instead.
     pub fn builder(
         init_seed: [u8; 32],
         allowed_notes: BTreeSet<NoteScriptRoot>,
         fee_policy_manager: FeePolicyManager,
     ) -> Result<AccountBuilder, NetworkAccountNoteAllowlistError> {
-        let auth_component = AuthNetworkAccount::new(allowed_notes, fee_policy_manager)?
-            .with_allowed_tx_scripts(
-                [ExpirationTransactionScript::script_root()].into_iter().collect(),
-            );
+        let auth_component = AuthNetworkAccount::new(allowed_notes, fee_policy_manager)?;
 
         Ok(AccountBuilder::new(init_seed)
             .account_type(AccountType::Public)
@@ -198,6 +188,7 @@ mod tests {
     use super::*;
     use crate::account::auth::network_account::AuthNetworkAccount;
     use crate::account::wallets::BasicWallet;
+    use crate::note::FeeSponsorshipNote;
 
     fn build_account(account_type: AccountType, roots: BTreeSet<NoteScriptRoot>) -> Account {
         AccountBuilder::new([0; 32])
@@ -207,10 +198,7 @@ mod tests {
                     roots,
                     FeePolicyManager::mock(FungibleAsset::mock_issuer()),
                 )
-                .expect("non-empty allowlist")
-                .with_allowed_tx_scripts(
-                    [ExpirationTransactionScript::script_root()].into_iter().collect(),
-                ),
+                .expect("non-empty allowlist"),
             )
             .with_component(BasicWallet)
             .build()
@@ -229,6 +217,7 @@ mod tests {
 
         let mut expected = roots;
         expected.insert(crate::note::NetworkAccountConfigNote::script_root());
+        expected.insert(FeeSponsorshipNote::script_root());
         assert_eq!(actual, expected);
     }
 
@@ -266,10 +255,12 @@ mod tests {
     #[test]
     fn account_without_expiration_script_is_rejected() {
         let note_root = NoteScriptRoot::from_array([1, 2, 3, 4]);
+        // `custom` applies no defaults, so the tx-script allowlist stays empty and the account
+        // lacks the canonical expiration root.
         let account = AccountBuilder::new([0; 32])
             .account_type(AccountType::Public)
             .with_components(
-                AuthNetworkAccount::new(
+                AuthNetworkAccount::custom(
                     BTreeSet::from_iter([note_root]),
                     FeePolicyManager::mock(FungibleAsset::mock_issuer()),
                 )
@@ -284,7 +275,8 @@ mod tests {
     }
 
     /// `NetworkAccount::builder` produces an account that satisfies the network account
-    /// specification and allowlists the canonical expiration tx script.
+    /// specification, allowlists the canonical expiration tx script, and allowlists the
+    /// FEE_SPONSORSHIP note script so the account can collect its fees.
     #[test]
     fn builder_produces_network_account_with_expiration_script_allowlisted() {
         let note_root = NoteScriptRoot::from_array([1, 2, 3, 4]);
@@ -304,5 +296,12 @@ mod tests {
 
         let other_root = TransactionScriptRoot::from_raw(Word::from([9u32, 10, 11, 12]));
         assert!(!network_account.allows_tx_script(&other_root));
+
+        assert!(
+            network_account
+                .allowed_notes()
+                .allowed_script_roots()
+                .contains(&FeeSponsorshipNote::script_root())
+        );
     }
 }

--- a/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/note_allowlist.rs
@@ -251,6 +251,7 @@ mod tests {
         // The map's ordering is determined by the StorageMapKey, so compare as sets.
         let mut expected: BTreeSet<NoteScriptRoot> = original_roots.into_iter().collect();
         expected.insert(crate::note::NetworkAccountConfigNote::script_root());
+        expected.insert(crate::note::FeeSponsorshipNote::script_root());
         let actual: BTreeSet<NoteScriptRoot> =
             allowlist.allowed_script_roots().iter().copied().collect();
 

--- a/crates/miden-standards/src/account/auth/network_account/tx_script_allowlist.rs
+++ b/crates/miden-standards/src/account/auth/network_account/tx_script_allowlist.rs
@@ -85,6 +85,14 @@ impl NetworkAccountTxScriptAllowlist {
         )
     }
 
+    /// Extends the set of allowed tx script roots.
+    pub(super) fn extend_script_roots(
+        &mut self,
+        allowed_tx_script_roots: impl IntoIterator<Item = TransactionScriptRoot>,
+    ) {
+        self.allowed_script_roots.extend(allowed_tx_script_roots);
+    }
+
     /// Consumes this allowlist and returns the [`StorageSlot`] suitable for inclusion in an
     /// [`AccountComponent`](miden_protocol::account::AccountComponent)'s storage layout.
     pub fn into_storage_slot(self) -> StorageSlot {
@@ -209,7 +217,7 @@ mod tests {
 
         let account = AccountBuilder::new([0; 32])
             .with_components(
-                AuthNetworkAccount::new(
+                AuthNetworkAccount::custom(
                     BTreeSet::from_iter([NoteScriptRoot::from_array([9, 9, 9, 9])]),
                     FeePolicyManager::mock(FungibleAsset::mock_issuer()),
                 )

--- a/crates/miden-standards/src/tx_script/expiration_script.rs
+++ b/crates/miden-standards/src/tx_script/expiration_script.rs
@@ -73,8 +73,8 @@ impl ExpirationTransactionScript {
         Word::from([Felt::from(self.delta.get()), Felt::ZERO, Felt::ZERO, Felt::ZERO])
     }
 
-    /// The [`TransactionScriptRoot`] of the canonical script, to be allowlisted on a network
-    /// account via `AuthNetworkAccount::with_allowed_tx_scripts`.
+    /// The [`TransactionScriptRoot`] of the canonical script, allowlisted on a network account by
+    /// default via `AuthNetworkAccount::new`.
     pub fn script_root() -> TransactionScriptRoot {
         EXPIRATION_TX_SCRIPT.root()
     }

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -66,14 +66,17 @@ fn build_account_with_allowlists(
     allowed_note_script_roots: Vec<Word>,
     allowed_tx_script_roots: Vec<TransactionScriptRoot>,
 ) -> anyhow::Result<Account> {
-    let note_roots: BTreeSet<NoteScriptRoot> =
-        allowed_note_script_roots.into_iter().map(NoteScriptRoot::from_raw).collect();
-    let fee_policy_manager = zero_fee_policy_manager(
-        note_roots.iter().copied().chain([NetworkAccountConfigNote::script_root()]),
-    )?;
+    // Add the config note to the allowlist (it may be consumed to update the allowlists, and the
+    // auth flow needs a price for the config note, too).
+    let note_roots: BTreeSet<NoteScriptRoot> = allowed_note_script_roots
+        .into_iter()
+        .map(NoteScriptRoot::from_raw)
+        .chain([NetworkAccountConfigNote::script_root()])
+        .collect();
+    let fee_policy_manager = zero_fee_policy_manager(note_roots.iter().copied())?;
 
-    let auth_component = AuthNetworkAccount::new(note_roots, fee_policy_manager)?
-        .with_allowed_tx_scripts(allowed_tx_script_roots.into_iter().collect::<BTreeSet<_>>());
+    let auth_component = AuthNetworkAccount::custom(note_roots, fee_policy_manager)?
+        .with_allowed_tx_scripts(allowed_tx_script_roots);
 
     Ok(AccountBuilder::new([0; 32])
         .with_components(auth_component)
@@ -364,8 +367,8 @@ fn build_owner_controlled_account(
     let note_roots: BTreeSet<NoteScriptRoot> =
         extra_allowed_note_roots.into_iter().map(NoteScriptRoot::from_raw).collect();
 
-    // The config note is always allowlisted by `with_allowed_notes` and may be consumed to update
-    // the allowlists; the network auth flow prices every consumed note, so it needs a fee schedule
+    // The config note is allowlisted explicitly below and may be consumed to update the
+    // allowlists; the network auth flow prices every consumed note, so it needs a fee schedule
     // entry too.
     let scheduled_roots = note_roots
         .iter()
@@ -374,8 +377,15 @@ fn build_owner_controlled_account(
         .chain([NetworkAccountConfigNote::script_root()]);
     let fee_policy_manager = zero_fee_policy_manager(scheduled_roots)?;
 
-    let auth_component = AuthNetworkAccount::new(note_roots, fee_policy_manager)?
-        .with_allowed_tx_scripts(BTreeSet::from_iter(allowed_tx_script_roots));
+    let auth_component = AuthNetworkAccount::custom(
+        note_roots
+            .iter()
+            .copied()
+            .chain([NetworkAccountConfigNote::script_root()])
+            .collect(),
+        fee_policy_manager,
+    )?
+    .with_allowed_tx_scripts(BTreeSet::from_iter(allowed_tx_script_roots));
 
     Ok(AccountBuilder::new([7; 32])
         .with_components(auth_component)

--- a/crates/miden-testing/tests/scripts/fee_collection.rs
+++ b/crates/miden-testing/tests/scripts/fee_collection.rs
@@ -14,7 +14,7 @@ use miden_protocol::testing::account_id::{
 };
 use miden_protocol::transaction::{RawOutputNote, TransactionScript};
 use miden_protocol::{Felt, Word};
-use miden_standards::account::auth::AuthNetworkAccount;
+use miden_standards::account::auth::{AuthNetworkAccount, NetworkAccount};
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicy, FeePolicyManager};
 use miden_standards::account::wallets::{BasicWallet, NoteCreator};
 use miden_standards::code_builder::CodeBuilder;
@@ -113,9 +113,10 @@ fn fee_collector_component() -> anyhow::Result<AccountComponent> {
     )?)
 }
 
-/// Builds an `AuthNetworkAccount`-authenticated network account with a `BasicWallet` and a
-/// `FeePolicyManager`. When `fee_entry` is provided, the fee policy manager schedules the
-/// given fee for that note script root; `allowed_note_roots` seeds the note-script allowlist.
+/// Builds a network account with a `BasicWallet` and a `FeePolicyManager`. When `fee_entry` is
+/// provided, the fee policy manager schedules the given fee for that note script root;
+/// `allowed_note_roots` seeds the note-script allowlist (the FEE_SPONSORSHIP root is added by
+/// [`NetworkAccount::builder`]).
 fn network_account(
     fee_entry: Option<(NoteScriptRoot, AssetAmount)>,
     allowed_note_roots: BTreeSet<NoteScriptRoot>,
@@ -129,13 +130,7 @@ fn network_account(
         .active_fee_policy(policy.into())
         .build();
 
-    Ok(AccountBuilder::new([7; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: allowed_note_roots,
-            allowed_tx_script_roots: BTreeSet::new(),
-            fee_policy_manager,
-        })
+    Ok(NetworkAccount::builder([7; 32], allowed_note_roots, fee_policy_manager)?
         .with_component(BasicWallet)
         .build_existing()?)
 }
@@ -169,9 +164,8 @@ fn build_test(
 
     let fee_entry = feature_note_fee.map(|fee| (feature_notes[0].script().root(), fee));
 
-    // The account consumes the feature notes (all sharing one P2ANY root) and their FEE_SPONSORSHIP
-    // notes, so both roots must be allowlisted for the auth procedure to reach fee collection.
-    let mut allowed_note_roots = BTreeSet::from([FeeSponsorshipNote::script_root()]);
+    // The account consumes the feature notes (all sharing one P2ANY root), so allowlist that root.
+    let mut allowed_note_roots = BTreeSet::new();
     if let Some(feature_note) = feature_notes.first() {
         allowed_note_roots.insert(feature_note.script().root());
     }
@@ -324,11 +318,11 @@ async fn set_fee_policy_switches_to_custom_policy() -> anyhow::Result<()> {
     let custom_fee =
         custom_fee_amount_for(set_policy_note.recipient().storage().commitment(), 0, 0);
 
-    // Allowlist both the set_fee_policy note and the FEE_SPONSORSHIP note that pays its fee.
+    // Allowlist the set_fee_policy note; `build_fee_account_with_switching` allowlists the
+    // FEE_SPONSORSHIP note that pays its fee.
     let account = build_fee_account_with_switching(
         owner_account_id,
-        BTreeSet::from([set_policy_note.script().root(), FeeSponsorshipNote::script_root()]),
-        BTreeSet::new(),
+        BTreeSet::from([set_policy_note.script().root()]),
     )?;
 
     let sponsorship_note = Note::from(
@@ -400,9 +394,8 @@ async fn set_fee_policy_rejects_non_allowed_root() -> anyhow::Result<()> {
         AccountId::builder().account_type(AccountType::Private).build_with_seed([4; 32]);
 
     // The set_fee_policy note aborts inside its note script, before the auth allowlist check runs,
-    // so the allowlists can stay empty.
-    let account =
-        build_fee_account_with_switching(owner_account_id, BTreeSet::new(), BTreeSet::new())?;
+    // so the allowlist can stay empty.
+    let account = build_fee_account_with_switching(owner_account_id, BTreeSet::new())?;
 
     // This root exists in the account code, but is not in the fee policy allowlist.
     let invalid_policy_root = AuthNetworkAccount::get_fee_policy_root().as_word();
@@ -485,9 +478,8 @@ async fn non_owner_cannot_set_fee_policy() -> anyhow::Result<()> {
         AccountId::builder().account_type(AccountType::Private).build_with_seed([5; 32]);
 
     // The set_fee_policy note aborts inside its note script, before the auth allowlist check runs,
-    // so the allowlists can stay empty.
-    let account =
-        build_fee_account_with_switching(owner_account_id, BTreeSet::new(), BTreeSet::new())?;
+    // so the allowlist can stay empty.
+    let account = build_fee_account_with_switching(owner_account_id, BTreeSet::new())?;
 
     let set_policy_note_script =
         create_fee_manager_note_script("set_fee_policy", custom_fee_policy()?.root().as_word());
@@ -624,11 +616,10 @@ async fn sponsorship_for_wrong_feature_note_is_rejected() -> anyhow::Result<()> 
     let feature_note = builder.add_p2any_note(sponsor.id(), NoteType::Public, [])?;
     let other_feature_note = builder.add_p2any_note(sponsor.id(), NoteType::Public, [])?;
 
-    // Both feature notes are P2ANY notes and so share one script root; allowlist it and the
-    // FEE_SPONSORSHIP root.
+    // Both feature notes are P2ANY notes and so share one script root; allowlist it.
     let network_account = network_account(
         Some((feature_note.script().root(), AssetAmount::new(FEE_AMOUNT)?)),
-        BTreeSet::from([feature_note.script().root(), FeeSponsorshipNote::script_root()]),
+        BTreeSet::from([feature_note.script().root()]),
     )?;
     builder.add_account(network_account.clone())?;
 
@@ -747,23 +738,17 @@ async fn feature_notes_priced_in_different_assets_are_rejected() -> anyhow::Resu
         other_fee_asset_id,
     )?;
 
-    // Both feature notes are P2ID notes sharing one script root; allowlist it and the
-    // FEE_SPONSORSHIP root.
-    let network_account = AccountBuilder::new([7; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: BTreeSet::from([
-                P2idNote::script_root(),
-                FeeSponsorshipNote::script_root(),
-            ]),
-            allowed_tx_script_roots: BTreeSet::new(),
-            fee_policy_manager: FeePolicyManager::builder()
-                .fee_faucet_id(fee_faucet_id()?)
-                .active_fee_policy(policy)
-                .build(),
-        })
-        .with_component(BasicWallet)
-        .build_existing()?;
+    // Both feature notes are P2ID notes sharing one script root; allowlist it.
+    let network_account = NetworkAccount::builder(
+        [7; 32],
+        BTreeSet::from([P2idNote::script_root()]),
+        FeePolicyManager::builder()
+            .fee_faucet_id(fee_faucet_id()?)
+            .active_fee_policy(policy)
+            .build(),
+    )?
+    .with_component(BasicWallet)
+    .build_existing()?;
 
     builder.add_account(network_account.clone())?;
 

--- a/crates/miden-testing/tests/scripts/fee_manager.rs
+++ b/crates/miden-testing/tests/scripts/fee_manager.rs
@@ -11,10 +11,10 @@ use miden_protocol::asset::{AssetAmount, AssetId, FungibleAsset};
 use miden_protocol::errors::MasmError;
 use miden_protocol::note::{Note, NoteScriptRoot, NoteType};
 use miden_protocol::testing::account_id::ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET;
-use miden_protocol::transaction::{RawOutputNote, TransactionScriptRoot};
+use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::{Felt, Word};
 use miden_standards::account::access::{Authority, Ownable2Step};
-use miden_standards::account::auth::AuthNetworkAccount;
+use miden_standards::account::auth::{AuthNetworkAccount, NetworkAccount};
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicy, FeePolicyManager};
 use miden_standards::account::wallets::BasicWallet;
 use miden_standards::code_builder::CodeBuilder;
@@ -185,25 +185,19 @@ pub(super) fn custom_fee_policy() -> anyhow::Result<FeePolicy> {
     Ok(FeePolicy::custom(root, [component])?)
 }
 
-/// Builds an `AuthNetworkAccount`-authenticated account exposing the fee policy manager procedures,
-/// owned by `owner` via `Ownable2Step` with an owner-controlled `Authority` so the owner-gated
-/// `set_fee_policy` can be exercised.
+/// Builds a network account exposing the fee policy manager procedures, owned by `owner` via
+/// `Ownable2Step` with an owner-controlled `Authority` so the owner-gated `set_fee_policy` can be
+/// exercised.
 ///
-/// `allowed_note_roots` and `allowed_tx_script_roots` seed the network-auth allowlists, so callers
-/// must register the roots of any note they consume or transaction script they run against the
-/// account (the auth procedure rejects a transaction touching a non-allowlisted root).
+/// `allowed_note_roots` seeds the note-script allowlist, so callers must register the root of any
+/// note they consume against the account (the auth procedure rejects a transaction touching a
+/// non-allowlisted root). The FEE_SPONSORSHIP root is allowlisted by [`NetworkAccount::builder`].
 pub(super) fn build_fee_account_with_switching(
     owner: AccountId,
     allowed_note_roots: BTreeSet<NoteScriptRoot>,
-    allowed_tx_script_roots: BTreeSet<TransactionScriptRoot>,
 ) -> anyhow::Result<Account> {
-    Ok(AccountBuilder::new([1; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            fee_policy_manager: fee_policy_manager(&allowed_note_roots)?,
-            allowed_script_roots: allowed_note_roots,
-            allowed_tx_script_roots,
-        })
+    let fee_policy_manager = fee_policy_manager(&allowed_note_roots)?;
+    Ok(NetworkAccount::builder([1; 32], allowed_note_roots, fee_policy_manager)?
         .with_component(BasicWallet)
         .with_component(Ownable2Step::new(owner))
         .with_component(Authority::OwnerControlled)
@@ -609,7 +603,6 @@ async fn get_fee_policy_returns_active_policy_root_via_note() -> anyhow::Result<
     let account = build_fee_account_with_switching(
         owner_account_id,
         BTreeSet::from([get_policy_note.script().root()]),
-        BTreeSet::new(),
     )?;
 
     let mut builder = MockChain::builder();
@@ -724,16 +717,11 @@ fn build_mutation_test_account(
         manager_builder = manager_builder.allowed_fee_policy(custom_fee_policy()?);
     }
 
-    let mut account_builder = AccountBuilder::new([1; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            fee_policy_manager: manager_builder.build(),
-            allowed_script_roots: allowed_note_roots,
-            allowed_tx_script_roots: BTreeSet::new(),
-        })
-        .with_component(BasicWallet)
-        .with_component(Ownable2Step::new(owner))
-        .with_component(Authority::OwnerControlled);
+    let mut account_builder =
+        NetworkAccount::builder([1; 32], allowed_note_roots, manager_builder.build())?
+            .with_component(BasicWallet)
+            .with_component(Ownable2Step::new(owner))
+            .with_component(Authority::OwnerControlled);
 
     // The manager only installs components for the policies it registers, so when the custom policy
     // is left off the initial allowlist its component must be installed separately to keep it
@@ -793,15 +781,11 @@ async fn owner_can_mutate_allowed_fee_policy_roots(
     )?;
 
     // The account consumes the mutation note, the switch note, and the switch note's sponsorship
-    // note, so allowlist all three roots. The helper schedules the mutation and switch note roots
-    // at a 0 fee, so the still-active constant policy prices them for free.
+    // note. Allowlist the mutation and switch note roots; the helper schedules those two roots at a
+    // 0 fee, so the still-active constant policy prices them for free.
     let account = build_mutation_test_account(
         owner_account_id,
-        BTreeSet::from([
-            mutation_note.script().root(),
-            set_note.script().root(),
-            FeeSponsorshipNote::script_root(),
-        ]),
+        BTreeSet::from([mutation_note.script().root(), set_note.script().root()]),
         custom_policy_initially_allowed,
     )?;
 
@@ -884,7 +868,6 @@ async fn non_owner_cannot_add_allowed_fee_policy_root() -> anyhow::Result<()> {
     let account = build_fee_account_with_switching(
         owner_account_id,
         BTreeSet::from([add_note.script().root()]),
-        BTreeSet::new(),
     )?;
 
     let mut builder = MockChain::builder();
@@ -930,7 +913,6 @@ async fn removing_active_policy_root_is_rejected() -> anyhow::Result<()> {
     let account = build_fee_account_with_switching(
         owner_account_id,
         BTreeSet::from([remove_note.script().root()]),
-        BTreeSet::new(),
     )?;
 
     let mut builder = MockChain::builder();


### PR DESCRIPTION

Adds `FeeSponsorshipNote::script_root` to the allowed note list in `AuthNetworkAccount::new` by default and adds `AuthNetworkAccount::custom` for a fully custom instantiation. Also moves the expiration tx script allowlisting to `new`, so all defaults are applied in one place (and no longer only by `NetworkAccount::builder`).

The rationale is that network account fee collection requires this note script and a network account cannot consume notes in production without this script, so it makes for a sensible default. Additionally, an unpaired sponsorship note is rejected, so allowing it cannot be abused (one cannot make a tx with just a sponsorship note, and any other note requires to be added explicitly to the allowlist).

Noticed while working on https://github.com/0xMiden/protocol/pull/3387.