### PR TITLE
fix: pin intra-workspace dependencies with exact version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,13 @@ lto           = true
 
 [workspace.dependencies]
 # Workspace crates
-miden-agglayer     = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-alpha.5" }
-miden-block-prover = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-alpha.5" }
-miden-protocol     = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-alpha.5" }
-miden-standards    = { default-features = false, path = "crates/miden-standards", version = "0.16.0-alpha.5" }
-miden-testing      = { default-features = false, path = "crates/miden-testing", version = "0.16.0-alpha.5" }
-miden-tx           = { default-features = false, path = "crates/miden-tx", version = "0.16.0-alpha.5" }
-miden-tx-batch     = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-alpha.5" }
+miden-agglayer     = { default-features = false, path = "crates/miden-agglayer", version = "=0.16.0-alpha.5" }
+miden-block-prover = { default-features = false, path = "crates/miden-block-prover", version = "=0.16.0-alpha.5" }
+miden-protocol     = { default-features = false, path = "crates/miden-protocol", version = "=0.16.0-alpha.5" }
+miden-standards    = { default-features = false, path = "crates/miden-standards", version = "=0.16.0-alpha.5" }
+miden-testing      = { default-features = false, path = "crates/miden-testing", version = "=0.16.0-alpha.5" }
+miden-tx           = { default-features = false, path = "crates/miden-tx", version = "=0.16.0-alpha.5" }
+miden-tx-batch     = { default-features = false, path = "crates/miden-tx-batch", version = "=0.16.0-alpha.5" }
 
 # Miden dependencies
 miden-assembly         = { default-features = false, version = "0.25" }


### PR DESCRIPTION
## Problem

The [v0.16.0-alpha.5 publish job](https://github.com/0xMiden/protocol/actions/runs/30102022540/job/89510181394) failed during `cargo publish`'s verification of `miden-standards`: the build compiled against `miden-protocol v0.16.0-beta.1` from crates.io instead of the `0.16.0-alpha.5` being published alongside it.

Root cause: `miden-protocol 0.16.0-beta.1` was published on 2026-07-21 from the beta release line. Semver orders `beta.1` above `alpha.5`, and a caret pre-release requirement (`^0.16.0-alpha.5`) matches any `0.16.0` pre-release at or above `alpha.5` - so cargo's resolver picked the higher `beta.1` from the registry over the locally packaged `alpha.5`. The two lines have diverged APIs (the alpha line still re-exports `Package as Library`), hence the compile errors. Any `0.16.0-alpha.x` release would keep failing this way.

## Fix

Pin all 7 intra-workspace dependencies in the root `Cargo.toml` with exact (`=`) requirements, forcing resolution to the version being published. A CI guard that keeps the pins in sync across version bumps follows in a separate PR.

## Verification

- `cargo publish --workspace --dry-run` passes: all 7 crates package and verify against the pinned siblings.
- Confirmed via the crates.io API that no crate was uploaded at `0.16.0-alpha.5` (verification failed before any upload), so the version remains usable.

## Release notes

After merging, the `v0.16.0-alpha.5` tag and GitHub release must be re-cut at the new branch HEAD: the publish job verifies tag == branch HEAD, and the artifact-upload job checks out the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)