### PR TITLE
feat(standards): support bytes32-embedded Ethereum-format addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Added `miden::standards::interop::eth_address::bytes32_to_account_id` and `EthAddress::try_from_bytes32` for converting bytes32-embedded Ethereum-format addresses (#TBD).
 - Added `<NOTE>_CONSUMPTION_CYCLES` constants in `miden_standards::note::costs` and `miden_agglayer::costs`, exposing each standard/agglayer note's benchmarked consumption cost for the canonical network-account transaction, regenerated via `make update-note-costs` and guarded by CI snapshot tests with a 5% drift tolerance ([#3354](https://github.com/0xMiden/protocol/pull/3354)).
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Added `miden::standards::interop::eth_address::bytes32_to_account_id` and `EthAddress::try_from_bytes32` for converting bytes32-embedded Ethereum-format addresses (#TBD).
+- Added `miden::standards::interop::eth_address::bytes32_to_account_id` and `EthAddress::try_from_bytes32` for converting bytes32-embedded Ethereum-format addresses ([#3426](https://github.com/0xMiden/protocol/pull/3426)).
 - Added `<NOTE>_CONSUMPTION_CYCLES` constants in `miden_standards::note::costs` and `miden_agglayer::costs`, exposing each standard/agglayer note's benchmarked consumption cost for the canonical network-account transaction, regenerated via `make update-note-costs` and guarded by CI snapshot tests with a 5% drift tolerance ([#3354](https://github.com/0xMiden/protocol/pull/3354)).
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Added `miden::standards::interop::eth_address::bytes32_to_account_id` and `EthAddress::try_from_bytes32` for converting bytes32-embedded Ethereum-format addresses ([#3426](https://github.com/0xMiden/protocol/pull/3426)).
+- Added `miden::standards::interop::eth_address::bytes32_to_account_id` and the `TryFrom<[u8; 32]>` impl for `EthAddress` for converting bytes32-embedded Ethereum-format addresses ([#3426](https://github.com/0xMiden/protocol/pull/3426)).
 - Added `<NOTE>_CONSUMPTION_CYCLES` constants in `miden_standards::note::costs` and `miden_agglayer::costs`, exposing each standard/agglayer note's benchmarked consumption cost for the canonical network-account transaction, regenerated via `make update-note-costs` and guarded by CI snapshot tests with a 5% drift tolerance ([#3354](https://github.com/0xMiden/protocol/pull/3354)).
 
 ### Changes

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -16,7 +16,7 @@ use miden::standards::assets::conversion
 use agglayer::bridge::bridge_config
 use agglayer::bridge::leaf_utils
 use agglayer::bridge::merkle_tree_frontier
-use {EthereumAddressFormat} from miden::standards::interop::eth_address
+use {EthereumAddress} from miden::standards::interop::eth_address
 
 # ERRORS
 # =================================================================================================
@@ -553,7 +553,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc write_address_to_memory(mem_ptr: MemoryAddress, address: EthereumAddressFormat)
+proc write_address_to_memory(mem_ptr: MemoryAddress, address: EthereumAddress)
     dup movdn.6 mem_store movup.4 add.1
     # => [mem_ptr+1, address(4)]
 

--- a/crates/miden-standards/asm/standards/interop/eth_address.masm
+++ b/crates/miden-standards/asm/standards/interop/eth_address.masm
@@ -17,7 +17,7 @@ const ERR_BYTES32_PADDING_NONZERO="leading 12 bytes must be zero for a bytes32-e
 # PUBLIC INTERFACE
 # =================================================================================================
 
-#! Converts an Ethereum address format (address[5] type) back into an AccountId [prefix, suffix] type.
+#! Converts an Ethereum address format (address[5] type) back into an AccountId [suffix, prefix] type.
 #!
 #! The Ethereum address format is represented as 5 u32 limbs (20 bytes total) in *big-endian limb order*
 #! (matching Solidity ABI encoding). Each limb encodes its 4 bytes in little-endian order:
@@ -78,7 +78,7 @@ pub proc to_account_id
     # => [suffix, prefix]
 end
 
-#! Converts a bytes32-embedded Ethereum address format back into an AccountId [prefix, suffix] type.
+#! Converts a bytes32-embedded Ethereum address format back into an AccountId [suffix, prefix] type.
 #!
 #! In EVM ABI encoding, a bytes32-embedded address is the 20-byte Ethereum address format
 #! left-padded to 32 bytes: bytes[0..12] are zero and bytes[12..32] hold the address. The bytes32

--- a/crates/miden-standards/asm/standards/interop/eth_address.masm
+++ b/crates/miden-standards/asm/standards/interop/eth_address.masm
@@ -4,8 +4,8 @@ use miden::protocol::account_id
 # TYPE ALIASES
 # =================================================================================================
 
-pub type EthereumAddressFormat = struct { a: felt, b: felt, c: felt, d: felt, e: felt }
-pub type EthereumBytes32Format = struct { a: felt, b: felt, c: felt, d: felt, e: felt, f: felt, g: felt, h: felt }
+pub type EthereumAddress = struct { a: felt, b: felt, c: felt, d: felt, e: felt }
+pub type EthereumBytes32 = struct { a: felt, b: felt, c: felt, d: felt, e: felt, f: felt, g: felt, h: felt }
 
 # ERRORS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/interop/eth_address.masm
+++ b/crates/miden-standards/asm/standards/interop/eth_address.masm
@@ -90,7 +90,7 @@ end
 #!   limb3..limb7 = bytes[12..32] (the embedded address[5] limbs)
 #!
 #! The three padding limbs are asserted to be zero directly on their raw packed form: a limb
-#! byte-swaps to zero iff it is zero, so no byte reordering is needed for the check. The remaining
+#! byte-swaps to zero if it is zero, so no byte reordering is needed for the check. The remaining
 #! 5 limbs are exactly the address[5] format (most-significant address limb on top) and are
 #! delegated to to_account_id for the AccountId conversion and validation.
 #!

--- a/crates/miden-standards/asm/standards/interop/eth_address.masm
+++ b/crates/miden-standards/asm/standards/interop/eth_address.masm
@@ -5,12 +5,14 @@ use miden::protocol::account_id
 # =================================================================================================
 
 pub type EthereumAddressFormat = struct { a: felt, b: felt, c: felt, d: felt, e: felt }
+pub type EthereumBytes32Format = struct { a: felt, b: felt, c: felt, d: felt, e: felt, f: felt, g: felt, h: felt }
 
 # ERRORS
 # =================================================================================================
 
 const ERR_NOT_U32="address limb is not u32"
 const ERR_MSB_NONZERO="most-significant 4 bytes must be zero for AccountId"
+const ERR_BYTES32_PADDING_NONZERO="leading 12 bytes must be zero for a bytes32-embedded address"
 
 # PUBLIC INTERFACE
 # =================================================================================================
@@ -73,6 +75,42 @@ pub proc to_account_id
     # => [suffix, prefix, suffix, prefix]
 
     exec.account_id::validate_structure
+    # => [suffix, prefix]
+end
+
+#! Converts a bytes32-embedded Ethereum address format back into an AccountId [prefix, suffix] type.
+#!
+#! In EVM ABI encoding, a bytes32-embedded address is the 20-byte Ethereum address format
+#! left-padded to 32 bytes: bytes[0..12] are zero and bytes[12..32] hold the address. The bytes32
+#! is represented as 8 u32 limbs (32 bytes total) in *big-endian limb order* (matching Solidity ABI
+#! encoding). Each limb encodes its 4 bytes in little-endian order:
+#!   limb0 = bytes[0..4]   (padding, must be zero)
+#!   limb1 = bytes[4..8]   (padding, must be zero)
+#!   limb2 = bytes[8..12]  (padding, must be zero)
+#!   limb3..limb7 = bytes[12..32] (the embedded address[5] limbs)
+#!
+#! The three padding limbs are asserted to be zero directly on their raw packed form: a limb
+#! byte-swaps to zero iff it is zero, so no byte reordering is needed for the check. The remaining
+#! 5 limbs are exactly the address[5] format (most-significant address limb on top) and are
+#! delegated to to_account_id for the AccountId conversion and validation.
+#!
+#! Inputs:  [limb0, limb1, limb2, limb3, limb4, limb5, limb6, limb7]
+#! Outputs: [suffix, prefix]
+#!
+#! Panics if:
+#! - any of the leading 12 padding bytes (limb0, limb1, limb2) are non-zero.
+#! - to_account_id fails to verify the embedded address.
+#!
+#! Invocation: exec
+pub proc bytes32_to_account_id
+    # the three padding limbs (bytes 0..12) must be 0
+    assertz.err=ERR_BYTES32_PADDING_NONZERO
+    assertz.err=ERR_BYTES32_PADDING_NONZERO
+    assertz.err=ERR_BYTES32_PADDING_NONZERO
+    # => [limb3, limb4, limb5, limb6, limb7]
+
+    # the remaining limbs are the address[5] format expected by to_account_id
+    exec.to_account_id
     # => [suffix, prefix]
 end
 

--- a/crates/miden-standards/src/interop/eth_address.rs
+++ b/crates/miden-standards/src/interop/eth_address.rs
@@ -66,24 +66,6 @@ impl EthAddress {
         Ok(Self(bytes))
     }
 
-    /// Creates an [`EthAddress`] from a 32-byte (bytes32) value embedding a left-padded address.
-    ///
-    /// In EVM ABI encoding, a bytes32-embedded address has bytes 0..12 zero and the 20-byte
-    /// address in bytes 12..32. This is the encoding used by bridges that carry an address in a
-    /// full bytes32 field.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any of the leading 12 padding bytes are non-zero.
-    pub fn try_from_bytes32(bytes: [u8; 32]) -> Result<Self, AddressConversionError> {
-        if bytes[0..12] != [0; 12] {
-            return Err(AddressConversionError::NonZeroBytes32Padding);
-        }
-
-        let addr: [u8; 20] = bytes[12..32].try_into().expect("slice is exactly 20 bytes");
-        Ok(Self(addr))
-    }
-
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -126,6 +108,28 @@ impl fmt::Display for EthAddress {
 impl From<[u8; 20]> for EthAddress {
     fn from(bytes: [u8; 20]) -> Self {
         Self(bytes)
+    }
+}
+
+/// Creates an [`EthAddress`] from a 32-byte (bytes32) value embedding a left-padded address.
+///
+/// In EVM ABI encoding, a bytes32-embedded address has bytes 0..12 zero and the 20-byte
+/// address in bytes 12..32. This is the encoding used by bridges that carry an address in a
+/// full bytes32 field.
+///
+/// # Errors
+///
+/// Returns an error if any of the leading 12 padding bytes are non-zero.
+impl TryFrom<[u8; 32]> for EthAddress {
+    type Error = AddressConversionError;
+
+    fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
+        if bytes[0..12] != [0; 12] {
+            return Err(AddressConversionError::NonZeroBytes32Padding);
+        }
+
+        let addr: [u8; 20] = bytes[12..32].try_into().expect("slice is exactly 20 bytes");
+        Ok(Self(addr))
     }
 }
 

--- a/crates/miden-standards/src/interop/eth_address.rs
+++ b/crates/miden-standards/src/interop/eth_address.rs
@@ -10,6 +10,7 @@ use miden_protocol::utils::{
     bytes_to_packed_u32_elements,
     hex_to_bytes,
 };
+use thiserror::Error;
 
 // ================================================================================================
 // ETHEREUM ADDRESS
@@ -143,39 +144,33 @@ impl From<EthAddress> for [u8; 20] {
 // ADDRESS CONVERSION ERROR
 // ================================================================================================
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Error type for Ethereum address conversions.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum AddressConversionError {
+    /// The address word has non-zero padding.
+    #[error("non-zero word padding")]
     NonZeroWordPadding,
+    /// The address has a non-zero 4-byte prefix.
+    #[error("address has non-zero 4-byte prefix")]
     NonZeroBytePrefix,
+    /// A bytes32-embedded address has non-zero leading padding bytes.
+    #[error("leading 12 bytes must be zero for a bytes32-embedded address")]
     NonZeroBytes32Padding,
+    /// The hex string has an unexpected length.
+    #[error("invalid hex length (expected 40 hex chars)")]
     InvalidHexLength,
+    /// The hex string contains an invalid character.
+    #[error("invalid hex character: {0}")]
     InvalidHexChar(char),
+    /// The hex string could not be parsed.
+    #[error("hex parse error")]
     HexParseError,
+    /// A packed 8-byte value does not fit in the field.
+    #[error("packed 8-byte value does not fit in the field")]
     FeltOutOfField,
+    /// The decoded value is not a valid AccountId.
+    #[error("invalid AccountId")]
     InvalidAccountId,
-}
-
-impl fmt::Display for AddressConversionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AddressConversionError::NonZeroWordPadding => write!(f, "non-zero word padding"),
-            AddressConversionError::NonZeroBytePrefix => {
-                write!(f, "address has non-zero 4-byte prefix")
-            },
-            AddressConversionError::NonZeroBytes32Padding => {
-                write!(f, "leading 12 bytes must be zero for a bytes32-embedded address")
-            },
-            AddressConversionError::InvalidHexLength => {
-                write!(f, "invalid hex length (expected 40 hex chars)")
-            },
-            AddressConversionError::InvalidHexChar(c) => write!(f, "invalid hex character: {}", c),
-            AddressConversionError::HexParseError => write!(f, "hex parse error"),
-            AddressConversionError::FeltOutOfField => {
-                write!(f, "packed 64-bit word does not fit in the field")
-            },
-            AddressConversionError::InvalidAccountId => write!(f, "invalid AccountId"),
-        }
-    }
 }
 
 impl From<HexParseError> for AddressConversionError {

--- a/crates/miden-standards/src/interop/eth_address.rs
+++ b/crates/miden-standards/src/interop/eth_address.rs
@@ -66,6 +66,24 @@ impl EthAddress {
         Ok(Self(bytes))
     }
 
+    /// Creates an [`EthAddress`] from a 32-byte (bytes32) value embedding a left-padded address.
+    ///
+    /// In EVM ABI encoding, a bytes32-embedded address has bytes 0..12 zero and the 20-byte
+    /// address in bytes 12..32. This is the encoding used by bridges that carry an address in a
+    /// full bytes32 field.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the leading 12 padding bytes are non-zero.
+    pub fn try_from_bytes32(bytes: [u8; 32]) -> Result<Self, AddressConversionError> {
+        if bytes[0..12] != [0; 12] {
+            return Err(AddressConversionError::NonZeroBytes32Padding);
+        }
+
+        let addr: [u8; 20] = bytes[12..32].try_into().expect("slice is exactly 20 bytes");
+        Ok(Self(addr))
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
@@ -125,6 +143,7 @@ impl From<EthAddress> for [u8; 20] {
 pub enum AddressConversionError {
     NonZeroWordPadding,
     NonZeroBytePrefix,
+    NonZeroBytes32Padding,
     InvalidHexLength,
     InvalidHexChar(char),
     HexParseError,
@@ -138,6 +157,9 @@ impl fmt::Display for AddressConversionError {
             AddressConversionError::NonZeroWordPadding => write!(f, "non-zero word padding"),
             AddressConversionError::NonZeroBytePrefix => {
                 write!(f, "address has non-zero 4-byte prefix")
+            },
+            AddressConversionError::NonZeroBytes32Padding => {
+                write!(f, "leading 12 bytes must be zero for a bytes32-embedded address")
             },
             AddressConversionError::InvalidHexLength => {
                 write!(f, "invalid hex length (expected 40 hex chars)")

--- a/crates/miden-standards/src/interop/eth_embedded_account_id.rs
+++ b/crates/miden-standards/src/interop/eth_embedded_account_id.rs
@@ -128,6 +128,14 @@ impl EthEmbeddedAccountId {
         self.to_eth_address().into_bytes()
     }
 
+    /// Returns the bytes32-embedded encoding: the 20-byte Ethereum address encoding left-padded
+    /// to 32 bytes (bytes 0..12 zero, address in bytes 12..32).
+    pub fn to_bytes32(&self) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        out[12..32].copy_from_slice(&self.to_bytes());
+        out
+    }
+
     /// Converts the address to a hex string (lowercase, 0x-prefixed).
     pub fn to_hex(&self) -> String {
         self.to_eth_address().to_hex()

--- a/crates/miden-testing/tests/standards/eth_address.rs
+++ b/crates/miden-testing/tests/standards/eth_address.rs
@@ -62,11 +62,8 @@ end",
 /// Returns a valid embedded-form address (as trailing 20 bytes) left-padded into a bytes32.
 fn valid_embedded_bytes32() -> ([u8; 20], [u8; 32]) {
     let valid_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
-    let addr_bytes = EthEmbeddedAccountId::from_account_id(valid_id).to_bytes();
-
-    let mut bytes32 = [0u8; 32];
-    bytes32[12..32].copy_from_slice(&addr_bytes);
-    (addr_bytes, bytes32)
+    let embedded = EthEmbeddedAccountId::from_account_id(valid_id);
+    (embedded.to_bytes(), embedded.to_bytes32())
 }
 
 /// Returns an embedded-form address that decodes into a structurally invalid `AccountId` (suffix

--- a/crates/miden-testing/tests/standards/eth_address.rs
+++ b/crates/miden-testing/tests/standards/eth_address.rs
@@ -1,4 +1,5 @@
-//! Tests for `AccountId` validation in `eth_address::to_account_id`.
+//! Tests for `AccountId` validation in `eth_address::to_account_id`, and for the bytes32-embedded
+//! variant `eth_address::bytes32_to_account_id`.
 //!
 //! The bridge-in claim decodes a deposit's `destinationAddress` into the `AccountId` target of a
 //! P2ID/MINT output. An invalid decoded id would produce an output that no account can consume.
@@ -13,10 +14,11 @@ use miden_protocol::Felt;
 use miden_protocol::account::AccountId;
 use miden_protocol::errors::protocol::ERR_ACCOUNT_ID_SUFFIX_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO;
 use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE;
-use miden_standards::errors::standards::ERR_MSB_NONZERO;
+use miden_protocol::utils::bytes_to_packed_u32_elements;
+use miden_standards::errors::standards::{ERR_BYTES32_PADDING_NONZERO, ERR_MSB_NONZERO};
 use miden_standards::interop::{AddressConversionError, EthAddress, EthEmbeddedAccountId};
 
-use super::test_utils::assert_execution_fails_with;
+use super::test_utils::{assert_execution_fails_with, execute_masm_script};
 
 /// Builds a script that pushes the 5 address limbs (`limb0` on top) and runs `to_account_id`.
 ///
@@ -35,6 +37,36 @@ begin
 end",
         limbs[4], limbs[3], limbs[2], limbs[1], limbs[0]
     )
+}
+
+/// Builds a script that pushes the 8 bytes32 limbs (`limb0` on top) and runs
+/// `bytes32_to_account_id`.
+fn bytes32_to_account_id_script(bytes: &[u8; 32]) -> String {
+    let limbs: Vec<u64> = bytes_to_packed_u32_elements(bytes)
+        .iter()
+        .map(|f| f.as_canonical_u64())
+        .collect();
+    format!(
+        "use miden::core::sys
+use miden::standards::interop::eth_address
+
+begin
+    push.{}.{}.{}.{}.{}.{}.{}.{}
+    exec.eth_address::bytes32_to_account_id
+    exec.sys::truncate_stack
+end",
+        limbs[7], limbs[6], limbs[5], limbs[4], limbs[3], limbs[2], limbs[1], limbs[0]
+    )
+}
+
+/// Returns a valid embedded-form address (as trailing 20 bytes) left-padded into a bytes32.
+fn valid_embedded_bytes32() -> ([u8; 20], [u8; 32]) {
+    let valid_id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
+    let addr_bytes = EthEmbeddedAccountId::from_account_id(valid_id).to_bytes();
+
+    let mut bytes32 = [0u8; 32];
+    bytes32[12..32].copy_from_slice(&addr_bytes);
+    (addr_bytes, bytes32)
 }
 
 /// Returns an embedded-form address that decodes into a structurally invalid `AccountId` (suffix
@@ -93,4 +125,69 @@ async fn to_account_id_rejects_structurally_invalid_account_id() {
         &ERR_ACCOUNT_ID_SUFFIX_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO,
     )
     .await;
+}
+
+/// A bytes32 with 12 zero leading bytes and a valid embedded `AccountId` converts to the same
+/// `[suffix, prefix]` as `to_account_id` applied to the trailing 20 bytes.
+#[tokio::test]
+async fn bytes32_to_account_id_matches_to_account_id_on_trailing_bytes() {
+    let (addr_bytes, bytes32) = valid_embedded_bytes32();
+
+    let bytes32_output = execute_masm_script(&bytes32_to_account_id_script(&bytes32))
+        .await
+        .expect("bytes32_to_account_id should accept a zero-padded embedded address");
+    let addr_output = execute_masm_script(&to_account_id_script(&EthAddress::new(addr_bytes)))
+        .await
+        .expect("to_account_id should accept a valid embedded address");
+
+    // Both paths must yield the same [suffix, prefix] (stack top is suffix).
+    assert_eq!(bytes32_output.stack[0..2], addr_output.stack[0..2]);
+
+    // The decoded id must round-trip to the original AccountId.
+    let recovered =
+        AccountId::try_from_elements(bytes32_output.stack[0], bytes32_output.stack[1]).unwrap();
+    assert_eq!(
+        recovered,
+        AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap()
+    );
+}
+
+/// Non-zero padding in any of the three leading limbs of the bytes32 is rejected with the
+/// dedicated padding error.
+#[tokio::test]
+async fn bytes32_to_account_id_rejects_nonzero_padding() {
+    let (_addr_bytes, bytes32) = valid_embedded_bytes32();
+
+    // One representative byte per padding limb: limb0 = bytes[0..4], limb1 = bytes[4..8],
+    // limb2 = bytes[8..12].
+    for corrupted_byte in [0, 5, 11] {
+        let mut bad = bytes32;
+        bad[corrupted_byte] = 0xff;
+        assert_execution_fails_with(
+            &bytes32_to_account_id_script(&bad),
+            &ERR_BYTES32_PADDING_NONZERO,
+        )
+        .await;
+    }
+}
+
+/// Rust mirror: `EthAddress::try_from_bytes32` accepts a zero-padded bytes32 and rejects non-zero
+/// padding.
+#[test]
+fn try_from_bytes32_accepts_and_rejects() {
+    let (addr_bytes, bytes32) = valid_embedded_bytes32();
+
+    // Accept: the trailing 20 bytes come back unchanged.
+    let addr = EthAddress::try_from_bytes32(bytes32).unwrap();
+    assert_eq!(addr, EthAddress::new(addr_bytes));
+
+    // Reject: a non-zero byte anywhere in the 12-byte padding.
+    for corrupted_byte in [0, 5, 11] {
+        let mut bad = bytes32;
+        bad[corrupted_byte] = 0x01;
+        assert_eq!(
+            EthAddress::try_from_bytes32(bad),
+            Err(AddressConversionError::NonZeroBytes32Padding),
+        );
+    }
 }

--- a/crates/miden-testing/tests/standards/eth_address.rs
+++ b/crates/miden-testing/tests/standards/eth_address.rs
@@ -171,23 +171,20 @@ async fn bytes32_to_account_id_rejects_nonzero_padding() {
     }
 }
 
-/// Rust mirror: `EthAddress::try_from_bytes32` accepts a zero-padded bytes32 and rejects non-zero
-/// padding.
+/// Rust mirror: `EthAddress::try_from::<[u8; 32]>` accepts a zero-padded bytes32 and rejects
+/// non-zero padding in any padding limb.
 #[test]
 fn try_from_bytes32_accepts_and_rejects() {
     let (addr_bytes, bytes32) = valid_embedded_bytes32();
 
     // Accept: the trailing 20 bytes come back unchanged.
-    let addr = EthAddress::try_from_bytes32(bytes32).unwrap();
+    let addr = EthAddress::try_from(bytes32).unwrap();
     assert_eq!(addr, EthAddress::new(addr_bytes));
 
     // Reject: a non-zero byte anywhere in the 12-byte padding.
     for corrupted_byte in [0, 5, 11] {
         let mut bad = bytes32;
         bad[corrupted_byte] = 0x01;
-        assert_eq!(
-            EthAddress::try_from_bytes32(bad),
-            Err(AddressConversionError::NonZeroBytes32Padding),
-        );
+        assert_eq!(EthAddress::try_from(bad), Err(AddressConversionError::NonZeroBytes32Padding),);
     }
 }


### PR DESCRIPTION
## Motivation

Some EVM bridges carry the destination in a full 32-byte (`bytes32`) field rather than a bare 20-byte address. In EVM ABI encoding, a bytes32-embedded address has bytes 0..12 zero and the Ethereum-format address in bytes 12..32. Split into u32 limbs, the trailing 5 limbs are exactly the `address[5]` format that `miden::standards::interop::eth_address::to_account_id` already consumes, so such bridges only need a thin validating wrapper instead of reimplementing the conversion.

## What was added

- MASM: `pub proc bytes32_to_account_id` in `miden::standards::interop::eth_address` - takes the bytes32 as 8 u32 limbs (big-endian limb order, little-endian bytes, `limb0` on top), asserts the three padding limbs are zero, and delegates the remaining limbs to `to_account_id`, returning `[suffix, prefix]`. 
- MASM: adds the `EthereumBytes32Format` type alias.
- Rust mirror: `EthAddress::try_from_bytes32([u8; 32])`

Stacked on #3423.