### PR TITLE
chore: bump alpha versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## v0.16.0-alpha.5 (TBD)
+## v0.16.0-alpha.5 (2026-07-24)
 
 ### Changes
 
-- [BREAKING] Made the AggLayer bridge's network ID a deployment setting: the ID is stored in the `agglayer::bridge::network_id` storage slot (written once at account creation and read at runtime via `bridge_config::load_network_id`) instead of being compiled in as the `MIDEN_NETWORK_ID` MASM constant, so all deployments share one bridge code commitment; `create_bridge_account` now takes a `network_id` argument ([#3062](https://github.com/0xMiden/protocol/pull/3062)).
+- [BREAKING] Made the AggLayer bridge's network ID a deployment setting ([#3386](https://github.com/0xMiden/protocol/pull/3386)).
 
 ## v0.16.0-alpha.4 (2026-07-16)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.16.0-alpha.4"
+version = "0.16.0-alpha.5"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-alpha.4"
+version = "0.16.0-alpha.5"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-alpha.4"
+version = "0.16.0-alpha.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-alpha.4"
+version = "0.16.0-alpha.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-alpha.4"
+version = "0.16.0-alpha.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-alpha.4"
+version = "0.16.0-alpha.5"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-alpha.4"
+version = "0.16.0-alpha.5"
 dependencies = [
  "miden-processor",
  "miden-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.96.1"
-version      = "0.16.0-alpha.4"
+version      = "0.16.0-alpha.5"
 
 [profile.release]
 codegen-units = 1
@@ -36,13 +36,13 @@ lto           = true
 
 [workspace.dependencies]
 # Workspace crates
-miden-agglayer     = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-alpha.4" }
-miden-block-prover = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-alpha.4" }
-miden-protocol     = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-alpha.4" }
-miden-standards    = { default-features = false, path = "crates/miden-standards", version = "0.16.0-alpha.4" }
-miden-testing      = { default-features = false, path = "crates/miden-testing", version = "0.16.0-alpha.4" }
-miden-tx           = { default-features = false, path = "crates/miden-tx", version = "0.16.0-alpha.4" }
-miden-tx-batch     = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-alpha.4" }
+miden-agglayer     = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-alpha.5" }
+miden-block-prover = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-alpha.5" }
+miden-protocol     = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-alpha.5" }
+miden-standards    = { default-features = false, path = "crates/miden-standards", version = "0.16.0-alpha.5" }
+miden-testing      = { default-features = false, path = "crates/miden-testing", version = "0.16.0-alpha.5" }
+miden-tx           = { default-features = false, path = "crates/miden-tx", version = "0.16.0-alpha.5" }
+miden-tx-batch     = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-alpha.5" }
 
 # Miden dependencies
 miden-assembly         = { default-features = false, version = "0.25" }


### PR DESCRIPTION
bump to `v0.16.-0-alpha.5` to include https://github.com/0xMiden/protocol/pull/3386 in the new patch release