### PR TITLE
refactor: limit notes to 16 assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- [BREAKING] Reduced the maximum number of assets a note can carry from 64 to 16 ([#3381](https://github.com/0xMiden/protocol/issues/3381)).
 - [BREAKING] Transaction summaries now bind the reference block, expiration delta, and seven user parameters; the Rust and MASM APIs changed accordingly ([#3210](https://github.com/0xMiden/protocol/issues/3210)).
 - Moved account-patch commitment validation from `AccountUpdateDetails::validate()` into `TxAccountUpdate::new()` and consolidated all `ProvenTransaction` invariant checks in `from_parts()`, fixing a deserialization bypass of the circular-note check ([#3412](https://github.com/0xMiden/protocol/pull/3412)).
 - [BREAKING] Renamed `TransactionContext` to `MockTransaction` and `TxContextInput` to `MockTransactionInput` in `miden-testing`, and migrated the transaction tests to `MockChain::build_transaction` ([#3313](https://github.com/0xMiden/protocol/pull/3313)).

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/constants.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/constants.masm
@@ -7,7 +7,7 @@ pub use {WORD_NUM_ELEMENTS} from miden::protocol_utils::constants
 pub const MAX_NOTE_STORAGE_ITEMS = 1024
 
 # The maximum number of assets that can be stored in a single note.
-pub const MAX_ASSETS_PER_NOTE = 64
+pub const MAX_ASSETS_PER_NOTE = 16
 
 # The maximum number of notes that can be consumed in a single transaction.
 pub const MAX_INPUT_NOTES_PER_TX = 1024

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
@@ -6,7 +6,7 @@ use {AccountId} from miden::protocol_utils::types
 # ERRORS
 # =================================================================================================
 
-const ERR_NOTE_NUM_OF_ASSETS_EXCEED_LIMIT = "number of assets in a note exceeds 64"
+const ERR_NOTE_NUM_OF_ASSETS_EXCEED_LIMIT = "number of assets in a note exceeds 16"
 
 const ERR_ACCOUNT_IS_NOT_NATIVE = "the active account is not native"
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/note.masm
@@ -10,7 +10,7 @@ pub use {ATTACHMENT_SCHEME_NONE, MAX_ATTACHMENT_SCHEME, MAX_ATTACHMENT_TOTAL_WOR
 # ERRORS
 # =================================================================================================
 
-const ERR_NOTE_NUM_OF_ASSETS_EXCEED_LIMIT = "number of assets in a note exceeds 64"
+const ERR_NOTE_NUM_OF_ASSETS_EXCEED_LIMIT = "number of assets in a note exceeds 16"
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/output_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/output_note.masm
@@ -235,7 +235,7 @@ end
 #! - the asset ID or value are malformed (e.g., invalid faucet ID).
 #! - the max amount of fungible assets is exceeded.
 #! - the non-fungible asset already exists in the note.
-#! - the total number of ASSETs exceeds the maximum of 64.
+#! - the total number of ASSETs exceeds the maximum of 16.
 pub proc add_asset
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
@@ -46,7 +46,7 @@ const ERR_PROLOGUE_MISMATCH_OF_REFERENCE_BLOCK_MMR_AND_NOTE_AUTHENTICATION_MMR =
     "reference block MMR and note's authentication MMR must match"
 
 const ERR_PROLOGUE_NUMBER_OF_NOTE_ASSETS_EXCEEDS_LIMIT =
-    "number of note assets exceeds the maximum limit of 64"
+    "number of note assets exceeds the maximum limit of 16"
 
 const ERR_PROLOGUE_PROVIDED_INPUT_ASSETS_INFO_DOES_NOT_MATCH_ITS_COMMITMENT =
     "provided info about assets of an input does not match its commitment"

--- a/crates/miden-protocol/src/constants.rs
+++ b/crates/miden-protocol/src/constants.rs
@@ -10,7 +10,7 @@ pub const ACCOUNT_UPDATE_MAX_SIZE: u32 = 2u32.pow(18);
 pub const NOTE_MAX_SIZE: u32 = 2u32.pow(18);
 
 /// The maximum number of assets that can be stored in a single note.
-pub const MAX_ASSETS_PER_NOTE: usize = 64;
+pub const MAX_ASSETS_PER_NOTE: usize = 16;
 
 /// The maximum number of storage items that can accompany a single note.
 ///

--- a/crates/miden-protocol/src/note/assets.rs
+++ b/crates/miden-protocol/src/note/assets.rs
@@ -18,7 +18,7 @@ use crate::{Felt, Hasher, MAX_ASSETS_PER_NOTE, WORD_SIZE, Word};
 
 /// An asset container for a note.
 ///
-/// A note can contain between 0 and 64 assets. No duplicates are allowed, but the order of assets
+/// A note can contain between 0 and 16 assets. No duplicates are allowed, but the order of assets
 /// is unspecified.
 ///
 /// All the assets in a note can be reduced to a single commitment which is computed by
@@ -44,7 +44,7 @@ impl NoteAssets {
     ///
     /// # Errors
     /// Returns an error if:
-    /// - The list contains more than 64 assets.
+    /// - The list contains more than 16 assets.
     /// - There are duplicate assets in the list.
     pub fn new(assets: Vec<Asset>) -> Result<Self, NoteError> {
         if assets.len() > Self::MAX_NUM_ASSETS {
@@ -234,6 +234,8 @@ mod tests {
 
     #[test]
     fn note_assets_at_max_succeeds() {
+        assert_eq!(NoteAssets::MAX_NUM_ASSETS, 16);
+
         let assets = make_non_fungible_assets(NoteAssets::MAX_NUM_ASSETS);
         assert_eq!(assets.len(), NoteAssets::MAX_NUM_ASSETS);
 

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -15,7 +15,10 @@ use miden_protocol::account::{
 };
 use miden_protocol::asset::{FungibleAsset, NonFungibleAsset};
 use miden_protocol::block::account_tree::AccountIdKey;
-use miden_protocol::errors::tx_kernel::ERR_ACCOUNT_SEED_AND_COMMITMENT_DIGEST_MISMATCH;
+use miden_protocol::errors::tx_kernel::{
+    ERR_ACCOUNT_SEED_AND_COMMITMENT_DIGEST_MISMATCH,
+    ERR_PROLOGUE_NUMBER_OF_NOTE_ASSETS_EXCEEDS_LIMIT,
+};
 use miden_protocol::note::NoteId;
 use miden_protocol::testing::account_id::{
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_UPDATABLE_CODE,
@@ -76,7 +79,7 @@ use miden_protocol::transaction::memory::{
     VERIFICATION_BASE_FEE_IDX,
 };
 use miden_protocol::transaction::{ExecutedTransaction, TransactionArgs, TransactionKernel};
-use miden_protocol::{EMPTY_WORD, WORD_SIZE};
+use miden_protocol::{EMPTY_WORD, MAX_ASSETS_PER_NOTE, WORD_SIZE};
 use miden_standards::account::wallets::BasicWallet;
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::testing::account_component::MockAccountComponent;
@@ -146,6 +149,54 @@ async fn test_transaction_prologue() -> anyhow::Result<()> {
     kernel_data_memory_assertions(exec_output);
     account_data_memory_assertions(exec_output, &mock_tx);
     input_notes_memory_assertions(exec_output, &mock_tx, &note_args_map);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_transaction_prologue_rejects_too_many_note_assets() -> anyhow::Result<()> {
+    const NOTE_DATA_NUM_ASSETS_IDX: usize = 7 * WORD_SIZE + 1;
+
+    let assets: Vec<_> = (0..MAX_ASSETS_PER_NOTE)
+        .map(|i| NonFungibleAsset::mock(&(i as u32).to_le_bytes()))
+        .collect();
+    let input_note = create_public_p2any_note(ACCOUNT_ID_SENDER.try_into()?, assets);
+    let mut mock_tx = TestTransactionBuilder::with_existing_mock_account()
+        .input_note(input_note)
+        .build()?;
+
+    // Start with the valid input-note advice generated from a note at the protocol limit, then
+    // forge one additional asset into it. This bypasses `NoteAssets::new` and exercises the
+    // transaction kernel's independent input-note validation.
+    let input_notes_commitment = mock_tx.input_notes().commitment();
+    let (_, advice_inputs) = TransactionKernel::prepare_inputs(mock_tx.tx_inputs());
+    let mut note_data = advice_inputs
+        .as_advice_inputs()
+        .map
+        .get(&input_notes_commitment)
+        .context("input-note advice should be present")?
+        .as_ref()
+        .to_vec();
+
+    note_data[NOTE_DATA_NUM_ASSETS_IDX] = Felt::from((MAX_ASSETS_PER_NOTE + 1) as u32);
+    let assets_end_idx = NOTE_DATA_NUM_ASSETS_IDX + 1 + MAX_ASSETS_PER_NOTE * ASSET_SIZE as usize;
+    let extra_asset = NonFungibleAsset::mock(&(MAX_ASSETS_PER_NOTE as u32).to_le_bytes());
+    note_data.splice(assets_end_idx..assets_end_idx, extra_asset.as_elements());
+
+    mock_tx.set_tx_args(TransactionArgs::new(
+        BTreeMap::from([(input_notes_commitment, note_data)]).into(),
+    ));
+
+    let code = "
+        use miden::tx_kernel_core::prologue
+
+        begin
+            exec.prologue::prepare_transaction
+        end
+        ";
+
+    let result = mock_tx.execute_code(code).await;
+    assert_execution_error!(result, ERR_PROLOGUE_NUMBER_OF_NOTE_ASSETS_EXCEEDS_LIMIT);
 
     Ok(())
 }

--- a/docs/src/asset.md
+++ b/docs/src/asset.md
@@ -138,7 +138,7 @@ Examples of such assets include NFTs like a DevCon ticket.
 
 ### Storage
 
-[Accounts](./account) and [notes](note) have vaults used to store assets. Accounts use a sparse Merkle tree as a vault while notes use a simple list. This enables an account to store a practically unlimited number of assets while a note can only store up to 64 assets.
+[Accounts](./account) and [notes](note) have vaults used to store assets. Accounts use a sparse Merkle tree as a vault while notes use a simple list. This enables an account to store a practically unlimited number of assets while a note can only store up to 16 assets.
 
 Asset IDs are hashed before being used as keys in the underlying sparse Merkle tree. Hashing the raw key ensures a uniform leaf distribution: in particular, it prevents non-fungible assets issued by the same faucet from sharing an SMT leaf (their raw asset IDs share the fourth element - the faucet ID prefix - which the SMT uses to determine leaf membership).
 

--- a/docs/src/note.md
+++ b/docs/src/note.md
@@ -37,7 +37,7 @@ These components are:
 An [asset](asset) container for a `Note`.
 :::
 
-A `Note` can contain from 0 up to 64 different assets. These assets represent fungible or non-fungible tokens, enabling flexible asset transfers.
+A `Note` can contain from 0 up to 16 different assets. These assets represent fungible or non-fungible tokens, enabling flexible asset transfers.
 
 ### Script
 


### PR DESCRIPTION
This PR reduces the protocol-wide `MAX_ASSETS_PER_NOTE` limit from 64 to 16 in Rust and the transaction kernel 

Closes #3381.
