### PR TITLE
chore: ensure delta computation uses native account state

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -1440,6 +1440,30 @@ pub proc get_item_patch
     # => [INITIAL_VALUE, CURRENT_VALUE, slot_id_suffix, slot_id_prefix]
 end
 
+#! Gets the slot ID of the storage slot at the provided index from the native account.
+#!
+#! WARNING: The index must be in bounds.
+#!
+#! Inputs:  [index]
+#! Outputs: [slot_id_suffix, slot_id_prefix]
+#!
+#! Where:
+#! - index is the index of the slot.
+#! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
+#!   the first two felts of the hashed slot name.
+pub proc get_native_slot_id
+    # convert the index into a memory offset
+    mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH
+    # => [offset]
+
+    exec.memory::get_native_account_active_storage_slots_ptr
+    add
+    # => [slot_ptr]
+
+    exec.get_slot_id_inner
+    # => [slot_id_suffix, slot_id_prefix]
+end
+
 #! Gets the slot ID of the storage slot at the provided index.
 #!
 #! WARNING: The index must be in bounds.
@@ -1460,6 +1484,23 @@ pub proc get_slot_id
     add
     # => [slot_ptr]
 
+    exec.get_slot_id_inner
+    # => [slot_id_suffix, slot_id_prefix]
+end
+
+
+#! Gets the slot ID of the storage slot pointed at by slot_ptr.
+#!
+#! WARNING: The slot_ptr must be valid.
+#!
+#! Inputs:  [slot_ptr]
+#! Outputs: [slot_id_suffix, slot_id_prefix]
+#!
+#! Where:
+#! - slot_ptr is the pointer to a slot.
+#! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
+#!   the first two felts of the hashed slot name.
+proc get_slot_id_inner
     dup add.ACCOUNT_SLOT_ID_PREFIX_OFFSET mem_load
     # => [slot_id_prefix, slot_ptr]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
@@ -365,7 +365,7 @@ proc commit_map_slot_patch
     push.0 loc_store.4
     # => [slot_idx, RATE0, RATE1, CAPACITY]
 
-    dup exec.account::get_slot_id
+    dup exec.account::get_native_slot_id
     # => [slot_id_suffix, slot_id_prefix, slot_idx, RATE0, RATE1, CAPACITY]
 
     loc_store.0 loc_store.1
@@ -764,7 +764,7 @@ pub proc was_nonce_incremented
     exec.memory::get_init_nonce
     # => [init_nonce]
 
-    exec.memory::get_account_nonce
+    exec.memory::get_native_account_nonce
     # => [current_nonce, init_nonce]
 
     neq

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/output_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/output_note.masm
@@ -52,7 +52,7 @@ const ERR_OUTPUT_NOTE_TOTAL_ATTACHMENT_WORDS_EXCEEDED =
     "total number of attachment words per note cannot exceed 512"
 
 const ERR_NOTE_FUNGIBLE_MAX_AMOUNT_EXCEEDED =
-    "adding a fungible asset to a note cannot exceed the max_amount of 9223372036854775807"
+    "adding a fungible asset to a note cannot exceed FUNGIBLE_ASSET_MAX_AMOUNT"
 
 const ERR_OUTPUT_NOTE_ATTACHMENT_COMMITMENT_MISMATCH =
     "the computed hash of fetched attachment elements does not match the provided commitment"


### PR DESCRIPTION
Follow-up to https://github.com/0xMiden/protocol/pull/2770 to address "L-04 Delta Commitment Computation May Use Foreign Account Context (Report 2)" in a clearer way: While we already assert that we compute the delta commitment only when the active account is the native account, it is clearer to use accessors that only ever return native account state, which this PR does.

This was noted in a response to an audit finding from that 2nd report.

Adds a one-line fix to a missed incorrect error message noted in "L-06 Misleading Documentation (Report 2)".