### PR TITLE
fix(hooks): stop miscounting reviewer diligence notes as blocking findings

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -90,9 +90,13 @@ then the incompleteness itself is NOT a Critical or Important finding - the chan
 ## Output Format
 
 ```
+<BLOCK or APPROVE>: [see the closing instructions at the end of this file. This must
+be the literal first thing in your response, substituting the real token for what's
+inside the angle brackets - do not write this line verbatim.]
+
 ## Review Summary
 
-**Verdict:** APPROVE | REQUEST CHANGES
+**Verdict:** APPROVE | BLOCK
 
 **Overview:** [1-2 sentences summarizing the change and overall assessment]
 
@@ -109,6 +113,14 @@ then the incompleteness itself is NOT a Critical or Important finding - the chan
 - [Specific positive observation - always include at least one]
 ```
 
+### Empty Sections
+
+If `### Critical Issues` or `### Important Issues` has no findings, its first line must
+open with `None.` - either bare, or with a period-terminated explanation on the same
+line; further explanation on the lines below is fine either way. The rule cuts the
+other way too: if the section has any real finding, do not write `None.` anywhere in
+it - list the finding(s) directly. A section never contains both.
+
 ## Rules
 
 1. Every Critical and Important finding must include a specific fix recommendation
@@ -119,6 +131,7 @@ then the incompleteness itself is NOT a Critical or Important finding - the chan
 6. Be direct. "This will panic when the vec is empty" not "this might possibly be a concern"
 7. New code without tests is always a finding
 8. Respect the user's intent. Your prompt may name what the user asked for this session - treat deliberate, explicitly-requested choices as intended, not mistakes, and don't recommend reversing them. Intent does not excuse a real defect: a genuine correctness bug or exploitable risk stays Critical or Important even when requested. Downgrade to a Nit only when your objection is stylistic or defensive-programming preference, not a real defect.
+9. Never mix `None.` with a real finding in the same section (see Empty Sections above). `### Critical Issues` / `### Important Issues` either has `None.` as its entire content, or lists real findings with no `None.` line anywhere in it - never both.
 
 **Critical and Important findings block the merge; Nits are surfaced but do not block.** Address the blocking findings before pushing.
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -95,6 +95,10 @@ then classify it as a NOTE, not CRITICAL or WARNING. Surfacing it keeps it visib
 ## Output Format
 
 ```
+<BLOCK or CLEAN>: [see the Verdicts below. This must be the literal first thing in
+your response, substituting the real token for what's inside the angle brackets - do
+not write this line verbatim.]
+
 ## Adversarial Security Review
 
 **Verdict:** BLOCK | CLEAN
@@ -118,9 +122,19 @@ then classify it as a NOTE, not CRITICAL or WARNING. Surfacing it keeps it visib
 - **BLOCK** - Any Critical or Warning finding. Do not merge until addressed.
 - **CLEAN** - No Critical or Warning findings (Notes, if any, are surfaced but do not block). Safe to merge.
 
+### Empty Sections
+
+If `### Critical Findings` or `### Warnings` has no findings, its first line must open
+with `None.` - either bare, or with a period-terminated explanation on the same line
+("None. I tried X, Y, Z..."); further diligence notes on the lines below are fine
+either way. The rule cuts the other way too: if the section has any real finding, do
+not write `None.` anywhere in it - list the finding(s) directly. A section never
+contains both.
+
 ## Anti-Patterns - Do NOT Do These
 
 - **"LGTM, no issues found"** - Be skeptical if you found nothing, but don't fabricate findings. If a change is genuinely clean, use the CLEAN verdict.
+- **Mixing `None.` with a real finding in the same section** - `### Warnings` / `### Critical Findings` either has `None.` as its entire content, or lists real findings with no `None.` line anywhere in it. Never both.
 - **Pulling punches** - "This might possibly be a minor concern" is useless. Say what's wrong.
 - **Restating the diff** - "This function was added" is not a finding. What's WRONG with it?
 - **Cosmetic-only findings** - Reporting style issues while missing a panic is worse than no review.

--- a/.claude/hooks/_review.py
+++ b/.claude/hooks/_review.py
@@ -10,6 +10,13 @@ Severity policy (single source of truth, not the agent prompts):
   BLOCK on  ### Critical Issues | ### Critical Findings
             ### Important Issues | ### Warnings
   IGNORE    ### Nits | ### Notes | ### What's Done Well | ### Summary
+
+Both prompts also require the response to open with a bare `BLOCK:` /
+`CLEAN:` / `APPROVE:` token. `_evaluate_reviewer` treats its absence as
+malformed output (blocks), and blocks on a leading `BLOCK:` even when the
+section-based count comes back 0 - a backstop for a section that opens with
+`None.` but is mistakenly followed by real findings; see
+`_count_blocking_findings`.
 """
 
 from __future__ import annotations
@@ -29,8 +36,21 @@ _ANY_THIRD_LEVEL = re.compile(r"^### ")
 _SECOND_LEVEL = re.compile(r"^##[^#]|^## ")
 # A bullet line `-` or `*` followed by content.
 _BULLET = re.compile(r"^\s*[-*]\s+\S")
-# Absence markers we explicitly do NOT count as findings.
-_ABSENCE = re.compile(r"^\s*[-*]\s+(None|N/A|n/a)\.?\s*$")
+# A line that is just "None"/"N/A" - bare, bolded, or with a period-
+# terminated explanation on the same line ("None. I tried X, Y, Z..."). No
+# ":" terminator (too easy for a real finding like "None: no authz check"
+# to slip through) - a real finding like "None of the callers validate X"
+# never matches either way, since there's no "." or end-of-line right after
+# "None".
+_ABSENCE = re.compile(r"^\s*(?:[-*]\s+)?\**(none|n/a)\**(?:\.\**(?:\s.*)?|\s*)$", re.IGNORECASE)
+# The mandatory leading token both prompts require, tolerating markdown bold
+# around it (the same habit `_ABSENCE` above tolerates) so the same model
+# bolding its own verdict doesn't turn a clean review into a spurious block.
+# Matched as its own line anywhere in the text before the review body starts
+# (see `_leading_verdict`) rather than strictly at byte 0, since a model
+# occasionally prefaces it with a sentence or two before the formatted
+# token line.
+_LEADING_VERDICT = re.compile(r"^\s*\**(BLOCK|CLEAN|APPROVE)\**\s*:", re.IGNORECASE | re.MULTILINE)
 
 
 @dataclass
@@ -115,7 +135,9 @@ def _run_reviewer(agent: str, prompt: str, cwd: str | None) -> tuple[int, str, s
 
 def _evaluate_reviewer(result: ReviewerResult) -> tuple[bool, str]:
     """Return `(cleared, rendered)` for one reviewer. `cleared` is False if
-    this reviewer blocks (crash, malformed output, or a blocking finding)."""
+    this reviewer blocks: a crash, malformed output (no `### ` sections, or
+    no leading verdict token), a blocking finding, or a self-reported BLOCK
+    verdict despite a 0 count."""
     lines = [f"=== {result.name} ==="]
 
     if result.returncode != 0:
@@ -127,9 +149,18 @@ def _evaluate_reviewer(result: ReviewerResult) -> tuple[bool, str]:
         return False, "\n".join(lines)
 
     if not _looks_like_review(result.stdout):
-        lines.append(f"{result.name}: empty or malformed output; treating as block.")
+        lines.append(f"{result.name}: empty output or no `### ` sections found; treating as block.")
         if result.stdout:
             lines.append(result.stdout)
+        return False, "\n".join(lines)
+
+    leading = _leading_verdict(result.stdout)
+    if not leading:
+        lines.append(
+            f"{result.name}: response did not open with a `BLOCK:`/`CLEAN:`/`APPROVE:` token "
+            "as its prompt requires; treating as block."
+        )
+        lines.append(result.stdout)
         return False, "\n".join(lines)
 
     lines.append(result.stdout)
@@ -137,6 +168,14 @@ def _evaluate_reviewer(result: ReviewerResult) -> tuple[bool, str]:
     if count > 0:
         lines.append(f"{result.name}: {count} blocking finding(s) (Critical/Important/Warning).")
         return False, "\n".join(lines)
+
+    if leading.group(1).upper() == "BLOCK":
+        lines.append(
+            f"{result.name}: 0 structured findings counted, but the agent's own leading "
+            "verdict says BLOCK; treating as block."
+        )
+        return False, "\n".join(lines)
+
     lines.append(f"{result.name}: no blocking findings (nits/notes do not block).")
     return True, "\n".join(lines)
 
@@ -145,26 +184,51 @@ def _looks_like_review(text: str) -> bool:
     return bool(text.strip()) and any(line.startswith("### ") for line in text.splitlines())
 
 
+def _leading_verdict(text: str) -> re.Match[str] | None:
+    """Find the mandatory leading token, searching only the text before the
+    first `##`/`### ` heading - i.e. the preamble the prompts require it to
+    open with. A plain `.match()` at byte 0 is too strict: a model
+    occasionally writes a sentence or two before the token line even though
+    told to lead with it. Restricting the search to the preamble (rather
+    than the whole document) keeps a quoted example of the token deeper in
+    the review body from being mistaken for the real one.
+    """
+    preamble = text.split("\n##", 1)[0]
+    return _LEADING_VERDICT.search(preamble)
+
+
 def _count_blocking_findings(text: str) -> int:
     """Walk the reviewer's markdown line by line. Count bullets that appear
     under `### Critical Issues / ### Important Issues / ### Warnings`
-    headings, treating any other `### ` heading or `##` heading as the end of
-    the current section. Bullets matching `- None.` / `- N/A` are explicitly
-    skipped — those are absence markers, not findings.
+    headings, treating any other `### ` heading or `##` heading as the end
+    of the current section. A section is cleared - and the rest of its
+    lines ignored - as soon as its first non-blank content line matches
+    `_ABSENCE`. A stray absence marker elsewhere in the section only skips
+    itself, so a real finding followed by a later `- None.` isn't
+    double-counted.
     """
     count = 0
     in_block = False
+    section_cleared = False
+    saw_content = False
     for line in text.splitlines():
         if _SECOND_LEVEL.match(line):
             in_block = False
             continue
         if _ANY_THIRD_LEVEL.match(line):
             in_block = bool(_BLOCKING_HEADINGS.match(line))
+            section_cleared = False
+            saw_content = False
             continue
-        if not in_block:
+        if not in_block or section_cleared:
+            continue
+        if not line.strip():
             continue
         if _ABSENCE.match(line):
+            if not saw_content:
+                section_cleared = True
             continue
+        saw_content = True
         if _BULLET.match(line):
             count += 1
     return count

--- a/.claude/hooks/tests/test_hooks.py
+++ b/.claude/hooks/tests/test_hooks.py
@@ -189,6 +189,232 @@ def test_count_blocking_findings_ignores_absence_markers() -> None:
     assert _review._count_blocking_findings(review) == 0
 
 
+def test_count_blocking_findings_ignores_notes_after_bare_none() -> None:
+    """Reproduces the reported bug: the reviewer opens the section with a bare
+    "None." line, then explains what it tried below it. Those bullets must
+    not count as findings."""
+    import _review
+
+    review = "\n".join(
+        [
+            "### Warnings",
+            "",
+            "None.",
+            "",
+            "I specifically tried and failed to break the following:",
+            "- Attachment-shadowing.",
+            "- Private/malformed targets.",
+            "### Notes",
+            "- consider adding a regression test",
+        ]
+    )
+    assert _review._count_blocking_findings(review) == 0
+
+
+def test_count_blocking_findings_ignores_notes_after_same_line_none() -> None:
+    """Reproduces the exact reported bug verbatim: "None." and the
+    explanation share one line, e.g. "None. I specifically tried and failed
+    to break the following:", followed by diligence bullets. Those bullets
+    must not count as findings."""
+    import _review
+
+    review = "\n".join(
+        [
+            "### Warnings",
+            "",
+            "None. I specifically tried and failed to break the following:",
+            "",
+            "- **Attachment-shadowing.** `ensure_presence` validates every attachment.",
+            "- **Private/malformed targets.** `TryFrom` terminates in `NetworkAccountTarget::new`.",
+            "### Notes",
+            "- consider adding a regression test",
+        ]
+    )
+    assert _review._count_blocking_findings(review) == 0
+
+
+def test_count_blocking_findings_does_not_treat_none_of_as_absence() -> None:
+    """A finding starting with the word "None" (e.g. "None of the callers
+    validate this") is not an absence marker - the trailing text keeps it
+    off the exact-line match, so it must still be counted."""
+    import _review
+
+    review = "\n".join(
+        [
+            "### Important Issues",
+            "- None of the new branches are covered by a test.",
+        ]
+    )
+    assert _review._count_blocking_findings(review) == 1
+
+
+def test_count_blocking_findings_treats_bold_none_as_absence_marker() -> None:
+    """Reviewers habitually bold things, and the period can land inside or
+    outside the closing `**` (`**None.**` or `**None**.`). Both, bare or
+    bulleted, must clear the section exactly like a plain `None.` would."""
+    import _review
+
+    review = "\n".join(
+        [
+            "### Warnings",
+            "**None.**",
+            "- Attachment-shadowing details ruled out.",
+            "### Critical Issues",
+            "- **None.**",
+            "- Private targets ruled out.",
+        ]
+    )
+    assert _review._count_blocking_findings(review) == 0
+
+
+def test_count_blocking_findings_counts_real_finding_before_trailing_none() -> None:
+    """A real finding bullet followed later by a stray `- None.` bullet must
+    count once, not twice - the `None.` special-case only applies when it's
+    the section's first content line; elsewhere it's just skipped, not
+    treated as clearing anything."""
+    import _review
+
+    review = "\n".join(
+        [
+            "### Important Issues",
+            "- foo.rs:10 will panic on empty input",
+            "- None.",
+        ]
+    )
+    assert _review._count_blocking_findings(review) == 1
+
+
+def test_count_blocking_findings_clearing_does_not_leak_into_next_section() -> None:
+    """A `None.`-cleared section must not suppress a *different* blocking
+    section that follows it - `section_cleared` has to reset on every new
+    `### ` heading, not just stay set once tripped."""
+    import _review
+
+    review = "\n".join(
+        [
+            "### Warnings",
+            "None. I tried the following:",
+            "- attachment shadowing ruled out",
+            "### Critical Issues",
+            "- foo.rs:10 unchecked unwrap panics on empty input",
+        ]
+    )
+    assert _review._count_blocking_findings(review) == 1
+
+
+# _evaluate_reviewer's verdict backstop: a section can be structurally
+# cleared (a "None." opener followed by content that reads as ordinary
+# bullets) while genuinely containing real findings further down - the
+# section-clearing logic in _count_blocking_findings can't tell diligence
+# bullets from real ones once a section is cleared. The agent's own leading
+# verdict token is a second, independent signal that catches this case even
+# when the structured count comes back 0.
+def test_evaluate_reviewer_blocks_on_self_reported_block_despite_zero_count() -> None:
+    import _review
+
+    stdout = (
+        "BLOCK:\n\n"
+        "## Adversarial Security Review\n\n"
+        "### Warnings\n"
+        "None. But actually see the Critical Findings below.\n\n"
+        "### Notes\n"
+        "- unrelated note\n"
+    )
+    result = _review.ReviewerResult(name="SECURITY REVIEWER", returncode=0, stdout=stdout, stderr="")
+    cleared, rendered = _review._evaluate_reviewer(result)
+    assert cleared is False
+    assert "verdict says BLOCK" in rendered
+
+
+@pytest.mark.parametrize("token", ["CLEAN:", "APPROVE:"])
+def test_evaluate_reviewer_clears_on_zero_count_for_either_clean_token(token: str) -> None:
+    """Both `CLEAN:` (security-reviewer) and `APPROVE:` (code-reviewer) must
+    clear a 0-count review."""
+    import _review
+
+    stdout = f"{token}\n\n## Review Summary\n\n### Critical Issues\nNone.\n### Important Issues\nNone.\n"
+    result = _review.ReviewerResult(name="REVIEWER", returncode=0, stdout=stdout, stderr="")
+    cleared, _rendered = _review._evaluate_reviewer(result)
+    assert cleared is True
+
+
+def test_evaluate_reviewer_blocks_when_leading_token_is_missing() -> None:
+    """Without the mandatory leading token, block with a diagnosable reason
+    instead of silently running with the backstop disabled."""
+    import _review
+
+    stdout = "## Adversarial Security Review\n\n### Warnings\nNone.\n### Notes\n- fine\n"
+    result = _review.ReviewerResult(name="SECURITY REVIEWER", returncode=0, stdout=stdout, stderr="")
+    cleared, rendered = _review._evaluate_reviewer(result)
+    assert cleared is False
+    assert "did not open with a" in rendered
+
+
+@pytest.mark.parametrize("token", ["**APPROVE:**", "**APPROVE**:"])
+def test_evaluate_reviewer_clears_on_bolded_leading_token(token: str) -> None:
+    """The same model that bolds diligence notes bolds its own leading
+    token too - must not turn a clean review into a spurious block."""
+    import _review
+
+    stdout = f"{token}\n\n## Review Summary\n\n### Critical Issues\nNone.\n### Important Issues\nNone.\n"
+    result = _review.ReviewerResult(name="CODE REVIEWER", returncode=0, stdout=stdout, stderr="")
+    cleared, _rendered = _review._evaluate_reviewer(result)
+    assert cleared is True
+
+
+def test_evaluate_reviewer_clears_when_token_follows_a_preamble_sentence() -> None:
+    """Reproduces an observed failure: the reviewer wrote a sentence or two
+    (e.g. noting it couldn't run the test suite) before its own leading
+    token line, instead of leading with the bare token as instructed. The
+    token must still be found - not just at byte 0."""
+    import _review
+
+    stdout = (
+        "I could not execute the test suite in this session, so I traced the "
+        "changes by hand instead.\n\n"
+        "APPROVE:\n\n"
+        "## Review Summary\n\n### Critical Issues\nNone.\n### Important Issues\nNone.\n"
+    )
+    result = _review.ReviewerResult(name="CODE REVIEWER", returncode=0, stdout=stdout, stderr="")
+    cleared, _rendered = _review._evaluate_reviewer(result)
+    assert cleared is True
+
+
+def test_evaluate_reviewer_ignores_token_quoted_later_in_the_review_body() -> None:
+    """The preamble search must not reach past the first `##` heading - a
+    token-shaped line appearing on its own line deeper in the review body
+    (e.g. an illustrative example, which would match `_LEADING_VERDICT` in
+    isolation) must not be mistaken for the real leading token when the real
+    one is genuinely missing."""
+    import _review
+
+    stdout = (
+        "## Review Summary\n\n"
+        "### Nits\n"
+        "- An example of what a leading token line looks like:\n"
+        "CLEAN:\n"
+        "- (illustrative only, not this response's own declaration)\n"
+        "### Critical Issues\nNone.\n### Important Issues\nNone.\n"
+    )
+    result = _review.ReviewerResult(name="CODE REVIEWER", returncode=0, stdout=stdout, stderr="")
+    cleared, rendered = _review._evaluate_reviewer(result)
+    assert cleared is False
+    assert "did not open with a" in rendered
+
+
+def test_evaluate_reviewer_count_takes_precedence_over_self_reported_clean() -> None:
+    """A structured finding always blocks, even if the agent's own leading
+    token contradicts it (e.g. says CLEAN). The count check must run before
+    the verdict-based backstop, not after."""
+    import _review
+
+    stdout = "CLEAN:\n\n## Review Summary\n\n### Critical Issues\n- foo.rs:1 real bug\n"
+    result = _review.ReviewerResult(name="CODE REVIEWER", returncode=0, stdout=stdout, stderr="")
+    cleared, rendered = _review._evaluate_reviewer(result)
+    assert cleared is False
+    assert "1 blocking finding(s)" in rendered
+
+
 # pre_pr_review reviews the whole PR against the integration branch. Verify the
 # base resolves to origin/HEAD when set and falls back to origin/next otherwise.
 def _fake_proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> SimpleNamespace:


### PR DESCRIPTION
## Summary

The `security-reviewer` / `code-reviewer` agents sometimes clear a section with prose like:

```
### Warnings

None. I specifically tried and failed to break the following:

- **Attachment-shadowing.** ...
- **Private/malformed targets.** ...
```

This is meant as "CLEAN, and here's the diligence I did," but `_review._count_blocking_findings` counted every bullet in a blocking section as a finding, producing a false `SECURITY REVIEWER: 7 blocking finding(s)` verdict even though the reviewer intended CLEAN.