### PR TITLE
chore: bump version to v0.16.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.16.0-rc.1"
+version = "0.16.0-rc.2"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-rc.1"
+version = "0.16.0-rc.2"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-rc.1"
+version = "0.16.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-build-utils"
-version = "0.16.0-rc.1"
+version = "0.16.0-rc.2"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-rc.1"
+version = "0.16.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-rc.1"
+version = "0.16.0-rc.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-rc.1"
+version = "0.16.0-rc.2"
 dependencies = [
  "bon",
  "miden-agglayer",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-rc.1"
+version = "0.16.0-rc.2"
 dependencies = [
  "miden-processor",
  "miden-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.96.1"
-version      = "0.16.0-rc.1"
+version      = "0.16.0-rc.2"
 
 [profile.release]
 codegen-units = 1
@@ -37,14 +37,14 @@ lto           = true
 
 [workspace.dependencies]
 # Workspace crates
-miden-agglayer             = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-rc.1" }
-miden-block-prover         = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-rc.1" }
-miden-protocol             = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-rc.1" }
-miden-protocol-build-utils = { default-features = false, path = "crates/miden-protocol-build-utils", version = "0.16.0-rc.1" }
-miden-standards            = { default-features = false, path = "crates/miden-standards", version = "0.16.0-rc.1" }
-miden-testing              = { default-features = false, path = "crates/miden-testing", version = "0.16.0-rc.1" }
-miden-tx                   = { default-features = false, path = "crates/miden-tx", version = "0.16.0-rc.1" }
-miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-rc.1" }
+miden-agglayer             = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-rc.2" }
+miden-block-prover         = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-rc.2" }
+miden-protocol             = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-rc.2" }
+miden-protocol-build-utils = { default-features = false, path = "crates/miden-protocol-build-utils", version = "0.16.0-rc.2" }
+miden-standards            = { default-features = false, path = "crates/miden-standards", version = "0.16.0-rc.2" }
+miden-testing              = { default-features = false, path = "crates/miden-testing", version = "0.16.0-rc.2" }
+miden-tx                   = { default-features = false, path = "crates/miden-tx", version = "0.16.0-rc.2" }
+miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-rc.2" }
 
 # Miden dependencies
 miden-assembly         = { default-features = false, version = "0.25" }


### PR DESCRIPTION
## What

Bumps the workspace version `0.16.0-rc.1` → `0.16.0-rc.2`.

## Why

The [rc.1 publish](https://github.com/0xMiden/protocol/actions/runs/30911423101) aborted partway: `miden-protocol-build-utils` had never been published, and crates.io does not let a Trusted Publishing token create a new crate name.

```
403 Forbidden: Trusted Publishing tokens do not support creating new
crates. Publish the crate manually, first
```

I then published manually, and the CI retry failed differently:

```
error: crate miden-protocol-build-utils@0.16.0-rc.1 already exists on
crates.io index
```

`cargo publish --workspace` is all-or-nothing and aborts on the first version already on the index, so`rc.1` cannot be finished by re-running. Publishing the remaining seven by hand would work, but goes against trusted publishing.

## State of rc.1

Left half-published. Worth considering yanking `miden-protocol-build-utils@0.16.0-rc.1`, but not strictly necessary once `rc.2` is up.

## Related

#3490 adds a preflight that catches this class of failure (a workspace crate whose name is not yet registered) before the release job publishes anything.