### PR TITLE
feat: enforce sponsorship policy in network account auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Features
 
-- [BREAKING] Added the `SponsorshipPolicy` setting to `AuthNetworkAccount` to configure whether a transaction is allowed to fund outgoing sponsorship notes from the account's vault or if all fees must come from input sponsorship notes. ([#TBD](https://github.com/0xMiden/protocol/pull/TBD)).
+- [BREAKING] Added the `SponsorshipPolicy` setting to `AuthNetworkAccount` to configure whether a transaction is allowed to fund outgoing sponsorship notes from the account's vault or if all fees must come from input sponsorship notes. ([#3456](https://github.com/0xMiden/protocol/pull/3456)).
 - [BREAKING] Cached each input note's `NoteId` in the transaction prologue and added the `miden::protocol::input_note::get_note_id` and `miden::protocol::active_note::get_note_id` accessors. The input note memory layout and the kernel procedure offsets shift, so the kernel commitment changes ([#3291](https://github.com/0xMiden/protocol/issues/3291)).
 - Added the standardized `ConstantFeePolicyConfigNote`, which schedules a fee for a note script root by calling a consuming network account's `ConstantFeeManager::set_note_fee`, and registered it as `StandardNote::CONSTANT_FEE_POLICY_CONFIG` ([#3322](https://github.com/0xMiden/protocol/issues/3322)).
 - Extended the standardized `NetworkAccountConfig` note with `AddAllowedFeePolicy` / `RemoveAllowedFeePolicy` actions, letting a network account manage its allowed fee policy roots post-deployment via the authority-gated `add_allowed_fee_policy` / `remove_allowed_fee_policy` procedures ([#3325](https://github.com/0xMiden/protocol/issues/3325)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Features
 
+- [BREAKING] Added the `SponsorshipPolicy` setting to `AuthNetworkAccount` to configure whether a transaction is allowed to fund outgoing sponsorship notes from the account's vault or if all fees must come from input sponsorship notes. ([#TBD](https://github.com/0xMiden/protocol/pull/TBD)).
 - [BREAKING] Cached each input note's `NoteId` in the transaction prologue and added the `miden::protocol::input_note::get_note_id` and `miden::protocol::active_note::get_note_id` accessors. The input note memory layout and the kernel procedure offsets shift, so the kernel commitment changes ([#3291](https://github.com/0xMiden/protocol/issues/3291)).
 - Added the standardized `ConstantFeePolicyConfigNote`, which schedules a fee for a note script root by calling a consuming network account's `ConstantFeeManager::set_note_fee`, and registered it as `StandardNote::CONSTANT_FEE_POLICY_CONFIG` ([#3322](https://github.com/0xMiden/protocol/issues/3322)).
 - Extended the standardized `NetworkAccountConfig` note with `AddAllowedFeePolicy` / `RemoveAllowedFeePolicy` actions, letting a network account manage its allowed fee policy roots post-deployment via the authority-gated `add_allowed_fee_policy` / `remove_allowed_fee_policy` procedures ([#3325](https://github.com/0xMiden/protocol/issues/3325)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ version = "0.16.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "bon",
  "itertools 0.15.0",
  "miden-agglayer",
  "miden-assembly",

--- a/bin/bench-transaction/bench-tx.json
+++ b/bin/bench-transaction/bench-tx.json
@@ -3,19 +3,19 @@
     "prologue": 3717,
     "notes_processing": 2148,
     "note_execution": {
-      "0x04680491717340767747649597cc884a8fb81e0616fa04d3f8e5bd2bc91d41c6": 2106
+      "0xf1ce1ff91dfa790f56bb0a84160437802ea72e947652f64ea95b1f3d4f1246c4": 2106
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 73698,
-      "auth_procedure": 72586
+      "total": 73710,
+      "auth_procedure": 72598
     },
     "trace": {
-      "core_rows": 79649,
-      "chiplets_rows": 64650,
-      "range_rows": 20367,
+      "core_rows": 79661,
+      "chiplets_rows": 64714,
+      "range_rows": 20499,
       "chiplets_shape": {
-        "hasher_rows": 61568,
+        "hasher_rows": 61632,
         "bitwise_rows": 640,
         "memory_rows": 2379,
         "kernel_rom_rows": 62,
@@ -27,19 +27,19 @@
     "prologue": 3717,
     "notes_processing": 2148,
     "note_execution": {
-      "0x496f36157bdb5fd67f3cbe40fcdbab9f0d4ad1bd952c84801cbc3e1126d273aa": 2106
+      "0x09f59a4357ac2bff04e6718aa64d10c94880fe2137f8a3f0d612734ddb45a364": 2106
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 5512,
-      "auth_procedure": 4400
+      "total": 5524,
+      "auth_procedure": 4412
     },
     "trace": {
-      "core_rows": 11463,
-      "chiplets_rows": 22476,
-      "range_rows": 1299,
+      "core_rows": 11475,
+      "chiplets_rows": 22540,
+      "range_rows": 1283,
       "chiplets_shape": {
-        "hasher_rows": 21024,
+        "hasher_rows": 21088,
         "bitwise_rows": 640,
         "memory_rows": 749,
         "kernel_rom_rows": 62,
@@ -56,15 +56,15 @@
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 73626,
-      "auth_procedure": 72550
+      "total": 73638,
+      "auth_procedure": 72562
     },
     "trace": {
-      "core_rows": 83178,
-      "chiplets_rows": 67650,
-      "range_rows": 20407,
+      "core_rows": 83190,
+      "chiplets_rows": 67730,
+      "range_rows": 20451,
       "chiplets_shape": {
-        "hasher_rows": 64080,
+        "hasher_rows": 64160,
         "bitwise_rows": 984,
         "memory_rows": 2523,
         "kernel_rom_rows": 62,
@@ -81,15 +81,15 @@
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 5440,
-      "auth_procedure": 4364
+      "total": 5452,
+      "auth_procedure": 4376
     },
     "trace": {
-      "core_rows": 14992,
-      "chiplets_rows": 25476,
-      "range_rows": 1241,
+      "core_rows": 15004,
+      "chiplets_rows": 25556,
+      "range_rows": 1245,
       "chiplets_shape": {
-        "hasher_rows": 23536,
+        "hasher_rows": 23616,
         "bitwise_rows": 984,
         "memory_rows": 893,
         "kernel_rom_rows": 62,
@@ -103,15 +103,15 @@
     "note_execution": {},
     "tx_script_processing": 1844,
     "epilogue": {
-      "total": 75144,
-      "auth_procedure": 73149
+      "total": 75156,
+      "auth_procedure": 73161
     },
     "trace": {
-      "core_rows": 78911,
-      "chiplets_rows": 63101,
-      "range_rows": 20285,
+      "core_rows": 78923,
+      "chiplets_rows": 63181,
+      "range_rows": 20267,
       "chiplets_shape": {
-        "hasher_rows": 60128,
+        "hasher_rows": 60208,
         "bitwise_rows": 616,
         "memory_rows": 2294,
         "kernel_rom_rows": 62,
@@ -125,15 +125,15 @@
     "note_execution": {},
     "tx_script_processing": 1844,
     "epilogue": {
-      "total": 6958,
-      "auth_procedure": 4963
+      "total": 6970,
+      "auth_procedure": 4975
     },
     "trace": {
-      "core_rows": 10725,
-      "chiplets_rows": 20895,
-      "range_rows": 1079,
+      "core_rows": 10737,
+      "chiplets_rows": 20959,
+      "range_rows": 1091,
       "chiplets_shape": {
-        "hasher_rows": 19552,
+        "hasher_rows": 19616,
         "bitwise_rows": 616,
         "memory_rows": 664,
         "kernel_rom_rows": 62,
@@ -142,631 +142,631 @@
     }
   },
   "consume CLAIM note (L1 to Miden)": {
-    "prologue": 3807,
+    "prologue": 3864,
     "notes_processing": 30793,
     "note_execution": {
       "0x9b9c228192e2126dd735d15bcae7da6500ad6cb4f2b065f25d596bc9291f8af5": 30751
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15603,
-      "auth_procedure": 10972
+      "total": 16338,
+      "auth_procedure": 11569
     },
     "trace": {
-      "core_rows": 50289,
-      "chiplets_rows": 59832,
-      "range_rows": 3295,
+      "core_rows": 51081,
+      "chiplets_rows": 60821,
+      "range_rows": 3343,
       "chiplets_shape": {
-        "hasher_rows": 52784,
-        "bitwise_rows": 2800,
-        "memory_rows": 4185,
+        "hasher_rows": 53712,
+        "bitwise_rows": 2808,
+        "memory_rows": 4238,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L2 to Miden)": {
-    "prologue": 3807,
+    "prologue": 3864,
     "notes_processing": 43771,
     "note_execution": {
       "0x7b3be6d8a08571425c29975912ca3209115461f56c5664ce47c50fd4b8582cd3": 43729
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15603,
-      "auth_procedure": 10972
+      "total": 16338,
+      "auth_procedure": 11569
     },
     "trace": {
-      "core_rows": 63267,
-      "chiplets_rows": 66662,
-      "range_rows": 3513,
+      "core_rows": 64059,
+      "chiplets_rows": 67651,
+      "range_rows": 3543,
       "chiplets_shape": {
-        "hasher_rows": 58128,
-        "bitwise_rows": 3056,
-        "memory_rows": 5415,
+        "hasher_rows": 59056,
+        "bitwise_rows": 3064,
+        "memory_rows": 5468,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out)": {
-    "prologue": 4731,
+    "prologue": 4788,
     "notes_processing": 118526,
     "note_execution": {
       "0x5bc84b4d1d5d3c2c62b1a9e14b8a8b928dff99f3abd16e72a244a9086078dcad": 118484
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 25370,
-      "auth_procedure": 11057
+      "total": 26105,
+      "auth_procedure": 11654
     },
     "trace": {
-      "core_rows": 148713,
-      "chiplets_rows": 181396,
-      "range_rows": 4515,
+      "core_rows": 149505,
+      "chiplets_rows": 182369,
+      "range_rows": 4583,
       "chiplets_shape": {
-        "hasher_rows": 167328,
-        "bitwise_rows": 3576,
-        "memory_rows": 10429,
+        "hasher_rows": 168240,
+        "bitwise_rows": 3584,
+        "memory_rows": 10482,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31 leaves)": {
-    "prologue": 4731,
+    "prologue": 4788,
     "notes_processing": 116829,
     "note_execution": {
       "0x5bc84b4d1d5d3c2c62b1a9e14b8a8b928dff99f3abd16e72a244a9086078dcad": 116787
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 25082,
-      "auth_procedure": 11057
+      "total": 25817,
+      "auth_procedure": 11654
     },
     "trace": {
-      "core_rows": 146728,
-      "chiplets_rows": 181793,
-      "range_rows": 4521,
+      "core_rows": 147520,
+      "chiplets_rows": 182782,
+      "range_rows": 4607,
       "chiplets_shape": {
-        "hasher_rows": 167856,
-        "bitwise_rows": 3576,
-        "memory_rows": 10298,
+        "hasher_rows": 168784,
+        "bitwise_rows": 3584,
+        "memory_rows": 10351,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31-1 leaves)": {
-    "prologue": 4731,
+    "prologue": 4788,
     "notes_processing": 62480,
     "note_execution": {
       "0x5bc84b4d1d5d3c2c62b1a9e14b8a8b928dff99f3abd16e72a244a9086078dcad": 62438
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 16442,
-      "auth_procedure": 11057
+      "total": 17177,
+      "auth_procedure": 11654
     },
     "trace": {
-      "core_rows": 83739,
-      "chiplets_rows": 88247,
-      "range_rows": 3421,
+      "core_rows": 84531,
+      "chiplets_rows": 89236,
+      "range_rows": 3519,
       "chiplets_shape": {
-        "hasher_rows": 78240,
-        "bitwise_rows": 3576,
-        "memory_rows": 6368,
+        "hasher_rows": 79168,
+        "bitwise_rows": 3584,
+        "memory_rows": 6421,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume P2ID note (network account)": {
-    "prologue": 3625,
+    "prologue": 3682,
     "notes_processing": 2148,
     "note_execution": {
       "0x734f068a0a81a2c92fecee5b845bfb97b660295c51b6b49a1cc6e664e81ed87f": 2106
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 11791,
-      "auth_procedure": 8799
+      "total": 12494,
+      "auth_procedure": 9364
     },
     "trace": {
-      "core_rows": 17650,
-      "chiplets_rows": 32501,
-      "range_rows": 1423,
+      "core_rows": 18410,
+      "chiplets_rows": 33390,
+      "range_rows": 1477,
       "chiplets_shape": {
-        "hasher_rows": 30512,
-        "bitwise_rows": 880,
-        "memory_rows": 1046,
+        "hasher_rows": 31344,
+        "bitwise_rows": 888,
+        "memory_rows": 1095,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume P2ID note (16 assets, network account)": {
-    "prologue": 12220,
+    "prologue": 12277,
     "notes_processing": 29792,
     "note_execution": {
       "0x2e356f4ddf273e2df75bf64c33a4db4645f699eb696b32b77ac05d435d9ee10a": 29750
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14270,
-      "auth_procedure": 9118
+      "total": 14973,
+      "auth_procedure": 9683
     },
     "trace": {
-      "core_rows": 56368,
-      "chiplets_rows": 73814,
-      "range_rows": 3561,
+      "core_rows": 57128,
+      "chiplets_rows": 74703,
+      "range_rows": 3635,
       "chiplets_shape": {
-        "hasher_rows": 65360,
-        "bitwise_rows": 5560,
-        "memory_rows": 2831,
+        "hasher_rows": 66192,
+        "bitwise_rows": 5568,
+        "memory_rows": 2880,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (claim, network account)": {
-    "prologue": 3625,
+    "prologue": 3682,
     "notes_processing": 2273,
     "note_execution": {
       "0xe78efa35c437bdea750e8151cd2917eca41a66bbc83049d3bcd58fe010f12b1f": 2231
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 11791,
-      "auth_procedure": 8799
+      "total": 12494,
+      "auth_procedure": 9364
     },
     "trace": {
-      "core_rows": 17775,
-      "chiplets_rows": 32633,
-      "range_rows": 1445,
+      "core_rows": 18535,
+      "chiplets_rows": 33522,
+      "range_rows": 1457,
       "chiplets_shape": {
-        "hasher_rows": 30640,
-        "bitwise_rows": 880,
-        "memory_rows": 1050,
+        "hasher_rows": 31472,
+        "bitwise_rows": 888,
+        "memory_rows": 1099,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (claim, 16 assets, network account)": {
-    "prologue": 12220,
+    "prologue": 12277,
     "notes_processing": 29917,
     "note_execution": {
       "0x0625c0de17b5fb7eeabd083367c2cf992f44bc8016e7cf4e30d951996e2e066b": 29875
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14270,
-      "auth_procedure": 9118
+      "total": 14973,
+      "auth_procedure": 9683
     },
     "trace": {
-      "core_rows": 56493,
-      "chiplets_rows": 73946,
-      "range_rows": 3593,
+      "core_rows": 57253,
+      "chiplets_rows": 74835,
+      "range_rows": 3675,
       "chiplets_shape": {
-        "hasher_rows": 65488,
-        "bitwise_rows": 5560,
-        "memory_rows": 2835,
+        "hasher_rows": 66320,
+        "bitwise_rows": 5568,
+        "memory_rows": 2884,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (reclaim, network account)": {
-    "prologue": 3728,
+    "prologue": 3785,
     "notes_processing": 2325,
     "note_execution": {
       "0xed21b1632bfc3453d75490fa1b3e48b26b1338c020c554031bc39d0b50db9599": 2283
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 11791,
-      "auth_procedure": 8799
+      "total": 12494,
+      "auth_procedure": 9364
     },
     "trace": {
-      "core_rows": 17930,
-      "chiplets_rows": 32864,
-      "range_rows": 1423,
+      "core_rows": 18690,
+      "chiplets_rows": 33753,
+      "range_rows": 1517,
       "chiplets_shape": {
-        "hasher_rows": 30864,
-        "bitwise_rows": 880,
-        "memory_rows": 1057,
+        "hasher_rows": 31696,
+        "bitwise_rows": 888,
+        "memory_rows": 1106,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume SWAP note (public payback, network account)": {
-    "prologue": 3625,
+    "prologue": 3682,
     "notes_processing": 4495,
     "note_execution": {
       "0x6597e806dd48b7221e192feac9c9660a3cf3548e6a39e8bdcd3684379d02a559": 4453
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 13438,
-      "auth_procedure": 9339
+      "total": 14141,
+      "auth_procedure": 9904
     },
     "trace": {
-      "core_rows": 21644,
-      "chiplets_rows": 36801,
-      "range_rows": 1729,
+      "core_rows": 22404,
+      "chiplets_rows": 37690,
+      "range_rows": 1719,
       "chiplets_shape": {
-        "hasher_rows": 34288,
-        "bitwise_rows": 1256,
-        "memory_rows": 1194,
+        "hasher_rows": 35120,
+        "bitwise_rows": 1264,
+        "memory_rows": 1243,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume SWAP note (private payback, network account)": {
-    "prologue": 3625,
+    "prologue": 3682,
     "notes_processing": 3984,
     "note_execution": {
       "0x282f1f571cd357fe8bab4f83e08738a760442ad866780e0aa32d33d30853ecf0": 3942
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 13438,
-      "auth_procedure": 9339
+      "total": 14141,
+      "auth_procedure": 9904
     },
     "trace": {
-      "core_rows": 21133,
-      "chiplets_rows": 36368,
-      "range_rows": 1695,
+      "core_rows": 21893,
+      "chiplets_rows": 37257,
+      "range_rows": 1761,
       "chiplets_shape": {
-        "hasher_rows": 33872,
-        "bitwise_rows": 1256,
-        "memory_rows": 1177,
+        "hasher_rows": 34704,
+        "bitwise_rows": 1264,
+        "memory_rows": 1226,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume PSWAP note (full fill, network account)": {
-    "prologue": 3625,
+    "prologue": 3682,
     "notes_processing": 7017,
     "note_execution": {
       "0x08d0fa9c9912c7605d2bf62ce6be9200342b212b1c2134c81c03eb3bc43fd380": 6975
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 13479,
-      "auth_procedure": 9339
+      "total": 14182,
+      "auth_procedure": 9904
     },
     "trace": {
-      "core_rows": 24207,
-      "chiplets_rows": 39857,
-      "range_rows": 1747,
+      "core_rows": 24967,
+      "chiplets_rows": 40746,
+      "range_rows": 1795,
       "chiplets_shape": {
-        "hasher_rows": 37104,
-        "bitwise_rows": 1320,
-        "memory_rows": 1370,
+        "hasher_rows": 37936,
+        "bitwise_rows": 1328,
+        "memory_rows": 1419,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume PSWAP note (partial fill, network account)": {
-    "prologue": 3625,
+    "prologue": 3682,
     "notes_processing": 9555,
     "note_execution": {
       "0x08d0fa9c9912c7605d2bf62ce6be9200342b212b1c2134c81c03eb3bc43fd380": 9513
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14882,
-      "auth_procedure": 9562
+      "total": 15585,
+      "auth_procedure": 10127
     },
     "trace": {
-      "core_rows": 28148,
-      "chiplets_rows": 43370,
-      "range_rows": 1921,
+      "core_rows": 28908,
+      "chiplets_rows": 44275,
+      "range_rows": 1991,
       "chiplets_shape": {
-        "hasher_rows": 40080,
-        "bitwise_rows": 1696,
-        "memory_rows": 1531,
+        "hasher_rows": 40928,
+        "bitwise_rows": 1704,
+        "memory_rows": 1580,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume MINT note (fungible faucet, network account)": {
-    "prologue": 5353,
+    "prologue": 5410,
     "notes_processing": 7260,
     "note_execution": {
       "0x1d9d2b5165863884fcb23f2d37f1089ec6aa9b0f4e6fab82725db66e8ee1135f": 7218
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 18228,
-      "auth_procedure": 9085
+      "total": 18940,
+      "auth_procedure": 9659
     },
     "trace": {
-      "core_rows": 30927,
-      "chiplets_rows": 39407,
-      "range_rows": 2671,
+      "core_rows": 31696,
+      "chiplets_rows": 40298,
+      "range_rows": 2793,
       "chiplets_shape": {
-        "hasher_rows": 36160,
-        "bitwise_rows": 1208,
-        "memory_rows": 1976,
+        "hasher_rows": 36992,
+        "bitwise_rows": 1216,
+        "memory_rows": 2027,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume MINT note (non-fungible faucet, network account)": {
-    "prologue": 5402,
+    "prologue": 5459,
     "notes_processing": 9797,
     "note_execution": {
       "0x36b1a5f973161e7a7a143c41a075d66cbe6ece697400a920d3721315963795f4": 9755
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 18521,
-      "auth_procedure": 9094
+      "total": 19233,
+      "auth_procedure": 9668
     },
     "trace": {
-      "core_rows": 33806,
-      "chiplets_rows": 42388,
-      "range_rows": 2881,
+      "core_rows": 34575,
+      "chiplets_rows": 43295,
+      "range_rows": 2919,
       "chiplets_shape": {
-        "hasher_rows": 39024,
-        "bitwise_rows": 1208,
-        "memory_rows": 2093,
+        "hasher_rows": 39872,
+        "bitwise_rows": 1216,
+        "memory_rows": 2144,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume BURN note (network account)": {
-    "prologue": 5952,
+    "prologue": 6009,
     "notes_processing": 4571,
     "note_execution": {
       "0x90c1f0a2c27744efd107c653e6dba134c6713257427980e503580fa4931dc935": 4529
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 17014,
-      "auth_procedure": 8864
+      "total": 17726,
+      "auth_procedure": 9438
     },
     "trace": {
-      "core_rows": 27623,
-      "chiplets_rows": 37378,
-      "range_rows": 2495,
+      "core_rows": 28392,
+      "chiplets_rows": 38269,
+      "range_rows": 2597,
       "chiplets_shape": {
-        "hasher_rows": 34592,
-        "bitwise_rows": 912,
-        "memory_rows": 1811,
+        "hasher_rows": 35424,
+        "bitwise_rows": 920,
+        "memory_rows": 1862,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume FAUCET_POLICY_CONFIG note (network account)": {
-    "prologue": 5306,
+    "prologue": 5363,
     "notes_processing": 4439,
     "note_execution": {
       "0x9fb35405004f36d6a0a80171d0538d66fedf5939be99028c872fde4656a4ea1f": 4397
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 16867,
-      "auth_procedure": 8855
+      "total": 17579,
+      "auth_procedure": 9429
     },
     "trace": {
-      "core_rows": 26698,
-      "chiplets_rows": 34238,
-      "range_rows": 2497,
+      "core_rows": 27467,
+      "chiplets_rows": 35145,
+      "range_rows": 2569,
       "chiplets_shape": {
-        "hasher_rows": 31920,
-        "bitwise_rows": 568,
-        "memory_rows": 1687,
+        "hasher_rows": 32768,
+        "bitwise_rows": 576,
+        "memory_rows": 1738,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume FAUCET_METADATA_CONFIG note (network account)": {
-    "prologue": 4730,
+    "prologue": 4787,
     "notes_processing": 5178,
     "note_execution": {
       "0xf3cd00a6634fb0a76bc7b111b8318d5e30f41d4bac98f982c6b282fc8aeb81f0": 5136
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15522,
-      "auth_procedure": 8774
+      "total": 16234,
+      "auth_procedure": 9348
     },
     "trace": {
-      "core_rows": 25516,
-      "chiplets_rows": 33214,
-      "range_rows": 2303,
+      "core_rows": 26285,
+      "chiplets_rows": 34121,
+      "range_rows": 2377,
       "chiplets_shape": {
-        "hasher_rows": 30864,
-        "bitwise_rows": 576,
-        "memory_rows": 1711,
+        "hasher_rows": 31712,
+        "bitwise_rows": 584,
+        "memory_rows": 1762,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume ALLOWLIST_CONFIG note (network account)": {
-    "prologue": 5363,
+    "prologue": 5420,
     "notes_processing": 2167,
     "note_execution": {
       "0x7083baac7b8e1ffeac1e684379b3adbd136a6df2d370654fe519a74f4aa44263": 2125
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 17190,
-      "auth_procedure": 8864
+      "total": 17902,
+      "auth_procedure": 9438
     },
     "trace": {
-      "core_rows": 24806,
-      "chiplets_rows": 35252,
-      "range_rows": 2397,
+      "core_rows": 25575,
+      "chiplets_rows": 36175,
+      "range_rows": 2445,
       "chiplets_shape": {
-        "hasher_rows": 32928,
-        "bitwise_rows": 568,
-        "memory_rows": 1693,
+        "hasher_rows": 33792,
+        "bitwise_rows": 576,
+        "memory_rows": 1744,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume BLOCKLIST_CONFIG note (network account)": {
-    "prologue": 5363,
+    "prologue": 5420,
     "notes_processing": 2167,
     "note_execution": {
       "0xecbbacdf71fdacaad8226c868d061ded2d262940e14f4605d78d05e418968bf7": 2125
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 17190,
-      "auth_procedure": 8864
+      "total": 17902,
+      "auth_procedure": 9438
     },
     "trace": {
-      "core_rows": 24806,
-      "chiplets_rows": 35092,
-      "range_rows": 2401,
+      "core_rows": 25575,
+      "chiplets_rows": 35999,
+      "range_rows": 2435,
       "chiplets_shape": {
-        "hasher_rows": 32768,
-        "bitwise_rows": 568,
-        "memory_rows": 1693,
+        "hasher_rows": 33616,
+        "bitwise_rows": 576,
+        "memory_rows": 1744,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume PAUSE_CONFIG note (network account)": {
-    "prologue": 3233,
+    "prologue": 3290,
     "notes_processing": 1608,
     "note_execution": {
       "0x52e76bdc5bc2b7e821777534931c576660068f2031e1a26090bda54c5df09a84": 1566
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 11829,
-      "auth_procedure": 8549
+      "total": 12541,
+      "auth_procedure": 9123
     },
     "trace": {
-      "core_rows": 16756,
-      "chiplets_rows": 28692,
-      "range_rows": 1469,
+      "core_rows": 17525,
+      "chiplets_rows": 29615,
+      "range_rows": 1531,
       "chiplets_shape": {
-        "hasher_rows": 27008,
-        "bitwise_rows": 568,
-        "memory_rows": 1053,
+        "hasher_rows": 27872,
+        "bitwise_rows": 576,
+        "memory_rows": 1104,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume OWNER_CONFIG note (network account)": {
-    "prologue": 3092,
+    "prologue": 3149,
     "notes_processing": 1637,
     "note_execution": {
       "0x2e73344a03095128de9658913d20a66445e3526d1d1f59d60cceac97666fdd72": 1595
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 11535,
-      "auth_procedure": 8531
+      "total": 12247,
+      "auth_procedure": 9105
     },
     "trace": {
-      "core_rows": 16350,
-      "chiplets_rows": 28436,
-      "range_rows": 1419,
+      "core_rows": 17119,
+      "chiplets_rows": 29359,
+      "range_rows": 1487,
       "chiplets_shape": {
-        "hasher_rows": 26768,
-        "bitwise_rows": 584,
-        "memory_rows": 1021,
+        "hasher_rows": 27632,
+        "bitwise_rows": 592,
+        "memory_rows": 1072,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume RBAC_CONFIG note (network account)": {
-    "prologue": 3271,
+    "prologue": 3328,
     "notes_processing": 3899,
     "note_execution": {
       "0x2754ef232d405d9009bcfdd992cefd8ace223bad9adb84c844ef51e36f8f1e52": 3857
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 12356,
-      "auth_procedure": 8558
+      "total": 13068,
+      "auth_procedure": 9132
     },
     "trace": {
-      "core_rows": 19612,
-      "chiplets_rows": 35904,
-      "range_rows": 1587,
+      "core_rows": 20381,
+      "chiplets_rows": 36811,
+      "range_rows": 1667,
       "chiplets_shape": {
-        "hasher_rows": 33952,
-        "bitwise_rows": 584,
-        "memory_rows": 1305,
+        "hasher_rows": 34800,
+        "bitwise_rows": 592,
+        "memory_rows": 1356,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume NETWORK_ACCOUNT_CONFIG note (network account)": {
-    "prologue": 3176,
+    "prologue": 3233,
     "notes_processing": 3002,
     "note_execution": {
       "0x963ba76870db04bbab4fd2fa4ed3939aa38dd709634296b681beac6723728d1e": 2960
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 11848,
-      "auth_procedure": 8540
+      "total": 12560,
+      "auth_procedure": 9114
     },
     "trace": {
-      "core_rows": 18112,
-      "chiplets_rows": 32664,
-      "range_rows": 1465,
+      "core_rows": 18881,
+      "chiplets_rows": 33555,
+      "range_rows": 1607,
       "chiplets_shape": {
-        "hasher_rows": 30848,
-        "bitwise_rows": 616,
-        "memory_rows": 1137,
+        "hasher_rows": 31680,
+        "bitwise_rows": 624,
+        "memory_rows": 1188,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CONSTANT_FEE_POLICY_CONFIG note (network account)": {
-    "prologue": 3223,
+    "prologue": 3280,
     "notes_processing": 3687,
     "note_execution": {
       "0xba847903cc257dbbe09852d5269201716661c41ad25494c8252ff15b423cc687": 3645
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 11995,
-      "auth_procedure": 8549
+      "total": 12707,
+      "auth_procedure": 9123
     },
     "trace": {
-      "core_rows": 18991,
-      "chiplets_rows": 33038,
-      "range_rows": 1595,
+      "core_rows": 19760,
+      "chiplets_rows": 33961,
+      "range_rows": 1619,
       "chiplets_shape": {
-        "hasher_rows": 31152,
-        "bitwise_rows": 616,
-        "memory_rows": 1207,
+        "hasher_rows": 32016,
+        "bitwise_rows": 624,
+        "memory_rows": 1258,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume FEE_SPONSORSHIP note with feature note (network account)": {
-    "prologue": 4681,
+    "prologue": 4738,
     "notes_processing": 1178,
     "note_execution": {
       "0x30e133565785ae090e4920c05bb4adac8004adba6ba51e887396e0082197e1e7": 461,
@@ -774,17 +774,17 @@
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14376,
-      "auth_procedure": 11528
+      "total": 15133,
+      "auth_procedure": 12147
     },
     "trace": {
-      "core_rows": 20321,
-      "chiplets_rows": 33949,
-      "range_rows": 1487,
+      "core_rows": 21135,
+      "chiplets_rows": 34781,
+      "range_rows": 1581,
       "chiplets_shape": {
-        "hasher_rows": 31792,
-        "bitwise_rows": 944,
-        "memory_rows": 1150,
+        "hasher_rows": 32560,
+        "bitwise_rows": 952,
+        "memory_rows": 1206,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -798,15 +798,15 @@
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 9723,
-      "auth_procedure": 7552
+      "total": 9735,
+      "auth_procedure": 7564
     },
     "trace": {
-      "core_rows": 16284,
-      "chiplets_rows": 29232,
-      "range_rows": 1409,
+      "core_rows": 16296,
+      "chiplets_rows": 29296,
+      "range_rows": 1347,
       "chiplets_shape": {
-        "hasher_rows": 27328,
+        "hasher_rows": 27392,
         "bitwise_rows": 960,
         "memory_rows": 881,
         "kernel_rom_rows": 62,
@@ -815,192 +815,192 @@
     }
   },
   "consume CLAIM note (L1 to Miden, with fee payment)": {
-    "prologue": 3807,
+    "prologue": 3864,
     "notes_processing": 30793,
     "note_execution": {
       "0x9b9c228192e2126dd735d15bcae7da6500ad6cb4f2b065f25d596bc9291f8af5": 30751
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 19648,
-      "auth_procedure": 13679
+      "total": 20383,
+      "auth_procedure": 14276
     },
     "trace": {
-      "core_rows": 54334,
-      "chiplets_rows": 67112,
-      "range_rows": 3439,
+      "core_rows": 55126,
+      "chiplets_rows": 68085,
+      "range_rows": 3477,
       "chiplets_shape": {
-        "hasher_rows": 59568,
-        "bitwise_rows": 3144,
-        "memory_rows": 4337,
+        "hasher_rows": 60480,
+        "bitwise_rows": 3152,
+        "memory_rows": 4390,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L2 to Miden, with fee payment)": {
-    "prologue": 3807,
+    "prologue": 3864,
     "notes_processing": 43771,
     "note_execution": {
       "0x7b3be6d8a08571425c29975912ca3209115461f56c5664ce47c50fd4b8582cd3": 43729
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 19648,
-      "auth_procedure": 13679
+      "total": 20383,
+      "auth_procedure": 14276
     },
     "trace": {
-      "core_rows": 67312,
-      "chiplets_rows": 73942,
-      "range_rows": 3679,
+      "core_rows": 68104,
+      "chiplets_rows": 74915,
+      "range_rows": 3699,
       "chiplets_shape": {
-        "hasher_rows": 64912,
-        "bitwise_rows": 3400,
-        "memory_rows": 5567,
+        "hasher_rows": 65824,
+        "bitwise_rows": 3408,
+        "memory_rows": 5620,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, with fee payment)": {
-    "prologue": 4731,
+    "prologue": 4788,
     "notes_processing": 118526,
     "note_execution": {
       "0x5bc84b4d1d5d3c2c62b1a9e14b8a8b928dff99f3abd16e72a244a9086078dcad": 118484
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 29415,
-      "auth_procedure": 13764
+      "total": 30150,
+      "auth_procedure": 14361
     },
     "trace": {
-      "core_rows": 152758,
-      "chiplets_rows": 187524,
-      "range_rows": 4759,
+      "core_rows": 153550,
+      "chiplets_rows": 188497,
+      "range_rows": 4799,
       "chiplets_shape": {
-        "hasher_rows": 172960,
-        "bitwise_rows": 3920,
-        "memory_rows": 10581,
+        "hasher_rows": 173872,
+        "bitwise_rows": 3928,
+        "memory_rows": 10634,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31-1 leaves, with fee payment)": {
-    "prologue": 4731,
+    "prologue": 4788,
     "notes_processing": 62480,
     "note_execution": {
       "0x5bc84b4d1d5d3c2c62b1a9e14b8a8b928dff99f3abd16e72a244a9086078dcad": 62438
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 20487,
-      "auth_procedure": 13764
+      "total": 21222,
+      "auth_procedure": 14361
     },
     "trace": {
-      "core_rows": 87784,
-      "chiplets_rows": 94359,
-      "range_rows": 3605,
+      "core_rows": 88576,
+      "chiplets_rows": 95332,
+      "range_rows": 3671,
       "chiplets_shape": {
-        "hasher_rows": 83856,
-        "bitwise_rows": 3920,
-        "memory_rows": 6520,
+        "hasher_rows": 84768,
+        "bitwise_rows": 3928,
+        "memory_rows": 6573,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CONFIG_AGG_BRIDGE note (with fee payment)": {
-    "prologue": 4115,
+    "prologue": 4172,
     "notes_processing": 12081,
     "note_execution": {
       "0x3d66bcfe6c3a9a193ff18927b5ac4fb0cdbf30d280f674ca8a3c8090a22e712e": 12039
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15090,
-      "auth_procedure": 8684
+      "total": 15802,
+      "auth_procedure": 9258
     },
     "trace": {
-      "core_rows": 31372,
-      "chiplets_rows": 49714,
-      "range_rows": 2219,
+      "core_rows": 32141,
+      "chiplets_rows": 50621,
+      "range_rows": 2347,
       "chiplets_shape": {
-        "hasher_rows": 46832,
-        "bitwise_rows": 672,
-        "memory_rows": 2147,
+        "hasher_rows": 47680,
+        "bitwise_rows": 680,
+        "memory_rows": 2198,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume DEREGISTER_AGG_FAUCET note (with fee payment)": {
-    "prologue": 4174,
+    "prologue": 4231,
     "notes_processing": 12032,
     "note_execution": {
       "0x5e6ea39565d7d35225ca26a8183372131803f229cfae3c1742903c18c7939b2b": 11990
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15090,
-      "auth_procedure": 8684
+      "total": 15802,
+      "auth_procedure": 9258
     },
     "trace": {
-      "core_rows": 31382,
-      "chiplets_rows": 48472,
-      "range_rows": 2187,
+      "core_rows": 32151,
+      "chiplets_rows": 49363,
+      "range_rows": 2297,
       "chiplets_shape": {
-        "hasher_rows": 45664,
-        "bitwise_rows": 664,
-        "memory_rows": 2081,
+        "hasher_rows": 46496,
+        "bitwise_rows": 672,
+        "memory_rows": 2132,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume UPDATE_GER note (with fee payment)": {
-    "prologue": 4115,
+    "prologue": 4172,
     "notes_processing": 3739,
     "note_execution": {
       "0x8534e92cc84d40698f339fca2a54c35509b3c15464d0867d3c21896a4c1ce824": 3697
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14290,
-      "auth_procedure": 8684
+      "total": 15002,
+      "auth_procedure": 9258
     },
     "trace": {
-      "core_rows": 22230,
-      "chiplets_rows": 37181,
-      "range_rows": 1921,
+      "core_rows": 22999,
+      "chiplets_rows": 38104,
+      "range_rows": 1987,
       "chiplets_shape": {
-        "hasher_rows": 35008,
-        "bitwise_rows": 616,
-        "memory_rows": 1494,
+        "hasher_rows": 35872,
+        "bitwise_rows": 624,
+        "memory_rows": 1545,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume REMOVE_GER note (with fee payment)": {
-    "prologue": 4174,
+    "prologue": 4231,
     "notes_processing": 5497,
     "note_execution": {
       "0x01588a5ff3ff7c1ccf544f00ca653d9b1572d93d45286ad9860b616e6da7038d": 5455
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14326,
-      "auth_procedure": 8684
+      "total": 15038,
+      "auth_procedure": 9258
     },
     "trace": {
-      "core_rows": 24083,
-      "chiplets_rows": 38539,
-      "range_rows": 1967,
+      "core_rows": 24852,
+      "chiplets_rows": 39446,
+      "range_rows": 2049,
       "chiplets_shape": {
-        "hasher_rows": 36224,
-        "bitwise_rows": 616,
-        "memory_rows": 1636,
+        "hasher_rows": 37072,
+        "bitwise_rows": 624,
+        "memory_rows": 1687,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }

--- a/bin/bench-transaction/src/context_setups/mod.rs
+++ b/bin/bench-transaction/src/context_setups/mod.rs
@@ -24,6 +24,7 @@ use miden_protocol::note::{Note, NoteAssets, NoteScriptRoot, NoteType};
 use miden_protocol::testing::account_id::{ACCOUNT_ID_FEE_FAUCET, ACCOUNT_ID_SENDER};
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::{Felt, Word};
+use miden_standards::account::auth::SponsorshipPolicy;
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicyManager};
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::interop::eth::EthAddress;
@@ -80,6 +81,7 @@ fn network_auth_with_fees(
         allowed_script_roots,
         allowed_tx_script_roots: BTreeSet::new(),
         fee_policy_manager,
+        sponsorship_policy: SponsorshipPolicy::default(),
     })
 }
 

--- a/crates/miden-agglayer/src/costs/table.rs
+++ b/crates/miden-agglayer/src/costs/table.rs
@@ -2,20 +2,20 @@
 // Values are maxima across the benchmarked paths; see `miden_standards::note::costs` for the
 // caveats on what they do and do not cover.
 
-/// Cycles of consuming a CLAIM note: L1 origin 54290, L2 origin 67268 (maximum).
-pub const CLAIM_CONSUMPTION_CYCLES: u32 = 67268;
+/// Cycles of consuming a CLAIM note: L1 origin 55082, L2 origin 68060 (maximum).
+pub const CLAIM_CONSUMPTION_CYCLES: u32 = 68060;
 
-/// Cycles of consuming a B2AGG note: empty frontier 152714 (maximum), 2^31-1 leaves 87740.
-pub const B2AGG_CONSUMPTION_CYCLES: u32 = 152714;
+/// Cycles of consuming a B2AGG note: empty frontier 153506 (maximum), 2^31-1 leaves 88532.
+pub const B2AGG_CONSUMPTION_CYCLES: u32 = 153506;
 
 /// Cycles of consuming a CONFIG_AGG_BRIDGE note (single benchmarked path).
-pub const CONFIG_AGG_BRIDGE_CONSUMPTION_CYCLES: u32 = 31328;
+pub const CONFIG_AGG_BRIDGE_CONSUMPTION_CYCLES: u32 = 32097;
 
 /// Cycles of consuming a DEREGISTER_AGG_FAUCET note (single benchmarked path).
-pub const DEREGISTER_AGG_FAUCET_CONSUMPTION_CYCLES: u32 = 31338;
+pub const DEREGISTER_AGG_FAUCET_CONSUMPTION_CYCLES: u32 = 32107;
 
 /// Cycles of consuming an UPDATE_GER note (single benchmarked path).
-pub const UPDATE_GER_CONSUMPTION_CYCLES: u32 = 22186;
+pub const UPDATE_GER_CONSUMPTION_CYCLES: u32 = 22955;
 
 /// Cycles of consuming a REMOVE_GER note (single benchmarked path).
-pub const REMOVE_GER_CONSUMPTION_CYCLES: u32 = 24039;
+pub const REMOVE_GER_CONSUMPTION_CYCLES: u32 = 24808;

--- a/crates/miden-protocol/src/note/assets.rs
+++ b/crates/miden-protocol/src/note/assets.rs
@@ -76,6 +76,11 @@ impl NoteAssets {
         self.commitment
     }
 
+    /// Returns the assets as a slice.
+    pub fn as_slice(&self) -> &[Asset] {
+        &self.assets
+    }
+
     /// Returns the number of assets.
     pub fn num_assets(&self) -> usize {
         self.assets.len()

--- a/crates/miden-standards/asm/components/auth/multisig/multisig.masm
+++ b/crates/miden-standards/asm/components/auth/multisig/multisig.masm
@@ -53,7 +53,7 @@ pub proc auth_tx_multisig(auth_args: word)
     exec.signature::estimate_multisig_authentication_cycles
     # => [num_extra_cycles, CONVERSION_INFO, AUTH_ARGS]
 
-    exec.fee::pay_fee
+    exec.fee::pay_fee drop
     # => [AUTH_ARGS]
 
     # Authenticate the transaction and record it for replay protection.

--- a/crates/miden-standards/asm/components/auth/network_account/network_account.masm
+++ b/crates/miden-standards/asm/components/auth/network_account/network_account.masm
@@ -5,6 +5,7 @@
 use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::core::word
+use miden::standards::assets::fungible_asset
 use miden::standards::auth::network_account
 use miden::standards::fee
 use miden::standards::fees
@@ -23,8 +24,16 @@ pub use {add_allowed_fee_policy} from miden::standards::fees::fee_manager
 pub use {remove_allowed_fee_policy} from miden::standards::fees::fee_manager
 
 # Estimated upper bound on the number of cycles this auth procedure spends after pay_fee
-# returns: the account commitment comparison and the nonce increment.
+# returns: the sponsorship conservation check, the account commitment comparison and the nonce
+# increment.
 const NETWORK_POST_FEE_CYCLES = 1024
+
+# ERRORS
+# =================================================================================================
+
+const ERR_NETWORK_ACCOUNT_FEE_ASSET_NOT_NATIVE = "sponsoring at most the collected fees requires the account's fee asset to be the native fee asset"
+
+const ERR_NETWORK_ACCOUNT_SPONSORED_FEES_EXCEED_COLLECTED = "the fees moved into sponsorship notes exceed the fees collected in this transaction"
 
 # AUTH PROCEDURE
 # =================================================================================================
@@ -43,7 +52,12 @@ const NETWORK_POST_FEE_CYCLES = 1024
 #!
 #! The transaction fee is then paid by creating a public TX_FEE note funded from the account's
 #! vault in the native fee asset at rate 1/1 (see fee::pay_fee and fee::native_conversion_info). On
-#! chains with a zero verification base fee no note is created.
+#! chains with a zero verification base fee no note is created. Paying the fee also sponsors every
+#! network output note of the transaction out of the account's vault.
+#!
+#! If the account's `sponsor_at_most_collected_fees` setting is enabled, what was sponsored must not
+#! exceed what was collected: the account then never subsidises a downstream consumer out of its own
+#! funds (see network_account::get_sponsor_at_most_collected_fees).
 #!
 #! Finally, the nonce is incremented when the account state changed or the account is new,
 #! matching the behavior of the NoAuth and SingleSig components. Note that on fee-charging
@@ -52,6 +66,12 @@ const NETWORK_POST_FEE_CYCLES = 1024
 #!
 #! Inputs:  [AUTH_ARGS, pad(12)]
 #! Outputs: [pad(16)]
+#!
+#! Panics if:
+#! - the transaction script root or a consumed input note's script root is not allowlisted.
+#! - the sponsorship setting is enabled, the transaction sponsored something and the configured fee
+#!   asset is not the native fee asset, which would make the two amounts incomparable.
+#! - the sponsorship setting is enabled and the sponsored fees exceed the collected fees.
 #!
 #! Invocation: call
 @auth_script
@@ -62,23 +82,53 @@ pub proc auth_network_transaction(auth_args: word)
     exec.network_account::assert_transaction_allowed
     # => [pad(16)]
 
-    # ---- Collect fees prepaid by sponsorship input notes into the account's vault ----
-    # done before paying the fee so the collected assets can fund the fee payment.
-    # collect fees in the asset the fee manager is configured with
-    exec.fee_manager::read_fee_asset_id
-    # => [FEE_ASSET_ID, pad(16)]
+    # ---- Read the sponsorship policy ----
+    # read before the fee is computed to keep its cost inside the region compute_fee measures
+    # negate the setting to make the assertions clearer
+    exec.network_account::get_sponsor_at_most_collected_fees not
+    # => [sponsor_unlimited, pad(16)]
 
-    exec.fees::collect_sponsored_fees drop
-    # => [pad(16)]
+    # ---- Read the conversion info of the native fee asset ----
+    exec.fee::native_conversion_info
+    # => [CONVERSION_INFO, sponsor_unlimited, pad(16)]
+
+    # ---- Collect fees from sponsorship input notes into the account's vault ----
+    # done before paying the fee so the collected assets can fund the fee payment.
+    # collect fees in the asset the fee manager is configured with.
+    exec.fee_manager::read_fee_asset_id
+    # => [FEE_ASSET_ID, CONVERSION_INFO, sponsor_unlimited, pad(16)]
+
+    # collected fees are denominated in the configured fee asset while sponsorship notes are funded
+    # in the native one, so the two amounts are only comparable when they are the same asset
+    dupw dup.9 dup.9 exec.fungible_asset::create_id exec.word::eq
+    # => [is_fee_asset_id_match, FEE_ASSET_ID, CONVERSION_INFO, sponsor_unlimited, pad(16)]
+
+    movdn.4 exec.fees::collect_sponsored_fees
+    # => [collected_fee_amount, is_fee_asset_id_match, CONVERSION_INFO, sponsor_unlimited, pad(16)]
 
     # ---- Pay the transaction fee in the native fee asset ----
-    exec.fee::native_conversion_info
-    # => [CONVERSION_INFO, pad(16)]
+    movdn.5 movdn.5
+    # => [CONVERSION_INFO, collected_fee_amount, is_fee_asset_id_match, sponsor_unlimited, pad(16)]
 
     push.NETWORK_POST_FEE_CYCLES
-    # => [num_extra_cycles, CONVERSION_INFO, pad(16)]
+    # => [num_extra_cycles, CONVERSION_INFO, collected_fee_amount, is_fee_asset_id_match,
+    #     sponsor_unlimited, pad(16)]
 
     exec.fee::pay_fee
+    # => [sponsored_fee_amount, collected_fee_amount, is_fee_asset_id_match, sponsor_unlimited, pad(16)]
+
+    # ---- Reject sponsoring more than was collected when the setting is enabled ----
+    dup eq.0
+    # => [has_sponsored_zero, sponsored_fee_amount, collected_fee_amount, is_fee_asset_id_match,
+    #     sponsor_unlimited, pad(16)]
+
+    # txs that sponsor 0 or unlimited don't require an asset ID match
+    # assert sponsor_unlimited || has_sponsored_zero || is_fee_asset_id_match
+    dup.4 or movup.3 or assert.err=ERR_NETWORK_ACCOUNT_FEE_ASSET_NOT_NATIVE
+    # => [sponsored_fee_amount, collected_fee_amount, sponsor_unlimited, pad(16)]
+
+    # assert collected >= sponsored || sponsor_unlimited
+    gte or assert.err=ERR_NETWORK_ACCOUNT_SPONSORED_FEES_EXCEED_COLLECTED
     # => [pad(16)]
 
     # ---- Increment nonce iff the account state changed or the account is new ----

--- a/crates/miden-standards/asm/components/auth/network_account/network_account.masm
+++ b/crates/miden-standards/asm/components/auth/network_account/network_account.masm
@@ -83,8 +83,8 @@ pub proc auth_network_transaction(auth_args: word)
     # => [pad(16)]
 
     # ---- Read the sponsorship policy ----
-    # read before the fee is computed to keep its cost inside the region compute_fee measures
-    # negate the setting to make the assertions clearer
+    # read before the fee is computed to keep its cost inside the region compute_fee measures.
+    # negate the setting to make the assertions clearer.
     exec.network_account::get_sponsor_at_most_collected_fees not
     # => [sponsor_unlimited, pad(16)]
 
@@ -99,7 +99,7 @@ pub proc auth_network_transaction(auth_args: word)
     # => [FEE_ASSET_ID, CONVERSION_INFO, sponsor_unlimited, pad(16)]
 
     # collected fees are denominated in the configured fee asset while sponsorship notes are funded
-    # in the native one, so the two amounts are only comparable when they are the same asset
+    # in the native one, so the two amounts are only comparable when they are the same asset.
     dupw dup.9 dup.9 exec.fungible_asset::create_id exec.word::eq
     # => [is_fee_asset_id_match, FEE_ASSET_ID, CONVERSION_INFO, sponsor_unlimited, pad(16)]
 

--- a/crates/miden-standards/asm/components/auth/no_auth/no_auth.masm
+++ b/crates/miden-standards/asm/components/auth/no_auth/no_auth.masm
@@ -41,7 +41,7 @@ pub proc auth_no_auth
     push.NO_AUTH_POST_FEE_CYCLES
     # => [num_extra_cycles, CONVERSION_INFO, pad(16)]
 
-    exec.fee::pay_fee
+    exec.fee::pay_fee drop
     # => [pad(16)]
 
     # check if the account state has changed by comparing initial and final commitments

--- a/crates/miden-standards/asm/components/auth/singlesig/singlesig.masm
+++ b/crates/miden-standards/asm/components/auth/singlesig/singlesig.masm
@@ -71,7 +71,7 @@ pub proc auth_tx(auth_args: word)
     swap movdn.5
     # => [num_extra_cycles, CONVERSION_INFO, scheme_id, pad(12)]
 
-    exec.fee::pay_fee
+    exec.fee::pay_fee drop
     # => [scheme_id, pad(12)]
 
     # Fetch public key commitment from storage.

--- a/crates/miden-standards/asm/components/auth/singlesig_acl/singlesig_acl.masm
+++ b/crates/miden-standards/asm/components/auth/singlesig_acl/singlesig_acl.masm
@@ -171,7 +171,7 @@ pub proc auth_tx_acl(auth_args: word)
         swap movdn.5
         # => [num_extra_cycles, CONVERSION_INFO, scheme_id, pad(16)]
 
-        exec.fee::pay_fee
+        exec.fee::pay_fee drop
         # => [scheme_id, pad(16)]
 
         # Fetch public key commitment from storage.
@@ -193,7 +193,7 @@ pub proc auth_tx_acl(auth_args: word)
         push.ACL_EXEMPT_POST_FEE_CYCLES
         # => [num_extra_cycles, CONVERSION_INFO, pad(16)]
 
-        exec.fee::pay_fee
+        exec.fee::pay_fee drop
         # => [pad(16)]
 
         # ------ Check if initial account commitment differs from current commitment ------

--- a/crates/miden-standards/asm/standards/auth/network_account.masm
+++ b/crates/miden-standards/asm/standards/auth/network_account.masm
@@ -1,16 +1,18 @@
-# Network-account allowlist management.
+# Network-account configuration storage.
 #
-# Owns the standardized allowlist slots and provides:
+# Owns the standardized `AuthNetworkAccount` slots and provides:
 # - `assert_transaction_allowed`, the tx-script and input-note allowlist check the
-#   `AuthNetworkAccount` auth procedure runs, and
+#   `AuthNetworkAccount` auth procedure runs,
 # - `add_allowed_note_script` / `remove_allowed_note_script` / `add_allowed_tx_script` /
 #   `remove_allowed_tx_script`, authority-gated procedures that mutate the allowlists after
-#   deployment.
+#   deployment, and
+# - `get_sponsor_at_most_collected_fees`, the account's sponsorship policy setting.
 
+use miden::protocol::native_account
 use miden::standards::access::authority
 use miden::standards::auth::note_script_allowlist
 use miden::standards::auth::tx_script_allowlist
-use {NoteScriptRoot, TransactionScriptRoot} from miden::protocol::types
+use {Bool, NoteScriptRoot, TransactionScriptRoot} from miden::protocol::types
 
 # CONSTANTS
 # =================================================================================================
@@ -22,6 +24,20 @@ const ALLOWED_NOTE_SCRIPTS_SLOT = word("miden::standards::auth::network_account:
 # The slot holding the map of allowed tx script roots. Keys are tx script roots; any non-empty value
 # marks a root as allowed.
 const ALLOWED_TX_SCRIPTS_SLOT = word("miden::standards::auth::network_account::allowed_tx_scripts")
+
+# The slot holding the sponsorship policy. Its first element is the policy discriminant, the
+# remaining elements are reserved for future policies and must be zero. See the `SponsorshipPolicy`
+# Rust type for the encoding.
+const SPONSOR_AT_MOST_COLLECTED_FEES_SLOT = word("miden::standards::auth::network_account::sponsor_at_most_collected_fees")
+
+# The policy discriminants, matching the `SponsorshipPolicy` variants on the Rust side.
+const UNLIMITED_DISCRIMINANT = 0
+const AT_MOST_COLLECTED_FEES_DISCRIMINANT = 1
+
+# ERRORS
+# =================================================================================================
+
+const ERR_NETWORK_ACCOUNT_INVALID_SPONSORSHIP_POLICY = "the network account sponsorship policy slot does not hold a valid policy"
 
 # ALLOWLIST CHECK
 # =================================================================================================
@@ -54,6 +70,51 @@ pub proc assert_transaction_allowed()
 
     exec.note_script_allowlist::assert_all_input_notes_allowed
     # => []
+end
+
+# SPONSORSHIP POLICY
+# =================================================================================================
+
+#! Returns whether the account may only sponsor outgoing network notes up to the fees it collected
+#! in the same transaction.
+#!
+#! When disabled, the account funds the sponsorship of its outgoing network notes from its own vault
+#! without bound. When enabled, its auth procedure rejects a transaction whose sponsorships exceed
+#! the fees it collected, so downstream consumption is paid for by upstream collection rather than by
+#! the account itself.
+#!
+#! The setting is read from the transaction's initial storage state so a change only takes effect
+#! starting from the next transaction.
+#!
+#! Inputs:  []
+#! Outputs: [sponsor_at_most_collected]
+#!
+#! Where:
+#! - sponsor_at_most_collected is 1 if the setting is enabled, 0 otherwise.
+#!
+#! Panics if:
+#! - the policy slot does not hold a valid policy.
+#!
+#! Invocation: exec
+pub proc get_sponsor_at_most_collected_fees() -> Bool
+    push.SPONSOR_AT_MOST_COLLECTED_FEES_SLOT[0..2]
+    # => [slot_id_suffix, slot_id_prefix]
+
+    exec.native_account::get_initial_item
+    # => [sponsor_at_most_collected, reserved0, reserved1, reserved2]
+
+    movdn.3
+    # => [reserved0, reserved1, reserved2, sponsor_at_most_collected]
+
+    eq.0 assert.err=ERR_NETWORK_ACCOUNT_INVALID_SPONSORSHIP_POLICY
+    eq.0 assert.err=ERR_NETWORK_ACCOUNT_INVALID_SPONSORSHIP_POLICY
+    eq.0 assert.err=ERR_NETWORK_ACCOUNT_INVALID_SPONSORSHIP_POLICY
+    # => [sponsor_at_most_collected]
+
+    # assert that sponsor_at_most_collected is validly encoded
+    dup eq.UNLIMITED_DISCRIMINANT dup.1 eq.AT_MOST_COLLECTED_FEES_DISCRIMINANT or
+    assert.err=ERR_NETWORK_ACCOUNT_INVALID_SPONSORSHIP_POLICY
+    # => [sponsor_at_most_collected]
 end
 
 # ALLOWLIST MANAGEMENT PROCEDURES

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -342,13 +342,15 @@ end
 #! fee policy via an FPI call, which requires that target to be provisioned as a foreign account.
 #!
 #! Inputs:  [num_extra_cycles, CONVERSION_INFO]
-#! Outputs: []
+#! Outputs: [total_sponsored_fee_amount]
 #!
 #! Where:
 #! - num_extra_cycles is the estimated number of cycles the caller spends after this call until
 #!   the end of the authentication procedure.
 #! - CONVERSION_INFO is [faucet_id_suffix, faucet_id_prefix, rate_num, rate_den], or the empty
 #!   word if no conversion info was committed (only accepted when the computed fee is zero).
+#! - total_sponsored_fee_amount is the total amount the sponsorship step moved into sponsorship
+#!   notes.
 #!
 #! Panics if:
 #! - the sponsorship step fails (propagates the panics of
@@ -362,56 +364,62 @@ end
 #! - the maximum number of output notes is exceeded.
 #!
 #! Invocation: exec
-pub proc pay_fee(num_extra_cycles: felt, conversion_info: ConversionInfo)
+pub proc pay_fee(num_extra_cycles: felt, conversion_info: ConversionInfo) -> felt
     # sponsor any network output notes before the fee is computed, so the sponsorship notes
     # this creates are counted by both the cycle estimate and compute_fee.
     exec.tx::get_fee_faucet_id exec.fungible_asset::create_id
     # => [FEE_ASSET_ID, num_extra_cycles, CONVERSION_INFO]
 
     exec.fees::create_network_note_sponsorships
-    # => [num_extra_cycles, CONVERSION_INFO]
+    # => [total_sponsored_fee_amount, num_extra_cycles, CONVERSION_INFO]
+
+    movdn.5
+    # => [num_extra_cycles, CONVERSION_INFO, total_sponsored_fee_amount]
 
     exec.apply_cycle_margins
-    # => [num_estimated_extra_cycles, CONVERSION_INFO]
+    # => [num_estimated_extra_cycles, CONVERSION_INFO, total_sponsored_fee_amount]
 
     # no output notes are excluded from the fee computation
     padw movup.4
-    # => [num_estimated_extra_cycles, EXCLUDE_NOTES_COMMITMENT, CONVERSION_INFO]
+    # => [num_estimated_extra_cycles, EXCLUDE_NOTES_COMMITMENT, CONVERSION_INFO,
+    #     total_sponsored_fee_amount]
 
     exec.tx::compute_fee
-    # => [fee_amount, CONVERSION_INFO]
+    # => [fee_amount, CONVERSION_INFO, total_sponsored_fee_amount]
 
     dup eq.0
     if.true
         # a zero fee requires no fee note
         drop dropw
-        # => []
+        # => [total_sponsored_fee_amount]
     else
         movdn.4
-        # => [CONVERSION_INFO, fee_amount]
+        # => [CONVERSION_INFO, fee_amount, total_sponsored_fee_amount]
 
         # a non-zero fee requires committed conversion info
         exec.word::testz assertz.err=ERR_FEE_CONVERSION_INFO_MISSING
-        # => [CONVERSION_INFO, fee_amount]
+        # => [CONVERSION_INFO, fee_amount, total_sponsored_fee_amount]
 
         # convert the fee amount into the payment asset's amount
         # (CONVERSION_INFO reads [faucet_id_suffix, faucet_id_prefix, rate_num, rate_den])
         movup.2 movup.3 movup.4
-        # => [fee_amount, rate_den, rate_num, faucet_id_suffix, faucet_id_prefix]
+        # => [fee_amount, rate_den, rate_num, faucet_id_suffix, faucet_id_prefix,
+        #     total_sponsored_fee_amount]
 
         movup.2 swap
-        # => [fee_amount, rate_num, rate_den, faucet_id_suffix, faucet_id_prefix]
+        # => [fee_amount, rate_num, rate_den, faucet_id_suffix, faucet_id_prefix,
+        #     total_sponsored_fee_amount]
 
         exec.convert_amount
-        # => [payment_amount, faucet_id_suffix, faucet_id_prefix]
+        # => [payment_amount, faucet_id_suffix, faucet_id_prefix, total_sponsored_fee_amount]
 
         movdn.2
-        # => [faucet_id_suffix, faucet_id_prefix, payment_amount]
+        # => [faucet_id_suffix, faucet_id_prefix, payment_amount, total_sponsored_fee_amount]
 
         exec.fungible_asset::create
-        # => [ASSET_ID, ASSET_VALUE]
+        # => [ASSET_ID, ASSET_VALUE, total_sponsored_fee_amount]
 
         exec.create_and_fund_fee_note
-        # => []
+        # => [total_sponsored_fee_amount]
     end
 end

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -267,11 +267,12 @@ end
 #! fee asset from that account's vault and creates notes from it.
 #!
 #! Inputs:  [FEE_ASSET_ID]
-#! Outputs: []
+#! Outputs: [total_sponsored_fee_amount]
 #!
 #! Where:
 #! - FEE_ASSET_ID is the ID of the asset sponsorship notes are funded with, typically read from
 #!   the fee manager's fee asset ID slot.
+#! - total_sponsored_fee_amount is the total amount moved into the created sponsorship notes.
 #!
 #! Panics if:
 #! - a network output note's target ID attachment does not consist of exactly one word.
@@ -282,49 +283,59 @@ end
 #! - the native account's vault does not hold enough of the fee asset.
 #!
 #! Invocation: exec
-pub proc create_network_note_sponsorships(fee_asset_id: AssetId)
+pub proc create_network_note_sponsorships(fee_asset_id: AssetId) -> felt
+    push.0 movdn.4
+    # => [FEE_ASSET_ID, total_sponsored_fee_amount = 0]
+
     # get the output note count before any sponsorship notes were created, since creating them
     # increments the count
     exec.tx::get_num_output_notes
-    # => [num_output_notes, FEE_ASSET_ID]
+    # => [num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
 
     push.0
-    # => [note_idx = 0, num_output_notes, FEE_ASSET_ID]
+    # => [note_idx = 0, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
 
     dup.1 dup.1 neq
-    # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID]
+    # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
 
     while.true
         # only network output notes are sponsored
         dup exec.is_network_note
-        # => [is_network_note, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID]
+        # => [is_network_note, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
+        #     total_sponsored_fee_amount]
 
         if.true
             dup.1
-            # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID]
+            # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount]
 
             # pass a copy of the expected fee asset ID along with the note parameters
             dupw.1 movup.5 movup.5
-            # => [note_idx, attachment_idx, FEE_ASSET_ID, note_idx, num_output_notes, FEE_ASSET_ID]
+            # => [note_idx, attachment_idx, FEE_ASSET_ID, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount]
 
             exec.create_network_note_sponsorship
-            # => [note_idx, num_output_notes, FEE_ASSET_ID]
+            # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount]
+
+            movup.7 add movdn.6
+            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
         else
             # do not sponsor non-network output notes
             drop
-            # => [note_idx, num_output_notes, FEE_ASSET_ID]
+            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
         end
 
         add.1
-        # => [note_idx+1, num_output_notes, FEE_ASSET_ID]
+        # => [note_idx+1, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
 
         dup.1 dup.1 neq
-        # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID]
+        # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
     end
-    # => [note_idx, num_output_notes, FEE_ASSET_ID]
+    # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
 
     drop drop dropw
-    # => []
+    # => [total_sponsored_fee_amount]
 end
 
 # HELPER PROCEDURES
@@ -597,12 +608,14 @@ end
 #! note. A network note the target account prices to zero produces no sponsorship note.
 #!
 #! Inputs:  [note_idx, attachment_idx, EXPECTED_FEE_ASSET_ID]
-#! Outputs: []
+#! Outputs: [sponsored_fee_amount]
 #!
 #! Where:
 #! - note_idx is the index of the network output note to sponsor.
 #! - attachment_idx is the index of the note's network account target attachment.
 #! - EXPECTED_FEE_ASSET_ID is the ID of the asset the sponsorship note must be funded with.
+#! - sponsored_fee_amount is the amount moved into the sponsorship note, or zero if none was
+#!   created.
 #!
 #! Panics if:
 #! - the note's target ID attachment does not consist of exactly one word.
@@ -618,7 +631,7 @@ proc create_network_note_sponsorship(
     note_idx: u16,
     attachment_idx: u8,
     expected_fee_asset_id: AssetId
-)
+) -> felt
     # cache the expected fee asset ID for the target fee asset check
     movdn.5 movdn.5 loc_storew_le.EXPECTED_FEE_ASSET_ID_LOC dropw
     # => [note_idx, attachment_idx]
@@ -629,21 +642,24 @@ proc create_network_note_sponsorship(
     exec.compute_sponsorship_fee
     # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx]
 
-    exec.fungible_asset::to_amount eq.0
-    # => [is_zero_fee, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx]
+    exec.fungible_asset::to_amount
+    # => [fee_amount, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx]
+
+    movdn.10 dup.10 eq.0
+    # => [is_zero_fee, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx, fee_amount]
 
     if.true
         # if the price of the note is zero, do not create a sponsorship note
         dropw dropw drop drop
-        # => []
+        # => [fee_amount]
     else
         # reject a target whose fee asset differs from the expected fee asset
         dupw padw loc_loadw_le.EXPECTED_FEE_ASSET_ID_LOC exec.word::eq
         assert.err=ERR_FEE_MANAGER_TARGET_FEE_ASSET_MISMATCH
-        # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx]
+        # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx, fee_amount]
 
         exec.create_sponsorship_note
-        # => []
+        # => [fee_amount]
     end
 end
 

--- a/crates/miden-standards/src/account/auth/mod.rs
+++ b/crates/miden-standards/src/account/auth/mod.rs
@@ -31,4 +31,6 @@ pub use network_account::{
     NetworkAccountNoteAllowlistError,
     NetworkAccountTxScriptAllowlist,
     NetworkAccountTxScriptAllowlistError,
+    SponsorshipPolicy,
+    SponsorshipPolicyError,
 };

--- a/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
+++ b/crates/miden-standards/src/account/auth/network_account/auth_network_account.rs
@@ -20,6 +20,7 @@ use super::{
     NetworkAccountNoteAllowlist,
     NetworkAccountNoteAllowlistError,
     NetworkAccountTxScriptAllowlist,
+    SponsorshipPolicy,
 };
 use crate::account::account_component_code;
 use crate::account::fees::FeePolicyManager;
@@ -158,15 +159,25 @@ procedure_root!(
 /// This component owns the fee-policy related storage slots and procedures. It carries the
 /// [`FeePolicyManager`] it was constructed with, which configures those slots, and, when expanded
 /// into [`AccountComponent`]s, yields the components of the manager's registered fee policies right
-/// after itself. The auth procedure also collects fees prepaid by `FEE_SPONSORSHIP` input notes,
+/// after itself. The auth procedure also collects fees from `FEE_SPONSORSHIP` input notes,
 /// denominated in the configured fee asset.
 ///
 /// Because every network transaction pays a fee, the fee policy is not optional: the component is
 /// constructed from a [`FeePolicyManager`], which initializes the slots from the manager's active
 /// policy, allowed policies and fee asset.
+///
+/// # Sponsorship policy
+///
+/// Paying the fee also sponsors every network output note the transaction creates, out of this
+/// account's vault. The component's [`SponsorshipPolicy`] decides whether that spending is bounded
+/// by what the account collected in the same transaction. It defaults to
+/// [`SponsorshipPolicy::AtMostCollectedFees`], so an account only forwards value it collected.
+/// Accounts that are meant to subsidise their own outgoing notes opt into
+/// [`SponsorshipPolicy::Unlimited`].
 pub struct AuthNetworkAccount {
     allowed_notes: NetworkAccountNoteAllowlist,
     allowed_tx_scripts: NetworkAccountTxScriptAllowlist,
+    sponsorship_policy: SponsorshipPolicy,
     policy_manager: FeePolicyManager,
 }
 
@@ -230,8 +241,16 @@ impl AuthNetworkAccount {
         Ok(Self {
             allowed_notes: NetworkAccountNoteAllowlist::new(allowed_notes)?,
             allowed_tx_scripts: NetworkAccountTxScriptAllowlist::default(),
+            sponsorship_policy: SponsorshipPolicy::default(),
             policy_manager: fee_policy_manager,
         })
+    }
+
+    /// Sets the [`SponsorshipPolicy`] bounding how much the account spends sponsoring the network
+    /// notes it creates.
+    pub fn with_sponsorship_policy(mut self, sponsorship_policy: SponsorshipPolicy) -> Self {
+        self.sponsorship_policy = sponsorship_policy;
+        self
     }
 
     /// Extends the tx-script allowlist with the given transaction script roots, keeping any that
@@ -270,6 +289,11 @@ impl AuthNetworkAccount {
     /// Returns the [`NetworkAccountTxScriptAllowlist`] of this component.
     pub fn allowed_tx_scripts(&self) -> &NetworkAccountTxScriptAllowlist {
         &self.allowed_tx_scripts
+    }
+
+    /// Returns the [`SponsorshipPolicy`] of this component.
+    pub fn sponsorship_policy(&self) -> SponsorshipPolicy {
+        self.sponsorship_policy
     }
 
     /// Returns the procedure root of the `add_allowed_note_script` procedure exposed by this
@@ -346,11 +370,22 @@ impl AuthNetworkAccount {
         NetworkAccountTxScriptAllowlist::slot_schema()
     }
 
+    /// Returns the storage slot holding the sponsorship policy.
+    pub fn sponsorship_policy_slot() -> &'static StorageSlotName {
+        SponsorshipPolicy::slot_name()
+    }
+
+    /// Returns the storage slot schema for the sponsorship policy slot.
+    pub fn sponsorship_policy_slot_schema() -> (StorageSlotName, StorageSlotSchema) {
+        SponsorshipPolicy::slot_schema()
+    }
+
     /// Returns the [`AccountComponentMetadata`] for this component.
     pub fn component_metadata() -> AccountComponentMetadata {
         let mut slot_schemas = vec![
             NetworkAccountNoteAllowlist::slot_schema(),
             NetworkAccountTxScriptAllowlist::slot_schema(),
+            SponsorshipPolicy::slot_schema(),
         ];
         slot_schemas.extend(FeePolicyManager::slot_schemas());
         let storage_schema =
@@ -375,12 +410,16 @@ impl IntoIterator for AuthNetworkAccount {
         let Self {
             allowed_notes,
             allowed_tx_scripts,
+            sponsorship_policy,
             policy_manager,
         } = self;
 
         let fee_policy_slots = policy_manager.to_storage_slots();
-        let mut storage_slots =
-            vec![allowed_notes.into_storage_slot(), allowed_tx_scripts.into_storage_slot()];
+        let mut storage_slots = vec![
+            allowed_notes.into_storage_slot(),
+            allowed_tx_scripts.into_storage_slot(),
+            sponsorship_policy.into_storage_slot(),
+        ];
         storage_slots.extend(fee_policy_slots);
 
         let auth_component =

--- a/crates/miden-standards/src/account/auth/network_account/mod.rs
+++ b/crates/miden-standards/src/account/auth/network_account/mod.rs
@@ -8,6 +8,9 @@ pub use network_account::{NetworkAccount, NetworkAccountError};
 mod note_allowlist;
 pub use note_allowlist::{NetworkAccountNoteAllowlist, NetworkAccountNoteAllowlistError};
 
+mod sponsorship_policy;
+pub use sponsorship_policy::{SponsorshipPolicy, SponsorshipPolicyError};
+
 mod tx_script_allowlist;
 pub use tx_script_allowlist::{
     NetworkAccountTxScriptAllowlist,

--- a/crates/miden-standards/src/account/auth/network_account/sponsorship_policy.rs
+++ b/crates/miden-standards/src/account/auth/network_account/sponsorship_policy.rs
@@ -1,0 +1,184 @@
+use miden_protocol::account::component::{SchemaType, StorageSlotSchema};
+use miden_protocol::account::{AccountStorage, StorageSlot, StorageSlotContent, StorageSlotName};
+use miden_protocol::utils::sync::LazyLock;
+use miden_protocol::{Felt, Word};
+
+// CONSTANTS
+// ================================================================================================
+
+static SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
+    StorageSlotName::new("miden::standards::auth::network_account::sponsor_at_most_collected_fees")
+        .expect("storage slot name should be valid")
+});
+
+// SPONSORSHIP POLICY
+// ================================================================================================
+
+/// How much of its own funds a network account is willing to spend sponsoring the network notes it
+/// creates.
+///
+/// Paying the transaction fee also creates a `FEE_SPONSORSHIP` note for every network output note
+/// of the transaction, funded from the account's vault, so that the target account is prepaid for
+/// consuming it. Independently, the account collects the fees prepaid by the `FEE_SPONSORSHIP`
+/// notes among its own input notes. This policy decides whether the former is bounded by the
+/// latter.
+///
+/// It is fixed at deployment: the auth procedure reads it from the transaction's initial storage
+/// state and there is no account procedure to change it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum SponsorshipPolicy {
+    /// Sponsorships must not exceed the fees collected in the same transaction, so the account
+    /// never subsidises a downstream consumer out of its own funds.
+    ///
+    /// A transaction that sponsors anything additionally requires the account's configured fee
+    /// asset to be the chain's native fee asset, since collected fees are denominated in the
+    /// former while sponsorship notes are funded in the latter and the two amounts would
+    /// otherwise not be comparable. An account that never creates network notes is unaffected
+    /// by that requirement.
+    #[default]
+    AtMostCollectedFees = Self::AT_MOST_COLLECTED_FEES,
+
+    /// Sponsorships are funded from the account's vault without bound, so the account pays for
+    /// outgoing notes that the fees it collected do not cover.
+    Unlimited = Self::UNLIMITED,
+}
+
+impl SponsorshipPolicy {
+    /// The discriminant of [`Unlimited`](Self::Unlimited) in the policy's storage encoding.
+    const UNLIMITED: u8 = 0;
+    /// The discriminant of [`AtMostCollectedFees`](Self::AtMostCollectedFees).
+    const AT_MOST_COLLECTED_FEES: u8 = 1;
+
+    /// Returns the [`StorageSlotName`] of the standardized sponsorship policy slot.
+    pub fn slot_name() -> &'static StorageSlotName {
+        &SLOT_NAME
+    }
+
+    /// Returns the schema entry for the sponsorship policy slot.
+    pub fn slot_schema() -> (StorageSlotName, StorageSlotSchema) {
+        (
+            Self::slot_name().clone(),
+            StorageSlotSchema::value(
+                "Whether sponsorships are capped at the fees collected in the same transaction",
+                SchemaType::native_word(),
+            ),
+        )
+    }
+
+    /// Returns the [`StorageSlot`] encoding this policy, suitable for inclusion in an
+    /// [`AccountComponent`](miden_protocol::account::AccountComponent)'s storage layout.
+    pub fn into_storage_slot(self) -> StorageSlot {
+        StorageSlot::with_value(Self::slot_name().clone(), self.to_word())
+    }
+
+    /// Returns the storage encoding of this policy.
+    ///
+    /// The policy is encoded as `[discriminant, 0, 0, 0]`.
+    pub fn to_word(self) -> Word {
+        Word::new([Felt::from(self as u8), Felt::ZERO, Felt::ZERO, Felt::ZERO])
+    }
+}
+
+// TRAIT IMPLEMENTATIONS
+// ================================================================================================
+
+impl TryFrom<Word> for SponsorshipPolicy {
+    type Error = SponsorshipPolicyError;
+
+    /// Decodes a policy from its storage encoding, see [`SponsorshipPolicy::to_word`].
+    ///
+    /// # Errors
+    /// Returns an error if the word's first element is not a known discriminant or any of its
+    /// reserved elements is non-zero.
+    fn try_from(word: Word) -> Result<Self, Self::Error> {
+        if word[1] != Felt::ZERO || word[2] != Felt::ZERO || word[3] != Felt::ZERO {
+            return Err(SponsorshipPolicyError::InvalidEncoding(word));
+        }
+
+        match u8::try_from(word[0].as_canonical_u64()).ok() {
+            Some(Self::AT_MOST_COLLECTED_FEES) => Ok(Self::AtMostCollectedFees),
+            Some(Self::UNLIMITED) => Ok(Self::Unlimited),
+            _ => Err(SponsorshipPolicyError::InvalidEncoding(word)),
+        }
+    }
+}
+
+impl TryFrom<&AccountStorage> for SponsorshipPolicy {
+    type Error = SponsorshipPolicyError;
+
+    /// Reads the sponsorship policy from account storage.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The standardized policy slot is not present in storage.
+    /// - The slot is present but is not a [`StorageSlotContent::Value`].
+    /// - The slot's value is not a valid policy encoding.
+    fn try_from(storage: &AccountStorage) -> Result<Self, Self::Error> {
+        let slot = storage.get(Self::slot_name()).ok_or(SponsorshipPolicyError::SlotNotFound)?;
+
+        let StorageSlotContent::Value(value) = slot.content() else {
+            return Err(SponsorshipPolicyError::UnexpectedSlotType);
+        };
+
+        Self::try_from(*value)
+    }
+}
+
+// SPONSORSHIP POLICY ERROR
+// ================================================================================================
+
+/// Errors that can occur when reading a [`SponsorshipPolicy`] from storage.
+#[derive(Debug, thiserror::Error)]
+pub enum SponsorshipPolicyError {
+    #[error(
+        "network account sponsorship policy storage slot {} not found in account storage",
+        SponsorshipPolicy::slot_name()
+    )]
+    SlotNotFound,
+    #[error(
+        "network account sponsorship policy storage slot {} must be a value",
+        SponsorshipPolicy::slot_name()
+    )]
+    UnexpectedSlotType,
+    #[error("word {0} is not a valid network account sponsorship policy encoding")]
+    InvalidEncoding(Word),
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+    use assert_matches::assert_matches;
+
+    use super::*;
+
+    #[rstest::rstest]
+    #[case(SponsorshipPolicy::AtMostCollectedFees, Word::from([1u32, 0, 0, 0]))]
+    #[case(SponsorshipPolicy::Unlimited, Word::empty())]
+    fn policy_round_trips_through_its_storage_encoding(
+        #[case] policy: SponsorshipPolicy,
+        #[case] expected_word: Word,
+    ) -> anyhow::Result<()> {
+        assert_eq!(policy.to_word(), expected_word);
+        assert_eq!(
+            SponsorshipPolicy::try_from(policy.to_word()).context("decoding the policy failed")?,
+            policy
+        );
+
+        Ok(())
+    }
+
+    #[rstest::rstest]
+    #[case::unknown_discriminant(Word::from([2u32, 0, 0, 0]))]
+    #[case::non_zero_reserved_element(Word::from([1u32, 0, 5, 0]))]
+    fn decoding_an_invalid_encoding_fails(#[case] word: Word) {
+        assert_matches!(
+            SponsorshipPolicy::try_from(word),
+            Err(SponsorshipPolicyError::InvalidEncoding(invalid)) if invalid == word
+        );
+    }
+}

--- a/crates/miden-standards/src/account/auth/network_account/sponsorship_policy.rs
+++ b/crates/miden-standards/src/account/auth/network_account/sponsorship_policy.rs
@@ -93,7 +93,7 @@ impl TryFrom<Word> for SponsorshipPolicy {
     /// Returns an error if the word's first element is not a known discriminant or any of its
     /// reserved elements is non-zero.
     fn try_from(word: Word) -> Result<Self, Self::Error> {
-        if word[1] != Felt::ZERO || word[2] != Felt::ZERO || word[3] != Felt::ZERO {
+        if word[1..4] != [Felt::ZERO; 3] {
             return Err(SponsorshipPolicyError::InvalidEncoding(word));
         }
 
@@ -174,7 +174,9 @@ mod tests {
 
     #[rstest::rstest]
     #[case::unknown_discriminant(Word::from([2u32, 0, 0, 0]))]
-    #[case::non_zero_reserved_element(Word::from([1u32, 0, 5, 0]))]
+    #[case::non_zero_reserved_element_1(Word::from([1u32, 5, 0, 0]))]
+    #[case::non_zero_reserved_element_2(Word::from([1u32, 0, 5, 0]))]
+    #[case::non_zero_reserved_element_3(Word::from([1u32, 0, 0, 5]))]
     fn decoding_an_invalid_encoding_fails(#[case] word: Word) {
         assert_matches!(
             SponsorshipPolicy::try_from(word),

--- a/crates/miden-standards/src/note/costs/table.rs
+++ b/crates/miden-standards/src/note/costs/table.rs
@@ -2,51 +2,51 @@
 // Values are maxima across the benchmarked paths; see `miden_standards::note::costs` for the
 // caveats on what they do and do not cover.
 
-/// Cycles of consuming a P2ID note: 1 asset 17606, 16 assets 56324 (maximum).
-pub const P2ID_CONSUMPTION_CYCLES: u32 = 56324;
+/// Cycles of consuming a P2ID note: 1 asset 18366, 16 assets 57084 (maximum).
+pub const P2ID_CONSUMPTION_CYCLES: u32 = 57084;
 
-/// Cycles of consuming a P2IDE note: claim 17731, claim with 16 assets 56449 (maximum), reclaim
-/// 17886.
-pub const P2IDE_CONSUMPTION_CYCLES: u32 = 56449;
+/// Cycles of consuming a P2IDE note: claim 18491, claim with 16 assets 57209 (maximum), reclaim
+/// 18646.
+pub const P2IDE_CONSUMPTION_CYCLES: u32 = 57209;
 
-/// Cycles of consuming a SWAP note: public payback 21600 (maximum), private payback 21089.
-pub const SWAP_CONSUMPTION_CYCLES: u32 = 21600;
+/// Cycles of consuming a SWAP note: public payback 22360 (maximum), private payback 21849.
+pub const SWAP_CONSUMPTION_CYCLES: u32 = 22360;
 
-/// Cycles of consuming a PSWAP note: full fill 24163, partial fill 28104 (maximum).
-pub const PSWAP_CONSUMPTION_CYCLES: u32 = 28104;
+/// Cycles of consuming a PSWAP note: full fill 24923, partial fill 28864 (maximum).
+pub const PSWAP_CONSUMPTION_CYCLES: u32 = 28864;
 
-/// Cycles of consuming a MINT note: fungible faucet 30883, non-fungible faucet 33762 (maximum).
-pub const MINT_CONSUMPTION_CYCLES: u32 = 33762;
+/// Cycles of consuming a MINT note: fungible faucet 31652, non-fungible faucet 34531 (maximum).
+pub const MINT_CONSUMPTION_CYCLES: u32 = 34531;
 
 /// Cycles of consuming a BURN note (single benchmarked path).
-pub const BURN_CONSUMPTION_CYCLES: u32 = 27579;
+pub const BURN_CONSUMPTION_CYCLES: u32 = 28348;
 
 /// Cycles of consuming a CONSTANT_FEE_POLICY_CONFIG note (single benchmarked path).
-pub const CONSTANT_FEE_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 18947;
+pub const CONSTANT_FEE_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 19716;
 
 /// Cycles of consuming a FAUCET_POLICY_CONFIG note (single benchmarked path).
-pub const FAUCET_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 26654;
+pub const FAUCET_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 27423;
 
 /// Cycles of consuming a FAUCET_METADATA_CONFIG note (single benchmarked path).
-pub const FAUCET_METADATA_CONFIG_CONSUMPTION_CYCLES: u32 = 25472;
+pub const FAUCET_METADATA_CONFIG_CONSUMPTION_CYCLES: u32 = 26241;
 
 /// Cycles of consuming an ALLOWLIST_CONFIG note (single benchmarked path).
-pub const ALLOWLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 24762;
+pub const ALLOWLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 25531;
 
 /// Cycles of consuming a BLOCKLIST_CONFIG note (single benchmarked path).
-pub const BLOCKLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 24762;
+pub const BLOCKLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 25531;
 
 /// Cycles of consuming a PAUSE_CONFIG note (single benchmarked path).
-pub const PAUSE_CONFIG_CONSUMPTION_CYCLES: u32 = 16712;
+pub const PAUSE_CONFIG_CONSUMPTION_CYCLES: u32 = 17481;
 
 /// Cycles of consuming an OWNER_CONFIG note (single benchmarked path).
-pub const OWNER_CONFIG_CONSUMPTION_CYCLES: u32 = 16306;
+pub const OWNER_CONFIG_CONSUMPTION_CYCLES: u32 = 17075;
 
 /// Cycles of consuming an RBAC_CONFIG note (single benchmarked path).
-pub const RBAC_CONFIG_CONSUMPTION_CYCLES: u32 = 19568;
+pub const RBAC_CONFIG_CONSUMPTION_CYCLES: u32 = 20337;
 
 /// Cycles of consuming a NETWORK_ACCOUNT_CONFIG note (single benchmarked path).
-pub const NETWORK_ACCOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 18068;
+pub const NETWORK_ACCOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 18837;
 
 /// Cycles of consuming a FEE_SPONSORSHIP note (single benchmarked path).
-pub const FEE_SPONSORSHIP_CONSUMPTION_CYCLES: u32 = 20277;
+pub const FEE_SPONSORSHIP_CONSUMPTION_CYCLES: u32 = 21091;

--- a/crates/miden-testing/Cargo.toml
+++ b/crates/miden-testing/Cargo.toml
@@ -38,6 +38,7 @@ thiserror   = { workspace = true }
 [dev-dependencies]
 anyhow          = { features = ["backtrace", "std"], workspace = true }
 assert_matches  = { workspace = true }
+bon             = { workspace = true }
 miden-agglayer  = { features = ["testing"], workspace = true }
 miden-assembly  = { workspace = true }
 miden-crypto    = { workspace = true }

--- a/crates/miden-testing/src/mock_chain/auth.rs
+++ b/crates/miden-testing/src/mock_chain/auth.rs
@@ -25,6 +25,7 @@ use miden_standards::account::auth::{
     AuthSingleSigAcl,
     AuthSingleSigAclConfig,
     GuardianConfig,
+    SponsorshipPolicy,
 };
 use miden_standards::account::fees::FeePolicyManager;
 use miden_standards::testing::account_component::{
@@ -92,6 +93,7 @@ pub enum Auth {
         allowed_script_roots: BTreeSet<NoteScriptRoot>,
         allowed_tx_script_roots: BTreeSet<TransactionScriptRoot>,
         fee_policy_manager: FeePolicyManager,
+        sponsorship_policy: SponsorshipPolicy,
     },
 }
 
@@ -192,6 +194,7 @@ impl Auth {
                 allowed_script_roots,
                 allowed_tx_script_roots,
                 fee_policy_manager,
+                sponsorship_policy,
             } => {
                 let components = AuthNetworkAccount::new(
                     allowed_script_roots.clone(),
@@ -199,6 +202,7 @@ impl Auth {
                 )
                 .expect("network account allowlist must be non-empty")
                 .with_allowed_tx_scripts(allowed_tx_script_roots.clone())
+                .with_sponsorship_policy(*sponsorship_policy)
                 .into_iter()
                 .collect();
                 (components, None)

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -56,6 +56,7 @@ use miden_protocol::testing::random_secret_key::random_secret_key;
 use miden_protocol::transaction::{OrderedTransactionHeaders, RawOutputNote, TransactionKernel};
 use miden_protocol::{MAX_OUTPUT_NOTES_PER_BATCH, Word};
 use miden_standards::account::access::{AccessControl, Authority, Pausable, PausableManager};
+use miden_standards::account::auth::SponsorshipPolicy;
 use miden_standards::account::faucets::{FungibleFaucet, TokenName};
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicyManager};
 use miden_standards::account::policies::{
@@ -410,6 +411,7 @@ impl MockChainBuilder {
             allowed_script_roots,
             allowed_tx_script_roots: BTreeSet::new(),
             fee_policy_manager,
+            sponsorship_policy: SponsorshipPolicy::default(),
         };
 
         self.add_account_from_builder(auth, account_builder, AccountState::Exists)

--- a/crates/miden-testing/tests/auth/fee_payment/sponsorship.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/sponsorship.rs
@@ -12,6 +12,7 @@ use miden_protocol::transaction::RawOutputNote;
 use miden_standards::account::auth::{
     AuthNetworkAccount,
     FeeConversionInfo,
+    SponsorshipPolicy,
     commit_fee_conversion_info,
 };
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicyManager};
@@ -50,12 +51,14 @@ fn fee_asset(amount: u64) -> anyhow::Result<Asset> {
 
 /// Builds an existing public network account (`AuthNetworkAccount` + `BasicWallet` +
 /// `FeePolicyManager`) that allowlists `allowed_notes`, prices each `(root, amount)` in `priced`
-/// through its active `BasicConstantFeePolicy`, and holds `assets` in its vault.
+/// through its active `BasicConstantFeePolicy`, holds `assets` in its vault, and bounds its
+/// sponsorship spending by `sponsorship_policy`.
 fn network_account(
     seed: [u8; 32],
     allowed_notes: impl IntoIterator<Item = NoteScriptRoot>,
     priced: &[(NoteScriptRoot, u64)],
     assets: impl IntoIterator<Item = Asset>,
+    sponsorship_policy: SponsorshipPolicy,
 ) -> anyhow::Result<Account> {
     let mut policy = BasicConstantFeePolicy::new();
     for (root, amount) in priced {
@@ -65,7 +68,8 @@ fn network_account(
         .active_fee_policy(policy.into())
         .fee_faucet_id(fee_faucet_id()?)
         .build();
-    let auth = AuthNetworkAccount::new(BTreeSet::from_iter(allowed_notes), fee_policy_manager)?;
+    let auth = AuthNetworkAccount::new(BTreeSet::from_iter(allowed_notes), fee_policy_manager)?
+        .with_sponsorship_policy(sponsorship_policy);
 
     Ok(AccountBuilder::new(seed)
         .account_type(AccountType::Public)
@@ -131,6 +135,7 @@ async fn pay_fee_sponsors_network_output_note() -> anyhow::Result<()> {
         [P2idNote::script_root(), FeeSponsorshipNote::script_root()],
         &[(P2idNote::script_root(), FEE_AMOUNT)],
         [],
+        SponsorshipPolicy::default(),
     )?;
     builder.add_account(target.clone())?;
 
@@ -223,6 +228,7 @@ async fn network_account_collects_sponsored_fee_single_hop() -> anyhow::Result<(
         [P2idNote::script_root(), FeeSponsorshipNote::script_root()],
         &[(P2idNote::script_root(), FEE_AMOUNT)],
         [fee_asset(NETWORK_INITIAL_FEE_BALANCE)?],
+        SponsorshipPolicy::default(),
     )?;
     builder.add_account(network.clone())?;
     let mut mock_chain = builder.build()?;
@@ -323,11 +329,14 @@ async fn spawned_network_note_sponsored_by_a_and_collected_by_b_multi_hop() -> a
         [P2idNote::script_root(), FeeSponsorshipNote::script_root()],
         &[(P2idNote::script_root(), FEE_AMOUNT)],
         [fee_asset(B_INITIAL_FEE_BALANCE)?],
+        SponsorshipPolicy::default(),
     )?;
 
     // probe network account A to learn its id (independent of allowlist storage), which the
     // spawned note names as sender; the spawn note is authored by A and consumed by A
-    let network_a_id = network_account([2; 32], [P2idNote::script_root()], &[], [])?.id();
+    let network_a_id =
+        network_account([2; 32], [P2idNote::script_root()], &[], [], SponsorshipPolicy::Unlimited)?
+            .id();
     let spawned_note = p2id_network_note(network_a_id, network_b.id(), payload_asset, &mut rng)?;
     let spawn_note = create_spawn_note([&spawned_note])?;
 
@@ -339,6 +348,7 @@ async fn spawned_network_note_sponsored_by_a_and_collected_by_b_multi_hop() -> a
         [spawn_note.script().root(), FeeSponsorshipNote::script_root()],
         &[(spawn_note.script().root(), 0)],
         [fee_asset(1_000_000)?, payload_asset],
+        SponsorshipPolicy::Unlimited,
     )?;
     assert_eq!(network_a.id(), network_a_id, "account id must not depend on the allowlist");
 

--- a/crates/miden-testing/tests/auth/network_account.rs
+++ b/crates/miden-testing/tests/auth/network_account.rs
@@ -15,6 +15,7 @@ use miden_standards::account::wallets::BasicWallet;
 use miden_standards::code_builder::CodeBuilder;
 use miden_standards::errors::standards::{
     ERR_NETWORK_ACCOUNT_CONFIG_TARGET_ACCOUNT_MISMATCH,
+    ERR_NETWORK_ACCOUNT_INVALID_SPONSORSHIP_POLICY,
     ERR_NOTE_SCRIPT_ALLOWLIST_NOTE_NOT_ALLOWED,
     ERR_SENDER_NOT_OWNER,
     ERR_TX_SCRIPT_ALLOWLIST_TX_SCRIPT_NOT_ALLOWED,
@@ -887,6 +888,31 @@ async fn test_auth_network_account_rejects_unauthorized_upgrade_note() -> anyhow
         .await;
 
     assert_transaction_executor_error!(result, ERR_SENDER_NOT_OWNER);
+
+    Ok(())
+}
+
+/// The auth procedure rejects a transaction whose sponsorship policy slot does not hold a valid
+/// policy: neither an unknown discriminant nor a non-zero reserved element is accepted.
+#[rstest]
+#[case::unknown_discriminant(Word::from([2u32, 0, 0, 0]))]
+#[case::non_zero_reserved_element(Word::from([1u32, 0, 0, 7]))]
+#[tokio::test]
+async fn test_auth_network_account_rejects_invalid_sponsorship_policy(
+    #[case] policy: Word,
+) -> anyhow::Result<()> {
+    let mut account = build_allowlist_account(vec![placeholder_script_root()])?;
+    account
+        .storage_mut()
+        .set_item(AuthNetworkAccount::sponsorship_policy_slot(), policy)?;
+
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+    let mock_chain = builder.build()?;
+
+    let result = mock_chain.build_transaction(account.id()).build()?.execute().await;
+
+    assert_transaction_executor_error!(result, ERR_NETWORK_ACCOUNT_INVALID_SPONSORSHIP_POLICY);
 
     Ok(())
 }

--- a/crates/miden-testing/tests/scripts/faucet.rs
+++ b/crates/miden-testing/tests/scripts/faucet.rs
@@ -33,6 +33,7 @@ use miden_protocol::testing::account_id::{ACCOUNT_ID_FEE_FAUCET, ACCOUNT_ID_PRIV
 use miden_protocol::transaction::{ExecutedTransaction, RawOutputNote};
 use miden_protocol::{Felt, Word};
 use miden_standards::account::access::{Authority, Ownable2Step, Pausable};
+use miden_standards::account::auth::SponsorshipPolicy;
 use miden_standards::account::faucets::{FungibleFaucet, TokenName};
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicyManager};
 use miden_standards::account::policies::{
@@ -2524,6 +2525,7 @@ fn build_network_faucet_with_blocklist_transfer(
             allowed_script_roots,
             allowed_tx_script_roots: BTreeSet::new(),
             fee_policy_manager,
+            sponsorship_policy: SponsorshipPolicy::default(),
         },
         account_builder,
         AccountState::Exists,

--- a/crates/miden-testing/tests/scripts/fee_collection.rs
+++ b/crates/miden-testing/tests/scripts/fee_collection.rs
@@ -2,20 +2,22 @@ use alloc::sync::Arc;
 use std::collections::BTreeSet;
 use std::sync::LazyLock;
 
+use anyhow::Context;
 use miden_processor::crypto::random::RandomCoin;
 use miden_protocol::account::component::{AccountComponentCode, AccountComponentMetadata};
 use miden_protocol::account::{Account, AccountBuilder, AccountComponent, AccountId, AccountType};
 use miden_protocol::assembly::DefaultSourceManager;
 use miden_protocol::asset::{Asset, AssetAmount, AssetId, FungibleAsset};
 use miden_protocol::block::BlockNumber;
+use miden_protocol::block::account_tree::AccountWitness;
 use miden_protocol::note::{Note, NoteAssets, NoteId, NoteScriptRoot, NoteType};
 use miden_protocol::testing::account_id::{
     ACCOUNT_ID_FEE_FAUCET,
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1,
 };
-use miden_protocol::transaction::{RawOutputNote, TransactionScript};
+use miden_protocol::transaction::{RawOutputNote, RawOutputNotes, TransactionScript};
 use miden_protocol::{Felt, Word};
-use miden_standards::account::auth::{AuthNetworkAccount, NetworkAccount};
+use miden_standards::account::auth::{AuthNetworkAccount, NetworkAccount, SponsorshipPolicy};
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicy, FeePolicyManager};
 use miden_standards::account::wallets::{BasicWallet, NoteCreator};
 use miden_standards::code_builder::CodeBuilder;
@@ -27,6 +29,8 @@ use miden_standards::errors::standards::{
     ERR_FEE_MANAGER_TARGET_FEE_ASSET_MISMATCH,
     ERR_FEE_POLICY_FEE_ASSET_MISMATCH,
     ERR_FEE_POLICY_ROOT_NOT_ALLOWED,
+    ERR_NETWORK_ACCOUNT_FEE_ASSET_NOT_NATIVE,
+    ERR_NETWORK_ACCOUNT_SPONSORED_FEES_EXCEED_COLLECTED,
     ERR_NOTE_SCRIPT_NOT_IN_FEE_SCHEDULE,
     ERR_SENDER_NOT_OWNER,
 };
@@ -37,7 +41,7 @@ use miden_standards::note::{
     P2idNote,
 };
 use miden_standards::testing::note::NoteBuilder;
-use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
+use miden_testing::{Auth, MockChain, MockTransaction, assert_transaction_executor_error};
 use rand::SeedableRng;
 use rand::rngs::Xoshiro256PlusPlus;
 use rand::seq::SliceRandom;
@@ -137,7 +141,8 @@ fn network_account(
         .build_existing()?)
 }
 
-/// A network account plus a set of feature notes and the FEE_SPONSORSHIP notes bound to them.
+/// A network account plus the feature notes it can consume and the FEE_SPONSORSHIP notes bound to
+/// them.
 struct Test {
     mock_chain: MockChain,
     network_account: Account,
@@ -145,60 +150,86 @@ struct Test {
     sponsorship_notes: Vec<Note>,
 }
 
-/// Builds a [`Test`] with `num_feature_notes` feature notes (0-asset P2ANY notes, so they all share
-/// the same script root) and one FEE_SPONSORSHIP note per `sponsorships` entry, each bound to the
-/// feature note at the entry's index and carrying its asset. Several entries may name the same
-/// feature note. The feature note script root is priced in the fee schedule with `feature_note_fee`
-/// when provided, and left unscheduled otherwise.
-fn build_test(
-    feature_note_fee: Option<AssetAmount>,
-    num_feature_notes: usize,
-    sponsorships: Vec<(usize, Asset)>,
-) -> anyhow::Result<Test> {
-    let mut rng = RandomCoin::new(Word::empty());
-    let mut builder = MockChain::builder();
-    let sponsor = builder.add_existing_wallet(Auth::IncrNonce)?;
+#[bon::bon]
+impl Test {
+    /// Builds a network account together with its feature notes and their FEE_SPONSORSHIP notes.
+    ///
+    /// The feature notes are P2ANY notes without assets, so they all share one script root. The
+    /// account allowlists that root, which lets it consume every feature note.
+    ///
+    /// Use [`TestBuilder::sponsorship`] to add the FEE_SPONSORSHIP notes.
+    #[builder]
+    fn new(
+        #[builder(field)] sponsorships: Vec<(usize, Asset)>,
+        /// Fee the fee schedule charges for each feature note. Without this fee the feature note
+        /// script root stays unscheduled.
+        feature_note_fee: Option<AssetAmount>,
+        /// Number of feature notes to create. Defaults to 1.
+        #[builder(default = 1)]
+        num_feature_notes: usize,
+    ) -> anyhow::Result<Self> {
+        let mut rng = RandomCoin::new(Word::empty());
+        let mut builder = MockChain::builder();
+        let sponsor = builder.add_existing_wallet(Auth::IncrNonce)?;
 
-    let feature_notes: Vec<Note> = (0..num_feature_notes)
-        .map(|_| builder.add_p2any_note(sponsor.id(), NoteType::Public, []))
-        .collect::<anyhow::Result<_>>()?;
-    let num_unique_notes = feature_notes.iter().map(Note::id).collect::<BTreeSet<_>>().len();
-    assert_eq!(feature_notes.len(), num_unique_notes, "feature notes should be unique");
+        let feature_notes: Vec<Note> = (0..num_feature_notes)
+            .map(|_| builder.add_p2any_note(sponsor.id(), NoteType::Public, []))
+            .collect::<anyhow::Result<_>>()?;
+        let num_unique_notes = feature_notes.iter().map(Note::id).collect::<BTreeSet<_>>().len();
+        assert_eq!(feature_notes.len(), num_unique_notes, "feature notes should be unique");
 
-    let fee_entry = feature_note_fee.map(|fee| (feature_notes[0].script().root(), fee));
+        // All feature notes share one script root, so one schedule entry prices all of them.
+        let mut allowed_note_roots = BTreeSet::new();
+        let mut fee_entry = None;
+        if let Some(feature_note) = feature_notes.first() {
+            allowed_note_roots.insert(feature_note.script().root());
+            fee_entry = feature_note_fee.map(|fee| (feature_note.script().root(), fee));
+        }
 
-    // The account consumes the feature notes (all sharing one P2ANY root), so allowlist that root.
-    let mut allowed_note_roots = BTreeSet::new();
-    if let Some(feature_note) = feature_notes.first() {
-        allowed_note_roots.insert(feature_note.script().root());
+        let network_account = network_account(fee_entry, allowed_note_roots)?;
+        builder.add_account(network_account.clone())?;
+
+        // The sponsorship notes target the network account, so they can only be built once it
+        // exists.
+        let mut sponsorship_notes = Vec::new();
+        for (feature_note_idx, asset) in sponsorships {
+            let feature_note = feature_notes.get(feature_note_idx).with_context(|| {
+                format!("sponsorship should name an existing feature note, got {feature_note_idx}")
+            })?;
+            let note = Note::from(
+                FeeSponsorshipNote::builder()
+                    .sender(sponsor.id())
+                    .target_account(network_account.id())
+                    .feature_note_id(feature_note.id())
+                    .asset(asset)
+                    .generate_serial_number(&mut rng)
+                    .build()?,
+            );
+            builder.add_output_note(RawOutputNote::Full(note.clone()));
+            sponsorship_notes.push(note);
+        }
+
+        let mut mock_chain = builder.build()?;
+        mock_chain.prove_next_block()?;
+
+        Ok(Test {
+            mock_chain,
+            network_account,
+            feature_notes,
+            sponsorship_notes,
+        })
     }
-    let network_account = network_account(fee_entry, allowed_note_roots)?;
-    builder.add_account(network_account.clone())?;
+}
 
-    let mut sponsorship_notes = Vec::new();
-    for (feature_note_idx, asset) in sponsorships {
-        let note = Note::from(
-            FeeSponsorshipNote::builder()
-                .sender(sponsor.id())
-                .target_account(network_account.id())
-                .feature_note_id(feature_notes[feature_note_idx].id())
-                .asset(asset)
-                .generate_serial_number(&mut rng)
-                .build()?,
-        );
-        builder.add_output_note(RawOutputNote::Full(note.clone()));
-        sponsorship_notes.push(note);
+impl<S: test_builder::State> TestBuilder<S> {
+    /// Adds a FEE_SPONSORSHIP note that carries `asset` and pays for the feature note at
+    /// `feature_note_idx`. More than one sponsorship note can pay for the same feature note.
+    ///
+    /// The notes keep the order in which they were added.
+    fn sponsorship(mut self, feature_note_idx: usize, asset: Asset) -> Self {
+        self.sponsorships.push((feature_note_idx, asset));
+        self
     }
-
-    let mut mock_chain = builder.build()?;
-    mock_chain.prove_next_block()?;
-
-    Ok(Test {
-        mock_chain,
-        network_account,
-        feature_notes,
-        sponsorship_notes,
-    })
 }
 
 /// Consumes the given input notes against the network account - triggering the auth procedure's
@@ -238,11 +269,10 @@ async fn collects_sponsored_fee_for_a_bound_pair(
         network_account,
         feature_notes,
         sponsorship_notes,
-    } = build_test(
-        Some(AssetAmount::new(feature_note_fee)?),
-        1,
-        vec![(0, fee_asset(sponsored_amount)?)],
-    )?;
+    } = Test::builder()
+        .feature_note_fee(AssetAmount::new(feature_note_fee)?)
+        .sponsorship(0, fee_asset(sponsored_amount)?)
+        .build()?;
     let input_notes = if sponsorship_first {
         [sponsorship_notes[0].id(), feature_notes[0].id()]
     } else {
@@ -275,11 +305,11 @@ async fn multiple_sponsorships_top_up_one_feature_note(
         network_account,
         feature_notes,
         sponsorship_notes,
-    } = build_test(
-        Some(AssetAmount::new(FEE_AMOUNT)?),
-        1,
-        vec![(0, fee_asset(first_amount)?), (0, fee_asset(second_amount)?)],
-    )?;
+    } = Test::builder()
+        .feature_note_fee(AssetAmount::new(FEE_AMOUNT)?)
+        .sponsorship(0, fee_asset(first_amount)?)
+        .sponsorship(0, fee_asset(second_amount)?)
+        .build()?;
     let input_notes = [feature_notes[0].id(), sponsorship_notes[0].id(), sponsorship_notes[1].id()];
 
     let balance = collect_fee_balance(mock_chain, network_account, &input_notes).await?;
@@ -305,15 +335,13 @@ async fn sponsorships_are_attributed_by_note_id(
         network_account,
         feature_notes,
         sponsorship_notes,
-    } = build_test(
-        Some(AssetAmount::new(FEE_AMOUNT)?),
-        2,
-        vec![
-            (0, fee_asset(FEE_AMOUNT)?),
-            (1, fee_asset(FEE_AMOUNT / 2)?),
-            (1, fee_asset(FEE_AMOUNT / 2)?),
-        ],
-    )?;
+    } = Test::builder()
+        .feature_note_fee(AssetAmount::new(FEE_AMOUNT)?)
+        .num_feature_notes(2)
+        .sponsorship(0, fee_asset(FEE_AMOUNT)?)
+        .sponsorship(1, fee_asset(FEE_AMOUNT / 2)?)
+        .sponsorship(1, fee_asset(FEE_AMOUNT / 2)?)
+        .build()?;
 
     let mut input_notes = [
         feature_notes[0].id(),
@@ -346,7 +374,11 @@ async fn over_sponsoring_one_note_does_not_cover_another() -> anyhow::Result<()>
         network_account,
         feature_notes,
         sponsorship_notes,
-    } = build_test(Some(AssetAmount::new(FEE_AMOUNT)?), 2, vec![(0, fee_asset(2 * FEE_AMOUNT)?)])?;
+    } = Test::builder()
+        .feature_note_fee(AssetAmount::new(FEE_AMOUNT)?)
+        .num_feature_notes(2)
+        .sponsorship(0, fee_asset(2 * FEE_AMOUNT)?)
+        .build()?;
 
     let result = mock_chain
         .build_transaction(network_account.id())
@@ -373,6 +405,7 @@ async fn collect_rejects_expected_fee_asset_mismatch() -> anyhow::Result<()> {
             allowed_script_roots: BTreeSet::new(),
             allowed_tx_script_roots: BTreeSet::new(),
             fee_policy_manager: FeePolicyManager::mock(fee_faucet_id()?),
+            sponsorship_policy: SponsorshipPolicy::default(),
         })
         .with_component(BasicWallet)
         .with_component(fee_collector_component()?)
@@ -482,11 +515,12 @@ async fn aggregates_fees_across_pairs() -> anyhow::Result<()> {
         network_account,
         feature_notes,
         sponsorship_notes,
-    } = build_test(
-        Some(AssetAmount::new(FEE_AMOUNT)?),
-        2,
-        vec![(0, fee_asset(FEE_AMOUNT)?), (1, fee_asset(FEE_AMOUNT)?)],
-    )?;
+    } = Test::builder()
+        .feature_note_fee(AssetAmount::new(FEE_AMOUNT)?)
+        .num_feature_notes(2)
+        .sponsorship(0, fee_asset(FEE_AMOUNT)?)
+        .sponsorship(1, fee_asset(FEE_AMOUNT)?)
+        .build()?;
     let input_notes = [
         feature_notes[0].id(),
         sponsorship_notes[0].id(),
@@ -555,7 +589,7 @@ async fn unscheduled_feature_note_aborts_fee_collection() -> anyhow::Result<()> 
         network_account,
         feature_notes,
         ..
-    } = build_test(None, 1, vec![])?;
+    } = Test::builder().build()?;
 
     let result = mock_chain
         .build_transaction(network_account.id())
@@ -578,7 +612,7 @@ async fn zero_fee_feature_note_requires_no_sponsorship() -> anyhow::Result<()> {
         network_account,
         feature_notes,
         ..
-    } = build_test(Some(AssetAmount::ZERO), 1, vec![])?;
+    } = Test::builder().feature_note_fee(AssetAmount::ZERO).build()?;
     let input_notes = [feature_notes[0].id()];
 
     let balance = collect_fee_balance(mock_chain, network_account, &input_notes).await?;
@@ -637,16 +671,16 @@ async fn non_owner_cannot_set_fee_policy() -> anyhow::Result<()> {
 async fn uncovered_feature_note_fee_is_rejected(
     #[case] sponsored_amount: Option<u64>,
 ) -> anyhow::Result<()> {
-    let sponsorships = match sponsored_amount {
-        Some(amount) => vec![(0, fee_asset(amount)?)],
-        None => vec![],
-    };
+    let mut test_builder = Test::builder().feature_note_fee(AssetAmount::new(FEE_AMOUNT)?);
+    if let Some(amount) = sponsored_amount {
+        test_builder = test_builder.sponsorship(0, fee_asset(amount)?);
+    }
     let Test {
         mock_chain,
         network_account,
         feature_notes,
         sponsorship_notes,
-    } = build_test(Some(AssetAmount::new(FEE_AMOUNT)?), 1, sponsorships)?;
+    } = test_builder.build()?;
 
     let mut builder = mock_chain
         .build_transaction(network_account.id())
@@ -669,7 +703,10 @@ async fn sponsorship_with_wrong_asset_is_rejected() -> anyhow::Result<()> {
         network_account,
         feature_notes,
         sponsorship_notes,
-    } = build_test(Some(AssetAmount::new(FEE_AMOUNT)?), 1, vec![(0, other_asset(FEE_AMOUNT)?)])?;
+    } = Test::builder()
+        .feature_note_fee(AssetAmount::new(FEE_AMOUNT)?)
+        .sponsorship(0, other_asset(FEE_AMOUNT)?)
+        .build()?;
 
     let result = mock_chain
         .build_transaction(network_account.id())
@@ -876,56 +913,25 @@ async fn feature_notes_priced_in_different_assets_are_rejected() -> anyhow::Resu
 
 // A network account's own auth procedure sponsors every network output note automatically (via
 // `pay_fee` -> `create_network_note_sponsorships`), so the sponsor only needs to create the note.
-// Note creation goes through the standard `NoteCreator` component's `create_note` procedure (the
-// only note operation restricted to the account context); the sponsor's tx script computes the
-// recipient and tag, calls into it, and adds the network account target attachment itself.
 
-/// A sponsor account (funded with [`FEE_AMOUNT`] of the fee asset) and a target network account
-/// whose fee policy manager charges [`FEE_AMOUNT`] in the asset of the given faucet, plus the
-/// script creating a network note targeted at it; the sponsor's auth procedure sponsors the note.
-struct CreateTest {
-    mock_chain: MockChain,
-    sponsor: Account,
-    tx_script: TransactionScript,
-    foreign_inputs: (Account, miden_protocol::block::account_tree::AccountWitness),
-}
+/// Builds the transaction script that creates `num_notes` network notes targeted at `target_id`.
+///
+/// The notes differ only in their serial numbers, so they get different note IDs. Each block of
+/// note creation code leaves the operand stack as it found it, which lets the blocks follow each
+/// other.
+fn create_network_notes_tx_script(
+    target_id: AccountId,
+    num_notes: u32,
+) -> anyhow::Result<TransactionScript> {
+    // The created notes carry a standard note script so the host can assemble the public note.
+    let script_root = P2idNote::script_root().as_word();
+    let target_prefix = target_id.prefix().as_felt();
+    let target_suffix = target_id.suffix();
 
-fn build_create_test(target_fee_faucet: AccountId) -> anyhow::Result<CreateTest> {
-    // The created note carries a standard note script so the host can assemble the public note.
-    let script_root = P2idNote::script_root();
-    let serial_num = Word::from([21u32, 22, 23, 24]);
-
-    // The target is only queried for its fee policy via FPI, so its auth never runs and its
-    // allowlists can stay empty. It is built first because its ID is embedded in the creator tx
-    // script, whose root the sponsor must in turn allowlist.
-    let target_policy =
-        BasicConstantFeePolicy::new().with_fee(script_root, AssetAmount::new(FEE_AMOUNT)?);
-    let target_fee_policy_manager = FeePolicyManager::builder()
-        .fee_faucet_id(target_fee_faucet)
-        .active_fee_policy(target_policy.into())
-        .build();
-    let target = AccountBuilder::new([9; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: BTreeSet::new(),
-            allowed_tx_script_roots: BTreeSet::new(),
-            fee_policy_manager: target_fee_policy_manager,
-        })
-        .with_component(BasicWallet)
-        .build_existing()?;
-
-    let tx_script_src = format!(
-        r#"
-        use miden::protocol::note
-        use miden::protocol::output_note
-
-        use miden::standards::attachments::network_account_target
-        use miden::standards::note_tag
-
-        use {{NOTE_TYPE_PUBLIC}} from miden::protocol::note
-
-        @transaction_script
-        pub proc main
+    let create_note_blocks: String = (0..num_notes)
+        .map(|note_idx| {
+            format!(
+                r#"
             # => [pad(16)]
 
             # compute the recipient of the storage-less network note
@@ -956,115 +962,245 @@ fn build_create_test(target_fee_faucet: AccountId) -> anyhow::Result<CreateTest>
 
             exec.output_note::add_word_attachment
             # => [pad(6)]
-        end
-        "#,
-        target_prefix = target.id().prefix().as_felt(),
-        target_suffix = target.id().suffix(),
-        script_root = script_root.as_word(),
-        serial_num = serial_num,
-    );
-    let tx_script = CodeBuilder::default().compile_tx_script(tx_script_src)?;
-
-    // The sponsor runs the tx script that creates a network note, so its root must be allowlisted.
-    let sponsor_fee_policy_manager = FeePolicyManager::mock(fee_faucet_id()?);
-    let sponsor = AccountBuilder::new([8; 32])
-        .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: BTreeSet::new(),
-            allowed_tx_script_roots: BTreeSet::from([tx_script.root()]),
-            fee_policy_manager: sponsor_fee_policy_manager,
+"#,
+                serial_num = Word::from([21u32, 22, 23, 24 + note_idx]),
+            )
         })
-        .with_component(NoteCreator)
-        .with_assets([native_fee_asset(FEE_AMOUNT)?])
-        .build_existing()?;
+        .collect();
 
-    let mut builder = MockChain::builder();
-    builder.add_account(sponsor.clone())?;
-    builder.add_account(target.clone())?;
-    let mut mock_chain = builder.build()?;
-    mock_chain.prove_next_block()?;
+    let tx_script_src = format!(
+        r#"
+        use miden::protocol::note
+        use miden::protocol::output_note
 
-    let foreign_inputs = mock_chain.get_foreign_account_inputs(target.id())?;
+        use miden::standards::attachments::network_account_target
+        use miden::standards::note_tag
 
-    Ok(CreateTest {
-        mock_chain,
-        sponsor,
-        tx_script,
-        foreign_inputs,
-    })
+        use {{NOTE_TYPE_PUBLIC}} from miden::protocol::note
+
+        @transaction_script
+        pub proc main
+            {create_note_blocks}
+        end
+        "#
+    );
+
+    Ok(CodeBuilder::default().compile_tx_script(tx_script_src)?)
+}
+
+/// A sponsor account and a target network account, plus the script creating network notes targeted
+/// at the target.
+///
+/// The sponsor runs that script. Its auth procedure then creates one FEE_SPONSORSHIP note for each
+/// created network note, funded from the sponsor's vault.
+///
+/// [`SponsorshipPolicy::AtMostCollectedFees`] is the default. The sponsor collects in its
+/// configured fee asset but funds sponsorships in the native one, so the default configures it with
+/// the native fee faucet to make the two amounts comparable.
+struct SponsorshipTest {
+    mock_chain: MockChain,
+    sponsor: Account,
+    /// The network account the created notes are targeted at.
+    target_id: AccountId,
+    tx_script: TransactionScript,
+    foreign_inputs: (Account, AccountWitness),
+    /// The feature notes and their FEE_SPONSORSHIP notes, which the sponsor consumes to collect
+    /// fees. Empty when no feature note was requested.
+    input_notes: Vec<NoteId>,
+}
+
+#[bon::bon]
+impl SponsorshipTest {
+    /// Builds a [`SponsorshipTest`].
+    ///
+    /// The target charges [`FEE_AMOUNT`] for each network note, so the sponsor must fund each
+    /// sponsorship note with that amount. Its vault holds exactly the total it must fund.
+    ///
+    /// The build order is fixed by three dependencies: the target ID goes into the transaction
+    /// script, the script root and the feature note script root go into the sponsor's allowlists,
+    /// and the sponsorship notes name the sponsor as their target account.
+    #[builder]
+    fn new(
+        /// Faucet whose asset the target charges its fee in. Defaults to the native fee faucet.
+        target_fee_faucet: Option<AccountId>,
+        /// Faucet whose asset the sponsor collects fees in. Defaults to the native fee faucet.
+        sponsor_fee_faucet: Option<AccountId>,
+        /// How much the sponsor may sponsor. Defaults to
+        /// [`SponsorshipPolicy::AtMostCollectedFees`].
+        #[builder(default)]
+        sponsorship_policy: SponsorshipPolicy,
+        /// Number of network notes the transaction script creates. Defaults to 1.
+        #[builder(default = 1)]
+        num_network_notes: u32,
+        /// Number of feature notes the sponsor consumes to collect fees. Each one is priced at
+        /// [`FEE_AMOUNT`] and comes with a FEE_SPONSORSHIP note that covers it. Defaults to 0, in
+        /// which case the sponsor collects nothing.
+        #[builder(default)]
+        num_collected_notes: u32,
+    ) -> anyhow::Result<Self> {
+        let target_fee_faucet = target_fee_faucet.unwrap_or(native_fee_faucet_id()?);
+        let sponsor_fee_faucet = sponsor_fee_faucet.unwrap_or(native_fee_faucet_id()?);
+
+        // The target is only queried for its fee policy via FPI, so its auth never runs and its
+        // allowlists can stay empty.
+        let target_policy = BasicConstantFeePolicy::new()
+            .with_fee(P2idNote::script_root(), AssetAmount::new(FEE_AMOUNT)?);
+        let target_fee_policy_manager = FeePolicyManager::builder()
+            .fee_faucet_id(target_fee_faucet)
+            .active_fee_policy(target_policy.into())
+            .build();
+        let target = AccountBuilder::new([9; 32])
+            .account_type(AccountType::Public)
+            .with_components(AuthNetworkAccount::new(BTreeSet::new(), target_fee_policy_manager)?)
+            .with_component(BasicWallet)
+            .build_existing()?;
+
+        let tx_script = create_network_notes_tx_script(target.id(), num_network_notes)?;
+
+        let mut rng = RandomCoin::new(Word::empty());
+        let mut builder = MockChain::builder();
+        builder.add_account(target.clone())?;
+
+        let funder = builder.add_existing_wallet(Auth::IncrNonce)?;
+        let feature_notes: Vec<Note> = (0..num_collected_notes)
+            .map(|_| builder.add_p2any_note(funder.id(), NoteType::Public, []))
+            .collect::<anyhow::Result<_>>()?;
+
+        // The feature notes are P2ANY notes without assets, so they all share one script root. The
+        // sponsor prices that root and allowlists it, which lets it consume every feature note. It
+        // also runs the note creation script, so that root must be allowlisted as well.
+        let mut sponsor_policy = BasicConstantFeePolicy::new();
+        let mut sponsor_allowed_notes = BTreeSet::new();
+        if let Some(feature_note) = feature_notes.first() {
+            sponsor_policy = sponsor_policy
+                .with_fee(feature_note.script().root(), AssetAmount::new(FEE_AMOUNT)?);
+            sponsor_allowed_notes.insert(feature_note.script().root());
+        }
+        let sponsor_fee_policy_manager = FeePolicyManager::builder()
+            .fee_faucet_id(sponsor_fee_faucet)
+            .active_fee_policy(sponsor_policy.into())
+            .build();
+        let sponsor = AccountBuilder::new([8; 32])
+            .account_type(AccountType::Public)
+            .with_components(
+                AuthNetworkAccount::new(sponsor_allowed_notes, sponsor_fee_policy_manager)?
+                    .with_allowed_tx_scripts(BTreeSet::from([tx_script.root()]))
+                    .with_sponsorship_policy(sponsorship_policy),
+            )
+            .with_component(NoteCreator)
+            .with_assets([native_fee_asset(u64::from(num_network_notes) * FEE_AMOUNT)?])
+            .build_existing()?;
+        builder.add_account(sponsor.clone())?;
+
+        // The sponsorship notes target the sponsor, so they can only be built once it exists.
+        let mut input_notes = Vec::new();
+        for feature_note in &feature_notes {
+            let sponsorship_note = Note::from(
+                FeeSponsorshipNote::builder()
+                    .sender(feature_note.metadata().sender())
+                    .target_account(sponsor.id())
+                    .feature_note_id(feature_note.id())
+                    .asset(Asset::from(FungibleAsset::new(sponsor_fee_faucet, FEE_AMOUNT)?))
+                    .generate_serial_number(&mut rng)
+                    .build()?,
+            );
+            builder.add_output_note(RawOutputNote::Full(sponsorship_note.clone()));
+            input_notes.extend([feature_note.id(), sponsorship_note.id()]);
+        }
+
+        let mut mock_chain = builder.build()?;
+        mock_chain.prove_next_block()?;
+
+        let foreign_inputs = mock_chain.get_foreign_account_inputs(target.id())?;
+
+        Ok(SponsorshipTest {
+            mock_chain,
+            sponsor,
+            target_id: target.id(),
+            tx_script,
+            foreign_inputs,
+            input_notes,
+        })
+    }
+}
+
+impl SponsorshipTest {
+    /// Builds the sponsor's transaction. It runs the note creation script and consumes the feature
+    /// notes together with their sponsorship notes.
+    ///
+    /// The target is passed as a foreign account, since the sponsorship step reads its fee policy
+    /// through FPI.
+    fn transaction(&self) -> anyhow::Result<MockTransaction> {
+        let mut builder = self
+            .mock_chain
+            .build_transaction(self.sponsor.id())
+            .foreign_accounts([self.foreign_inputs.clone()])
+            .tx_script(self.tx_script.clone());
+        for note_id in &self.input_notes {
+            builder = builder.authenticated_input_note(*note_id);
+        }
+
+        builder.build()
+    }
+}
+
+/// Asserts that the output note at `network_note_idx` is a created network note and that the output
+/// note at `sponsorship_note_idx` is the FEE_SPONSORSHIP note that pays for it.
+///
+/// The sponsorship note must name the network note as its feature note and carry the target's fee
+/// in the native fee asset.
+fn assert_network_note_is_sponsored(
+    output_notes: &RawOutputNotes,
+    network_note_idx: usize,
+    sponsorship_note_idx: usize,
+) -> anyhow::Result<()> {
+    let network_note = output_notes.get_note(network_note_idx);
+    let sponsorship_note = output_notes.get_note(sponsorship_note_idx);
+
+    let network_recipient =
+        network_note.recipient().expect("recipient should exist for public notes");
+    assert_eq!(network_recipient.script().root(), P2idNote::script_root());
+
+    let sponsorship_recipient =
+        sponsorship_note.recipient().expect("recipient should exist for public notes");
+    assert_eq!(sponsorship_recipient.script().root(), FeeSponsorshipNote::script_root());
+
+    // The sponsorship note names the network note it pays for.
+    let sponsorship_storage =
+        FeeSponsorshipNoteStorage::try_from(sponsorship_recipient.storage().items())?;
+    assert_eq!(sponsorship_storage.feature_note_id(), network_note.id());
+
+    // The sponsorship note carries exactly the target's fee in the native fee asset.
+    assert_eq!(sponsorship_note.assets().as_slice(), &[native_fee_asset(FEE_AMOUNT)?]);
+
+    Ok(())
 }
 
 /// A network note whose target charges its fee in the native fee asset is sponsored by the auth
 /// procedure: the sponsorship note is funded with the fee from the sponsor's vault.
+///
+/// The sponsor collects nothing, so this also covers [`SponsorshipPolicy::Unlimited`] permitting a
+/// sponsorship that no collected fee backs. Its configured fee asset is not the native one, which
+/// shows that sponsorship notes are always funded in the native fee asset.
 #[tokio::test]
 async fn create_sponsorships_funds_note_in_native_fee_asset() -> anyhow::Result<()> {
-    let CreateTest {
-        mock_chain,
-        mut sponsor,
-        tx_script,
-        foreign_inputs,
-    } = build_create_test(native_fee_faucet_id()?)?;
-    let target_id = foreign_inputs.0.id();
+    let test = SponsorshipTest::builder()
+        .sponsor_fee_faucet(fee_faucet_id()?)
+        .sponsorship_policy(SponsorshipPolicy::Unlimited)
+        .build()?;
+    let mut sponsor = test.sponsor.clone();
 
-    let executed = mock_chain
-        .build_transaction(sponsor.id())
-        .foreign_accounts([foreign_inputs])
-        .tx_script(tx_script)
-        .build()?
-        .execute()
-        .await?;
+    let executed = test.transaction()?.execute().await?;
 
-    // The tx creates the feature note, which the auth procedure pairs with a sponsorship note.
+    // The transaction script creates the network note, then the auth procedure appends its
+    // sponsorship note.
     let output_notes = executed.output_notes();
-    assert_eq!(
-        output_notes.num_notes(),
-        2,
-        "the transaction should create the feature note and its sponsorship note"
-    );
-    let feature_note = output_notes
-        .iter()
-        .find(|note| {
-            note.recipient()
-                .is_some_and(|recipient| recipient.script().root() == P2idNote::script_root())
-        })
-        .expect("the P2ID feature note should be created");
-    let sponsorship_note = output_notes
-        .iter()
-        .find(|note| {
-            note.recipient().is_some_and(|recipient| {
-                recipient.script().root() == FeeSponsorshipNote::script_root()
-            })
-        })
-        .expect("the sponsorship note should be created");
+    assert_eq!(output_notes.num_notes(), 2);
+    assert_network_note_is_sponsored(output_notes, 0, 1)?;
 
-    // The sponsorship note names the feature note it pays for.
-    let sponsorship_storage = FeeSponsorshipNoteStorage::try_from(
-        sponsorship_note
-            .recipient()
-            .expect("a public sponsorship note has recipient details")
-            .storage()
-            .items(),
-    )?;
-    assert_eq!(
-        sponsorship_storage.feature_note_id(),
-        feature_note.id(),
-        "the sponsorship note should sponsor the feature note"
-    );
-
-    // It carries exactly the target's fee in the native fee asset.
-    assert_eq!(
-        sponsorship_note.assets().iter().copied().collect::<Vec<_>>(),
-        vec![native_fee_asset(FEE_AMOUNT)?],
-        "the sponsorship note should carry the target's fee in the native fee asset"
-    );
-
-    // The feature note is tagged for the target network account via its attachment.
-    let network_target = NetworkAccountTarget::try_from(feature_note.attachments())?;
-    assert_eq!(
-        network_target.target_id(),
-        target_id,
-        "the feature note should target the network account"
-    );
+    // The network note is tagged for the target network account via its attachment.
+    let network_target = NetworkAccountTarget::try_from(output_notes.get_note(0).attachments())?;
+    assert_eq!(network_target.target_id(), test.target_id);
 
     sponsor.apply_patch(executed.account_patch())?;
     assert_eq!(
@@ -1083,22 +1219,80 @@ async fn create_sponsorships_funds_note_in_native_fee_asset() -> anyhow::Result<
 /// is rejected: fee asset conversion is not supported yet.
 #[tokio::test]
 async fn create_sponsorships_reject_target_with_different_fee_asset() -> anyhow::Result<()> {
-    let CreateTest {
-        mock_chain,
-        sponsor,
-        tx_script,
-        foreign_inputs,
-    } = build_create_test(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1)?)?;
+    let test = SponsorshipTest::builder()
+        .target_fee_faucet(AccountId::try_from(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_1)?)
+        .sponsorship_policy(SponsorshipPolicy::Unlimited)
+        .build()?;
 
-    let result = mock_chain
-        .build_transaction(sponsor.id())
-        .foreign_accounts([foreign_inputs])
-        .tx_script(tx_script)
-        .build()?
-        .execute()
-        .await;
+    let result = test.transaction()?.execute().await;
 
     assert_transaction_executor_error!(result, ERR_FEE_MANAGER_TARGET_FEE_ASSET_MISMATCH);
+
+    Ok(())
+}
+
+/// One transaction that collects two sponsorship input notes and creates two sponsorship output
+/// notes, so the collection loop and the creation loop both run more than once.
+///
+/// Each created network note gets its own sponsorship note. The two collected fees cover the two
+/// sponsored fees exactly, so [`SponsorshipPolicy::AtMostCollectedFees`] accepts the transaction.
+#[tokio::test]
+async fn sponsors_and_collects_multiple_notes() -> anyhow::Result<()> {
+    let test = SponsorshipTest::builder().num_network_notes(2).num_collected_notes(2).build()?;
+
+    let executed = test.transaction()?.execute().await?;
+
+    let output_notes = executed.output_notes();
+    assert_eq!(output_notes.num_notes(), 4);
+
+    // The transaction script creates both network notes, then the auth procedure appends their
+    // sponsorship notes in the same order.
+    assert_network_note_is_sponsored(output_notes, 0, 2)?;
+    assert_network_note_is_sponsored(output_notes, 1, 3)?;
+
+    Ok(())
+}
+
+// SPONSORSHIP POLICY
+// ================================================================================================
+
+/// Under [`SponsorshipPolicy::AtMostCollectedFees`], a sponsorship that no collected fee backs is
+/// rejected.
+#[tokio::test]
+async fn sponsoring_more_than_collected_is_rejected() -> anyhow::Result<()> {
+    let test = SponsorshipTest::builder().build()?;
+
+    let result = test.transaction()?.execute().await;
+
+    assert_transaction_executor_error!(result, ERR_NETWORK_ACCOUNT_SPONSORED_FEES_EXCEED_COLLECTED);
+
+    Ok(())
+}
+
+/// Under [`SponsorshipPolicy::AtMostCollectedFees`], a sponsorship the collected fees cover is
+/// accepted.
+#[tokio::test]
+async fn sponsoring_within_collected_is_accepted() -> anyhow::Result<()> {
+    let test = SponsorshipTest::builder().num_collected_notes(1).build()?;
+
+    let executed = test.transaction()?.execute().await?;
+
+    assert_eq!(executed.output_notes().num_notes(), 2);
+    assert_network_note_is_sponsored(executed.output_notes(), 0, 1)?;
+
+    Ok(())
+}
+
+/// Under [`SponsorshipPolicy::AtMostCollectedFees`], sponsoring while configured with a fee asset
+/// other than the native one is rejected: the collected and sponsored amounts would be denominated
+/// in different assets, so the cap would not bound anything.
+#[tokio::test]
+async fn sponsoring_with_a_non_native_fee_asset_is_rejected() -> anyhow::Result<()> {
+    let test = SponsorshipTest::builder().sponsor_fee_faucet(fee_faucet_id()?).build()?;
+
+    let result = test.transaction()?.execute().await;
+
+    assert_transaction_executor_error!(result, ERR_NETWORK_ACCOUNT_FEE_ASSET_NOT_NATIVE);
 
     Ok(())
 }

--- a/crates/miden-testing/tests/scripts/fee_manager.rs
+++ b/crates/miden-testing/tests/scripts/fee_manager.rs
@@ -350,11 +350,13 @@ async fn estimate_note_fee_returns_scheduled_fee(
     // or input note, so allowlist both the estimate script and the consumed note.
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: BTreeSet::from([consumed_root]),
-            allowed_tx_script_roots: BTreeSet::from([tx_script.root()]),
-            fee_policy_manager: fee_policy_manager(&BTreeSet::from([consumed_root]))?,
-        })
+        .with_components(
+            AuthNetworkAccount::new(
+                BTreeSet::from([consumed_root]),
+                fee_policy_manager(&BTreeSet::from([consumed_root]))?,
+            )?
+            .with_allowed_tx_scripts(BTreeSet::from([tx_script.root()])),
+        )
         .with_component(BasicWallet)
         .build_existing()?;
 
@@ -394,11 +396,10 @@ async fn estimate_note_fee_rejects_non_u32_timeframe_or_priority(
 
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: BTreeSet::new(),
-            allowed_tx_script_roots: BTreeSet::from([tx_script.root()]),
-            fee_policy_manager: fee_policy_manager(&BTreeSet::new())?,
-        })
+        .with_components(
+            AuthNetworkAccount::new(BTreeSet::new(), fee_policy_manager(&BTreeSet::new())?)?
+                .with_allowed_tx_scripts(BTreeSet::from([tx_script.root()])),
+        )
         .with_component(BasicWallet)
         .build_existing()?;
 
@@ -440,11 +441,10 @@ async fn estimate_note_fee_aborts_for_unscheduled_root() -> anyhow::Result<()> {
 
     let account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: BTreeSet::new(),
-            allowed_tx_script_roots: BTreeSet::from([tx_script.root()]),
-            fee_policy_manager: fee_policy_manager(&BTreeSet::new())?,
-        })
+        .with_components(
+            AuthNetworkAccount::new(BTreeSet::new(), fee_policy_manager(&BTreeSet::new())?)?
+                .with_allowed_tx_scripts(BTreeSet::from([tx_script.root()])),
+        )
         .with_component(BasicWallet)
         .build_existing()?;
 
@@ -484,11 +484,7 @@ async fn estimate_note_fee_dispatches_to_custom_policy_via_fpi() -> anyhow::Resu
     // The foreign account's auth never runs under FPI, so its allowlists can stay empty.
     let foreign_account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: BTreeSet::new(),
-            allowed_tx_script_roots: BTreeSet::new(),
-            fee_policy_manager,
-        })
+        .with_components(AuthNetworkAccount::new(BTreeSet::new(), fee_policy_manager)?)
         .with_component(BasicWallet)
         .build_existing()?;
 
@@ -629,11 +625,10 @@ async fn get_fee_asset_id_returns_configured_fee_asset_via_fpi() -> anyhow::Resu
     // The foreign account's auth never runs under FPI, so its allowlists can stay empty.
     let foreign_account = AccountBuilder::new([1; 32])
         .account_type(AccountType::Public)
-        .with_components(Auth::NetworkAccount {
-            allowed_script_roots: BTreeSet::new(),
-            allowed_tx_script_roots: BTreeSet::new(),
-            fee_policy_manager: fee_policy_manager(&BTreeSet::new())?,
-        })
+        .with_components(AuthNetworkAccount::new(
+            BTreeSet::new(),
+            fee_policy_manager(&BTreeSet::new())?,
+        )?)
         .with_component(BasicWallet)
         .build_existing()?;
 


### PR DESCRIPTION


## Problem

A network account pays for the network notes it creates. When the account pays the transaction fee, it also creates a `FEE_SPONSORSHIP` note for each network output note, funded from its own vault. This prepays the target account for the consumption of that note.

Independently, the account collects the fees that the `FEE_SPONSORSHIP` notes among its input notes prepaid.

Before this change, the two amounts were unrelated. An account could sponsor more than it collected, and thus pay for downstream consumers out of its own funds. Nothing prevented this.

## Solution

This PR adds the `SponsorshipPolicy` setting to the `AuthNetworkAccount` component. The setting has two values:

- `AtMostCollectedFees` (the default): the fees moved into sponsorship notes must not exceed the fees collected in the same transaction. The account only forwards value that it collected.
- `Unlimited`: sponsorships are funded from the account's vault without a bound. This is the behavior from before this change. Accounts that must subsidize their own outgoing notes select this value.

The setting is fixed at deployment. The auth procedure reads it from the initial storage state of the transaction, and there is no procedure to change it (at least not yet - we can add this later).

## How it works

`SponsorshipPolicy` owns a new standardized storage slot. The slot holds `[discriminant, 0, 0, 0]`.

To make the check possible, two MASM procedures now return the amounts they moved:

- `fees::create_network_note_sponsorships` returns the total amount that it moved into the sponsorship notes it created.
- `fee::pay_fee` passes that total through to its caller.

The network account auth procedure then makes two assertions when the policy is `AtMostCollectedFees`:

1. The collected amount must be greater than or equal to the sponsored amount.
2. If the transaction sponsored a non-zero amount, the account's configured fee asset must be the native fee asset. Collected fees use the configured asset, but sponsorship notes are funded in the native asset. If the two assets are different, the amounts are not comparable. An account that creates no network notes is not affected by this rule.

## Test Refactor

The sponsorship and collection tests were refactored to a hopefully better state to make it easier to follow how a test is setup. This became necessary after the PR initially required extended helpers to cover the new functionality, and it became very hard to follow.

addresses one of the items in https://github.com/0xMiden/protocol/issues/3345
