### PR TITLE
Prepare v0.16.0-rc.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Changelog
 
-## TBD
-
-### Changes
-
-- [BREAKING] Renamed `miden-standards` component `NAME` constants to mirror their module paths, with `procedure_root!` lookups now using dedicated `*_LIBRARY_PATH` constants ([#3495](https://github.com/0xMiden/protocol/pull/3495)).
-
-## v0.16.0 (2026-08-04)
+## v0.16.0 (2026-08-06)
 
 ### Features
 
@@ -57,15 +51,16 @@ Added a new `INPUT_NOTE_INDEX_LOOKUP_EVENT` that lets transaction hosts provide 
 - Added test coverage for the `FungibleFaucet` metadata string setters (`set_description`, `set_logo_uri`, `set_external_link`) ([#3450](https://github.com/0xMiden/protocol/pull/3450)).
 - [BREAKING] Removed the `AuthSingleSigAcl` auth component, the `Auth::Acl` `miden-testing` mock-chain variant, and the `user_faucet_single_sig_acl` testing helper: the exempt (no-signature) branch let fee-charging accounts be drained via calls to exempt procedures. The plain `AuthSingleSig` component (every call requires a signature) remains available and now backs the "singlesig user faucet" factories; a `BurnNote` targeted at a singlesig user faucet, previously exempt via `receive_and_burn`, now requires the owner's signature to be consumed ([#3360](https://github.com/0xMiden/protocol/issues/3360)).
 - [BREAKING] Updated `miden-vm` dependencies to v0.29. Notable downstream changes: `CoreLibrary` now bundles a separate `miden-precompiles` package that must also be seeded into the package registry (`CoreLibrary::packages()`), the advice stack moved behind the typed `AdviceStack` API on `AdviceInputs`, `Kernel` was renamed to `KernelDescriptor` (with `Package::to_kernel` becoming `to_kernel_descriptor` and `Package::module_infos` becoming `module_descriptors`), and `miden_verifier::verify` now takes an `ExecutionClaim` and verifies bundled precompile proofs itself, replacing `verify_with_precompiles` ([#3492](https://github.com/0xMiden/protocol/pull/3492)).
+- [BREAKING] Renamed `miden-standards` component `NAME` constants to mirror their module paths, with `procedure_root!` lookups now using dedicated `*_LIBRARY_PATH` constants ([#3495](https://github.com/0xMiden/protocol/pull/3495)).
 
 ### Fixes
 
-- [BREAKING] The transaction kernel now asserts that asset callbacks return the asset value they received, aborting with `ERR_FAUCET_CALLBACK_ASSET_VALUE_MUST_MATCH_INPUT` otherwise; previously, offsetting callback transformations could redistribute value between outputs while passing the epilogue's aggregate conservation check. The kernel commitment changes ([#3442](https://github.com/0xMiden/protocol/issues/3442)).
-- Restricted indexed input-note asset removal to the native account's context while preserving active-note self-removal. As a consequence, note scripts and transaction scripts can no longer remove input-note assets by index directly, and neither can foreign accounts invoked through FPI; indexed removal must go through a procedure of the native account ([#3445](https://github.com/0xMiden/protocol/issues/3445)).
 - Fixed `faucet::mint` and `faucet::burn` failing when the asset's witness in the input vault had not already been loaded, which happened when minting into a faucet whose vault held other assets, or when burning an asset the transaction had not otherwise accessed; both procedures now request the witness from the host before updating the input vault ([#3409](https://github.com/0xMiden/protocol/pull/3409)).
 - Enforced the canonical encoding of `Authority` role map values on read: `Authority::try_from_storage` now rejects a procedure-role value word whose reserved felts (`value[1..=3]`) are non-zero, matching the value-slot check and completing the fix started in [#3209](https://github.com/0xMiden/protocol/pull/3209) ([#3415](https://github.com/0xMiden/protocol/pull/3415)).
-- Fixed `CodeInspection`'s `get_code_commitment`, `get_num_procedures` and `get_procedure_root` and the `min_burn_amount` burn policy's `get_min_burn_amount` returning above the 16-element stack depth ([#3470](https://github.com/0xMiden/protocol/pull/3470)).
+- [BREAKING] The transaction kernel now asserts that asset callbacks return the asset value they received, aborting with `ERR_FAUCET_CALLBACK_ASSET_VALUE_MUST_MATCH_INPUT` otherwise; previously, offsetting callback transformations could redistribute value between outputs while passing the epilogue's aggregate conservation check. The kernel commitment changes ([#3442](https://github.com/0xMiden/protocol/issues/3442)).
+- Restricted indexed input-note asset removal to the native account's context while preserving active-note self-removal. As a consequence, note scripts and transaction scripts can no longer remove input-note assets by index directly, and neither can foreign accounts invoked through FPI; indexed removal must go through a procedure of the native account ([#3445](https://github.com/0xMiden/protocol/issues/3445)).
 - Fixed the PSWAP note-fill asset to its own payback note ([#3469](https://github.com/0xMiden/protocol/pull/3469)).
+- Fixed `CodeInspection`'s `get_code_commitment`, `get_num_procedures` and `get_procedure_root` and the `min_burn_amount` burn policy's `get_min_burn_amount` returning above the 16-element stack depth ([#3470](https://github.com/0xMiden/protocol/pull/3470)).
 - [BREAKING] Bounded the length of the encoded signature that the transaction host's `AuthRequest` event handler takes from the advice map, so an entry planted under a signature key can no longer make the host allocate an arbitrary amount of memory ([#3472](https://github.com/0xMiden/protocol/pull/3472)).
 - [BREAKING] Renamed `Signature::to_prepared_signature` to `Signature::to_encoded_signature` ([#3472](https://github.com/0xMiden/protocol/pull/3472)).
 - Clarified the `ERR_BURN_AMOUNT_BELOW_MIN_BURN_AMOUNT` error message to better match the actual validated constraint ([#3474](https://github.com/0xMiden/protocol/pull/3474)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1974,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-build-utils"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "bon",
  "miden-agglayer",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3692,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.96.1"
-version      = "0.16.0-rc.2"
+version      = "0.16.0-rc.3"
 
 [profile.release]
 codegen-units = 1
@@ -37,14 +37,14 @@ lto           = true
 
 [workspace.dependencies]
 # Workspace crates
-miden-agglayer             = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-rc.2" }
-miden-block-prover         = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-rc.2" }
-miden-protocol             = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-rc.2" }
-miden-protocol-build-utils = { default-features = false, path = "crates/miden-protocol-build-utils", version = "0.16.0-rc.2" }
-miden-standards            = { default-features = false, path = "crates/miden-standards", version = "0.16.0-rc.2" }
-miden-testing              = { default-features = false, path = "crates/miden-testing", version = "0.16.0-rc.2" }
-miden-tx                   = { default-features = false, path = "crates/miden-tx", version = "0.16.0-rc.2" }
-miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-rc.2" }
+miden-agglayer             = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-rc.3" }
+miden-block-prover         = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-rc.3" }
+miden-protocol             = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-rc.3" }
+miden-protocol-build-utils = { default-features = false, path = "crates/miden-protocol-build-utils", version = "0.16.0-rc.3" }
+miden-standards            = { default-features = false, path = "crates/miden-standards", version = "0.16.0-rc.3" }
+miden-testing              = { default-features = false, path = "crates/miden-testing", version = "0.16.0-rc.3" }
+miden-tx                   = { default-features = false, path = "crates/miden-tx", version = "0.16.0-rc.3" }
+miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-rc.3" }
 
 # Miden dependencies
 miden-assembly         = { default-features = false, version = "0.29" }


### PR DESCRIPTION
This PR increments crate versions to v0.16.0-rc.3 (and cleans up the changelog a bit). The intent is that after this release, we don't make any changes to the v0.16.0 branch unless these are critical bug fixes.