### PR TITLE
feat: request asset witnesses during minting and burning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - [BREAKING] Renamed `ConstantFeePolicy` to `BasicConstantFeePolicy` ([#3391](https://github.com/0xMiden/protocol/issues/3391)).
 - [BREAKING] Moved the network-account default configuration into `AuthNetworkAccount::new`, which now allowlists the `NetworkAccountConfigNote` and `FeeSponsorshipNote` script roots and the canonical `ExpirationTransactionScript` tx-script root; added `AuthNetworkAccount::custom` to build a raw component with no default configuration for low-level use, and removed `AuthNetworkAccount::with_allowed_tx_scripts` ([#3392](https://github.com/0xMiden/protocol/pull/3392)).
 
+### Fixes
+
+- Fixed `faucet::mint` and `faucet::burn` failing when the asset's witness in the input vault had not already been loaded, which happened when minting into a faucet whose vault held other assets, or when burning an asset the transaction had not otherwise accessed; both procedures now request the witness from the host before updating the input vault ([#3409](https://github.com/0xMiden/protocol/pull/3409)).
+
 ## v0.16.0-beta.1 (2026-07-20)
 
 ### Features

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/faucet.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/faucet.masm
@@ -3,6 +3,21 @@ use miden::tx_kernel_core::asset
 use miden::tx_kernel_core::asset_vault
 use {INPUT_VAULT_ROOT_PTR} from miden::tx_kernel_core::memory
 
+# EVENTS
+# =================================================================================================
+
+# Event emitted before an asset is minted into the input vault.
+const ACCOUNT_VAULT_BEFORE_MINT_ASSET_EVENT =
+    event(
+        "miden::protocol::account::vault_before_mint_asset"
+    )
+
+# Event emitted before an asset is burned from the input vault.
+const ACCOUNT_VAULT_BEFORE_BURN_ASSET_EVENT =
+    event(
+        "miden::protocol::account::vault_before_burn_asset"
+    )
+
 # PUBLIC INTERFACE
 # ==================================================================================================
 
@@ -34,6 +49,10 @@ pub proc mint
 
     push.INPUT_VAULT_ROOT_PTR
     movdn.8
+    # => [ASSET_ID, ASSET_VALUE, input_vault_root_ptr]
+
+    # emit event to signal that an asset is going to be minted into the input vault
+    emit.ACCOUNT_VAULT_BEFORE_MINT_ASSET_EVENT
     # => [ASSET_ID, ASSET_VALUE, input_vault_root_ptr]
 
     # add the asset to the input vault for asset preservation
@@ -74,6 +93,10 @@ pub proc burn
 
     push.INPUT_VAULT_ROOT_PTR
     movdn.8
+    # => [ASSET_ID, ASSET_VALUE, input_vault_root_ptr]
+
+    # emit event to signal that an asset is going to be burned from the input vault
+    emit.ACCOUNT_VAULT_BEFORE_BURN_ASSET_EVENT
     # => [ASSET_ID, ASSET_VALUE, input_vault_root_ptr]
 
     # remove the asset from the input vault for asset preservation

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
@@ -20,15 +20,6 @@ use {BLOCK_DATA_SECTION_OFFSET, INPUT_VAULT_ROOT_PTR, KERNEL_PROCEDURES_PTR, PAR
 # Max U32 value, used for initializing the expiration block number
 const MAX_BLOCK_NUM = 0xFFFFFFFF
 
-# EVENTS
-#=================================================================================================
-
-# Emission of an equivalent to `ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT`, use in `add_input_note_assets_to_vault`
-const ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT =
-    event(
-        "miden::protocol::account::vault_before_add_asset"
-    )
-
 # ERRORS
 # =================================================================================================
 

--- a/crates/miden-protocol/src/transaction/kernel/tx_event_id.rs
+++ b/crates/miden-protocol/src/transaction/kernel/tx_event_id.rs
@@ -27,6 +27,9 @@ pub enum TransactionEventId {
     AccountVaultBeforeRemoveAsset = ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_ID,
     AccountVaultAfterRemoveAsset = ACCOUNT_VAULT_AFTER_REMOVE_ASSET_ID,
 
+    AccountVaultBeforeMintAsset = ACCOUNT_VAULT_BEFORE_MINT_ASSET_ID,
+    AccountVaultBeforeBurnAsset = ACCOUNT_VAULT_BEFORE_BURN_ASSET_ID,
+
     AccountBeforeAssetDeltaComputation = ACCOUNT_BEFORE_ASSET_DELTA_COMPUTATION_ID,
     AccountOnAssetDeltaComputation = ACCOUNT_ON_ASSET_DELTA_COMPUTATION_ID,
 
@@ -102,6 +105,8 @@ impl TransactionEventId {
             Self::AccountVaultAfterAddAsset => &ACCOUNT_VAULT_AFTER_ADD_ASSET_NAME,
             Self::AccountVaultBeforeRemoveAsset => &ACCOUNT_VAULT_BEFORE_REMOVE_ASSET_NAME,
             Self::AccountVaultAfterRemoveAsset => &ACCOUNT_VAULT_AFTER_REMOVE_ASSET_NAME,
+            Self::AccountVaultBeforeMintAsset => &ACCOUNT_VAULT_BEFORE_MINT_ASSET_NAME,
+            Self::AccountVaultBeforeBurnAsset => &ACCOUNT_VAULT_BEFORE_BURN_ASSET_NAME,
             Self::AccountBeforeAssetDeltaComputation => {
                 &ACCOUNT_BEFORE_ASSET_DELTA_COMPUTATION_NAME
             },
@@ -163,6 +168,13 @@ impl TryFrom<EventId> for TransactionEventId {
             },
             ACCOUNT_VAULT_AFTER_REMOVE_ASSET_ID => {
                 Ok(TransactionEventId::AccountVaultAfterRemoveAsset)
+            },
+
+            ACCOUNT_VAULT_BEFORE_MINT_ASSET_ID => {
+                Ok(TransactionEventId::AccountVaultBeforeMintAsset)
+            },
+            ACCOUNT_VAULT_BEFORE_BURN_ASSET_ID => {
+                Ok(TransactionEventId::AccountVaultBeforeBurnAsset)
             },
 
             ACCOUNT_ON_ASSET_DELTA_COMPUTATION_ID => {

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -1,14 +1,17 @@
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 
 use miden_protocol::Felt;
 use miden_protocol::account::{Account, AccountBuilder, AccountComponent, AccountId};
 use miden_protocol::assembly::DefaultSourceManager;
 use miden_protocol::asset::{
+    Asset,
     AssetClass,
     AssetComposition,
     AssetId,
     FungibleAsset,
     NonFungibleAsset,
+    NonFungibleAssetDetails,
 };
 use miden_protocol::errors::tx_kernel::{
     ERR_FAUCET_IS_NOT_ASSET_ORIGIN,
@@ -27,69 +30,27 @@ use miden_protocol::testing::account_id::{
 use miden_protocol::testing::constants::{
     CONSUMED_ASSET_1_AMOUNT,
     FUNGIBLE_ASSET_AMOUNT,
-    NON_FUNGIBLE_ASSET_DATA,
     NON_FUNGIBLE_ASSET_DATA_2,
 };
 use miden_protocol::testing::noop_auth_component::NoopAuthComponent;
 use miden_protocol::transaction::memory::INPUT_VAULT_ROOT_PTR;
 use miden_standards::code_builder::CodeBuilder;
+use miden_standards::testing::account_component::MockFaucetComponent;
 use miden_standards::testing::mock_account::MockAccountExt;
+use rstest::rstest;
 
 use crate::utils::create_public_p2any_note;
-use crate::{TestTransactionBuilder, assert_execution_error, assert_transaction_executor_error};
+use crate::{
+    AccountState,
+    Auth,
+    MockChain,
+    TestTransactionBuilder,
+    assert_execution_error,
+    assert_transaction_executor_error,
+};
 
 // FUNGIBLE FAUCET MINT TESTS
 // ================================================================================================
-
-#[tokio::test]
-async fn test_mint_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).unwrap();
-    let asset = FungibleAsset::new(faucet_id, FUNGIBLE_ASSET_AMOUNT)?;
-
-    let code = format!(
-        r#"
-        use mock::faucet as mock_faucet
-        use miden::protocol::faucet
-        use miden::tx_kernel_core::asset_vault
-        use miden::tx_kernel_core::memory
-        use miden::tx_kernel_core::prologue
-
-        begin
-            exec.prologue::prepare_transaction
-
-            # mint asset
-            push.{FUNGIBLE_ASSET_VALUE}
-            push.{FUNGIBLE_ASSET_ID}
-            call.mock_faucet::mint
-            # => []
-
-            # assert the input vault has been updated
-            push.{INPUT_VAULT_ROOT_PTR}
-            push.{FUNGIBLE_ASSET_ID}
-            exec.asset_vault::get_asset
-            # => [ASSET_VALUE]
-
-            # extract balance from asset
-            movdn.3 drop drop drop
-            # => [balance]
-
-            push.{FUNGIBLE_ASSET_AMOUNT} assert_eq.err="input vault should contain minted asset"
-
-            # truncate the stack
-            dropw dropw
-        end
-        "#,
-        FUNGIBLE_ASSET_ID = asset.to_id_word(),
-        FUNGIBLE_ASSET_VALUE = asset.to_value_word(),
-    );
-
-    TestTransactionBuilder::with_fungible_faucet(faucet_id.into())
-        .build()?
-        .execute_code(&code)
-        .await?;
-
-    Ok(())
-}
 
 /// Tests that minting a fungible asset on a non-faucet account fails.
 #[tokio::test]
@@ -227,47 +188,114 @@ async fn test_mint_fungible_asset_fails_when_amount_exceeds_max_representable_am
 // NON-FUNGIBLE FAUCET MINT TESTS
 // ================================================================================================
 
+/// Tests minting succeeds in the tx kernel memory context (to assert input vault conditions).
+#[rstest]
 #[tokio::test]
-async fn test_mint_non_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let mock_tx =
-        TestTransactionBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
-            .build()?;
-    let non_fungible_asset = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA);
+async fn test_mint_asset_succeeds_in_tx_kernel(
+    // The 2nd case has an unrelated asset in the initial vault.
+    #[values(vec![], vec![FungibleAsset::mock(345)])] initial_assets: Vec<Asset>,
+    #[values(
+      |id| NonFungibleAsset::new(&NonFungibleAssetDetails::new(id, vec![42])).into(),
+      |id| FungibleAsset::new(id, 42).unwrap().into(),
+    )]
+    make_asset: impl FnOnce(AccountId) -> Asset,
+) -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let account_builder = AccountBuilder::new([1; 32])
+        .with_component(MockFaucetComponent)
+        .with_assets(initial_assets);
+    let faucet =
+        builder.add_account_from_builder(Auth::IncrNonce, account_builder, AccountState::Exists)?;
+    let asset = make_asset(faucet.id());
+    let chain = builder.build()?;
 
     let code = format!(
         r#"
-        use miden::core::collections::smt
-
-        use miden::tx_kernel_core::account
         use miden::tx_kernel_core::asset_vault
-        use miden::tx_kernel_core::memory
         use miden::tx_kernel_core::prologue
         use mock::faucet as mock_faucet
 
         begin
             # mint asset
             exec.prologue::prepare_transaction
-            push.{NON_FUNGIBLE_ASSET_VALUE}
-            push.{NON_FUNGIBLE_ASSET_ID}
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
             call.mock_faucet::mint
             # => []
 
             # assert the input vault has been updated.
             push.{INPUT_VAULT_ROOT_PTR}
-            push.{NON_FUNGIBLE_ASSET_ID}
+            push.{ASSET_ID}
             exec.asset_vault::get_asset
-            push.{NON_FUNGIBLE_ASSET_VALUE}
+            push.{ASSET_VALUE}
             assert_eqw.err="vault should contain asset"
+            # => []
 
             # truncate the stack
             dropw dropw
         end
         "#,
-        NON_FUNGIBLE_ASSET_ID = non_fungible_asset.to_id_word(),
-        NON_FUNGIBLE_ASSET_VALUE = non_fungible_asset.to_value_word(),
+        ASSET_ID = asset.to_id_word(),
+        ASSET_VALUE = asset.to_value_word(),
     );
 
-    mock_tx.execute_code(&code).await?;
+    chain.build_transaction(faucet).build()?.execute_code(&code).await?;
+
+    Ok(())
+}
+
+/// Tests minting succeeds in a real transaction.
+#[rstest]
+#[tokio::test]
+async fn test_mint_asset_succeeds(
+    // The 2nd case has an unrelated asset in the initial vault.
+    #[values(vec![], vec![FungibleAsset::mock(345)])] initial_assets: Vec<Asset>,
+    #[values(
+      |id| NonFungibleAsset::new(&NonFungibleAssetDetails::new(id, vec![42])).into(),
+      |id| FungibleAsset::new(id, 42).unwrap().into(),
+    )]
+    make_asset: impl FnOnce(AccountId) -> Asset,
+) -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let account_builder = AccountBuilder::new([1; 32])
+        .with_component(MockFaucetComponent)
+        .with_component(MockAccountComponent::with_empty_slots())
+        .with_assets(initial_assets);
+    let faucet =
+        builder.add_account_from_builder(Auth::IncrNonce, account_builder, AccountState::Exists)?;
+    let asset = make_asset(faucet.id());
+    let chain = builder.build()?;
+
+    let tx_script = format!(
+        r#"
+        use mock::faucet as mock_faucet
+        use mock::account as mock_account
+
+        @transaction_script
+        pub proc main
+            # mint asset
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
+            call.mock_faucet::mint
+            # => []
+
+            # add the asset to the account vault for asset preservation AFTER the mint to ensure
+            # mint requests the asset witness
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
+            call.mock_account::add_asset
+            # => []
+
+            # truncate the stack
+            dropw dropw dropw dropw
+        end
+        "#,
+        ASSET_ID = asset.to_id_word(),
+        ASSET_VALUE = asset.to_value_word(),
+    );
+
+    let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(tx_script)?;
+    chain.build_transaction(faucet).tx_script(tx_script).build()?.execute().await?;
 
     Ok(())
 }

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -44,6 +44,121 @@ use crate::{
     assert_transaction_executor_error,
 };
 
+// MINT TESTS
+// ================================================================================================
+
+/// Tests minting succeeds in the tx kernel memory context (to assert input vault conditions).
+#[rstest]
+#[tokio::test]
+async fn test_mint_asset_succeeds_in_tx_kernel(
+    // The 2nd case has an unrelated asset in the initial vault.
+    #[values(vec![], vec![FungibleAsset::mock(345)])] initial_assets: Vec<Asset>,
+    #[values(
+      |id| NonFungibleAsset::new(&NonFungibleAssetDetails::new(id, vec![42])).into(),
+      |id| FungibleAsset::new(id, 42).unwrap().into(),
+    )]
+    make_asset: impl FnOnce(AccountId) -> Asset,
+) -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let account_builder = AccountBuilder::new([1; 32])
+        .with_component(MockFaucetComponent)
+        .with_assets(initial_assets);
+    let faucet =
+        builder.add_account_from_builder(Auth::IncrNonce, account_builder, AccountState::Exists)?;
+    let asset = make_asset(faucet.id());
+    let chain = builder.build()?;
+
+    let code = format!(
+        r#"
+        use miden::tx_kernel_core::asset_vault
+        use miden::tx_kernel_core::prologue
+        use mock::faucet as mock_faucet
+
+        begin
+            # mint asset
+            exec.prologue::prepare_transaction
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
+            call.mock_faucet::mint
+            # => []
+
+            # assert the input vault has been updated.
+            push.{INPUT_VAULT_ROOT_PTR}
+            push.{ASSET_ID}
+            exec.asset_vault::get_asset
+            push.{ASSET_VALUE}
+            assert_eqw.err="vault should contain asset"
+            # => []
+
+            # truncate the stack
+            dropw dropw
+        end
+        "#,
+        ASSET_ID = asset.to_id_word(),
+        ASSET_VALUE = asset.to_value_word(),
+    );
+
+    chain.build_transaction(faucet).build()?.execute_code(&code).await?;
+
+    Ok(())
+}
+
+/// Tests minting succeeds in a real transaction.
+#[rstest]
+#[tokio::test]
+async fn test_mint_asset_succeeds(
+    // The 2nd case has an unrelated asset in the initial vault.
+    #[values(vec![], vec![FungibleAsset::mock(345)])] initial_assets: Vec<Asset>,
+    #[values(
+      |id| NonFungibleAsset::new(&NonFungibleAssetDetails::new(id, vec![42])).into(),
+      |id| FungibleAsset::new(id, 42).unwrap().into(),
+    )]
+    make_asset: impl FnOnce(AccountId) -> Asset,
+) -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let account_builder = AccountBuilder::new([1; 32])
+        .with_component(MockFaucetComponent)
+        .with_component(MockAccountComponent::with_empty_slots())
+        .with_assets(initial_assets);
+    let faucet =
+        builder.add_account_from_builder(Auth::IncrNonce, account_builder, AccountState::Exists)?;
+    let asset = make_asset(faucet.id());
+    let chain = builder.build()?;
+
+    let tx_script = format!(
+        r#"
+        use mock::faucet as mock_faucet
+        use mock::account as mock_account
+
+        @transaction_script
+        pub proc main
+            # mint asset
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
+            call.mock_faucet::mint
+            # => []
+
+            # add the asset to the account vault for asset preservation AFTER the mint to ensure
+            # mint requests the asset witness
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
+            call.mock_account::add_asset
+            # => []
+
+            # truncate the stack
+            dropw dropw dropw dropw
+        end
+        "#,
+        ASSET_ID = asset.to_id_word(),
+        ASSET_VALUE = asset.to_value_word(),
+    );
+
+    let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(tx_script)?;
+    chain.build_transaction(faucet).tx_script(tx_script).build()?.execute().await?;
+
+    Ok(())
+}
+
 // FUNGIBLE FAUCET MINT TESTS
 // ================================================================================================
 
@@ -180,120 +295,43 @@ async fn test_mint_fungible_asset_fails_when_amount_exceeds_max_representable_am
     Ok(())
 }
 
-// NON-FUNGIBLE FAUCET MINT TESTS
-// ================================================================================================
-
-/// Tests minting succeeds in the tx kernel memory context (to assert input vault conditions).
-#[rstest]
+/// Tests minting a fungible asset with callbacks enabled.
 #[tokio::test]
-async fn test_mint_asset_succeeds_in_tx_kernel(
-    // The 2nd case has an unrelated asset in the initial vault.
-    #[values(vec![], vec![FungibleAsset::mock(345)])] initial_assets: Vec<Asset>,
-    #[values(
-      |id| NonFungibleAsset::new(&NonFungibleAssetDetails::new(id, vec![42])).into(),
-      |id| FungibleAsset::new(id, 42).unwrap().into(),
-    )]
-    make_asset: impl FnOnce(AccountId) -> Asset,
-) -> anyhow::Result<()> {
-    let mut builder = MockChain::builder();
-    let account_builder = AccountBuilder::new([1; 32])
-        .with_component(MockFaucetComponent)
-        .with_assets(initial_assets);
-    let faucet =
-        builder.add_account_from_builder(Auth::IncrNonce, account_builder, AccountState::Exists)?;
-    let asset = make_asset(faucet.id());
-    let chain = builder.build()?;
+async fn test_mint_fungible_asset_with_callbacks_enabled() -> anyhow::Result<()> {
+    // Use a faucet ID with callbacks enabled.
+    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_WITH_CALLBACKS).unwrap();
+    let asset = FungibleAsset::new(faucet_id, FUNGIBLE_ASSET_AMOUNT)?;
+    let asset_id = AssetId::new(AssetClass::default(), faucet_id, AssetComposition::Fungible)?;
 
     let code = format!(
         r#"
-        use miden::tx_kernel_core::asset_vault
-        use miden::tx_kernel_core::prologue
         use mock::faucet as mock_faucet
+        use miden::tx_kernel_core::prologue
 
         begin
-            # mint asset
             exec.prologue::prepare_transaction
-            push.{ASSET_VALUE}
-            push.{ASSET_ID}
+
+            push.{FUNGIBLE_ASSET_VALUE}
+            push.{FUNGIBLE_ASSET_ID}
             call.mock_faucet::mint
-            # => []
 
-            # assert the input vault has been updated.
-            push.{INPUT_VAULT_ROOT_PTR}
-            push.{ASSET_ID}
-            exec.asset_vault::get_asset
-            push.{ASSET_VALUE}
-            assert_eqw.err="vault should contain asset"
-            # => []
-
-            # truncate the stack
             dropw dropw
         end
         "#,
-        ASSET_ID = asset.to_id_word(),
-        ASSET_VALUE = asset.to_value_word(),
+        FUNGIBLE_ASSET_ID = asset_id.to_word(),
+        FUNGIBLE_ASSET_VALUE = asset.to_value_word(),
     );
 
-    chain.build_transaction(faucet).build()?.execute_code(&code).await?;
+    TestTransactionBuilder::with_fungible_faucet(faucet_id.into())
+        .build()?
+        .execute_code(&code)
+        .await?;
 
     Ok(())
 }
 
-/// Tests minting succeeds in a real transaction.
-#[rstest]
-#[tokio::test]
-async fn test_mint_asset_succeeds(
-    // The 2nd case has an unrelated asset in the initial vault.
-    #[values(vec![], vec![FungibleAsset::mock(345)])] initial_assets: Vec<Asset>,
-    #[values(
-      |id| NonFungibleAsset::new(&NonFungibleAssetDetails::new(id, vec![42])).into(),
-      |id| FungibleAsset::new(id, 42).unwrap().into(),
-    )]
-    make_asset: impl FnOnce(AccountId) -> Asset,
-) -> anyhow::Result<()> {
-    let mut builder = MockChain::builder();
-    let account_builder = AccountBuilder::new([1; 32])
-        .with_component(MockFaucetComponent)
-        .with_component(MockAccountComponent::with_empty_slots())
-        .with_assets(initial_assets);
-    let faucet =
-        builder.add_account_from_builder(Auth::IncrNonce, account_builder, AccountState::Exists)?;
-    let asset = make_asset(faucet.id());
-    let chain = builder.build()?;
-
-    let tx_script = format!(
-        r#"
-        use mock::faucet as mock_faucet
-        use mock::account as mock_account
-
-        @transaction_script
-        pub proc main
-            # mint asset
-            push.{ASSET_VALUE}
-            push.{ASSET_ID}
-            call.mock_faucet::mint
-            # => []
-
-            # add the asset to the account vault for asset preservation AFTER the mint to ensure
-            # mint requests the asset witness
-            push.{ASSET_VALUE}
-            push.{ASSET_ID}
-            call.mock_account::add_asset
-            # => []
-
-            # truncate the stack
-            dropw dropw dropw dropw
-        end
-        "#,
-        ASSET_ID = asset.to_id_word(),
-        ASSET_VALUE = asset.to_value_word(),
-    );
-
-    let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(tx_script)?;
-    chain.build_transaction(faucet).tx_script(tx_script).build()?.execute().await?;
-
-    Ok(())
-}
+// NON-FUNGIBLE FAUCET MINT TESTS
+// ================================================================================================
 
 #[tokio::test]
 async fn test_mint_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::Result<()> {
@@ -356,140 +394,7 @@ async fn mint_non_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result
     Ok(())
 }
 
-/// Tests minting a fungible asset with callbacks enabled.
-#[tokio::test]
-async fn test_mint_fungible_asset_with_callbacks_enabled() -> anyhow::Result<()> {
-    // Use a faucet ID with callbacks enabled.
-    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_WITH_CALLBACKS).unwrap();
-    let asset = FungibleAsset::new(faucet_id, FUNGIBLE_ASSET_AMOUNT)?;
-    let asset_id = AssetId::new(AssetClass::default(), faucet_id, AssetComposition::Fungible)?;
-
-    let code = format!(
-        r#"
-        use mock::faucet as mock_faucet
-        use miden::tx_kernel_core::prologue
-
-        begin
-            exec.prologue::prepare_transaction
-
-            push.{FUNGIBLE_ASSET_VALUE}
-            push.{FUNGIBLE_ASSET_ID}
-            call.mock_faucet::mint
-
-            dropw dropw
-        end
-        "#,
-        FUNGIBLE_ASSET_ID = asset_id.to_word(),
-        FUNGIBLE_ASSET_VALUE = asset.to_value_word(),
-    );
-
-    TestTransactionBuilder::with_fungible_faucet(faucet_id.into())
-        .build()?
-        .execute_code(&code)
-        .await?;
-
-    Ok(())
-}
-
-// FUNGIBLE FAUCET BURN TESTS
-// ================================================================================================
-
-/// Tests that burning a fungible asset on a non-faucet account fails.
-#[tokio::test]
-async fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
-    let account = setup_non_faucet_account()?;
-    let asset = FungibleAsset::mock(50);
-
-    let code = format!(
-        "
-      use mock::faucet
-
-      @transaction_script
-      pub proc main
-          push.{FUNGIBLE_ASSET_VALUE}
-          push.{FUNGIBLE_ASSET_ID}
-          call.faucet::burn
-      end
-      ",
-        FUNGIBLE_ASSET_VALUE = asset.to_value_word(),
-        FUNGIBLE_ASSET_ID = asset.to_id_word(),
-    );
-    let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(code)?;
-
-    let result = TestTransactionBuilder::new(account)
-        .tx_script(tx_script)
-        .build()?
-        .execute()
-        .await;
-    assert_transaction_executor_error!(result, ERR_FAUCET_IS_NOT_ASSET_ORIGIN);
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
-    let mock_tx =
-        TestTransactionBuilder::with_fungible_faucet(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).build()?;
-
-    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
-    let fungible_asset = FungibleAsset::new(faucet_id, FUNGIBLE_ASSET_AMOUNT)?;
-
-    let code = format!(
-        "
-        use miden::tx_kernel_core::prologue
-        use mock::faucet
-
-        begin
-            exec.prologue::prepare_transaction
-            push.{FUNGIBLE_ASSET_VALUE}
-            push.{FUNGIBLE_ASSET_ID}
-            call.faucet::burn
-        end
-        ",
-        FUNGIBLE_ASSET_VALUE = fungible_asset.to_value_word(),
-        FUNGIBLE_ASSET_ID = fungible_asset.to_id_word(),
-    );
-
-    let exec_output = mock_tx.execute_code(&code).await;
-
-    assert_execution_error!(exec_output, ERR_FAUCET_IS_NOT_ASSET_ORIGIN);
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
-    let mock_tx = TestTransactionBuilder::with_fungible_faucet(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1)
-        .build()?;
-
-    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
-    let fungible_asset = FungibleAsset::new(faucet_id, CONSUMED_ASSET_1_AMOUNT + 1)?;
-
-    let code = format!(
-        "
-        use miden::tx_kernel_core::prologue
-        use mock::faucet
-
-        begin
-            exec.prologue::prepare_transaction
-            push.{FUNGIBLE_ASSET_VALUE}
-            push.{FUNGIBLE_ASSET_ID}
-            call.faucet::burn
-        end
-        ",
-        FUNGIBLE_ASSET_VALUE = fungible_asset.to_value_word(),
-        FUNGIBLE_ASSET_ID = fungible_asset.to_id_word(),
-    );
-
-    let exec_output = mock_tx.execute_code(&code).await;
-
-    assert_execution_error!(
-        exec_output,
-        ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW
-    );
-    Ok(())
-}
-
-// NON-FUNGIBLE FAUCET BURN TESTS
+// BURN TESTS
 // ================================================================================================
 
 /// Tests burning succeeds in the tx kernel memory context (to assert input vault conditions).
@@ -595,6 +500,107 @@ async fn test_burn_asset_succeeds(
 
     Ok(())
 }
+
+// FUNGIBLE FAUCET BURN TESTS
+// ================================================================================================
+
+/// Tests that burning a fungible asset on a non-faucet account fails.
+#[tokio::test]
+async fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
+    let account = setup_non_faucet_account()?;
+    let asset = FungibleAsset::mock(50);
+
+    let code = format!(
+        "
+      use mock::faucet
+
+      @transaction_script
+      pub proc main
+          push.{FUNGIBLE_ASSET_VALUE}
+          push.{FUNGIBLE_ASSET_ID}
+          call.faucet::burn
+      end
+      ",
+        FUNGIBLE_ASSET_VALUE = asset.to_value_word(),
+        FUNGIBLE_ASSET_ID = asset.to_id_word(),
+    );
+    let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(code)?;
+
+    let result = TestTransactionBuilder::new(account)
+        .tx_script(tx_script)
+        .build()?
+        .execute()
+        .await;
+    assert_transaction_executor_error!(result, ERR_FAUCET_IS_NOT_ASSET_ORIGIN);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_burn_fungible_asset_inconsistent_faucet_id() -> anyhow::Result<()> {
+    let mock_tx =
+        TestTransactionBuilder::with_fungible_faucet(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET).build()?;
+
+    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
+    let fungible_asset = FungibleAsset::new(faucet_id, FUNGIBLE_ASSET_AMOUNT)?;
+
+    let code = format!(
+        "
+        use miden::tx_kernel_core::prologue
+        use mock::faucet
+
+        begin
+            exec.prologue::prepare_transaction
+            push.{FUNGIBLE_ASSET_VALUE}
+            push.{FUNGIBLE_ASSET_ID}
+            call.faucet::burn
+        end
+        ",
+        FUNGIBLE_ASSET_VALUE = fungible_asset.to_value_word(),
+        FUNGIBLE_ASSET_ID = fungible_asset.to_id_word(),
+    );
+
+    let exec_output = mock_tx.execute_code(&code).await;
+
+    assert_execution_error!(exec_output, ERR_FAUCET_IS_NOT_ASSET_ORIGIN);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<()> {
+    let mock_tx = TestTransactionBuilder::with_fungible_faucet(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1)
+        .build()?;
+
+    let faucet_id = AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1).unwrap();
+    let fungible_asset = FungibleAsset::new(faucet_id, CONSUMED_ASSET_1_AMOUNT + 1)?;
+
+    let code = format!(
+        "
+        use miden::tx_kernel_core::prologue
+        use mock::faucet
+
+        begin
+            exec.prologue::prepare_transaction
+            push.{FUNGIBLE_ASSET_VALUE}
+            push.{FUNGIBLE_ASSET_ID}
+            call.faucet::burn
+        end
+        ",
+        FUNGIBLE_ASSET_VALUE = fungible_asset.to_value_word(),
+        FUNGIBLE_ASSET_ID = fungible_asset.to_id_word(),
+    );
+
+    let exec_output = mock_tx.execute_code(&code).await;
+
+    assert_execution_error!(
+        exec_output,
+        ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW
+    );
+    Ok(())
+}
+
+// NON-FUNGIBLE FAUCET BURN TESTS
+// ================================================================================================
 
 #[tokio::test]
 async fn test_burn_non_fungible_asset_fails_does_not_exist() -> anyhow::Result<()> {

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -20,6 +20,7 @@ use miden_protocol::errors::tx_kernel::{
     ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW,
     ERR_VAULT_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND,
 };
+use miden_protocol::note::{Note, NoteType};
 use miden_protocol::testing::account_id::{
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
@@ -27,19 +28,13 @@ use miden_protocol::testing::account_id::{
     ACCOUNT_ID_PUBLIC_NON_FUNGIBLE_FAUCET_1,
     ACCOUNT_ID_SENDER,
 };
-use miden_protocol::testing::constants::{
-    CONSUMED_ASSET_1_AMOUNT,
-    FUNGIBLE_ASSET_AMOUNT,
-    NON_FUNGIBLE_ASSET_DATA_2,
-};
+use miden_protocol::testing::constants::{CONSUMED_ASSET_1_AMOUNT, FUNGIBLE_ASSET_AMOUNT};
 use miden_protocol::testing::noop_auth_component::NoopAuthComponent;
 use miden_protocol::transaction::memory::INPUT_VAULT_ROOT_PTR;
 use miden_standards::code_builder::CodeBuilder;
-use miden_standards::testing::account_component::MockFaucetComponent;
-use miden_standards::testing::mock_account::MockAccountExt;
+use miden_standards::testing::account_component::{MockAccountComponent, MockFaucetComponent};
 use rstest::rstest;
 
-use crate::utils::create_public_p2any_note;
 use crate::{
     AccountState,
     Auth,
@@ -399,56 +394,6 @@ async fn test_mint_fungible_asset_with_callbacks_enabled() -> anyhow::Result<()>
 // FUNGIBLE FAUCET BURN TESTS
 // ================================================================================================
 
-#[tokio::test]
-async fn test_burn_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let account = Account::mock_fungible_faucet(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1);
-    let asset = FungibleAsset::new(account.id(), 100u64).unwrap().into();
-    let note = create_public_p2any_note(ACCOUNT_ID_SENDER.try_into().unwrap(), [asset]);
-    let mock_tx = TestTransactionBuilder::new(account).input_note(note).build()?;
-
-    let code = format!(
-        r#"
-        use mock::faucet as mock_faucet
-        use miden::protocol::faucet
-        use miden::tx_kernel_core::asset_vault
-        use miden::tx_kernel_core::memory
-        use miden::tx_kernel_core::prologue
-
-        begin
-            exec.prologue::prepare_transaction
-
-            # burn asset
-            push.{FUNGIBLE_ASSET_VALUE}
-            push.{FUNGIBLE_ASSET_ID}
-            call.mock_faucet::burn
-
-            # assert the input vault has been updated
-            push.{INPUT_VAULT_ROOT_PTR}
-
-            push.{FUNGIBLE_ASSET_ID}
-            exec.asset_vault::get_asset
-            # => [ASSET_VALUE]
-
-            # extract balance from asset
-            movdn.3 drop drop drop
-            # => [balance]
-
-            push.{final_input_vault_asset_amount}
-            assert_eq.err="vault balance does not match expected balance"
-
-            exec.::miden::core::sys::truncate_stack
-        end
-        "#,
-        FUNGIBLE_ASSET_VALUE = asset.to_value_word(),
-        FUNGIBLE_ASSET_ID = asset.to_id_word(),
-        final_input_vault_asset_amount = CONSUMED_ASSET_1_AMOUNT - FUNGIBLE_ASSET_AMOUNT,
-    );
-
-    mock_tx.execute_code(&code).await?;
-
-    Ok(())
-}
-
 /// Tests that burning a fungible asset on a non-faucet account fails.
 #[tokio::test]
 async fn burn_fungible_asset_fails_on_non_faucet_account() -> anyhow::Result<()> {
@@ -547,31 +492,26 @@ async fn test_burn_fungible_asset_insufficient_input_amount() -> anyhow::Result<
 // NON-FUNGIBLE FAUCET BURN TESTS
 // ================================================================================================
 
+/// Tests burning succeeds in the tx kernel memory context (to assert input vault conditions).
+#[rstest]
 #[tokio::test]
-async fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
-    let mock_tx =
-        TestTransactionBuilder::with_non_fungible_faucet(NonFungibleAsset::mock_issuer().into())
-            .build()?;
-    let non_fungible_asset_burnt = NonFungibleAsset::mock(&NON_FUNGIBLE_ASSET_DATA_2);
+async fn test_burn_asset_succeeds_in_tx_kernel(
+    #[values(BurnAssetType::Fungible, BurnAssetType::NonFungible)] asset_type: BurnAssetType,
+    #[values(BurnAssetSource::InputNote, BurnAssetSource::FaucetVault)]
+    asset_source: BurnAssetSource,
+) -> anyhow::Result<()> {
+    let (chain, faucet, asset, note) = setup_burn_chain(asset_type, asset_source)?;
 
     let code = format!(
         r#"
-        use miden::tx_kernel_core::account
         use miden::tx_kernel_core::asset_vault
-        use miden::tx_kernel_core::memory
         use miden::tx_kernel_core::prologue
         use mock::faucet as mock_faucet
 
         begin
             exec.prologue::prepare_transaction
 
-            # add non-fungible asset to the vault
-            push.{INPUT_VAULT_ROOT_PTR}
-            push.{NON_FUNGIBLE_ASSET_VALUE}
-            push.{NON_FUNGIBLE_ASSET_ID}
-            exec.asset_vault::add_asset dropw dropw
-
-            # check that the non-fungible asset is presented in the input vault
+            # check that the non-fungible asset is present in the input vault
             push.{INPUT_VAULT_ROOT_PTR}
             push.{NON_FUNGIBLE_ASSET_ID}
             exec.asset_vault::get_asset
@@ -579,14 +519,14 @@ async fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
             assert_eqw.err="input vault should contain the asset"
 
             # burn the non-fungible asset
-            push.{NON_FUNGIBLE_ASSET_VALUE}
-            push.{NON_FUNGIBLE_ASSET_ID}
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
             call.mock_faucet::burn
             dropw
 
             # assert the input vault has been updated and does not have the burnt asset
             push.{INPUT_VAULT_ROOT_PTR}
-            push.{NON_FUNGIBLE_ASSET_ID}
+            push.{ASSET_ID}
             exec.asset_vault::get_asset
             # the returned word should be empty, indicating the asset is absent
             padw assert_eqw.err="input vault should not contain burned asset"
@@ -594,11 +534,72 @@ async fn test_burn_non_fungible_asset_succeeds() -> anyhow::Result<()> {
             dropw
         end
         "#,
-        NON_FUNGIBLE_ASSET_ID = non_fungible_asset_burnt.to_id_word(),
-        NON_FUNGIBLE_ASSET_VALUE = non_fungible_asset_burnt.to_value_word(),
+        ASSET_ID = asset.to_id_word(),
+        ASSET_VALUE = asset.to_value_word(),
     );
 
-    mock_tx.execute_code(&code).await?;
+    chain
+        .build_transaction(faucet)
+        .authenticated_input_notes(note.map(|note| note.id()))
+        .build()?
+        .execute_code(&code)
+        .await?;
+
+    Ok(())
+}
+
+/// Tests burning succeeds in a real transaction.
+#[rstest]
+#[tokio::test]
+async fn test_burn_asset_succeeds(
+    #[values(BurnAssetType::Fungible, BurnAssetType::NonFungible)] asset_type: BurnAssetType,
+    #[values(BurnAssetSource::InputNote, BurnAssetSource::FaucetVault)]
+    asset_source: BurnAssetSource,
+) -> anyhow::Result<()> {
+    let (chain, faucet, asset, note) = setup_burn_chain(asset_type, asset_source)?;
+
+    let tx_script = format!(
+        r#"
+        use mock::faucet as mock_faucet
+        use mock::account as mock_account
+
+        @transaction_script
+        pub proc main
+            # burn the non-fungible asset
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
+            call.mock_faucet::burn
+            dropw
+            # => []
+
+            # remove the asset from the account vault AFTER the burn to ensure burn requests the
+            # asset witness
+            push.{ASSET_VALUE}
+            push.{ASSET_ID}
+            call.mock_account::remove_asset
+            # => []
+
+            # the final asset value should be empty indicating the asset was fully removed
+            padw assert_eqw.err="input vault should not contain burned asset"
+            # => []
+
+            dropw dropw
+        end
+        "#,
+        ASSET_ID = asset.to_id_word(),
+        ASSET_VALUE = asset.to_value_word(),
+    );
+
+    let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(tx_script)?;
+
+    chain
+        .build_transaction(faucet)
+        .authenticated_input_notes(note.map(|note| note.id()))
+        .tx_script(tx_script)
+        .build()?
+        .execute()
+        .await?;
+
     Ok(())
 }
 
@@ -699,6 +700,90 @@ async fn test_burn_non_fungible_asset_fails_inconsistent_faucet_id() -> anyhow::
 
 // HELPER FUNCTIONS
 // ================================================================================================
+
+/// The type of the asset to be burned.
+#[derive(Debug, Clone, Copy)]
+enum BurnAssetType {
+    Fungible,
+    NonFungible,
+}
+
+impl BurnAssetType {
+    /// Returns an asset of this type issued by the given faucet.
+    fn asset(self, faucet_id: AccountId) -> anyhow::Result<Asset> {
+        match self {
+            BurnAssetType::Fungible => {
+                Ok(FungibleAsset::new(faucet_id, FUNGIBLE_ASSET_AMOUNT)?.into())
+            },
+            BurnAssetType::NonFungible => {
+                Ok(NonFungibleAsset::new(&NonFungibleAssetDetails::new(faucet_id, vec![42])).into())
+            },
+        }
+    }
+}
+
+/// The way in which the asset to be burned is made available to the transaction.
+///
+/// An asset can only be burned if it exists, so it must either be carried by an input note or be
+/// held in the faucet's vault.
+#[derive(Debug, Clone, Copy)]
+enum BurnAssetSource {
+    InputNote,
+    FaucetVault,
+}
+
+/// The authentication method of the mock faucet used in the burn tests.
+const BURN_FAUCET_AUTH: Auth = Auth::IncrNonce;
+
+/// Returns a builder for the mock faucet used in the burn tests.
+fn mock_faucet_builder() -> AccountBuilder {
+    AccountBuilder::new([1; 32])
+        .with_component(MockFaucetComponent)
+        .with_component(MockAccountComponent::with_empty_slots())
+}
+
+/// Builds a chain containing the mock faucet with an asset of the given type made available to a
+/// transaction against that faucet through the given source, so it can be burned.
+///
+/// Returns the chain, the faucet account, the asset and, if the asset comes from an input note,
+/// that note.
+fn setup_burn_chain(
+    asset_type: BurnAssetType,
+    asset_source: BurnAssetSource,
+) -> anyhow::Result<(MockChain, Account, Asset, Option<Note>)> {
+    let (auth_components, _) = BURN_FAUCET_AUTH.build_components();
+
+    // The asset names the faucet as its origin, but the faucet may have to hold that asset in its
+    // vault. Since the ID of an existing account does not depend on its vault, it can be taken from
+    // an asset-less build of the same faucet.
+    let faucet_id = mock_faucet_builder().with_components(auth_components).build_existing()?.id();
+    let asset = asset_type.asset(faucet_id)?;
+
+    let mut chain_builder = MockChain::builder();
+    let mut faucet_builder = mock_faucet_builder();
+    let mut note = None;
+
+    match asset_source {
+        BurnAssetSource::InputNote => {
+            note = Some(chain_builder.add_p2any_note(
+                AccountId::try_from(ACCOUNT_ID_SENDER)?,
+                NoteType::Public,
+                [asset],
+            )?);
+        },
+        BurnAssetSource::FaucetVault => {
+            faucet_builder = faucet_builder.with_assets([asset]);
+        },
+    }
+
+    let faucet = chain_builder.add_account_from_builder(
+        BURN_FAUCET_AUTH,
+        faucet_builder,
+        AccountState::Exists,
+    )?;
+
+    Ok((chain_builder.build()?, faucet, asset, note))
+}
 
 /// Creates a regular account that exposes the faucet mint and burn procedures.
 ///

--- a/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_faucet.rs
@@ -511,13 +511,6 @@ async fn test_burn_asset_succeeds_in_tx_kernel(
         begin
             exec.prologue::prepare_transaction
 
-            # check that the non-fungible asset is present in the input vault
-            push.{INPUT_VAULT_ROOT_PTR}
-            push.{NON_FUNGIBLE_ASSET_ID}
-            exec.asset_vault::get_asset
-            push.{NON_FUNGIBLE_ASSET_VALUE}
-            assert_eqw.err="input vault should contain the asset"
-
             # burn the non-fungible asset
             push.{ASSET_VALUE}
             push.{ASSET_ID}

--- a/crates/miden-testing/src/mock_host.rs
+++ b/crates/miden-testing/src/mock_host.rs
@@ -72,6 +72,8 @@ impl<'store> MockHost<'store> {
                 &TransactionEventId::AccountVaultBeforeGetAsset,
                 &TransactionEventId::AccountVaultBeforeAddAsset,
                 &TransactionEventId::AccountVaultBeforeRemoveAsset,
+                &TransactionEventId::AccountVaultBeforeMintAsset,
+                &TransactionEventId::AccountVaultBeforeBurnAsset,
                 &TransactionEventId::AccountStorageBeforeSetMapItem,
                 &TransactionEventId::AccountStorageBeforeGetMapItem,
             ]

--- a/crates/miden-tx/src/host/tx_event.rs
+++ b/crates/miden-tx/src/host/tx_event.rs
@@ -205,14 +205,17 @@ impl TransactionEvent {
                 Some(TransactionEvent::AccountBeforeForeignLoad { foreign_account_id: account_id })
             },
             TransactionEventId::AccountVaultBeforeAddAsset
-            | TransactionEventId::AccountVaultBeforeRemoveAsset => {
-                // Expected stack state: [event, ASSET_ID, ASSET_VALUE, account_vault_root_ptr]
+            | TransactionEventId::AccountVaultBeforeRemoveAsset
+            | TransactionEventId::AccountVaultBeforeMintAsset
+            | TransactionEventId::AccountVaultBeforeBurnAsset => {
+                // Expected stack state:
+                // [event, ASSET_ID, ASSET_VALUE, {input,account}_vault_root_ptr]
                 let asset_id = process.get_stack_word(1);
                 let vault_root_ptr = process.get_stack_item(9);
 
                 let asset_id = AssetId::try_from(asset_id).map_err(|source| {
                     TransactionKernelError::MalformedAssetInEventHandler {
-                        handler: "AccountVaultBefore{Add,Remove}Asset",
+                        handler: "AccountVaultBefore{Add,Remove,Mint,Burn}Asset",
                         source,
                     }
                 })?;


### PR DESCRIPTION


## Problem

`faucet::mint` and `faucet::burn` modify the input vault directly via `asset_vault::add_asset` / `asset_vault::remove_asset`, but never signalled that access to the host. The input vault is initialized in the prologue to the native account's initial vault root and then extended with the input notes' assets, so its merkle store only contains paths for:

- the leaves touched while adding the input note assets (witnesses preloaded before execution), and
- the account vault leaves fetched lazily through the `AccountVaultBefore{Add,Remove,Get}Asset`
  events.

Minting or burning an asset whose leaf is in neither set leaves the merkle path missing, and the SMT update inside `add_asset` / `remove_asset` fails. Concretely this happens when minting into a faucet whose vault already holds an unrelated asset, and when burning an asset that the transaction did not already touch through the account vault. This commonly happens when minting a new asset - it is minted and **then** added to the account vault (that would request the witness). The burn path commonly does not run into this, but could in principle.

The existing tests did not catch this because they used faucets with empty vaults, or added the asset to the vault before burning it, which loaded the witness as a side effect.

## Burn Path

The asset witness request during `faucet::burn` is unnecessary in the majority of cases:
- If the asset to be burnt arrives via an input note, the tx executor will have already fetched witnesses during tx preparation.
- If the asset exists in the account, it is likely removed before being burnt.

However, the 2nd point is not mandated by the tx kernel. The order could validly be burn-then-remove. This could happen in some edge cases and so for this reason, asset witnesses are also requested during `faucet::burn`, as there is no real downside to it (if the asset was already touched before the operation, the event handler will return immediately). This case is encoded in the refactored tests.

## Fix

Emit a new event before each input vault mutation in `faucet.masm`:

- `miden::protocol::account::vault_before_mint_asset`
- `miden::protocol::account::vault_before_burn_asset`

Both are handled by the existing `on_account_vault_asset_accessed`, which is a no-op when the witness is already in the merkle store and
otherwise requests it from the data store. Because the input vault starts out as the native account's initial vault root, the existing native-account rule of always requesting witnesses against the *initial* vault root is exactly what is needed here, so no new host logic is required - the new event IDs are just added to the existing match arm.

Separate event IDs (rather than reusing `AccountVaultBefore{Add,Remove}Asset`) keep the emitting site identifiable in traces and keep the account vault and input vault accesses distinguishable.

Also removes the unused `ACCOUNT_VAULT_BEFORE_ADD_ASSET_EVENT` constant from `prologue.masm`, which was declared but is no longer emitted.

## Tests

`test_faucet.rs` mint/burn success tests were rewritten as parameterized `rstest` cases over the dimensions that actually trigger the bug:

- mint: empty vs. non-empty initial faucet vault, fungible vs. non-fungible asset
- burn: fungible vs. non-fungible asset, asset sourced from an input note vs. from the faucet's own vault

Each scenario is covered twice: once in the kernel memory context (`execute_code`, so the input vault can be asserted directly) and once as a real transaction driven by a tx script. In the real transaction variants, the account vault update is deliberately performed *after* the mint/burn so that the mint/burn is the first access to that vault key, which is what forces the witness request.


closes https://github.com/0xMiden/protocol/issues/3406