### PR TITLE
refactor: followup to send notes script migration

### DIFF
--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/common.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/common.masm
@@ -31,10 +31,14 @@ use miden::protocol::tx
 # https://github.com/0xMiden/miden-vm/issues/3429 is fixed.
 pub const WORD_NUM_ELEMENTS = 4
 
-# Memory addresses of the payload and of the two header elements it starts with.
-const PAYLOAD_ADDR = 0
+# Memory address at which the `send_notes` scripts write the payload, and the address of the note
+# count, which is the payload header's first element.
+pub const PAYLOAD_ADDR = 0
 pub const NUM_NOTES_ADDR = PAYLOAD_ADDR
-const EXPIRATION_DELTA_ADDR = PAYLOAD_ADDR + 1
+
+# Element offset of the expiration delta, the payload header's second element, relative to the
+# payload start.
+const EXPIRATION_DELTA_OFFSET = 1
 
 # Memory address of the first note record, which starts right after the header word.
 pub const NOTES_START_ADDR = PAYLOAD_ADDR + WORD_NUM_ELEMENTS
@@ -62,11 +66,11 @@ const ERR_SEND_NOTES_PAYLOAD_EMPTY = "send notes payload must not be empty"
 # PUBLIC INTERFACE
 # =================================================================================================
 
-#! Loads the payload committed to by the transaction script argument from the advice map into
-#! memory at `PAYLOAD_ADDR` and sets the transaction expiration delta if requested.
+#! Writes the payload committed to by the transaction script argument from the advice map to
+#! memory at `payload_addr` and sets the transaction expiration delta if requested.
 #!
 #! Inputs:
-#!   Operand stack: [PAYLOAD_COMMITMENT, pad(12)]
+#!   Operand stack: [payload_addr, PAYLOAD_COMMITMENT, pad(11)]
 #!   Advice map: {
 #!     PAYLOAD_COMMITMENT: [[payload]]
 #!   }
@@ -74,6 +78,7 @@ const ERR_SEND_NOTES_PAYLOAD_EMPTY = "send notes payload must not be empty"
 #!   Operand stack: [pad(16)]
 #!
 #! Where:
+#! - payload_addr is the memory address at which to write the payload.
 #! - PAYLOAD_COMMITMENT is the sequential hash of the payload elements.
 #! - payload is the element stream described in the file header.
 #!
@@ -84,37 +89,38 @@ const ERR_SEND_NOTES_PAYLOAD_EMPTY = "send notes payload must not be empty"
 #! - the expiration delta is non-zero and not in the range 1..=0xFFFF.
 #!
 #! Invocation: exec
-pub proc load_payload(payload_commitment: word)
+pub proc write_payload_to_memory(payload_addr: u32, payload_commitment: word)
     # push the payload from the advice map onto the advice stack, together with its length
-    adv.push_mapvaln
-    # OS => [PAYLOAD_COMMITMENT, pad(12)]
+    movdn.4 adv.push_mapvaln
+    # OS => [PAYLOAD_COMMITMENT, payload_addr, pad(11)]
     # AS => [num_elements, [payload]]
 
     # SAFETY: if the provided num_elements is invalid, the commitment check would fail in
     # pipe_preimage_to_memory so we assume validity and only do basic checks to protect against
     # invalid advice inputs.
     adv_push u32assert.err=ERR_SEND_NOTES_PAYLOAD_LENGTH_INVALID
-    # OS => [num_elements, PAYLOAD_COMMITMENT, pad(12)]
+    # OS => [num_elements, PAYLOAD_COMMITMENT, payload_addr, pad(11)]
     # AS => [[payload]]
 
     u32divmod.WORD_NUM_ELEMENTS
-    # => [remainder, num_words, PAYLOAD_COMMITMENT, pad(12)]
+    # => [remainder, num_words, PAYLOAD_COMMITMENT, payload_addr, pad(11)]
 
     eq.0 assert.err=ERR_SEND_NOTES_PAYLOAD_NOT_WORD_ALIGNED
-    # => [num_words, PAYLOAD_COMMITMENT, pad(12)]
+    # => [num_words, PAYLOAD_COMMITMENT, payload_addr, pad(11)]
 
     dup neq.0 assert.err=ERR_SEND_NOTES_PAYLOAD_EMPTY
-    # => [num_words, PAYLOAD_COMMITMENT, pad(12)]
+    # => [num_words, PAYLOAD_COMMITMENT, payload_addr, pad(11)]
 
-    # pipe the payload to memory and validate it matches the PAYLOAD_COMMITMENT
-    push.PAYLOAD_ADDR swap
-    # => [num_words, write_ptr, PAYLOAD_COMMITMENT, pad(12)]
+    # pipe the payload to memory and validate it matches the PAYLOAD_COMMITMENT, keeping a copy of
+    # payload_addr to read the expiration delta from afterwards
+    dup.5 swap
+    # => [num_words, write_ptr, PAYLOAD_COMMITMENT, payload_addr, pad(11)]
 
     exec.mem::pipe_preimage_to_memory drop
-    # => [pad(16)]
+    # => [payload_addr, pad(15)]
 
     # set the transaction expiration delta if one was provided
-    mem_load.EXPIRATION_DELTA_ADDR
+    add.EXPIRATION_DELTA_OFFSET mem_load
     # => [expiration_delta, pad(15)]
 
     dup neq.0

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/fungible_faucet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/fungible_faucet.masm
@@ -9,9 +9,9 @@
 # note creation.
 
 use miden::protocol::asset
-use miden::standards::faucets::fungible
+use miden::standards::faucets::fungible as fungible_faucet
 use miden::standards::tx_scripts::send_notes::common
-use {ITEMS_OFFSET, ITEM_NUM_ELEMENTS, NOTES_START_ADDR, NOTE_TYPE_OFFSET, NUM_ASSETS_OFFSET, NUM_ATTACHMENTS_OFFSET, NUM_NOTES_ADDR, TAG_OFFSET} from miden::standards::tx_scripts::send_notes::common
+use {ITEMS_OFFSET, ITEM_NUM_ELEMENTS, NOTES_START_ADDR, NOTE_TYPE_OFFSET, NUM_ASSETS_OFFSET, NUM_ATTACHMENTS_OFFSET, NUM_NOTES_ADDR, PAYLOAD_ADDR, TAG_OFFSET} from miden::standards::tx_scripts::send_notes::common
 
 # CONSTANTS
 # =================================================================================================
@@ -50,7 +50,10 @@ const ERR_SEND_NOTES_FAUCET_NOTE_REQUIRES_ONE_ASSET = "faucet note must contain 
 #! Invocation: call
 @transaction_script
 pub proc main
-    exec.common::load_payload
+    push.PAYLOAD_ADDR
+    # => [payload_addr, PAYLOAD_COMMITMENT, pad(11)]
+
+    exec.common::write_payload_to_memory
     # => [pad(16)]
 
     exec.process_notes
@@ -117,7 +120,7 @@ proc process_notes
         loc_load.PROCESS_NOTES_READ_PTR_LOC add.ITEMS_OFFSET exec.asset::load
         # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2), notes_left, pad(16)]
 
-        call.fungible::mint_and_send
+        call.fungible_faucet::mint_and_send
         # => [note_idx, pad(15), notes_left, pad(16)]
 
         loc_store.PROCESS_NOTES_NOTE_IDX_LOC

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/non_fungible_faucet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/non_fungible_faucet.masm
@@ -6,12 +6,13 @@
 # set of output notes. See `send_notes::common` for the payload layout.
 #
 # Every note record must contain exactly one asset, which is minted by the faucet as part of
-# note creation. Unlike the fungible faucet, `non_fungible::mint_and_send` derives the asset from
-# the faucet itself, so only the asset's value word (its commitment) is read from the record.
+# note creation. Unlike the fungible faucet, `non_fungible_faucet::mint_and_send` derives the
+# asset from the faucet itself, so only the asset's value word (its commitment) is read from the
+# record.
 
-use miden::standards::faucets::non_fungible
+use miden::standards::faucets::non_fungible as non_fungible_faucet
 use miden::standards::tx_scripts::send_notes::common
-use {ITEMS_OFFSET, ITEM_NUM_ELEMENTS, NOTES_START_ADDR, NOTE_TYPE_OFFSET, NUM_ASSETS_OFFSET, NUM_ATTACHMENTS_OFFSET, NUM_NOTES_ADDR, TAG_OFFSET, WORD_NUM_ELEMENTS} from miden::standards::tx_scripts::send_notes::common
+use {ITEMS_OFFSET, ITEM_NUM_ELEMENTS, NOTES_START_ADDR, NOTE_TYPE_OFFSET, NUM_ASSETS_OFFSET, NUM_ATTACHMENTS_OFFSET, NUM_NOTES_ADDR, PAYLOAD_ADDR, TAG_OFFSET, WORD_NUM_ELEMENTS} from miden::standards::tx_scripts::send_notes::common
 
 # CONSTANTS
 # =================================================================================================
@@ -53,7 +54,10 @@ const ERR_SEND_NOTES_FAUCET_NOTE_REQUIRES_ONE_ASSET = "faucet note must contain 
 #! Invocation: call
 @transaction_script
 pub proc main
-    exec.common::load_payload
+    push.PAYLOAD_ADDR
+    # => [payload_addr, PAYLOAD_COMMITMENT, pad(11)]
+
+    exec.common::write_payload_to_memory
     # => [pad(16)]
 
     exec.process_notes
@@ -121,7 +125,7 @@ proc process_notes
         padw loc_load.PROCESS_NOTES_READ_PTR_LOC add.ASSET_VALUE_OFFSET mem_loadw_le
         # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(6), notes_left, pad(16)]
 
-        call.non_fungible::mint_and_send
+        call.non_fungible_faucet::mint_and_send
         # => [note_idx, pad(15), notes_left, pad(16)]
 
         loc_store.PROCESS_NOTES_NOTE_IDX_LOC

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/wallet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/wallet.masm
@@ -8,8 +8,8 @@
 use miden::protocol::asset
 use miden::standards::note::note_creator
 use miden::standards::tx_scripts::send_notes::common
-use miden::standards::wallets::basic
-use {ITEMS_OFFSET, ITEM_NUM_ELEMENTS, NOTES_START_ADDR, NOTE_TYPE_OFFSET, NUM_ASSETS_OFFSET, NUM_ATTACHMENTS_OFFSET, NUM_NOTES_ADDR, TAG_OFFSET} from miden::standards::tx_scripts::send_notes::common
+use miden::standards::wallets::basic as basic_wallet
+use {ITEMS_OFFSET, ITEM_NUM_ELEMENTS, NOTES_START_ADDR, NOTE_TYPE_OFFSET, NUM_ASSETS_OFFSET, NUM_ATTACHMENTS_OFFSET, NUM_NOTES_ADDR, PAYLOAD_ADDR, TAG_OFFSET} from miden::standards::tx_scripts::send_notes::common
 
 # CONSTANTS
 # =================================================================================================
@@ -46,7 +46,10 @@ const ERR_SEND_NOTES_NUM_ATTACHMENTS_INVALID = "send notes payload attachment co
 #! Invocation: call
 @transaction_script
 pub proc main
-    exec.common::load_payload
+    push.PAYLOAD_ADDR
+    # => [payload_addr, PAYLOAD_COMMITMENT, pad(11)]
+
+    exec.common::write_payload_to_memory
     # => [pad(16)]
 
     exec.process_notes
@@ -136,7 +139,7 @@ proc process_notes
             loc_load.PROCESS_NOTES_ITEM_PTR_LOC exec.asset::load
             # => [ASSET_ID, ASSET_VALUE, note_idx, pad(7), assets_left, notes_left, pad(16)]
 
-            call.basic::move_asset_to_note
+            call.basic_wallet::move_asset_to_note
             # => [pad(16), assets_left, notes_left, pad(16)]
 
             dropw dropw dropw dropw


### PR DESCRIPTION
Address small comments remaining from https://github.com/0xMiden/protocol/pull/3250:

1. Renamed `load_payload` -> `write_payload_to_memory`
2. `write_payload_to_memory` now takes the destination address from the caller
3. Added alias `use miden::standards::wallets::basic as basic_wallet`
4. Added alias `use miden::standards::faucets::fungible as fungible_faucet`
5. Added alias `use miden::standards::faucets::non_fungible as non_fungible_faucet`