### PR TITLE
chore: insert input note recipients into advice map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [BREAKING] Replaced `SwapNote::create` with `SwapNote::builder()` ([#3414](https://github.com/0xMiden/protocol/pull/3414)).
 - [BREAKING] Moved the network-account default configuration into `AuthNetworkAccount::new`, which now allowlists the `NetworkAccountConfigNote` and `FeeSponsorshipNote` script roots and the canonical `ExpirationTransactionScript` tx-script root; added `AuthNetworkAccount::custom` to build a raw component with no default configuration for low-level use, and removed `AuthNetworkAccount::with_allowed_tx_scripts` ([#3392](https://github.com/0xMiden/protocol/pull/3392)).
 - [BREAKING] Removed the redundant zero-nomination check and the `ERR_NO_NOMINATED_OWNER` error constant from `ownable2step::accept_ownership`; since a note sender can never be the zero address stored when no transfer is nominated, accepting ownership without a pending nomination now fails with `ERR_SENDER_NOT_NOMINATED_OWNER` ([#3416](https://github.com/0xMiden/protocol/pull/3416)).
+- Always insert recipients of input notes into the advice map to simplify note fee stimation ([#3421](https://github.com/0xMiden/protocol/pull/3421)).
 
 ### Fixes
 

--- a/crates/miden-protocol/src/note/recipient.rs
+++ b/crates/miden-protocol/src/note/recipient.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use super::{
@@ -11,6 +12,7 @@ use super::{
     Serializable,
     Word,
 };
+use crate::Felt;
 
 /// Value that describes under which condition a note can be consumed.
 ///
@@ -32,7 +34,7 @@ pub struct NoteRecipient {
 
 impl NoteRecipient {
     pub fn new(serial_num: Word, script: NoteScript, storage: NoteStorage) -> Self {
-        let digest = compute_recipient_digest(serial_num, &script, &storage);
+        let (_, _, digest) = compute_recipient_chain(serial_num, &script, &storage);
         Self { serial_num, script, storage, digest }
     }
 
@@ -61,6 +63,25 @@ impl NoteRecipient {
         self.digest
     }
 
+    /// Returns the advice map entries opening every link of the recipient's hash chain.
+    ///
+    /// They allow the VM to recover the note's script root and storage commitment from the
+    /// recipient alone, which is all a note is committed to on chain.
+    pub fn to_advice_map_entries(&self) -> [(Word, Vec<Felt>); 5] {
+        let (serial_commitment, serial_script_commitment, digest) =
+            compute_recipient_chain(self.serial_num, &self.script, &self.storage);
+        let script_root = Word::from(self.script.root());
+        let script_encoded = <Vec<Felt>>::from(&self.script);
+
+        [
+            (serial_commitment, concat_words(self.serial_num, Word::empty())),
+            (serial_script_commitment, concat_words(serial_commitment, script_root)),
+            (digest, concat_words(serial_script_commitment, self.storage.commitment())),
+            (self.storage().commitment(), self.storage().to_elements()),
+            (script_root, script_encoded),
+        ]
+    }
+
     // MUTATORS
     // --------------------------------------------------------------------------------------------
 
@@ -75,10 +96,25 @@ impl NoteRecipient {
     }
 }
 
-fn compute_recipient_digest(serial_num: Word, script: &NoteScript, storage: &NoteStorage) -> Word {
-    let serial_num_hash = Hasher::merge(&[serial_num, Word::empty()]);
-    let merge_script = Hasher::merge(&[serial_num_hash, script.root().into()]);
-    Hasher::merge(&[merge_script, storage.commitment()])
+/// Returns the links of the recipient's hash chain: the serial commitment, the serial-script
+/// commitment and the recipient digest itself.
+fn compute_recipient_chain(
+    serial_num: Word,
+    script: &NoteScript,
+    storage: &NoteStorage,
+) -> (Word, Word, Word) {
+    let serial_commitment = Hasher::merge(&[serial_num, Word::empty()]);
+    let serial_script_commitment = Hasher::merge(&[serial_commitment, script.root().into()]);
+    let recipient_digest = Hasher::merge(&[serial_script_commitment, storage.commitment()]);
+
+    (serial_commitment, serial_script_commitment, recipient_digest)
+}
+
+fn concat_words(first: Word, second: Word) -> Vec<Felt> {
+    let mut elements = Vec::with_capacity(2 * Word::NUM_ELEMENTS);
+    elements.extend(first);
+    elements.extend(second);
+    elements
 }
 
 // SERIALIZATION

--- a/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
+++ b/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
@@ -316,6 +316,7 @@ impl TransactionAdviceInputs {
     /// - For each note:
     ///     - The note's private arguments.
     ///     - The note's details (serial number, script root, and its storage / assets commitment).
+    ///     - The preimages of the note recipient's hash chain.
     ///     - The note's public metadata (sender account ID, note type, note tag, attachment
     ///       schemes).
     ///     - The note's storage (unpadded).
@@ -338,8 +339,8 @@ impl TransactionAdviceInputs {
             let recipient = note.recipient();
             let note_arg = tx_inputs.tx_args().get_note_args(note.id()).unwrap_or(&EMPTY_WORD);
 
-            // recipient storage
-            self.add_map_entry(recipient.storage().commitment(), recipient.storage().to_elements());
+            // recipient chain entries
+            self.extend_map(recipient.to_advice_map_entries());
             // assets commitments
             self.add_map_entry(assets.commitment(), assets.to_elements());
 

--- a/crates/miden-protocol/src/transaction/tx_args.rs
+++ b/crates/miden-protocol/src/transaction/tx_args.rs
@@ -171,25 +171,9 @@ impl TransactionArgs {
     /// - storage_commitment |-> storage_items.
     /// - script_root |-> script.
     pub fn add_output_note_recipient<T: AsRef<NoteRecipient>>(&mut self, note_recipient: T) {
-        let note_recipient = note_recipient.as_ref();
-        let storage = note_recipient.storage();
-        let script = note_recipient.script();
-        let script_encoded: Vec<Felt> = script.into();
-
-        // Build the advice map entries
-        let script_root: Word = script.root().into();
-        let sn_hash = Hasher::merge(&[note_recipient.serial_num(), Word::empty()]);
-        let sn_script_hash = Hasher::merge(&[sn_hash, script_root]);
-
-        let new_elements = vec![
-            (sn_hash, concat_words(note_recipient.serial_num(), Word::empty())),
-            (sn_script_hash, concat_words(sn_hash, script_root)),
-            (note_recipient.digest(), concat_words(sn_script_hash, storage.commitment())),
-            (storage.commitment(), storage.to_elements()),
-            (script_root, script_encoded),
-        ];
-
-        self.advice_inputs.extend(AdviceInputs::default().with_map(new_elements));
+        self.advice_inputs.extend(
+            AdviceInputs::default().with_map(note_recipient.as_ref().to_advice_map_entries()),
+        );
     }
 
     /// Adds the `signature` corresponding to `pub_key` on `message` to the advice inputs' map.
@@ -243,13 +227,6 @@ impl TransactionArgs {
 }
 
 /// Concatenates two [`Word`]s into a [`Vec<Felt>`] containing 8 elements.
-fn concat_words(first: Word, second: Word) -> Vec<Felt> {
-    let mut result = Vec::with_capacity(8);
-    result.extend(first);
-    result.extend(second);
-    result
-}
-
 impl Default for TransactionArgs {
     fn default() -> Self {
         Self::new(AdviceMap::default())

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -162,16 +162,15 @@ pub proc collect_sponsored_fees(fee_asset_id: AssetId) -> felt
         dup exec.input_note::get_script_root
         # => [FEATURE_NOTE_SCRIPT_ROOT, note_idx, num_input_notes, total_fee_amount]
 
-        procref.fee_sponsorship::main exec.word::test_eq
-        # => [is_sponsorship, SPONSORSHIP_ROOT, FEATURE_NOTE_SCRIPT_ROOT, note_idx, num_input_notes, total_fee_amount]
+        procref.fee_sponsorship::main exec.word::eq
+        # => [is_sponsorship, note_idx, num_input_notes, total_fee_amount]
 
         # reject unpaired sponsorship notes
         assertz.err=ERR_FEE_MANAGER_UNEXPECTED_SPONSORSHIP_NOTE
-        dropw
-        # => [FEATURE_NOTE_SCRIPT_ROOT, note_idx, num_input_notes, total_fee_amount]
+        # => [note_idx, num_input_notes, total_fee_amount]
 
         # price the feature note through the active fee policy
-        dup.4 movdn.4 exec.estimate_input_note_fee
+        dup exec.estimate_input_note_fee
         # => [required_fee_amount, note_idx, num_input_notes, total_fee_amount]
 
         dup eq.0
@@ -293,39 +292,19 @@ end
 
 #! Prices the input note at the given index through the active fee policy.
 #!
-#! The note's script root is supplied by the caller (which already fetched it for the sponsorship
-#! check) so it is not fetched a second time here. The note's recipient is recomputed from its
-#! serial number, script root, and storage commitment, inserting the recipient preimages into the
-#! advice map so the policy can recover the script root and storage commitment from the recipient.
-#! The remaining note parameters are read from the note and forwarded to the policy along with a
-#! timeframe and priority of 0.
+#! The note's parameters are read from the note and forwarded to the policy along with a timeframe
+#! and priority of 0.
 #!
-#! Inputs:  [NOTE_SCRIPT_ROOT, note_index]
+#! Inputs:  [note_index]
 #! Outputs: [required_fee_amount]
 #!
 #! Where:
-#! - NOTE_SCRIPT_ROOT is the script root of the input note at note_index.
 #! - note_index is the index of the input note whose fee is priced.
 #! - required_fee_amount is the fee amount charged for the note, or 0 if the policy prices it to 0.
 #!
 #! Invocation: exec
 proc estimate_input_note_fee
-    # gather the storage commitment and serial number of the recipient preimage
-    dup.4 exec.input_note::get_storage_info movup.4 drop swapw
-    # => [NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, note_index]
-
-    dup.8 exec.input_note::get_serial_number padw swapw
-    # => [SERIAL_NUM, EMPTY_WORD, NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, note_index]
-
-    # compute the note's recipient, inserting the recipient preimages into the advice map so the
-    # fee policy can recover the script root and storage commitment from the recipient
-    adv.insert_hdword exec.poseidon2::merge
-    # => [SERIAL_COMMITMENT, NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT, note_index]
-
-    adv.insert_hdword exec.poseidon2::merge
-    # => [SERIAL_SCRIPT_COMMITMENT, STORAGE_COMMITMENT, note_index]
-
-    adv.insert_hdword exec.poseidon2::merge
+    dup exec.input_note::get_recipient
     # => [RECIPIENT, note_index]
 
     # pass a timeframe and priority of 0, along with the fee policy padding
@@ -335,24 +314,19 @@ proc estimate_input_note_fee
     dup.8 exec.input_note::get_attachments_commitment swapw
     # => [RECIPIENT, ATTACHMENTS_COMMITMENT, timeframe, priority, pad(2), note_index]
 
-    dup.12 exec.input_note::get_initial_assets_info movup.4 drop swapw
-    # => [RECIPIENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT, timeframe, priority, pad(2),
-    #     note_index]
+    movup.12 exec.input_note::get_initial_assets_info movup.4 drop swapw
+    # => [RECIPIENT, ASSETS_COMMITMENT, ATTACHMENTS_COMMITMENT, timeframe, priority, pad(2)]
 
     exec.fee_manager::estimate_note_fee_internal
-    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(8), note_index]
+    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, pad(8)]
 
     # drop the policy's call-boundary padding
     movupw.3 dropw movupw.2 dropw
-    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, note_index]
+    # => [FEE_ASSET_ID, FEE_ASSET_VALUE]
 
     # the manager asserts the estimate is denominated in its configured fee asset, so only the
     # fee amount is needed here
     dropw exec.fungible_asset::value_into_amount
-    # => [required_fee_amount, note_index]
-
-    # drop note_index, which the caller tracks itself
-    swap drop
     # => [required_fee_amount]
 end
 

--- a/crates/miden-standards/asm/standards/note/mod.masm
+++ b/crates/miden-standards/asm/standards/note/mod.masm
@@ -84,9 +84,8 @@ end
 #! Recovers a note's script root and storage commitment from the given recipient via the advice
 #! provider.
 #!
-#! Requires the recipient preimage in the advice provider. Generally present for public notes
-#! (recipients added to advice inputs, or created via compute_and_store_recipient) and for private
-#! notes whose preimage is available.
+#! Requires the recipient preimage in the advice provider. Always present for input notes and
+#! must be present for public output notes.
 #!
 #! Inputs:  [RECIPIENT]
 #! Outputs: [NOTE_SCRIPT_ROOT, STORAGE_COMMITMENT]


### PR DESCRIPTION
Follow-up to https://github.com/0xMiden/protocol/pull/3349#discussion_r3606894753.

The recipients of input notes were only added to the advice stack for consumption by the tx kernel prologue, but not to the advice map. This PR inserts the 5 recipient entries for all input notes to make them available. Deduplicates with the existing recipient insertion logic and simplifies the note fee estimation procedure.