### PR TITLE
chore: Remove outdated `AccountId` to `[Felt; 2]` conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [BREAKING] Replaced `SwapNote::create` with `SwapNote::builder()` ([#3414](https://github.com/0xMiden/protocol/pull/3414)).
 - [BREAKING] Moved the network-account default configuration into `AuthNetworkAccount::new`, which now allowlists the `NetworkAccountConfigNote` and `FeeSponsorshipNote` script roots and the canonical `ExpirationTransactionScript` tx-script root; added `AuthNetworkAccount::custom` to build a raw component with no default configuration for low-level use, and removed `AuthNetworkAccount::with_allowed_tx_scripts` ([#3392](https://github.com/0xMiden/protocol/pull/3392)).
 - [BREAKING] Removed the redundant zero-nomination check and the `ERR_NO_NOMINATED_OWNER` error constant from `ownable2step::accept_ownership`; since a note sender can never be the zero address stored when no transfer is nominated, accepting ownership without a pending nomination now fails with `ERR_SENDER_NOT_NOMINATED_OWNER` ([#3416](https://github.com/0xMiden/protocol/pull/3416)).
+- [BREAKING] Removed the outdated `AccountId` to `[Felt; 2]` conversion. Use `AccountId::{suffix, prefix}` accessors instead ([#3422](https://github.com/0xMiden/protocol/pull/3422)).
 
 ### Fixes
 

--- a/crates/miden-protocol/src/account/account_id/mod.rs
+++ b/crates/miden-protocol/src/account/account_id/mod.rs
@@ -361,14 +361,6 @@ impl AccountId {
 // CONVERSIONS FROM ACCOUNT ID
 // ================================================================================================
 
-impl From<AccountId> for [Felt; 2] {
-    fn from(id: AccountId) -> Self {
-        match id {
-            AccountId::V1(account_id) => account_id.into(),
-        }
-    }
-}
-
 impl From<AccountId> for [u8; 15] {
     fn from(id: AccountId) -> Self {
         match id {

--- a/crates/miden-protocol/src/account/account_id/v1/mod.rs
+++ b/crates/miden-protocol/src/account/account_id/v1/mod.rs
@@ -310,12 +310,6 @@ impl AccountIdV1 {
 // CONVERSIONS FROM ACCOUNT ID
 // ================================================================================================
 
-impl From<AccountIdV1> for [Felt; 2] {
-    fn from(id: AccountIdV1) -> Self {
-        [id.prefix, id.suffix]
-    }
-}
-
 impl From<AccountIdV1> for [u8; 15] {
     fn from(id: AccountIdV1) -> Self {
         let mut result = [0_u8; 15];

--- a/crates/miden-protocol/src/batch/batch_id.rs
+++ b/crates/miden-protocol/src/batch/batch_id.rs
@@ -1,10 +1,10 @@
 use alloc::string::String;
-use alloc::vec::Vec;
 
 use miden_crypto_derive::WordWrapper;
 
+use crate::Word;
 use crate::account::AccountId;
-use crate::transaction::{ProvenTransaction, TransactionId};
+use crate::transaction::{OrderedTransactionHeaders, ProvenTransaction, TransactionId};
 use crate::utils::serde::{
     ByteReader,
     ByteWriter,
@@ -12,7 +12,6 @@ use crate::utils::serde::{
     DeserializationError,
     Serializable,
 };
-use crate::{Felt, Hasher, Word, ZERO};
 
 // BATCH ID
 // ================================================================================================
@@ -20,8 +19,8 @@ use crate::{Felt, Hasher, Word, ZERO};
 /// Uniquely identifies a batch of transactions, i.e. both
 /// [`ProposedBatch`](crate::batch::ProposedBatch) and [`ProvenBatch`](crate::batch::ProvenBatch).
 ///
-/// This is a sequential hash of the tuple `(TRANSACTION_ID || [account_id_prefix,
-/// account_id_suffix, 0, 0])` of all transactions and the accounts their executed against in the
+/// This is a sequential hash of the tuple `(TRANSACTION_ID || [account_id_suffix,
+/// account_id_prefix, 0, 0])` of all transactions and the accounts their executed against in the
 /// batch.
 #[derive(Debug, Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Hash, WordWrapper)]
 pub struct BatchId(Word);
@@ -37,14 +36,9 @@ impl BatchId {
 
     /// Calculates a batch ID from the given transaction ID and account ID tuple.
     pub fn from_ids(iter: impl IntoIterator<Item = (TransactionId, AccountId)>) -> Self {
-        let mut elements: Vec<Felt> = Vec::new();
-        for (tx_id, account_id) in iter {
-            elements.extend_from_slice(tx_id.as_elements());
-            let [account_id_prefix, account_id_suffix] = <[Felt; 2]>::from(account_id);
-            elements.extend_from_slice(&[account_id_prefix, account_id_suffix, ZERO, ZERO]);
-        }
-
-        Self(Hasher::hash_elements(&elements))
+        // A batch ID commits to the set of transaction it contains which is the same computation as
+        // in OrderedTransactionHeaders, so it is reused.
+        Self(OrderedTransactionHeaders::compute_commitment(iter))
     }
 }
 

--- a/crates/miden-protocol/src/transaction/ordered_transactions.rs
+++ b/crates/miden-protocol/src/transaction/ordered_transactions.rs
@@ -9,7 +9,7 @@ use crate::utils::serde::{
     DeserializationError,
     Serializable,
 };
-use crate::{Felt, Hasher, Word, ZERO};
+use crate::{Felt, Hasher, Word};
 
 // ORDERED TRANSACTION HEADERS
 // ================================================================================================
@@ -63,15 +63,19 @@ impl OrderedTransactionHeaders {
     /// Computes a commitment to the provided list of transactions.
     ///
     /// Each transaction is represented by a transaction ID and an account ID which it was executed
-    /// against. The commitment is a sequential hash over (transaction_id, account_id) tuples.
-    pub fn compute_commitment(
-        transactions: impl Iterator<Item = (TransactionId, AccountId)>,
+    /// against. The commitment is a sequential hash over (TRANSACTION_ID, ACCOUNT_ID) tuples.
+    pub(crate) fn compute_commitment(
+        transactions: impl IntoIterator<Item = (TransactionId, AccountId)>,
     ) -> Word {
         let mut elements = vec![];
         for (transaction_id, account_id) in transactions {
-            let [account_id_prefix, account_id_suffix] = <[Felt; 2]>::from(account_id);
             elements.extend_from_slice(transaction_id.as_elements());
-            elements.extend_from_slice(&[account_id_prefix, account_id_suffix, ZERO, ZERO]);
+            elements.extend_from_slice(&[
+                account_id.suffix(),
+                account_id.prefix().as_felt(),
+                Felt::ZERO,
+                Felt::ZERO,
+            ]);
         }
 
         Hasher::hash_elements(&elements)

--- a/crates/miden-testing/tests/agglayer/solidity_miden_address_conversion.rs
+++ b/crates/miden-testing/tests/agglayer/solidity_miden_address_conversion.rs
@@ -14,6 +14,7 @@ use miden_processor::{
     Program,
     StackInputs,
 };
+use miden_protocol::ProtocolLib;
 use miden_protocol::account::AccountId;
 use miden_protocol::address::NetworkId;
 use miden_protocol::testing::account_id::{
@@ -24,7 +25,6 @@ use miden_protocol::testing::account_id::{
     AccountIdBuilder,
 };
 use miden_protocol::transaction::TransactionKernel;
-use miden_protocol::{Felt, ProtocolLib};
 
 /// Execute a program with default host
 async fn execute_program_with_default_host(
@@ -133,10 +133,6 @@ async fn test_ethereum_address_to_account_id_in_masm() -> anyhow::Result<()> {
 
         assert_eq!(limb0, 0, "test {}: expected msb limb (limb0) to be zero", idx);
 
-        let account_id_felts: [Felt; 2] = (*original_account_id).into();
-        let expected_prefix = account_id_felts[0];
-        let expected_suffix = account_id_felts[1];
-
         let script_code = format!(
             r#"
             use miden::core::sys
@@ -166,8 +162,13 @@ async fn test_ethereum_address_to_account_id_in_masm() -> anyhow::Result<()> {
         let actual_suffix = exec_output.stack[0];
         let actual_prefix = exec_output.stack[1];
 
-        assert_eq!(actual_prefix, expected_prefix, "test {}: prefix mismatch", idx);
-        assert_eq!(actual_suffix, expected_suffix, "test {}: suffix mismatch", idx);
+        assert_eq!(
+            actual_prefix,
+            original_account_id.prefix().as_felt(),
+            "test {}: prefix mismatch",
+            idx
+        );
+        assert_eq!(actual_suffix, original_account_id.suffix(), "test {}: suffix mismatch", idx);
 
         let reconstructed_account_id = AccountId::try_from_elements(actual_suffix, actual_prefix)?;
 

--- a/crates/miden-testing/tests/scripts/allowlist.rs
+++ b/crates/miden-testing/tests/scripts/allowlist.rs
@@ -111,11 +111,6 @@ fn add_faucet_with_owner_allowlist_transfer_initialized(
     )
 }
 
-fn account_id_felts(account_id: AccountId) -> (Felt, Felt) {
-    let [prefix, suffix]: [Felt; 2] = account_id.into();
-    (prefix, suffix)
-}
-
 /// Builds a `sender`-authored note whose script invokes
 /// `manager::{allow_account|disallow_account}` on the given target account. The sender must be
 /// authorized per the faucet's installed `Authority` component (the owner under
@@ -126,7 +121,6 @@ fn build_admin_note(
     proc: &str,
     rng_seed: u32,
 ) -> anyhow::Result<Note> {
-    let (prefix, suffix) = account_id_felts(target_id);
     let script_code = format!(
         r#"
         use miden::standards::faucets::policies::transfer::allowlist::manager
@@ -141,7 +135,9 @@ fn build_admin_note(
 
             dropw dropw dropw dropw
         end
-        "#
+        "#,
+        suffix = target_id.suffix(),
+        prefix = target_id.prefix().as_felt(),
     );
 
     let mut rng = RandomCoin::new([Felt::from(rng_seed); 4].into());

--- a/crates/miden-testing/tests/scripts/blocklist.rs
+++ b/crates/miden-testing/tests/scripts/blocklist.rs
@@ -109,11 +109,6 @@ fn add_faucet_with_owner_blocklist_transfer_initialized(
     )
 }
 
-fn account_id_felts(account_id: AccountId) -> (Felt, Felt) {
-    let [prefix, suffix]: [Felt; 2] = account_id.into();
-    (prefix, suffix)
-}
-
 /// Builds a `sender`-authored note whose script invokes
 /// `manager::{block_account|unblock_account}` on the given target account. The sender must be
 /// authorized per the faucet's installed `Authority` component (the owner under
@@ -124,7 +119,6 @@ fn build_admin_note(
     proc: &str,
     rng_seed: u32,
 ) -> anyhow::Result<Note> {
-    let (prefix, suffix) = account_id_felts(target_id);
     let script_code = format!(
         r#"
         use miden::standards::faucets::policies::transfer::blocklist::manager
@@ -139,7 +133,9 @@ fn build_admin_note(
 
             dropw dropw dropw dropw
         end
-        "#
+        "#,
+        suffix = target_id.suffix(),
+        prefix = target_id.prefix().as_felt()
     );
 
     let mut rng = RandomCoin::new([Felt::from(rng_seed); 4].into());


### PR DESCRIPTION
Removes the outdated `AccountId` to `[Felt; 2]` conversion, which returned `[prefix, suffix]` order rather than the `[suffix, prefix]` order that we have used since the big-endian to little-endian migration.

Wherever we used this conversion, we always destructured the resulting `[Felt; 2]` array into its individual parts, so a better alternative is accessing the suffix and prefix directly, as this is much less likely to result in incorrectly assigning prefix and suffix.

Makes `OrderedTransactionHeaders::compute_commitment` private, as it isn't used outside `miden-protocol` (I checked client and node).

As part of this, I noticed the `BatchId` and `OrderedTransactionHeaders::commitment` committed to `[prefix, suffix]` and this was changed to `[suffix, prefix]` for overall consistency. This might need to be updated in the in-flight batch kernel (cc @mmagician). Also cc @Mirko-von-Leipzig, in case the node relies on this exact ordering, but I suspect it doesn't.

We also still use `[prefix, suffix]` ordering in `From<AccountIdV1> for [u8; 15]`, and we may want to change it for consistency. It would make the prefix word serialize to indices `7..15`, but that probably doesn't have any negative consequences. Not done in this PR.