### PR TITLE
documentation: warn that authority-gated procedures must be direct `call` entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [BREAKING] Renamed the `FeeManager` component to `FeePolicyManager` and turned it from an account component into the fee-policy configuration of the `AuthNetworkAccount` component ([#3353](https://github.com/0xMiden/protocol/pull/3353)).
 - [BREAKING] Renamed `ConstantFeePolicy` to `BasicConstantFeePolicy` ([#3391](https://github.com/0xMiden/protocol/issues/3391)).
 - [BREAKING] Moved the network-account default configuration into `AuthNetworkAccount::new`, which now allowlists the `NetworkAccountConfigNote` and `FeeSponsorshipNote` script roots and the canonical `ExpirationTransactionScript` tx-script root; added `AuthNetworkAccount::custom` to build a raw component with no default configuration for low-level use, and removed `AuthNetworkAccount::with_allowed_tx_scripts` ([#3392](https://github.com/0xMiden/protocol/pull/3392)).
+- Added a documentation on every authority-gated procedure that it must be invoked as a direct `call` entrypoint and never `exec`ed from a compound procedure ([#3417](https://github.com/0xMiden/protocol/pull/3417)).
 
 ### Fixes
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -67,6 +67,9 @@ const FAUCET_METADATA_SUBKEY_HASH_HI = 3  # METADATA_HASH_HI[4]
 
 #! Updates the Global Exit Root (GER) in the bridge account storage.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Computes hash(GER) = poseidon2::merge(GER_LOWER, GER_UPPER) and stores it in a map with value
 #! GER_KNOWN_FLAG to indicate the GER is known.
 #!
@@ -108,6 +111,9 @@ end
 
 #! Removes a Global Exit Root (GER) from the bridge account storage and folds it into the running
 #! removed-GER keccak256 hash chain.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Computes hash(GER) = poseidon2::merge(GER_LOWER, GER_UPPER), overwrites the map entry with
 #! [0, 0, 0, 0] (Miden equivalent of Solidity's `delete globalExitRootMap[ger]`) while asserting
@@ -193,6 +199,9 @@ pub proc assert_valid_ger
 end
 
 #! Registers a faucet in the bridge's faucet registry, token registry, and metadata map.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Stores conversion metadata for the faucet using a sub-key scheme in faucet_metadata_map:
 #! 1. KEY [0, 0, faucet_id_suffix, faucet_id_prefix] -> [addr0, addr1, addr2, addr3]  (origin address part 1)
@@ -347,6 +356,9 @@ end
 
 #! Stores the metadata hash for a registered faucet in the bridge's faucet metadata map.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! This is the second call in the faucet registration flow (called after register_faucet).
 #! Stores the metadata hash using sub-keys 2 and 3 in faucet_metadata_map:
 #! - KEY [2, 0, faucet_id_suffix, faucet_id_prefix] -> METADATA_HASH_LO
@@ -392,6 +404,9 @@ end
 #! is currently registered first. Afterwards `assert_faucet_registered` and
 #! `lookup_faucet_by_token_address` fail for the faucet, so in-flight B2AGG / CLAIM notes targeting
 #! it are rejected.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Inputs:  [faucet_id_suffix, faucet_id_prefix, pad(14)]
 #! Outputs: [pad(16)]

--- a/crates/miden-standards/asm/standards/access/authority.masm
+++ b/crates/miden-standards/asm/standards/access/authority.masm
@@ -48,6 +48,9 @@ const ERR_AUTHORITY_FROZEN = "authority is frozen"
 
 #! Freezes the account's authority-gated surface as an emergency switch.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `assert_authorized`).
+#!
 #! Inputs:  [pad(16)]
 #! Outputs: [pad(16)]
 #!
@@ -65,6 +68,9 @@ pub proc freeze
 end
 
 #! Unfreezes the account's authority-gated surface, clearing the emergency switch.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `assert_authorized`).
 #!
 #! Inputs:  [pad(16)]
 #! Outputs: [pad(16)]

--- a/crates/miden-standards/asm/standards/access/pausable/manager.masm
+++ b/crates/miden-standards/asm/standards/access/pausable/manager.masm
@@ -19,6 +19,9 @@ use miden::standards::access::pausable
 
 #! Pause the account.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Inputs:  [pad(16)]
 #! Outputs: [pad(16)]
 #!
@@ -36,6 +39,9 @@ pub proc pause
 end
 
 #! Unpause the account.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Inputs:  [pad(16)]
 #! Outputs: [pad(16)]

--- a/crates/miden-standards/asm/standards/access/warden.masm
+++ b/crates/miden-standards/asm/standards/access/warden.masm
@@ -58,6 +58,9 @@ end
 
 #! Sets or clears the warden account ID.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Authorized through `authority::assert_authorized`, so the gate is mode-aware. The owner under
 #! `OwnerControlled`, the configured role (or the owner fallback) under `RbacControlled`, and the
 #! account's auth component under `AuthControlled`. Requires the [`Authority`] component to be

--- a/crates/miden-standards/asm/standards/account_upgrade.masm
+++ b/crates/miden-standards/asm/standards/account_upgrade.masm
@@ -15,6 +15,9 @@ use miden::protocol::native_account
 #! Records the commitments describing an upgrade of the account's code and storage, gated by the
 #! account-wide `Authority` component.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! This is currently a no-op beyond storing the two commitments in kernel memory (via the protocol
 #! `native_account::upgrade` wrapper); the actual application of the upgrade is not yet implemented,
 #! and the commitment formats are not yet defined.

--- a/crates/miden-standards/asm/standards/auth/network_account.masm
+++ b/crates/miden-standards/asm/standards/auth/network_account.masm
@@ -61,6 +61,9 @@ end
 
 #! Adds a note script root to the account's note script allowlist.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Gated by the account-wide `Authority` component. The auth procedure reads the allowlist from the
 #! transaction's initial state, so an added root only takes effect from the next transaction.
 #!
@@ -87,6 +90,9 @@ pub proc add_allowed_note_script(script_root: NoteScriptRoot)
 end
 
 #! Removes a note script root from the account's note script allowlist.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Gated by the account-wide `Authority` component. The auth procedure reads the allowlist from the
 #! transaction's initial state, so a removed root only takes effect from the next transaction.
@@ -116,6 +122,9 @@ end
 
 #! Adds a tx script root to the account's tx script allowlist.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Gated by the account-wide `Authority` component. The auth procedure reads the allowlist from the
 #! transaction's initial state, so an added root only takes effect from the next transaction.
 #!
@@ -142,6 +151,9 @@ pub proc add_allowed_tx_script(script_root: TransactionScriptRoot)
 end
 
 #! Removes a tx script root from the account's tx script allowlist.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Gated by the account-wide `Authority` component. The auth procedure reads the allowlist from the
 #! transaction's initial state, so a removed root only takes effect from the next transaction.

--- a/crates/miden-standards/asm/standards/faucets/fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/fungible.masm
@@ -174,6 +174,9 @@ end
 #! Updates the max supply if the max supply mutability flag is 1
 #! and the caller satisfies the account-wide authority configuration.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Inputs:  [new_max_supply, pad(15)]
 #! Outputs: [pad(16)]
 #!

--- a/crates/miden-standards/asm/standards/faucets/mod.masm
+++ b/crates/miden-standards/asm/standards/faucets/mod.masm
@@ -131,6 +131,9 @@ end
 #! Updates the description (7 Words) if the description mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! The caller passes the Poseidon2 hash of the new description on the stack and provides
 #! the actual 7 Words in the advice map under that hash. The hash is verified against
 #! the preimage during loading.
@@ -208,6 +211,9 @@ end
 #! Updates the logo URI (7 Words) if the logo URI mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! The caller passes the Poseidon2 hash of the new logo URI on the stack and provides
 #! the actual 7 Words in the advice map under that hash. The hash is verified against
 #! the preimage during loading.
@@ -283,6 +289,9 @@ end
 
 #! Updates the external link (7 Words) if the external link mutability flag is 1
 #! and the caller satisfies the account-wide [`Authority`] configuration.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! The caller passes the Poseidon2 hash of the new external link on the stack and provides
 #! the actual 7 Words in the advice map under that hash. The hash is verified against

--- a/crates/miden-standards/asm/standards/faucets/policies/burn/min_burn_amount.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/burn/min_burn_amount.masm
@@ -80,6 +80,9 @@ end
 
 #! Sets the minimum burn amount.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Inputs:  [new_min_burn_amount, pad(15)]
 #! Outputs: [pad(16)]
 #!

--- a/crates/miden-standards/asm/standards/faucets/policies/policy_manager.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/policy_manager.masm
@@ -81,6 +81,9 @@ end
 
 #! Sets active mint policy root.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Inputs:  [NEW_POLICY_ROOT, pad(12)]
 #! Outputs: [pad(16)]
 #!
@@ -119,6 +122,9 @@ pub proc get_burn_policy
 end
 
 #! Sets active burn policy root.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Inputs:  [NEW_POLICY_ROOT, pad(12)]
 #! Outputs: [pad(16)]
@@ -186,6 +192,9 @@ pub proc get_send_policy
 end
 
 #! Sets active send policy root.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Writes into [`ACTIVE_SEND_POLICY_PROC_ROOT_SLOT`].
 #!
@@ -257,6 +266,9 @@ pub proc get_receive_policy
 end
 
 #! Sets active receive policy root.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Writes into [`ACTIVE_RECEIVE_POLICY_PROC_ROOT_SLOT`].
 #!

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/allowlist/manager.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/allowlist/manager.masm
@@ -21,6 +21,9 @@ use miden::standards::faucets::policies::transfer::allowlist
 
 #! Allow an account, gated by the account-wide `Authority` component.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Inputs:  [account_id_suffix, account_id_prefix, pad(14)]
 #! Outputs: [pad(16)]
 #!
@@ -38,6 +41,9 @@ pub proc allow_account
 end
 
 #! Disallow an account, gated by the account-wide `Authority` component.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Inputs:  [account_id_suffix, account_id_prefix, pad(14)]
 #! Outputs: [pad(16)]

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/blocklist/manager.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/blocklist/manager.masm
@@ -21,6 +21,9 @@ use miden::standards::faucets::policies::transfer::blocklist
 
 #! Block an account, gated by the account-wide `Authority` component.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Inputs:  [account_id_suffix, account_id_prefix, pad(14)]
 #! Outputs: [pad(16)]
 #!
@@ -38,6 +41,9 @@ pub proc block_account
 end
 
 #! Unblock an account, gated by the account-wide `Authority` component.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Inputs:  [account_id_suffix, account_id_prefix, pad(14)]
 #! Outputs: [pad(16)]

--- a/crates/miden-standards/asm/standards/fees/fee_manager.masm
+++ b/crates/miden-standards/asm/standards/fees/fee_manager.masm
@@ -139,6 +139,9 @@ end
 
 #! Sets active fee policy root.
 #!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
+#!
 #! Inputs:  [NEW_POLICY_ROOT, pad(12)]
 #! Outputs: [pad(16)]
 #!
@@ -162,6 +165,9 @@ pub proc set_fee_policy(new_policy_root: AccountProcedureRoot)
 end
 
 #! Adds a fee policy root to the allowed fee policy roots map.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Registers `FEE_POLICY_ROOT` as an allowed alternative that `set_fee_policy` may later activate.
 #! Adding a root that is already allowed is a no-op. This only mutates the allowlist gate; the root
@@ -193,6 +199,9 @@ pub proc add_allowed_fee_policy(policy_root: AccountProcedureRoot)
 end
 
 #! Removes a fee policy root from the allowed fee policy roots map.
+#!
+#! This procedure MUST be a direct `call` entrypoint; never `exec` it from a compound procedure,
+#! or the `Authority` role check resolves to the wrong root (see `authority::assert_authorized`).
 #!
 #! Writes the empty word for `FEE_POLICY_ROOT`, which `set_fee_policy` treats as not allowed.
 #! Removing a root that is not currently allowed is a no-op. The active fee policy's root cannot be


### PR DESCRIPTION
## Summary

Follow-up to the audit finding whose per-procedure role design was resolved in #3072.

That per-procedure design resolves the required role from the *calling* procedure's root via the `caller` instruction. `caller` only equals a gated procedure's own root when the procedure is invoked directly as a `call` entrypoint - the transaction VM sets the caller register to the callee's root on `call` (it does not change on `exec`). As a result, `exec`ing a gated procedure from a compound procedure (e.g. an `emergency_lock_and_pause` wrapper) resolves `caller` to the *wrapper's* root instead, silently falling back to the `ADMIN` role rather than the procedure's configured role.

This is acknowledged on `assert_authorized` itself, it is noted by reviewers that a single warning on the shared helper is easy to miss - a developer composing a gated procedure reads that procedure's documentation, not the helper's. This PR surfaces the constraint at each call site.

The failure mode is fail-closed (it becomes *more* restrictive - ADMIN instead of the configured role), so this is a composability/usability footgun rather than a privilege-escalation bug; the fix is documentation only.

## Changes

- Added a short two-line warning to each of the 31 authority-gated procedures across `miden-standards` and `miden-agglayer`, pointing to `authority::assert_authorized` for the full explanation (no mechanism duplication). Procedures covered: `pause`/`unpause`, the `TokenPolicyManager` `set_*_policy` setters, `set_max_supply`, the faucet metadata setters, `set_min_burn_amount`, the block/allow-list managers, the `FeeManager` fee-policy setters, the `AuthNetworkAccount` allowlist management procedures, `upgrade`, `set_warden`, `freeze`/`unfreeze`, and the AggLayer bridge config setters.
