### PR TITLE
refactor(standards): drop redundant nominated-owner check in `accept_ownership`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [BREAKING] Renamed the `FeeManager` component to `FeePolicyManager` and turned it from an account component into the fee-policy configuration of the `AuthNetworkAccount` component ([#3353](https://github.com/0xMiden/protocol/pull/3353)).
 - [BREAKING] Renamed `ConstantFeePolicy` to `BasicConstantFeePolicy` ([#3391](https://github.com/0xMiden/protocol/issues/3391)).
 - [BREAKING] Moved the network-account default configuration into `AuthNetworkAccount::new`, which now allowlists the `NetworkAccountConfigNote` and `FeeSponsorshipNote` script roots and the canonical `ExpirationTransactionScript` tx-script root; added `AuthNetworkAccount::custom` to build a raw component with no default configuration for low-level use, and removed `AuthNetworkAccount::with_allowed_tx_scripts` ([#3392](https://github.com/0xMiden/protocol/pull/3392)).
+- [BREAKING] Removed the redundant zero-nomination check and the `ERR_NO_NOMINATED_OWNER` error constant from `ownable2step::accept_ownership`; since a note sender can never be the zero address stored when no transfer is nominated, accepting ownership without a pending nomination now fails with `ERR_SENDER_NOT_NOMINATED_OWNER` ([#3416](https://github.com/0xMiden/protocol/pull/3416)).
 
 ### Fixes
 

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -48,7 +48,6 @@ const OWNER_CONFIG_SLOT = word("miden::standards::access::ownable2step::owner_co
 const ERR_NO_OWNER = "component has no owner"
 const ERR_SENDER_NOT_OWNER = "note sender is not the owner"
 const ERR_SENDER_NOT_NOMINATED_OWNER = "note sender is not the nominated owner"
-const ERR_NO_NOMINATED_OWNER = "no nominated ownership transfer exists"
 
 # PUBLIC INTERFACE
 # =================================================================================================
@@ -143,8 +142,8 @@ end
 #!
 #! Panics if:
 #! - the component has no owner (owner is zero).
-#! - there is no nominated ownership transfer (nominated owner is zero).
-#! - the note sender is not the nominated owner.
+#! - the note sender is not the nominated owner. Since a note sender can never be the zero
+#!   address, this also covers the case where no ownership transfer is nominated.
 #!
 #! Invocation: call
 @account_procedure
@@ -159,13 +158,6 @@ pub proc accept_ownership
     assertz.err=ERR_NO_OWNER
     # => [nominated_owner_suffix, nominated_owner_prefix, pad(16)]
 
-    # Check that a nominated transfer exists (nominated owner is not zero).
-    dup.1 dup.1 exec.account_id::eqz
-    # => [is_zero, nominated_owner_suffix, nominated_owner_prefix, pad(16)]
-
-    assertz.err=ERR_NO_NOMINATED_OWNER
-    # => [nominated_owner_suffix, nominated_owner_prefix, pad(16)]
-
     exec.active_note::get_sender
     # => [sender_suffix, sender_prefix, nominated_owner_suffix, nominated_owner_prefix, pad(16)]
 
@@ -173,6 +165,8 @@ pub proc accept_ownership
     exec.account_id::eq
     # => [is_sender_nominated_owner, nominated_owner_suffix, nominated_owner_prefix, pad(16)]
 
+    # A valid account ID always has a non-zero version, so the sender can never be the zero
+    # address. This assertion therefore also rejects the case where no transfer is nominated.
     assert.err=ERR_SENDER_NOT_NOMINATED_OWNER
     # => [nominated_owner_suffix, nominated_owner_prefix, pad(16)]
 

--- a/crates/miden-testing/tests/scripts/ownable2step.rs
+++ b/crates/miden-testing/tests/scripts/ownable2step.rs
@@ -11,11 +11,7 @@ use miden_protocol::note::Note;
 use miden_protocol::testing::account_id::AccountIdBuilder;
 use miden_protocol::transaction::RawOutputNote;
 use miden_standards::account::access::Ownable2Step;
-use miden_standards::errors::standards::{
-    ERR_NO_NOMINATED_OWNER,
-    ERR_SENDER_NOT_NOMINATED_OWNER,
-    ERR_SENDER_NOT_OWNER,
-};
+use miden_standards::errors::standards::{ERR_SENDER_NOT_NOMINATED_OWNER, ERR_SENDER_NOT_OWNER};
 use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
 
@@ -310,7 +306,9 @@ async fn test_accept_ownership_no_nominated() -> anyhow::Result<()> {
         .build()?;
     let result = tx.execute().await;
 
-    assert_transaction_executor_error!(result, ERR_NO_NOMINATED_OWNER);
+    // With no nomination stored, the nominated owner is the zero address, which no valid sender
+    // can equal, so this fails the sender comparison rather than a dedicated emptiness check.
+    assert_transaction_executor_error!(result, ERR_SENDER_NOT_NOMINATED_OWNER);
     Ok(())
 }
 


### PR DESCRIPTION
`accept_ownership` asserted that the stored nominated owner is non-zero before comparing it against the note sender:

```masm
# Check that a nominated transfer exists (nominated owner is not zero).
dup.1 dup.1 exec.account_id::eqz
assertz.err=ERR_NO_NOMINATED_OWNER
```

When no transfer is nominated, the nominated owner field holds the zero address `(0, 0)`. A note sender can never be the zero address, because [`account_id::validate_structure`](https://github.com/0xMiden/protocol/blob/5ed4cc0f4dac2b9dc3f3b131677891d8aa96d830/crates/miden-protocol/asm/protocol_utils/src/account_id.masm#L96-L102) requires every valid account ID to carry a non-zero version. The `ERR_SENDER_NOT_NOMINATED_OWNER` comparison that follows therefore already rejects the "no nomination" case, and the extra check only spends cycles and adds a second error path for a state that the next assertion cannot let through.

### Changes

- Removed the zero-nomination check from `accept_ownership` (about 7 cycles) and documented on the remaining `ERR_SENDER_NOT_NOMINATED_OWNER` assertion why it also covers the missing-nomination case.
- Removed the now-unused `ERR_NO_NOMINATED_OWNER` constant, which also removes the generated `miden_standards::errors::standards::ERR_NO_NOMINATED_OWNER` Rust constant.
- Updated the `accept_ownership` doc comment's panic list.
- Updated `test_accept_ownership_no_nominated` to expect `ERR_SENDER_NOT_NOMINATED_OWNER`.