### PR TITLE
docs(standards): fix line wrapping in basic constant fee policy header

### DIFF
--- a/crates/miden-standards/asm/standards/fees/policies/basic_constant_fee.masm
+++ b/crates/miden-standards/asm/standards/fees/policies/basic_constant_fee.masm
@@ -3,11 +3,11 @@
 # Basic constant fee policy: derives the fee from a fixed per-note-script fee schedule. It is a
 # simple baseline; more sophisticated constant fee policies can be derived from it by swapping
 # the lookup-key computation. Note that a derived policy must also rename the `fee_schedule`
-# storage slot, since two components on the same account cannot share a slot name. Designed to be registered as a fee policy of an `AuthNetworkAccount`,
-# whose fee manager (see `miden::standards::fees::fee_manager`) dispatches fee estimation to
-# `compute_note_fee` via `dyncall`. The fee is charged in the fee asset the network account is
-# configured with, read from its storage, so this component must be installed on an
-# `AuthNetworkAccount`.
+# storage slot, since two components on the same account cannot share a slot name. Designed to be
+# registered as a fee policy of an `AuthNetworkAccount`, whose fee manager
+# (see `miden::standards::fees::fee_manager`) dispatches fee estimation to `compute_note_fee` via
+# `dyncall`. The fee is charged in the fee asset the network account is configured with, read from
+# its storage, so this component must be installed on an `AuthNetworkAccount`.
 #
 # Storage layout:
 # - `fee_schedule` map: NOTE_SCRIPT_ROOT => [fee_amount, 0, 0, 1]. The last element is a


### PR DESCRIPTION
Addresses the line-wrapping nit @bobbinth left on [#3395](https://github.com/0xMiden/protocol/pull/3395).

The `ConstantFeePolicy` -> `BasicConstantFeePolicy` rename left one line of the module header in `basic_constant_fee.masm` running to 148 chars. This re-wraps the paragraph so every line fits within 100 columns.

Comment-only change; the prose is word-for-word identical and the compiled `.masp` is byte-identical, so no procedure roots move.
