### PR TITLE
docs(standards): fix missing invocation comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Added a new `INPUT_NOTE_INDEX_LOOKUP_EVENT` that lets transaction hosts provide 
 - [BREAKING] Bounded the length of the encoded signature that the transaction host's `AuthRequest` event handler takes from the advice map, so an entry planted under a signature key can no longer make the host allocate an arbitrary amount of memory ([#3472](https://github.com/0xMiden/protocol/pull/3472)).
 - [BREAKING] Renamed `Signature::to_prepared_signature` to `Signature::to_encoded_signature` ([#3472](https://github.com/0xMiden/protocol/pull/3472)).
 - Clarified the `ERR_BURN_AMOUNT_BELOW_MIN_BURN_AMOUNT` error message to better match the actual validated constraint ([#3474](https://github.com/0xMiden/protocol/pull/3474)).
+- Added the missing `Invocation: exec` label to the document comments of the public `miden-standards` MASM procedures([#3503](https://github.com/0xMiden/protocol/pull/3503)).
 
 ## v0.16.0-beta.1 (2026-07-20)
 

--- a/crates/miden-standards/asm/standards/assets/asset_amount.masm
+++ b/crates/miden-standards/asm/standards/assets/asset_amount.masm
@@ -27,6 +27,8 @@ const MAX_SCALING_FACTOR=18
 #!
 #! Panics if:
 #! - scale > 18 (overflow protection)
+#!
+#! Invocation: exec
 pub proc pow10
     u32assert.err=ERR_SCALE_AMOUNT_EXCEEDED_LIMIT
     # => [scale]
@@ -110,6 +112,8 @@ pub proc scale_asset_amount_to_u256
 end
 
 #! Reverse the limbs and change the byte endianness of the result.
+#!
+#! Invocation: exec
 pub proc reverse_limbs_and_change_byte_endianness
     # reverse the felts within each word
     # [a, b, c, d, e, f, g, h] -> [h, g, f, e, d, c, b, a]
@@ -253,6 +257,8 @@ end
 #! - x < y * 10^scale_exp (underflow)
 #! - z does not fit in 64 bits
 #! - (z1, z0) >= 10^scale_exp (remainder too large)
+#!
+#! Invocation: exec
 pub proc verify_u128_to_asset_amount_conversion
     # => [x0, x1, x2, x3, scale_exp, y]
 
@@ -374,6 +380,8 @@ end
 #! - x < y * 10^scale_exp (underflow)
 #! - z does not fit in 64 bits
 #! - (z1, z0) >= 10^scale_exp (remainder too large)
+#!
+#! Invocation: exec
 pub proc verify_u256_to_asset_amount_conversion
 
     # reverse limbs and byte endianness

--- a/crates/miden-standards/asm/standards/assets/non_fungible_asset.masm
+++ b/crates/miden-standards/asm/standards/assets/non_fungible_asset.masm
@@ -91,6 +91,8 @@ end
 #! Where:
 #! - ASSET_VALUE is the non-fungible asset value, whose first two elements are the asset class.
 #! - asset_class is the (suffix, prefix) pair of the non-fungible asset.
+#!
+#! Invocation: exec
 pub proc value_into_asset_class
     # => [asset_class_suffix, asset_class_prefix, value_2, value_3]
     movup.3 drop movup.2 drop

--- a/crates/miden-standards/asm/standards/auth/signature.masm
+++ b/crates/miden-standards/asm/standards/auth/signature.masm
@@ -202,6 +202,8 @@ end
 #! Returns 1 if scheme_id is supported, else 0.
 #! Inputs:  [scheme_id]
 #! Outputs: [is_supported]
+#!
+#! Invocation: exec
 pub proc is_supported_scheme
     dup eq.ECDSA_K256_KECCAK_SCHEME_ID
     # => [is_1, scheme_id]
@@ -216,6 +218,8 @@ end
 #! Reverts if scheme_id is not supported.
 #! Inputs:  [scheme_id]
 #! Outputs: []
+#!
+#! Invocation: exec
 pub proc assert_supported_scheme
     exec.is_supported_scheme
     # => [is_supported]
@@ -228,6 +232,8 @@ end
 #! Validates scheme id word shape: [scheme_id, 0, 0, 0]
 #! Inputs:  [SCHEME_ID_WORD]
 #! Outputs: [SCHEME_ID_WORD]
+#!
+#! Invocation: exec
 pub proc assert_supported_scheme_word
     dupw exec.assert_supported_scheme
     # => [0, 0, 0, SCHEME_ID_WORD]
@@ -254,6 +260,8 @@ end
 #!           approver_pub_key_slot_id_suffix, approver_pub_key_slot_id_prefix,
 #!           num_of_approvers, MSG]
 #! Outputs: [num_verified_signatures, MSG]
+#!
+#! Invocation: exec
 @locals(5)
 pub proc verify_signatures
     loc_store.APPROVER_SCHEME_ID_SLOT_ID_SUFFIX_LOC
@@ -380,6 +388,8 @@ end
 #!
 #! Inputs: [key_index]
 #! Outputs: [APPROVER_MAP_KEY]
+#!
+#! Invocation: exec
 pub proc create_approver_map_key
     push.0.0.0 movup.3
     # => [APPROVER_MAP_KEY]

--- a/crates/miden-standards/asm/standards/interop/eth.masm
+++ b/crates/miden-standards/asm/standards/interop/eth.masm
@@ -124,6 +124,8 @@ end
 #!
 #! Inputs:  [lo, hi]
 #! Outputs: [felt]
+#!
+#! Invocation: exec
 pub proc build_felt
     # --- validate u32 limbs ---
     u32assert2.err=ERR_NOT_U32

--- a/crates/miden-standards/asm/standards/utils.masm
+++ b/crates/miden-standards/asm/standards/utils.masm
@@ -33,6 +33,8 @@ const ERR_MERGE_OVERFLOW="merged u32 limbs do not fit in a field element"
 #!
 #! Inputs:  [value]
 #! Outputs: [swapped]
+#!
+#! Invocation: exec
 pub proc swap_u32_bytes
     # part0 = (value & 0xFF) << 24
     dup u32and.0xFF u32shl.24
@@ -66,6 +68,8 @@ end
 #! Panics if:
 #! - the merged value does not split back into the input limbs (an input is not a valid u32, or
 #!   the combined value was reduced modulo the field prime).
+#!
+#! Invocation: exec
 pub proc merge_u32_limbs
     # keep copies for the round-trip check
     dup.1 dup.1
@@ -98,6 +102,8 @@ end
 #! Outputs: [WORD_1, WORD_2, ptr]
 #!
 #! Total cycles: 28
+#!
+#! Invocation: exec
 pub proc mem_store_double_word(
     double_word_to_store: DoubleWord,
     mem_ptr: MemoryAddress
@@ -113,6 +119,8 @@ end
 #!
 #! Inputs:  [WORD_1, WORD_2, ptr]
 #! Outputs: []
+#!
+#! Invocation: exec
 pub proc mem_store_double_word_unaligned(
     double_word_to_store: DoubleWord,
     mem_ptr: MemoryAddress
@@ -141,6 +149,8 @@ end
 #!
 #! Inputs:  [ptr]
 #! Outputs: [WORD_1, WORD_2]
+#!
+#! Invocation: exec
 pub proc mem_load_double_word(mem_ptr: MemoryAddress) -> DoubleWord
     padw dup.4 add.4 mem_loadw_le
     # => [WORD_2, ptr]
@@ -157,6 +167,8 @@ end
 #!
 #! Inputs:  [ptr]
 #! Outputs: [WORD_1, WORD_2]
+#!
+#! Invocation: exec
 pub proc mem_load_double_word_unaligned(mem_ptr: MemoryAddress) -> DoubleWord
     # Load WORD_2 first so it ends up underneath WORD_1 on the final stack.
     dup add.7 mem_load


### PR DESCRIPTION
This PR fixes the missing invocation comments especially in:
- [`value_into_asset_class` in `non_fungible_asset.masm`](https://github.com/0xMiden/protocol/blob/8411bf093bde25285708faac152b6d7269009617/crates/miden-standards/asm/standards/assets/non_fungible_asset.masm#L42-L56)
- [`to_amount` in `fungible_asset.masm`](https://github.com/0xMiden/protocol/blob/8411bf093bde25285708faac152b6d7269009617/crates/miden-standards/asm/standards/assets/fungible_asset.masm#L138-L152)