### PR TITLE
feat: allow seeding RBAC delegated admins at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## TBD
-
-### Changes
-
-- [BREAKING] Replaced `RoleBasedAccessControl::new` with a validating `RoleBasedAccessControl::builder()` over `RoleSeed`s, which seeds each role's members together with its delegated admin, so exclusive delegation is established at account creation instead of through on-chain `set_role_admin` calls ([#XXXX](https://github.com/0xMiden/protocol/pull/XXXX)).
-
 ## v0.16.0 (2026-08-06)
 
 ### Features
@@ -58,6 +52,7 @@ Added a new `INPUT_NOTE_INDEX_LOOKUP_EVENT` that lets transaction hosts provide 
 - [BREAKING] Removed the `AuthSingleSigAcl` auth component, the `Auth::Acl` `miden-testing` mock-chain variant, and the `user_faucet_single_sig_acl` testing helper: the exempt (no-signature) branch let fee-charging accounts be drained via calls to exempt procedures. The plain `AuthSingleSig` component (every call requires a signature) remains available and now backs the "singlesig user faucet" factories; a `BurnNote` targeted at a singlesig user faucet, previously exempt via `receive_and_burn`, now requires the owner's signature to be consumed ([#3360](https://github.com/0xMiden/protocol/issues/3360)).
 - [BREAKING] Updated `miden-vm` dependencies to v0.29. Notable downstream changes: `CoreLibrary` now bundles a separate `miden-precompiles` package that must also be seeded into the package registry (`CoreLibrary::packages()`), the advice stack moved behind the typed `AdviceStack` API on `AdviceInputs`, `Kernel` was renamed to `KernelDescriptor` (with `Package::to_kernel` becoming `to_kernel_descriptor` and `Package::module_infos` becoming `module_descriptors`), and `miden_verifier::verify` now takes an `ExecutionClaim` and verifies bundled precompile proofs itself, replacing `verify_with_precompiles` ([#3492](https://github.com/0xMiden/protocol/pull/3492)).
 - [BREAKING] Renamed `miden-standards` component `NAME` constants to mirror their module paths, with `procedure_root!` lookups now using dedicated `*_LIBRARY_PATH` constants ([#3495](https://github.com/0xMiden/protocol/pull/3495)).
+- [BREAKING] Replaced `RoleBasedAccessControl::new` with a validating `RoleBasedAccessControl::builder()` over `RoleConfig`s, which seeds each role's members together with its delegated admin, so exclusive delegation is established at account creation instead of through on-chain `set_role_admin` calls ([#3515](https://github.com/0xMiden/protocol/pull/3515)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Changes
+
+- [BREAKING] Replaced `RoleBasedAccessControl::new` with a validating `RoleBasedAccessControl::builder()` over `RoleSeed`s, which seeds each role's members together with its delegated admin, so exclusive delegation is established at account creation instead of through on-chain `set_role_admin` calls ([#XXXX](https://github.com/0xMiden/protocol/pull/XXXX)).
+
 ## v0.16.0 (2026-08-06)
 
 ### Features

--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -19,7 +19,7 @@ use miden_protocol::errors::NoteError;
 use miden_protocol::note::{Note, NoteScriptRoot};
 #[cfg(any(feature = "testing", test))]
 use miden_standards::account::access::PausableStorage;
-use miden_standards::account::access::RoleSeed;
+use miden_standards::account::access::RoleConfig;
 use miden_standards::note::{
     NetworkAccountTarget,
     NetworkAccountTargetError,
@@ -231,16 +231,14 @@ impl BridgeRoles {
 
     /// Returns the role seeds used to seed the account's RBAC component. Each role is left
     /// administered by the `ADMIN` role.
-    pub(crate) fn role_seeds(&self) -> Vec<RoleSeed> {
+    pub(crate) fn role_seeds(&self) -> Vec<RoleConfig> {
         [
             (AggLayerBridge::faucet_manager_role(), &self.faucet_managers),
             (AggLayerBridge::ger_injector_role(), &self.ger_injectors),
             (AggLayerBridge::ger_remover_role(), &self.ger_removers),
         ]
         .into_iter()
-        .map(|(role, members)| {
-            RoleSeed::builder().role(role).members(members.iter().copied()).build()
-        })
+        .map(|(role, members)| RoleConfig::new(role).with_members(members.iter().copied()))
         .collect()
     }
 }

--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -19,6 +19,7 @@ use miden_protocol::errors::NoteError;
 use miden_protocol::note::{Note, NoteScriptRoot};
 #[cfg(any(feature = "testing", test))]
 use miden_standards::account::access::PausableStorage;
+use miden_standards::account::access::RoleSeed;
 use miden_standards::note::{
     NetworkAccountTarget,
     NetworkAccountTargetError,
@@ -228,13 +229,19 @@ impl BridgeRoles {
         })
     }
 
-    /// Returns the RBAC role-membership map used to seed the account's RBAC component.
-    pub(crate) fn role_members(&self) -> BTreeMap<RoleSymbol, BTreeSet<AccountId>> {
-        BTreeMap::from([
-            (AggLayerBridge::faucet_manager_role(), self.faucet_managers.clone()),
-            (AggLayerBridge::ger_injector_role(), self.ger_injectors.clone()),
-            (AggLayerBridge::ger_remover_role(), self.ger_removers.clone()),
-        ])
+    /// Returns the role seeds used to seed the account's RBAC component. Each role is left
+    /// administered by the `ADMIN` role.
+    pub(crate) fn role_seeds(&self) -> Vec<RoleSeed> {
+        [
+            (AggLayerBridge::faucet_manager_role(), &self.faucet_managers),
+            (AggLayerBridge::ger_injector_role(), &self.ger_injectors),
+            (AggLayerBridge::ger_remover_role(), &self.ger_removers),
+        ]
+        .into_iter()
+        .map(|(role, members)| {
+            RoleSeed::builder().role(role).members(members.iter().copied()).build()
+        })
+        .collect()
     }
 }
 

--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -186,6 +186,9 @@ procedure_root!(
     AggLayerBridge::code()
 );
 
+// BRIDGE ROLES
+// ================================================================================================
+
 /// The accounts that initially hold each of the bridge's privileged RBAC roles.
 ///
 /// Used to seed the bridge account's RBAC role membership at creation. Each role gates a distinct
@@ -195,13 +198,13 @@ procedure_root!(
 /// - `GER_REMOVER` gates `remove_ger`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BridgeRoles {
-    faucet_managers: BTreeSet<AccountId>,
-    ger_injectors: BTreeSet<AccountId>,
-    ger_removers: BTreeSet<AccountId>,
+    roles: Vec<RoleConfig>,
 }
 
 impl BridgeRoles {
     /// Creates the initial bridge role membership from the holders of each role.
+    ///
+    /// The roles are left administered by the `ADMIN` role.
     ///
     /// # Errors
     ///
@@ -212,6 +215,7 @@ impl BridgeRoles {
         ger_injectors: BTreeSet<AccountId>,
         ger_removers: BTreeSet<AccountId>,
     ) -> Result<Self, AgglayerBridgeError> {
+        let mut roles = Vec::new();
         for (role, members) in [
             (AggLayerBridge::faucet_manager_role(), &faucet_managers),
             (AggLayerBridge::ger_injector_role(), &ger_injectors),
@@ -220,28 +224,24 @@ impl BridgeRoles {
             if members.is_empty() {
                 return Err(AgglayerBridgeError::EmptyBridgeRole(role));
             }
+            roles.push(RoleConfig::new(role).with_members(members.iter().copied()));
         }
 
-        Ok(Self {
-            faucet_managers,
-            ger_injectors,
-            ger_removers,
-        })
-    }
-
-    /// Returns the role seeds used to seed the account's RBAC component. Each role is left
-    /// administered by the `ADMIN` role.
-    pub(crate) fn role_seeds(&self) -> Vec<RoleConfig> {
-        [
-            (AggLayerBridge::faucet_manager_role(), &self.faucet_managers),
-            (AggLayerBridge::ger_injector_role(), &self.ger_injectors),
-            (AggLayerBridge::ger_remover_role(), &self.ger_removers),
-        ]
-        .into_iter()
-        .map(|(role, members)| RoleConfig::new(role).with_members(members.iter().copied()))
-        .collect()
+        Ok(Self { roles })
     }
 }
+
+impl IntoIterator for BridgeRoles {
+    type Item = RoleConfig;
+    type IntoIter = alloc::vec::IntoIter<RoleConfig>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.roles.into_iter()
+    }
+}
+
+// AGG LAYER BRIDGE
+// ================================================================================================
 
 /// An [`AccountComponent`] implementing the AggLayer Bridge.
 ///

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -16,7 +16,7 @@ use miden_standards::account::access::{
     Pausable,
     PausableManager,
     RoleBasedAccessControl,
-    RoleSeed,
+    RoleConfig,
 };
 use miden_standards::account::auth::NetworkAccount;
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicyManager};
@@ -219,12 +219,7 @@ fn create_bridge_account_builder(
         .with_component(AggLayerBridge::new(network_id))
         .with_component(
             RoleBasedAccessControl::builder()
-                .role(
-                    RoleSeed::builder()
-                        .role(RoleBasedAccessControl::admin_role())
-                        .member(admin)
-                        .build(),
-                )
+                .role(RoleConfig::new(RoleBasedAccessControl::admin_role()).with_member(admin))
                 .roles(roles.role_seeds())
                 .build()
                 .expect("the bridge seeds distinct non-empty roles administered by ADMIN"),

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -16,6 +16,7 @@ use miden_standards::account::access::{
     Pausable,
     PausableManager,
     RoleBasedAccessControl,
+    RoleSeed,
 };
 use miden_standards::account::auth::NetworkAccount;
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicyManager};
@@ -216,7 +217,18 @@ fn create_bridge_account_builder(
     NetworkAccount::builder(seed.into(), AggLayerBridge::allowed_notes(), fee_policy_manager)
         .expect("bridge note allowlist is non-empty")
         .with_component(AggLayerBridge::new(network_id))
-        .with_component(RoleBasedAccessControl::new(BTreeSet::from([admin]), roles.role_members()))
+        .with_component(
+            RoleBasedAccessControl::builder()
+                .role(
+                    RoleSeed::builder()
+                        .role(RoleBasedAccessControl::admin_role())
+                        .member(admin)
+                        .build(),
+                )
+                .roles(roles.role_seeds())
+                .build()
+                .expect("the bridge seeds distinct non-empty roles administered by ADMIN"),
+        )
         .with_component(Authority::RbacControlled {
             procedure_roles: AggLayerBridge::procedure_roles(),
         })

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -220,7 +220,7 @@ fn create_bridge_account_builder(
         .with_component(
             RoleBasedAccessControl::builder()
                 .role(RoleConfig::new(RoleBasedAccessControl::admin_role()).with_member(admin))
-                .roles(roles.role_seeds())
+                .roles(roles)
                 .build()
                 .expect("the bridge seeds distinct non-empty roles administered by ADMIN"),
         )

--- a/crates/miden-standards/src/account/access/mod.rs
+++ b/crates/miden-standards/src/account/access/mod.rs
@@ -93,7 +93,7 @@ impl IntoIterator for AccessControl {
 pub use authority::{Authority, AuthorityError};
 pub use ownable2step::{Ownable2Step, Ownable2StepError};
 pub use pausable::{Pausable, PausableManager, PausableStorage};
-pub use rbac::{RoleBasedAccessControl, RoleBasedAccessControlError, RoleSeed};
+pub use rbac::{RoleBasedAccessControl, RoleBasedAccessControlError, RoleConfig};
 
 // HELPERS
 // ================================================================================================

--- a/crates/miden-standards/src/account/access/mod.rs
+++ b/crates/miden-standards/src/account/access/mod.rs
@@ -1,4 +1,4 @@
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::BTreeMap;
 use alloc::vec;
 
 use miden_protocol::Felt;
@@ -80,7 +80,9 @@ impl IntoIterator for AccessControl {
                 vec![Ownable2Step::new(owner).into(), Authority::OwnerControlled.into()].into_iter()
             },
             AccessControl::Rbac { admin, procedure_roles } => vec![
-                RoleBasedAccessControl::new(BTreeSet::from([admin]), BTreeMap::default()).into(),
+                RoleBasedAccessControl::with_admins([admin])
+                    .expect("a single ADMIN member is a valid seed")
+                    .into(),
                 Authority::RbacControlled { procedure_roles }.into(),
             ]
             .into_iter(),
@@ -91,7 +93,7 @@ impl IntoIterator for AccessControl {
 pub use authority::{Authority, AuthorityError};
 pub use ownable2step::{Ownable2Step, Ownable2StepError};
 pub use pausable::{Pausable, PausableManager, PausableStorage};
-pub use rbac::RoleBasedAccessControl;
+pub use rbac::{RoleBasedAccessControl, RoleBasedAccessControlError, RoleSeed};
 
 // HELPERS
 // ================================================================================================

--- a/crates/miden-standards/src/account/access/rbac.rs
+++ b/crates/miden-standards/src/account/access/rbac.rs
@@ -258,11 +258,11 @@ impl RoleBasedAccessControl {
 
         // Check the effective admin of every role, not just of the explicitly delegated ones: a
         // role left with the default admin is just as frozen when `ADMIN` can never hold members.
-        for config in roles.values() {
-            let admin = config.admin.clone().unwrap_or_else(Self::admin_role);
+        for role_config in roles.values() {
+            let admin = role_config.admin.clone().unwrap_or_else(Self::admin_role);
             if !reaches_populated_role(&admin, &roles) {
                 return Err(RoleBasedAccessControlError::UnmanageableRole {
-                    role: config.role.clone(),
+                    role: role_config.role.clone(),
                     admin,
                 });
             }
@@ -398,8 +398,8 @@ fn reaches_populated_role(role: &RoleSymbol, configs: &BTreeMap<RoleSymbol, Role
 
     while visited.insert(current.clone()) {
         current = match configs.get(&current) {
-            Some(config) if !config.members.is_empty() => return true,
-            Some(config) => config.admin.clone().unwrap_or_else(|| admin_role.clone()),
+            Some(role) if !role.members.is_empty() => return true,
+            Some(role) => role.admin.clone().unwrap_or_else(|| admin_role.clone()),
             None => admin_role.clone(),
         };
     }

--- a/crates/miden-standards/src/account/access/rbac.rs
+++ b/crates/miden-standards/src/account/access/rbac.rs
@@ -35,73 +35,73 @@ static ROLE_MEMBERSHIP_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
         .expect("storage slot name should be valid")
 });
 
-// ROLE SEED
+// ROLE CONFIG
 // ================================================================================================
 
-/// A role seeded into the [`RoleBasedAccessControl`] component at construction: the accounts
-/// holding the role and the role administering it.
+/// A role configuration for the [`RoleBasedAccessControl`] component: the accounts holding the
+/// role and the role administering it.
 ///
-/// A seed establishes the state that the `grant_role` and `set_role_admin` procedures would
+/// A config establishes the state that the `grant_role` and `set_role_admin` procedures would
 /// otherwise have to reach on-chain, so an account can be created with its final role graph
-/// already in place. A seed is validated only once it is passed to the
+/// already in place. A config is validated only once it is passed to the
 /// [`RoleBasedAccessControl` builder][RoleBasedAccessControl::builder], which checks it against
-/// the other seeds; a `RoleSeed` on its own carries no guarantee of being usable.
+/// the other roles; a `RoleConfig` on its own carries no guarantee of being usable.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RoleSeed {
+pub struct RoleConfig {
     role: RoleSymbol,
     members: BTreeSet<AccountId>,
     admin: Option<RoleSymbol>,
 }
 
-#[bon::bon]
-impl RoleSeed {
-    /// Returns a seed for `role`, held by the accounts added through the
-    /// [`member`][RoleSeedBuilder::member] and [`members`][RoleSeedBuilder::members] setters.
+impl RoleConfig {
+    /// Returns an empty configuration for a new role.
+    pub fn new(role: RoleSymbol) -> Self {
+        Self {
+            role,
+            members: BTreeSet::new(),
+            admin: None,
+        }
+    }
+
+    /// Defines an admin for the role. `admin` delegates the role's administration to another role.
+    /// Leaving it unset leaves the role administered by the built-in
+    /// [`ADMIN`][RoleBasedAccessControl::ADMIN_ROLE] role.
     ///
-    /// `admin` delegates the role's administration to another role. Leaving it unset leaves the
-    /// role administered by the built-in [`ADMIN`][RoleBasedAccessControl::ADMIN_ROLE] role.
-    ///
-    /// A seed carrying a delegated admin but no members configures administration for a role that
-    /// does not exist yet; the role starts existing once it is granted its first member.
-    #[builder]
-    pub fn new(
-        #[builder(field)] members: BTreeSet<AccountId>,
-        role: RoleSymbol,
-        admin: Option<RoleSymbol>,
-    ) -> Self {
-        Self { role, members, admin }
+    /// A role with a delegated admin but no members configures administration for a role that does
+    /// not exist yet; the role starts existing once it is granted its first member.
+    pub fn with_admin(mut self, admin: RoleSymbol) -> Self {
+        self.admin = Some(admin);
+        self
+    }
+
+    /// Adds the specified accounts to the role's member set.
+    pub fn with_members(mut self, members: impl IntoIterator<Item = AccountId>) -> Self {
+        self.members.extend(members);
+        self
+    }
+
+    /// Adds a single account to this role's member set.
+    pub fn with_member(mut self, member: AccountId) -> Self {
+        self.members.insert(member);
+        self
     }
 }
 
-impl RoleSeed {
-    /// Returns the symbol of the seeded role.
+impl RoleConfig {
+    /// Returns the symbol of the role.
     pub fn role(&self) -> &RoleSymbol {
         &self.role
     }
 
-    /// Returns the accounts seeded as members of the role.
+    /// Returns the members set of the role.
     pub fn members(&self) -> &BTreeSet<AccountId> {
         &self.members
     }
 
-    /// Returns the role administering the seeded role, or `None` if it is administered by the
+    /// Returns the role administering the this role, or `None` if it is administered by the
     /// built-in [`ADMIN`][RoleBasedAccessControl::ADMIN_ROLE] role.
     pub fn admin(&self) -> Option<&RoleSymbol> {
         self.admin.as_ref()
-    }
-}
-
-impl<S: role_seed_builder::State> RoleSeedBuilder<S> {
-    /// Adds a single account as a member of the seeded role.
-    pub fn member(mut self, member: AccountId) -> Self {
-        self.members.insert(member);
-        self
-    }
-
-    /// Adds multiple accounts as members of the seeded role.
-    pub fn members(mut self, members: impl IntoIterator<Item = AccountId>) -> Self {
-        self.members.extend(members);
-        self
     }
 }
 
@@ -131,7 +131,7 @@ impl<S: role_seed_builder::State> RoleSeedBuilder<S> {
 /// [`ADMIN`][Self::ADMIN_ROLE] role. Only members of a role's effective admin role may grant,
 /// revoke, or re-point (`set_role_admin`) that role.
 ///
-/// A component seeding any role is seeded with a live administration path for it (see
+/// A component defined any role is configured with a live administration path for it (see
 /// [`builder`][Self::builder]), which for a role left with the default admin means members of the
 /// `ADMIN` role. The `ADMIN` role administers itself, so `ADMIN` membership can be granted,
 /// revoked, and renounced through the standard API.
@@ -150,12 +150,12 @@ impl<S: role_seed_builder::State> RoleSeedBuilder<S> {
 /// administrator. To hand authority back, the current delegated admin re-points the role
 /// (passing `0` reverts it to the `ADMIN` role).
 ///
-/// Both members and delegated admins can be seeded at construction (see [`RoleSeed`]), which
-/// establishes exclusive delegation atomically: a role seeded with a delegated admin is never
+/// Both members and delegated admins can be configured at construction (see [`RoleConfig`]), which
+/// establishes exclusive delegation atomically: a role configured with a delegated admin is never
 /// reachable by `ADMIN`, not even transiently. Reaching the same configuration on an existing
 /// account requires the sequence below, during which `ADMIN` still administers the role. That
-/// window is also the only chance to repair a mistyped or hostile admin role, so a seeded
-/// delegation must be verified before account creation: seeding proves that *some* role can
+/// window is also the only chance to repair a mistyped or hostile admin role, so a configured
+/// delegation must be verified before account creation: initialization proves that *some* role can
 /// administer the delegated role, never that the deployer controls it.
 ///
 /// This supports a fully decentralized configuration: for each delegated role, (1) grant the
@@ -211,58 +211,58 @@ impl<S: role_seed_builder::State> RoleSeedBuilder<S> {
 /// [`RoleSymbol`]: miden_protocol::account::RoleSymbol
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RoleBasedAccessControl {
-    /// The roles seeded at construction, keyed by their symbol. May be empty, in which case the
+    /// The roles defined at construction, keyed by their symbol. May be empty, in which case the
     /// component starts with no administrator and no role members.
-    roles: BTreeMap<RoleSymbol, RoleSeed>,
+    roles: BTreeMap<RoleSymbol, RoleConfig>,
 }
 
 #[bon::bon]
 impl RoleBasedAccessControl {
-    /// Returns an RBAC component seeded with the given roles, each carrying its members and its
-    /// delegated admin (see [`RoleSeed`]).
+    /// Returns an RBAC component initialized with the given roles, each carrying its members and
+    /// its delegated admin (see [`RoleConfig`]).
     ///
-    /// Seeds are added with the [`role`][RoleBasedAccessControlBuilder::role] and
-    /// [`roles`][RoleBasedAccessControlBuilder::roles] setters. Seeding no role at all is allowed
-    /// and produces a component with no roles and no administrator.
+    /// Roles are added with the [`role`][RoleBasedAccessControlBuilder::role] and
+    /// [`roles`][RoleBasedAccessControlBuilder::roles] setters. Initializing no role at all is
+    /// allowed and produces a component with no roles and no administrator.
     ///
     /// # Errors
     ///
     /// Returns an error if:
-    /// - the same role is seeded more than once.
-    /// - a role is seeded with neither members nor a delegated admin, which would seed nothing.
+    /// - the same role is specified more than once.
+    /// - a role is configured with neither members nor a delegated admin.
     /// - a role's member count exceeds [`u32::MAX`].
     /// - a role's effective admin — its delegated admin, or `ADMIN` when unset — can never hold
-    ///   members, which would leave the role permanently unmanageable. Seeding an operational role
-    ///   without seeding `ADMIN` is the common case: `ADMIN` administers itself, so nothing can
+    ///   members, which would leave the role permanently unmanageable. Setting an operational role
+    ///   without defining `ADMIN` is the common case: `ADMIN` administers itself, so nothing can
     ///   ever populate it.
     #[builder]
     pub fn new(
-        #[builder(field)] role_seeds: Vec<RoleSeed>,
+        #[builder(field)] role_configs: Vec<RoleConfig>,
     ) -> Result<Self, RoleBasedAccessControlError> {
         let mut roles = BTreeMap::new();
-        for seed in role_seeds {
-            if seed.members.is_empty() && seed.admin.is_none() {
-                return Err(RoleBasedAccessControlError::EmptyRoleSeed(seed.role));
+        for config in role_configs {
+            if config.members.is_empty() && config.admin.is_none() {
+                return Err(RoleBasedAccessControlError::EmptyRoleConfig(config.role));
             }
-            if u32::try_from(seed.members.len()).is_err() {
+            if u32::try_from(config.members.len()).is_err() {
                 return Err(RoleBasedAccessControlError::MemberCountOverflow {
-                    role: seed.role,
-                    member_count: seed.members.len(),
+                    role: config.role,
+                    member_count: config.members.len(),
                 });
             }
-            if roles.contains_key(&seed.role) {
-                return Err(RoleBasedAccessControlError::DuplicateRole(seed.role));
+            if roles.contains_key(&config.role) {
+                return Err(RoleBasedAccessControlError::DuplicateRole(config.role));
             }
-            roles.insert(seed.role.clone(), seed);
+            roles.insert(config.role.clone(), config);
         }
 
-        // Check the effective admin of every seed, not just of the explicitly delegated ones: a
-        // seed left with the default admin is just as frozen when `ADMIN` can never hold members.
-        for seed in roles.values() {
-            let admin = seed.admin.clone().unwrap_or_else(Self::admin_role);
+        // Check the effective admin of every role, not just of the explicitly delegated ones: a
+        // role left with the default admin is just as frozen when `ADMIN` can never hold members.
+        for config in roles.values() {
+            let admin = config.admin.clone().unwrap_or_else(Self::admin_role);
             if !reaches_populated_role(&admin, &roles) {
                 return Err(RoleBasedAccessControlError::UnmanageableRole {
-                    role: seed.role.clone(),
+                    role: config.role.clone(),
                     admin,
                 });
             }
@@ -285,8 +285,8 @@ impl RoleBasedAccessControl {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns an RBAC component whose built-in [`ADMIN`][Self::ADMIN_ROLE] role is seeded with
-    /// `admins` and which seeds no other role.
+    /// Returns an RBAC component whose built-in [`ADMIN`][Self::ADMIN_ROLE] role is configured
+    /// with `admins` and which defines no other role.
     ///
     /// # Errors
     ///
@@ -296,7 +296,7 @@ impl RoleBasedAccessControl {
         admins: impl IntoIterator<Item = AccountId>,
     ) -> Result<Self, RoleBasedAccessControlError> {
         Self::builder()
-            .role(RoleSeed::builder().role(Self::admin_role()).members(admins).build())
+            .role(RoleConfig::new(Self::admin_role()).with_members(admins))
             .build()
     }
 
@@ -367,15 +367,15 @@ impl RoleBasedAccessControl {
 }
 
 impl<S: role_based_access_control_builder::State> RoleBasedAccessControlBuilder<S> {
-    /// Adds a single role seed to the component.
-    pub fn role(mut self, seed: RoleSeed) -> Self {
-        self.role_seeds.push(seed);
+    /// Adds a single role to the component.
+    pub fn role(mut self, config: RoleConfig) -> Self {
+        self.role_configs.push(config);
         self
     }
 
-    /// Adds multiple role seeds to the component.
-    pub fn roles(mut self, seeds: impl IntoIterator<Item = RoleSeed>) -> Self {
-        self.role_seeds.extend(seeds);
+    /// Adds multiple role to the component.
+    pub fn roles(mut self, configs: impl IntoIterator<Item = RoleConfig>) -> Self {
+        self.role_configs.extend(configs);
         self
     }
 }
@@ -383,22 +383,23 @@ impl<S: role_based_access_control_builder::State> RoleBasedAccessControlBuilder<
 // HELPERS
 // ================================================================================================
 
-/// Returns `true` if walking the delegated-admin chain starting at `role` reaches a role seeded
+/// Returns `true` if walking the delegated-admin chain starting at `role` reaches a role defined
 /// with at least one member.
 ///
 /// Only a populated role can grant members to the role below it in the chain, so a chain that
-/// reaches none of them can never be acted on by anyone. A role that is not seeded, or seeded
-/// without members, is administered by its delegated admin, defaulting to `ADMIN`. Every role has
-/// exactly one admin, so the walk always ends in a cycle, which the visited set terminates.
-fn reaches_populated_role(role: &RoleSymbol, seeds: &BTreeMap<RoleSymbol, RoleSeed>) -> bool {
+/// reaches none of them can never be acted on by anyone. A role that is not configured, or
+/// configured without members, is administered by its delegated admin, defaulting to `ADMIN`.
+/// Every role has exactly one admin, so the walk always ends in a cycle, which the visited set
+/// terminates.
+fn reaches_populated_role(role: &RoleSymbol, configs: &BTreeMap<RoleSymbol, RoleConfig>) -> bool {
     let admin_role = RoleBasedAccessControl::admin_role();
     let mut visited = BTreeSet::new();
     let mut current = role.clone();
 
     while visited.insert(current.clone()) {
-        current = match seeds.get(&current) {
-            Some(seed) if !seed.members.is_empty() => return true,
-            Some(seed) => seed.admin.clone().unwrap_or_else(|| admin_role.clone()),
+        current = match configs.get(&current) {
+            Some(config) if !config.members.is_empty() => return true,
+            Some(config) => config.admin.clone().unwrap_or_else(|| admin_role.clone()),
             None => admin_role.clone(),
         };
     }
@@ -411,21 +412,21 @@ fn reaches_populated_role(role: &RoleSymbol, seeds: &BTreeMap<RoleSymbol, RoleSe
 
 impl From<RoleBasedAccessControl> for AccountComponent {
     fn from(rbac: RoleBasedAccessControl) -> Self {
-        // Seed, for every role:
+        // Config, for every role:
         // - role_config:     [0, 0, 0, role] -> [member_count, admin_role, 0, 0]
         // - role_membership: [0, role, acct_suffix, acct_prefix] -> [1, 0, 0, 0]
         let mut config_entries = Vec::new();
         let mut membership_entries = Vec::new();
-        for seed in rbac.roles.into_values() {
-            let role_symbol: Felt = seed.role.as_element();
-            let member_count =
-                u32::try_from(seed.members.len()).expect("member count is validated on seeding");
-            let admin_symbol = seed.admin.as_ref().map_or(Felt::ZERO, RoleSymbol::as_element);
+        for config in rbac.roles.into_values() {
+            let role_symbol: Felt = config.role.as_element();
+            let member_count = u32::try_from(config.members.len())
+                .expect("member count is validated on initialization");
+            let admin_symbol = config.admin.as_ref().map_or(Felt::ZERO, RoleSymbol::as_element);
             config_entries.push((
                 StorageMapKey::new(Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, role_symbol])),
                 Word::from([Felt::from(member_count), admin_symbol, Felt::ZERO, Felt::ZERO]),
             ));
-            for member in seed.members {
+            for member in config.members {
                 membership_entries.push((
                     StorageMapKey::new(Word::from([
                         Felt::ZERO,
@@ -439,9 +440,9 @@ impl From<RoleBasedAccessControl> for AccountComponent {
         }
 
         let role_membership_map = StorageMap::with_entries(membership_entries)
-            .expect("seeded role membership map should be valid");
+            .expect("config role membership map should be valid");
         let role_config_map = StorageMap::with_entries(config_entries)
-            .expect("seeded role config map should be valid");
+            .expect("config role config map should be valid");
 
         let role_config_slot = StorageSlot::with_map(
             RoleBasedAccessControl::role_config_slot().clone(),
@@ -464,23 +465,26 @@ impl From<RoleBasedAccessControl> for AccountComponent {
 // ROLE BASED ACCESS CONTROL ERROR
 // ================================================================================================
 
-/// Errors that can occur when seeding the [`RoleBasedAccessControl`] component.
+/// Errors that can occur when initializing the [`RoleBasedAccessControl`] component.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum RoleBasedAccessControlError {
-    #[error("role {0} is seeded more than once")]
+    #[error("role {0} is defined more than once")]
     DuplicateRole(RoleSymbol),
-    #[error("role {0} is seeded with neither members nor a delegated admin")]
-    EmptyRoleSeed(RoleSymbol),
+    #[error("role {0} is defined with neither members nor a delegated admin")]
+    EmptyRoleConfig(RoleSymbol),
     #[error(
-        "role {role} is seeded with {member_count} members which exceeds the maximum of {}",
+        "role {role} is defined with {member_count} members which exceeds the maximum of {}",
         u32::MAX
     )]
     MemberCountOverflow { role: RoleSymbol, member_count: usize },
     #[error(
-        "role {role} is seeded with delegated admin {admin}, which can never hold members and so leaves {role} unmanageable"
+        "role {role} is defined with delegated admin {admin}, which can never hold members and so leaves {role} unmanageable"
     )]
     UnmanageableRole { role: RoleSymbol, admin: RoleSymbol },
 }
+
+// TESTS
+// ================================================================================================
 
 #[cfg(test)]
 mod tests {
@@ -530,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn with_admins_seeds_every_admin_and_the_member_count() -> anyhow::Result<()> {
+    fn with_admins_sets_every_admin_and_the_member_count() -> anyhow::Result<()> {
         // Members are held in a `BTreeSet`, so duplicate account IDs collapse before this point
         // and the member count always matches the number of membership entries.
         let admins = [test_admin(1), test_admin(2), test_admin(3)];
@@ -566,16 +570,16 @@ mod tests {
     #[test]
     fn with_admins_rejects_an_empty_member_set() {
         let error =
-            RoleBasedAccessControl::with_admins([]).expect_err("seeding should have failed");
+            RoleBasedAccessControl::with_admins([]).expect_err("initialization should have failed");
 
         assert_eq!(
             error,
-            RoleBasedAccessControlError::EmptyRoleSeed(RoleBasedAccessControl::admin_role())
+            RoleBasedAccessControlError::EmptyRoleConfig(RoleBasedAccessControl::admin_role())
         );
     }
 
     #[test]
-    fn seeding_no_role_seeds_no_admin() -> anyhow::Result<()> {
+    fn defining_no_role_defines_no_admin() -> anyhow::Result<()> {
         let component: AccountComponent = RoleBasedAccessControl::builder().build()?.into();
 
         // No membership entries and an empty config: the component starts with no administrator.
@@ -587,10 +591,10 @@ mod tests {
         Ok(())
     }
 
-    /// A delegated admin is seeded into the role config, which places the role out of `ADMIN`'s
+    /// A delegated admin is defined in the role config, which places the role out of `ADMIN`'s
     /// reach without any on-chain `set_role_admin`.
     #[test]
-    fn seeded_delegated_admin_is_written_to_the_role_config() -> anyhow::Result<()> {
+    fn defining_delegated_admin_is_written_to_the_role_config() -> anyhow::Result<()> {
         let admin = test_admin(1);
         let manager = test_admin(2);
         let pauser = test_admin(3);
@@ -600,25 +604,16 @@ mod tests {
 
         let component: AccountComponent = RoleBasedAccessControl::builder()
             .role(
-                RoleSeed::builder()
-                    .role(RoleBasedAccessControl::admin_role())
-                    .member(admin)
-                    .build(),
+                RoleConfig::new(RoleBasedAccessControl::admin_role()).with_member(admin),
             )
             // DOM_MANAGER administers itself, so ADMIN cannot rotate its membership.
             .role(
-                RoleSeed::builder()
-                    .role(manager_role.clone())
-                    .member(manager)
-                    .admin(manager_role.clone())
-                    .build(),
+                RoleConfig::new(manager_role.clone()).with_member(manager)
+                    .with_admin(manager_role.clone())
             )
             .role(
-                RoleSeed::builder()
-                    .role(pauser_role.clone())
-                    .member(pauser)
-                    .admin(manager_role.clone())
-                    .build(),
+                RoleConfig::new(pauser_role.clone()).with_member(pauser)
+                    .with_admin(manager_role.clone())
             )
             .build()?
             .into();
@@ -638,16 +633,16 @@ mod tests {
     }
 
     /// Delegating the admin of a role that has no members yet is what `set_role_admin` does on an
-    /// existing account, so seeding it must be expressible too.
+    /// existing account, so initializing it must be expressible too.
     #[test]
-    fn role_seeded_without_members_holds_its_delegated_admin() -> anyhow::Result<()> {
+    fn role_initialized_without_members_holds_its_delegated_admin() -> anyhow::Result<()> {
         let admin = test_admin(1);
         let minter_role = RoleSymbol::new("MINTER")?;
         let minter_admin_role = RoleBasedAccessControl::admin_role();
 
         let component: AccountComponent = RoleBasedAccessControl::builder()
-            .role(RoleSeed::builder().role(minter_admin_role.clone()).member(admin).build())
-            .role(RoleSeed::builder().role(minter_role.clone()).admin(minter_admin_role).build())
+            .role(RoleConfig::new(minter_admin_role.clone()).with_member(admin))
+            .role(RoleConfig::new(minter_role.clone()).with_admin(minter_admin_role))
             .build()?
             .into();
 
@@ -677,13 +672,8 @@ mod tests {
         let minter_admin_role = RoleSymbol::new("MINTER_ADMIN")?;
 
         RoleBasedAccessControl::builder()
-            .role(
-                RoleSeed::builder()
-                    .role(RoleBasedAccessControl::admin_role())
-                    .member(admin)
-                    .build(),
-            )
-            .role(RoleSeed::builder().role(minter_role).admin(minter_admin_role).build())
+            .role(RoleConfig::new(RoleBasedAccessControl::admin_role()).with_member(admin))
+            .role(RoleConfig::new(minter_role).with_admin(minter_admin_role))
             .build()?;
 
         Ok(())
@@ -692,21 +682,21 @@ mod tests {
     #[rstest::rstest]
     #[case::duplicate_role(
         vec![
-            RoleSeed::builder().role(role("MINTER")).member(test_admin(1)).build(),
-            RoleSeed::builder().role(role("MINTER")).member(test_admin(2)).build(),
+            RoleConfig::new(role("MINTER")).with_member(test_admin(1)),
+            RoleConfig::new(role("MINTER")).with_member(test_admin(2)),
         ],
         RoleBasedAccessControlError::DuplicateRole(role("MINTER")),
     )]
-    #[case::empty_seed(
-        vec![RoleSeed::builder().role(role("MINTER")).build()],
-        RoleBasedAccessControlError::EmptyRoleSeed(role("MINTER")),
+    #[case::empty_config(
+        vec![RoleConfig::new(role("MINTER"))],
+        RoleBasedAccessControlError::EmptyRoleConfig(role("MINTER")),
     )]
     // MINTER delegates to a self-administering role that has no members, so nobody can ever
     // populate MINTER_ADMIN and MINTER stays unmanageable.
     #[case::unmanageable_role(
         vec![
-            RoleSeed::builder().role(role("MINTER")).admin(role("MINTER_ADMIN")).build(),
-            RoleSeed::builder().role(role("MINTER_ADMIN")).admin(role("MINTER_ADMIN")).build(),
+            RoleConfig::new(role("MINTER")).with_admin(role("MINTER_ADMIN")),
+            RoleConfig::new(role("MINTER_ADMIN")).with_admin(role("MINTER_ADMIN")),
         ],
         RoleBasedAccessControlError::UnmanageableRole {
             role: role("MINTER"),
@@ -714,27 +704,27 @@ mod tests {
         },
     )]
     #[case::empty_admins(
-        vec![RoleSeed::builder().role(RoleBasedAccessControl::admin_role()).build()],
-        RoleBasedAccessControlError::EmptyRoleSeed(RoleBasedAccessControl::admin_role()),
+        vec![RoleConfig::new(RoleBasedAccessControl::admin_role())],
+        RoleBasedAccessControlError::EmptyRoleConfig(RoleBasedAccessControl::admin_role()),
     )]
     // Leaving MINTER's admin unset makes ADMIN administer it, but ADMIN administers itself, so an
-    // unseeded ADMIN can never hold members. This is the same defect as `unmanageable_role`,
+    // unspecified ADMIN can never hold members. This is the same defect as `unmanageable_role`,
     // spelled implicitly.
-    #[case::unseeded_default_admin(
-        vec![RoleSeed::builder().role(role("MINTER")).member(test_admin(1)).build()],
+    #[case::unspecified_default_admin(
+        vec![RoleConfig::new(role("MINTER")).with_member(test_admin(1))],
         RoleBasedAccessControlError::UnmanageableRole {
             role: role("MINTER"),
             admin: RoleBasedAccessControl::admin_role(),
         },
     )]
-    fn invalid_seeds_are_rejected(
-        #[case] seeds: Vec<RoleSeed>,
+    fn invalid_role_configs_are_rejected(
+        #[case] configs: Vec<RoleConfig>,
         #[case] expected: RoleBasedAccessControlError,
     ) {
         let error = RoleBasedAccessControl::builder()
-            .roles(seeds)
+            .roles(configs)
             .build()
-            .expect_err("seeding should have failed");
+            .expect_err("initialization should have failed");
 
         assert_eq!(error, expected);
     }

--- a/crates/miden-standards/src/account/access/rbac.rs
+++ b/crates/miden-standards/src/account/access/rbac.rs
@@ -35,6 +35,79 @@ static ROLE_MEMBERSHIP_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
         .expect("storage slot name should be valid")
 });
 
+// ROLE SEED
+// ================================================================================================
+
+/// A role seeded into the [`RoleBasedAccessControl`] component at construction: the accounts
+/// holding the role and the role administering it.
+///
+/// A seed establishes the state that the `grant_role` and `set_role_admin` procedures would
+/// otherwise have to reach on-chain, so an account can be created with its final role graph
+/// already in place. A seed is validated only once it is passed to the
+/// [`RoleBasedAccessControl` builder][RoleBasedAccessControl::builder], which checks it against
+/// the other seeds; a `RoleSeed` on its own carries no guarantee of being usable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoleSeed {
+    role: RoleSymbol,
+    members: BTreeSet<AccountId>,
+    admin: Option<RoleSymbol>,
+}
+
+#[bon::bon]
+impl RoleSeed {
+    /// Returns a seed for `role`, held by the accounts added through the
+    /// [`member`][RoleSeedBuilder::member] and [`members`][RoleSeedBuilder::members] setters.
+    ///
+    /// `admin` delegates the role's administration to another role. Leaving it unset leaves the
+    /// role administered by the built-in [`ADMIN`][RoleBasedAccessControl::ADMIN_ROLE] role.
+    ///
+    /// A seed carrying a delegated admin but no members configures administration for a role that
+    /// does not exist yet; the role starts existing once it is granted its first member.
+    #[builder]
+    pub fn new(
+        #[builder(field)] members: BTreeSet<AccountId>,
+        role: RoleSymbol,
+        admin: Option<RoleSymbol>,
+    ) -> Self {
+        Self { role, members, admin }
+    }
+}
+
+impl RoleSeed {
+    /// Returns the symbol of the seeded role.
+    pub fn role(&self) -> &RoleSymbol {
+        &self.role
+    }
+
+    /// Returns the accounts seeded as members of the role.
+    pub fn members(&self) -> &BTreeSet<AccountId> {
+        &self.members
+    }
+
+    /// Returns the role administering the seeded role, or `None` if it is administered by the
+    /// built-in [`ADMIN`][RoleBasedAccessControl::ADMIN_ROLE] role.
+    pub fn admin(&self) -> Option<&RoleSymbol> {
+        self.admin.as_ref()
+    }
+}
+
+impl<S: role_seed_builder::State> RoleSeedBuilder<S> {
+    /// Adds a single account as a member of the seeded role.
+    pub fn member(mut self, member: AccountId) -> Self {
+        self.members.insert(member);
+        self
+    }
+
+    /// Adds multiple accounts as members of the seeded role.
+    pub fn members(mut self, members: impl IntoIterator<Item = AccountId>) -> Self {
+        self.members.extend(members);
+        self
+    }
+}
+
+// ROLE BASED ACCESS CONTROL
+// ================================================================================================
+
 /// Role-based access control (RBAC) for account components.
 ///
 /// Instead of having one account holding every privilege, privileges are split into named
@@ -58,9 +131,10 @@ static ROLE_MEMBERSHIP_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// [`ADMIN`][Self::ADMIN_ROLE] role. Only members of a role's effective admin role may grant,
 /// revoke, or re-point (`set_role_admin`) that role.
 ///
-/// The component is seeded at construction with one or more members of the `ADMIN` role (see
-/// [`new`][Self::new]); this bootstraps administration. The `ADMIN` role administers itself, so
-/// `ADMIN` membership can be granted, revoked, and renounced through the standard API.
+/// A component seeding any role is seeded with a live administration path for it (see
+/// [`builder`][Self::builder]), which for a role left with the default admin means members of the
+/// `ADMIN` role. The `ADMIN` role administers itself, so `ADMIN` membership can be granted,
+/// revoked, and renounced through the standard API.
 ///
 /// ## Role hierarchy and exclusive delegation
 ///
@@ -75,6 +149,14 @@ static ROLE_MEMBERSHIP_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// exclusively under a dedicated admin role and kept out of reach of the general
 /// administrator. To hand authority back, the current delegated admin re-points the role
 /// (passing `0` reverts it to the `ADMIN` role).
+///
+/// Both members and delegated admins can be seeded at construction (see [`RoleSeed`]), which
+/// establishes exclusive delegation atomically: a role seeded with a delegated admin is never
+/// reachable by `ADMIN`, not even transiently. Reaching the same configuration on an existing
+/// account requires the sequence below, during which `ADMIN` still administers the role. That
+/// window is also the only chance to repair a mistyped or hostile admin role, so a seeded
+/// delegation must be verified before account creation: seeding proves that *some* role can
+/// administer the delegated role, never that the deployer controls it.
 ///
 /// This supports a fully decentralized configuration: for each delegated role, (1) grant the
 /// dedicated admin role's members, (2) make it self-administering (`set_role_admin(X, X)` —
@@ -129,14 +211,65 @@ static ROLE_MEMBERSHIP_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// [`RoleSymbol`]: miden_protocol::account::RoleSymbol
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RoleBasedAccessControl {
-    /// Accounts seeded as members of the built-in [`ADMIN`][Self::ADMIN_ROLE] role at
-    /// construction. Bootstraps role administration; may be empty for an account that seeds
-    /// `ADMIN` membership by other means, but such a component starts with no administrator.
-    initial_admins: BTreeSet<AccountId>,
-    /// Additional roles seeded at construction, keyed by role symbol. Each seeded role's
-    /// delegated admin is left unset, so it is administered by the `ADMIN` role (see
-    /// [`with_role_members`][Self::with_role_members]).
-    initial_role_members: BTreeMap<RoleSymbol, BTreeSet<AccountId>>,
+    /// The roles seeded at construction, keyed by their symbol. May be empty, in which case the
+    /// component starts with no administrator and no role members.
+    roles: BTreeMap<RoleSymbol, RoleSeed>,
+}
+
+#[bon::bon]
+impl RoleBasedAccessControl {
+    /// Returns an RBAC component seeded with the given roles, each carrying its members and its
+    /// delegated admin (see [`RoleSeed`]).
+    ///
+    /// Seeds are added with the [`role`][RoleBasedAccessControlBuilder::role] and
+    /// [`roles`][RoleBasedAccessControlBuilder::roles] setters. Seeding no role at all is allowed
+    /// and produces a component with no roles and no administrator.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - the same role is seeded more than once.
+    /// - a role is seeded with neither members nor a delegated admin, which would seed nothing.
+    /// - a role's member count exceeds [`u32::MAX`].
+    /// - a role's effective admin — its delegated admin, or `ADMIN` when unset — can never hold
+    ///   members, which would leave the role permanently unmanageable. Seeding an operational role
+    ///   without seeding `ADMIN` is the common case: `ADMIN` administers itself, so nothing can
+    ///   ever populate it.
+    #[builder]
+    pub fn new(
+        #[builder(field)] role_seeds: Vec<RoleSeed>,
+    ) -> Result<Self, RoleBasedAccessControlError> {
+        let mut roles = BTreeMap::new();
+        for seed in role_seeds {
+            if seed.members.is_empty() && seed.admin.is_none() {
+                return Err(RoleBasedAccessControlError::EmptyRoleSeed(seed.role));
+            }
+            if u32::try_from(seed.members.len()).is_err() {
+                return Err(RoleBasedAccessControlError::MemberCountOverflow {
+                    role: seed.role,
+                    member_count: seed.members.len(),
+                });
+            }
+            if roles.contains_key(&seed.role) {
+                return Err(RoleBasedAccessControlError::DuplicateRole(seed.role));
+            }
+            roles.insert(seed.role.clone(), seed);
+        }
+
+        // Check the effective admin of every seed, not just of the explicitly delegated ones: a
+        // seed left with the default admin is just as frozen when `ADMIN` can never hold members.
+        for seed in roles.values() {
+            let admin = seed.admin.clone().unwrap_or_else(Self::admin_role);
+            if !reaches_populated_role(&admin, &roles) {
+                return Err(RoleBasedAccessControlError::UnmanageableRole {
+                    role: seed.role.clone(),
+                    admin,
+                });
+            }
+        }
+
+        Ok(Self { roles })
+    }
 }
 
 impl RoleBasedAccessControl {
@@ -152,21 +285,19 @@ impl RoleBasedAccessControl {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns an RBAC component whose `ADMIN` role is seeded with `initial_admins` and whose
-    /// additional roles are each seeded with the given `role_members` set at construction.
+    /// Returns an RBAC component whose built-in [`ADMIN`][Self::ADMIN_ROLE] role is seeded with
+    /// `admins` and which seeds no other role.
     ///
-    /// Each seeded role's delegated admin is left unset, so — like any role — it is administered
-    /// by the `ADMIN` role until an admin is delegated via `set_role_admin`. This lets an account
-    /// be created already populated with role holders alongside the bootstrap administrator. A role
-    /// mapped to an empty member set is dropped: a role with no members is a no-op.
-    pub fn new(
-        initial_admins: BTreeSet<AccountId>,
-        role_members: BTreeMap<RoleSymbol, BTreeSet<AccountId>>,
-    ) -> Self {
-        Self {
-            initial_admins,
-            initial_role_members: role_members,
-        }
+    /// # Errors
+    ///
+    /// Returns an error if `admins` is empty, since the resulting component would have no
+    /// administrator. Build such a component with the [`builder`][Self::builder] instead.
+    pub fn with_admins(
+        admins: impl IntoIterator<Item = AccountId>,
+    ) -> Result<Self, RoleBasedAccessControlError> {
+        Self::builder()
+            .role(RoleSeed::builder().role(Self::admin_role()).members(admins).build())
+            .build()
     }
 
     // PUBLIC ACCESSORS
@@ -235,37 +366,66 @@ impl RoleBasedAccessControl {
     }
 }
 
+impl<S: role_based_access_control_builder::State> RoleBasedAccessControlBuilder<S> {
+    /// Adds a single role seed to the component.
+    pub fn role(mut self, seed: RoleSeed) -> Self {
+        self.role_seeds.push(seed);
+        self
+    }
+
+    /// Adds multiple role seeds to the component.
+    pub fn roles(mut self, seeds: impl IntoIterator<Item = RoleSeed>) -> Self {
+        self.role_seeds.extend(seeds);
+        self
+    }
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Returns `true` if walking the delegated-admin chain starting at `role` reaches a role seeded
+/// with at least one member.
+///
+/// Only a populated role can grant members to the role below it in the chain, so a chain that
+/// reaches none of them can never be acted on by anyone. A role that is not seeded, or seeded
+/// without members, is administered by its delegated admin, defaulting to `ADMIN`. Every role has
+/// exactly one admin, so the walk always ends in a cycle, which the visited set terminates.
+fn reaches_populated_role(role: &RoleSymbol, seeds: &BTreeMap<RoleSymbol, RoleSeed>) -> bool {
+    let admin_role = RoleBasedAccessControl::admin_role();
+    let mut visited = BTreeSet::new();
+    let mut current = role.clone();
+
+    while visited.insert(current.clone()) {
+        current = match seeds.get(&current) {
+            Some(seed) if !seed.members.is_empty() => return true,
+            Some(seed) => seed.admin.clone().unwrap_or_else(|| admin_role.clone()),
+            None => admin_role.clone(),
+        };
+    }
+
+    false
+}
+
+// CONVERSIONS
+// ================================================================================================
+
 impl From<RoleBasedAccessControl> for AccountComponent {
     fn from(rbac: RoleBasedAccessControl) -> Self {
-        // Combine the seeded ADMIN members with any additional seeded roles into a single
-        // role -> members map. Each seeded role (including ADMIN) leaves its delegated admin unset
-        // (0), so ADMIN administers it. Members provided for the `ADMIN` role are merged with
-        // `initial_admins`.
-        let mut roles = rbac.initial_role_members;
-        if !rbac.initial_admins.is_empty() {
-            roles
-                .entry(RoleBasedAccessControl::admin_role())
-                .or_default()
-                .extend(rbac.initial_admins);
-        }
-
-        // Seed, for every non-empty role:
-        // - role_config:     [0, 0, 0, role] -> [member_count, 0, 0, 0]
+        // Seed, for every role:
+        // - role_config:     [0, 0, 0, role] -> [member_count, admin_role, 0, 0]
         // - role_membership: [0, role, acct_suffix, acct_prefix] -> [1, 0, 0, 0]
         let mut config_entries = Vec::new();
         let mut membership_entries = Vec::new();
-        for (role, members) in &roles {
-            if members.is_empty() {
-                continue;
-            }
-            let role_symbol: Felt = role.as_element();
+        for seed in rbac.roles.into_values() {
+            let role_symbol: Felt = seed.role.as_element();
             let member_count =
-                u32::try_from(members.len()).expect("role member count should fit in u32");
+                u32::try_from(seed.members.len()).expect("member count is validated on seeding");
+            let admin_symbol = seed.admin.as_ref().map_or(Felt::ZERO, RoleSymbol::as_element);
             config_entries.push((
                 StorageMapKey::new(Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, role_symbol])),
-                Word::from([Felt::from(member_count), Felt::ZERO, Felt::ZERO, Felt::ZERO]),
+                Word::from([Felt::from(member_count), admin_symbol, Felt::ZERO, Felt::ZERO]),
             ));
-            for member in members {
+            for member in seed.members {
                 membership_entries.push((
                     StorageMapKey::new(Word::from([
                         Felt::ZERO,
@@ -301,6 +461,27 @@ impl From<RoleBasedAccessControl> for AccountComponent {
     }
 }
 
+// ROLE BASED ACCESS CONTROL ERROR
+// ================================================================================================
+
+/// Errors that can occur when seeding the [`RoleBasedAccessControl`] component.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RoleBasedAccessControlError {
+    #[error("role {0} is seeded more than once")]
+    DuplicateRole(RoleSymbol),
+    #[error("role {0} is seeded with neither members nor a delegated admin")]
+    EmptyRoleSeed(RoleSymbol),
+    #[error(
+        "role {role} is seeded with {member_count} members which exceeds the maximum of {}",
+        u32::MAX
+    )]
+    MemberCountOverflow { role: RoleSymbol, member_count: usize },
+    #[error(
+        "role {role} is seeded with delegated admin {admin}, which can never hold members and so leaves {role} unmanageable"
+    )]
+    UnmanageableRole { role: RoleSymbol, admin: RoleSymbol },
+}
+
 #[cfg(test)]
 mod tests {
     use miden_protocol::account::{AccountType, StorageSlotContent};
@@ -311,6 +492,15 @@ mod tests {
         AccountId::builder()
             .account_type(AccountType::Private)
             .build_with_seed([seed; 32])
+    }
+
+    fn role(symbol: &str) -> RoleSymbol {
+        RoleSymbol::new_unchecked(symbol)
+    }
+
+    /// Returns the role config map key of the given role.
+    fn role_config_key(role: &RoleSymbol) -> StorageMapKey {
+        StorageMapKey::new(Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, role.as_element()]))
     }
 
     /// Returns the map content of the component's storage slot with the given name.
@@ -340,13 +530,11 @@ mod tests {
     }
 
     #[test]
-    fn with_admins_seeds_every_admin_and_the_member_count() {
-        // `initial_admins` is a `BTreeSet`, so duplicate account IDs collapse before this point
+    fn with_admins_seeds_every_admin_and_the_member_count() -> anyhow::Result<()> {
+        // Members are held in a `BTreeSet`, so duplicate account IDs collapse before this point
         // and the member count always matches the number of membership entries.
         let admins = [test_admin(1), test_admin(2), test_admin(3)];
-        let component: AccountComponent =
-            RoleBasedAccessControl::new(admins.iter().copied().collect(), BTreeMap::default())
-                .into();
+        let component: AccountComponent = RoleBasedAccessControl::with_admins(admins)?.into();
 
         let admin_symbol = RoleBasedAccessControl::admin_role().as_element();
 
@@ -366,24 +554,188 @@ mod tests {
         }
 
         let config = find_map(&component, RoleBasedAccessControl::role_config_slot());
-        let config_key =
-            StorageMapKey::new(Word::from([Felt::ZERO, Felt::ZERO, Felt::ZERO, admin_symbol]));
-        let member_count = u32::try_from(admins.len()).unwrap();
+        let member_count = u32::try_from(admins.len())?;
         assert_eq!(
-            config.get(&config_key),
+            config.get(&role_config_key(&RoleBasedAccessControl::admin_role())),
             Word::from([Felt::from(member_count), Felt::ZERO, Felt::ZERO, Felt::ZERO]),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn with_admins_rejects_an_empty_member_set() {
+        let error =
+            RoleBasedAccessControl::with_admins([]).expect_err("seeding should have failed");
+
+        assert_eq!(
+            error,
+            RoleBasedAccessControlError::EmptyRoleSeed(RoleBasedAccessControl::admin_role())
         );
     }
 
     #[test]
-    fn with_admins_empty_seeds_no_admin() {
-        let component: AccountComponent =
-            RoleBasedAccessControl::new(BTreeSet::default(), BTreeMap::default()).into();
+    fn seeding_no_role_seeds_no_admin() -> anyhow::Result<()> {
+        let component: AccountComponent = RoleBasedAccessControl::builder().build()?.into();
 
         // No membership entries and an empty config: the component starts with no administrator.
         let membership = find_map(&component, RoleBasedAccessControl::role_membership_slot());
         assert_eq!(membership.num_entries(), 0);
         let config = find_map(&component, RoleBasedAccessControl::role_config_slot());
         assert_eq!(config.num_entries(), 0);
+
+        Ok(())
+    }
+
+    /// A delegated admin is seeded into the role config, which places the role out of `ADMIN`'s
+    /// reach without any on-chain `set_role_admin`.
+    #[test]
+    fn seeded_delegated_admin_is_written_to_the_role_config() -> anyhow::Result<()> {
+        let admin = test_admin(1);
+        let manager = test_admin(2);
+        let pauser = test_admin(3);
+
+        let manager_role = RoleSymbol::new("DOM_MANAGER")?;
+        let pauser_role = RoleSymbol::new("DOM_PAUSER")?;
+
+        let component: AccountComponent = RoleBasedAccessControl::builder()
+            .role(
+                RoleSeed::builder()
+                    .role(RoleBasedAccessControl::admin_role())
+                    .member(admin)
+                    .build(),
+            )
+            // DOM_MANAGER administers itself, so ADMIN cannot rotate its membership.
+            .role(
+                RoleSeed::builder()
+                    .role(manager_role.clone())
+                    .member(manager)
+                    .admin(manager_role.clone())
+                    .build(),
+            )
+            .role(
+                RoleSeed::builder()
+                    .role(pauser_role.clone())
+                    .member(pauser)
+                    .admin(manager_role.clone())
+                    .build(),
+            )
+            .build()?
+            .into();
+
+        let config = find_map(&component, RoleBasedAccessControl::role_config_slot());
+        let manager_symbol = manager_role.as_element();
+        assert_eq!(
+            config.get(&role_config_key(&manager_role)),
+            Word::from([Felt::ONE, manager_symbol, Felt::ZERO, Felt::ZERO]),
+        );
+        assert_eq!(
+            config.get(&role_config_key(&pauser_role)),
+            Word::from([Felt::ONE, manager_symbol, Felt::ZERO, Felt::ZERO]),
+        );
+
+        Ok(())
+    }
+
+    /// Delegating the admin of a role that has no members yet is what `set_role_admin` does on an
+    /// existing account, so seeding it must be expressible too.
+    #[test]
+    fn role_seeded_without_members_holds_its_delegated_admin() -> anyhow::Result<()> {
+        let admin = test_admin(1);
+        let minter_role = RoleSymbol::new("MINTER")?;
+        let minter_admin_role = RoleBasedAccessControl::admin_role();
+
+        let component: AccountComponent = RoleBasedAccessControl::builder()
+            .role(RoleSeed::builder().role(minter_admin_role.clone()).member(admin).build())
+            .role(RoleSeed::builder().role(minter_role.clone()).admin(minter_admin_role).build())
+            .build()?
+            .into();
+
+        // The role has a config entry but no members, so it does not exist yet.
+        let config = find_map(&component, RoleBasedAccessControl::role_config_slot());
+        assert_eq!(
+            config.get(&role_config_key(&minter_role)),
+            Word::from([
+                Felt::ZERO,
+                RoleBasedAccessControl::admin_role().as_element(),
+                Felt::ZERO,
+                Felt::ZERO
+            ]),
+        );
+        let membership = find_map(&component, RoleBasedAccessControl::role_membership_slot());
+        assert_eq!(membership.num_entries(), 1);
+
+        Ok(())
+    }
+
+    /// A role whose delegated admin is empty is still manageable as long as the admin itself can
+    /// be populated, which is the case while `ADMIN` is populated.
+    #[test]
+    fn delegating_to_a_role_populated_later_is_allowed() -> anyhow::Result<()> {
+        let admin = test_admin(1);
+        let minter_role = RoleSymbol::new("MINTER")?;
+        let minter_admin_role = RoleSymbol::new("MINTER_ADMIN")?;
+
+        RoleBasedAccessControl::builder()
+            .role(
+                RoleSeed::builder()
+                    .role(RoleBasedAccessControl::admin_role())
+                    .member(admin)
+                    .build(),
+            )
+            .role(RoleSeed::builder().role(minter_role).admin(minter_admin_role).build())
+            .build()?;
+
+        Ok(())
+    }
+
+    #[rstest::rstest]
+    #[case::duplicate_role(
+        vec![
+            RoleSeed::builder().role(role("MINTER")).member(test_admin(1)).build(),
+            RoleSeed::builder().role(role("MINTER")).member(test_admin(2)).build(),
+        ],
+        RoleBasedAccessControlError::DuplicateRole(role("MINTER")),
+    )]
+    #[case::empty_seed(
+        vec![RoleSeed::builder().role(role("MINTER")).build()],
+        RoleBasedAccessControlError::EmptyRoleSeed(role("MINTER")),
+    )]
+    // MINTER delegates to a self-administering role that has no members, so nobody can ever
+    // populate MINTER_ADMIN and MINTER stays unmanageable.
+    #[case::unmanageable_role(
+        vec![
+            RoleSeed::builder().role(role("MINTER")).admin(role("MINTER_ADMIN")).build(),
+            RoleSeed::builder().role(role("MINTER_ADMIN")).admin(role("MINTER_ADMIN")).build(),
+        ],
+        RoleBasedAccessControlError::UnmanageableRole {
+            role: role("MINTER"),
+            admin: role("MINTER_ADMIN"),
+        },
+    )]
+    #[case::empty_admins(
+        vec![RoleSeed::builder().role(RoleBasedAccessControl::admin_role()).build()],
+        RoleBasedAccessControlError::EmptyRoleSeed(RoleBasedAccessControl::admin_role()),
+    )]
+    // Leaving MINTER's admin unset makes ADMIN administer it, but ADMIN administers itself, so an
+    // unseeded ADMIN can never hold members. This is the same defect as `unmanageable_role`,
+    // spelled implicitly.
+    #[case::unseeded_default_admin(
+        vec![RoleSeed::builder().role(role("MINTER")).member(test_admin(1)).build()],
+        RoleBasedAccessControlError::UnmanageableRole {
+            role: role("MINTER"),
+            admin: RoleBasedAccessControl::admin_role(),
+        },
+    )]
+    fn invalid_seeds_are_rejected(
+        #[case] seeds: Vec<RoleSeed>,
+        #[case] expected: RoleBasedAccessControlError,
+    ) {
+        let error = RoleBasedAccessControl::builder()
+            .roles(seeds)
+            .build()
+            .expect_err("seeding should have failed");
+
+        assert_eq!(error, expected);
     }
 }

--- a/crates/miden-testing/tests/scripts/rbac/mod.rs
+++ b/crates/miden-testing/tests/scripts/rbac/mod.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 mod config;
 
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 
 use miden_processor::crypto::random::RandomCoin;
@@ -16,7 +16,7 @@ use miden_protocol::account::{
 };
 use miden_protocol::note::{Note, NoteType};
 use miden_protocol::{Felt, Word};
-use miden_standards::account::access::{AccessControl, RoleBasedAccessControl};
+use miden_standards::account::access::{AccessControl, RoleBasedAccessControl, RoleSeed};
 use miden_standards::errors::standards::{
     ERR_ACCOUNT_NOT_IN_ROLE,
     ERR_ROLE_SYMBOL_ZERO,
@@ -920,11 +920,10 @@ async fn test_rbac_admin_can_renounce_admin_role() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// `RoleBasedAccessControl::with_role_members` seeds the `ADMIN` role plus arbitrary operator
-/// roles at construction. Each seeded operator role's delegated admin is left unset (0), and a role
-/// mapped to an empty member set is dropped.
+/// The component builder seeds the `ADMIN` role plus arbitrary operator roles at construction,
+/// each with its own delegated admin.
 #[test]
-fn test_rbac_with_role_members_seeds_admin_and_operator_roles() -> anyhow::Result<()> {
+fn test_rbac_builder_seeds_admin_and_operator_roles() -> anyhow::Result<()> {
     let admin = test_account_id(201);
     let minter = test_account_id(202);
     let burner = test_account_id(203);
@@ -932,19 +931,17 @@ fn test_rbac_with_role_members_seeds_admin_and_operator_roles() -> anyhow::Resul
     let admin_role = RoleBasedAccessControl::admin_role();
     let minter_role = role("MINTER");
     let burner_role = role("BURNER");
-    let empty_role = role("EMPTY");
 
     let account = AccountBuilder::new([9; 32])
         .account_type(AccountType::Public)
         .with_components(Auth::IncrNonce)
-        .with_component(RoleBasedAccessControl::new(
-            BTreeSet::from([admin]),
-            BTreeMap::from([
-                (minter_role.clone(), BTreeSet::from([minter])),
-                (burner_role.clone(), BTreeSet::from([burner])),
-                (empty_role.clone(), BTreeSet::new()),
-            ]),
-        ))
+        .with_component(
+            RoleBasedAccessControl::builder()
+                .role(RoleSeed::builder().role(admin_role.clone()).member(admin).build())
+                .role(RoleSeed::builder().role(minter_role.clone()).member(minter).build())
+                .role(RoleSeed::builder().role(burner_role.clone()).member(burner).build())
+                .build()?,
+        )
         .build_existing()?;
 
     // ADMIN is seeded and administers itself (delegated admin unset).
@@ -956,8 +953,66 @@ fn test_rbac_with_role_members_seeds_admin_and_operator_roles() -> anyhow::Resul
     assert_eq!(get_role_config(&account, &minter_role)?, (Felt::ONE, Felt::ZERO));
     assert!(is_role_member(&account, &burner_role, burner)?);
 
-    // A role mapped to an empty member set is dropped.
-    assert_eq!(get_role_config(&account, &empty_role)?.0, Felt::ZERO);
+    Ok(())
+}
+
+/// A role seeded with a delegated admin is administered by that role from genesis: `ADMIN` cannot
+/// grant or revoke it, while the delegated admin's members can.
+#[tokio::test]
+async fn test_rbac_seeded_delegated_admin_excludes_admin() -> anyhow::Result<()> {
+    let admin = test_account_id(211);
+    let manager = test_account_id(212);
+    let pauser = test_account_id(213);
+
+    let admin_role = RoleBasedAccessControl::admin_role();
+    let manager_role = role("DOM_MANAGER");
+    let pauser_role = role("DOM_PAUSER");
+
+    let account = AccountBuilder::new([11; 32])
+        .account_type(AccountType::Public)
+        .with_components(Auth::IncrNonce)
+        .with_component(
+            RoleBasedAccessControl::builder()
+                .role(RoleSeed::builder().role(admin_role).member(admin).build())
+                .role(
+                    RoleSeed::builder()
+                        .role(manager_role.clone())
+                        .member(manager)
+                        .admin(manager_role.clone())
+                        .build(),
+                )
+                .role(
+                    RoleSeed::builder()
+                        .role(pauser_role.clone())
+                        .admin(manager_role.clone())
+                        .build(),
+                )
+                .build()?,
+        )
+        .build_existing()?;
+
+    // DOM_PAUSER has no members yet, but its delegated admin is already in place.
+    assert_eq!(
+        get_role_config(&account, &pauser_role)?,
+        (Felt::ZERO, manager_role.as_element())
+    );
+
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+    let mock_chain = builder.build()?;
+
+    // ADMIN cannot grant DOM_PAUSER: the role is out of its reach from genesis.
+    let admin_grant = build_note(admin, grant_role_script(&pauser_role, pauser))?;
+    let tx = mock_chain
+        .build_transaction(account.clone())
+        .unauthenticated_input_note(admin_grant)
+        .build()?;
+    assert_transaction_executor_error!(tx.execute().await, ERR_SENDER_NOT_ROLE_ADMIN);
+
+    // A DOM_MANAGER member can.
+    let manager_grant = build_note(manager, grant_role_script(&pauser_role, pauser))?;
+    let updated = execute_note_and_apply(&mock_chain, &account, &manager_grant).await?;
+    assert!(is_role_member(&updated, &pauser_role, pauser)?);
 
     Ok(())
 }

--- a/crates/miden-testing/tests/scripts/rbac/mod.rs
+++ b/crates/miden-testing/tests/scripts/rbac/mod.rs
@@ -16,7 +16,7 @@ use miden_protocol::account::{
 };
 use miden_protocol::note::{Note, NoteType};
 use miden_protocol::{Felt, Word};
-use miden_standards::account::access::{AccessControl, RoleBasedAccessControl, RoleSeed};
+use miden_standards::account::access::{AccessControl, RoleBasedAccessControl, RoleConfig};
 use miden_standards::errors::standards::{
     ERR_ACCOUNT_NOT_IN_ROLE,
     ERR_ROLE_SYMBOL_ZERO,
@@ -937,9 +937,9 @@ fn test_rbac_builder_seeds_admin_and_operator_roles() -> anyhow::Result<()> {
         .with_components(Auth::IncrNonce)
         .with_component(
             RoleBasedAccessControl::builder()
-                .role(RoleSeed::builder().role(admin_role.clone()).member(admin).build())
-                .role(RoleSeed::builder().role(minter_role.clone()).member(minter).build())
-                .role(RoleSeed::builder().role(burner_role.clone()).member(burner).build())
+                .role(RoleConfig::new(admin_role.clone()).with_member(admin))
+                .role(RoleConfig::new(minter_role.clone()).with_member(minter))
+                .role(RoleConfig::new(burner_role.clone()).with_member(burner))
                 .build()?,
         )
         .build_existing()?;
@@ -973,20 +973,13 @@ async fn test_rbac_seeded_delegated_admin_excludes_admin() -> anyhow::Result<()>
         .with_components(Auth::IncrNonce)
         .with_component(
             RoleBasedAccessControl::builder()
-                .role(RoleSeed::builder().role(admin_role).member(admin).build())
+                .role(RoleConfig::new(admin_role).with_member(admin))
                 .role(
-                    RoleSeed::builder()
-                        .role(manager_role.clone())
-                        .member(manager)
-                        .admin(manager_role.clone())
-                        .build(),
+                    RoleConfig::new(manager_role.clone())
+                        .with_member(manager)
+                        .with_admin(manager_role.clone()),
                 )
-                .role(
-                    RoleSeed::builder()
-                        .role(pauser_role.clone())
-                        .admin(manager_role.clone())
-                        .build(),
-                )
+                .role(RoleConfig::new(pauser_role.clone()).with_admin(manager_role.clone()))
                 .build()?,
         )
         .build_existing()?;


### PR DESCRIPTION
Haven't self-reviewed yet, but feel free to review :slightly_smiling_face: 

---

Replace `RoleBasedAccessControl::new` with a `bon` builder over `RoleSeed`s. A seed carries a role's members and its delegated admin, so the role config word is seeded as `[member_count, admin_role_symbol, 0, 0]` instead of always leaving the admin unset. Exclusive delegation is therefore established at account creation rather than through a sequence of on-chain `set_role_admin` calls during which `ADMIN` still administers the role.

The builder's `build()` rejects duplicate role seeds, seeds that carry neither members nor a delegated admin, member counts exceeding `u32::MAX`, and seeds whose effective admin chain never reaches a populated role, which would leave the role permanently unmanageable. The last check covers the default admin too: seeding an operational role without seeding `ADMIN` freezes it just as a dead explicit delegation does, since `ADMIN` administers itself.

closes https://github.com/0xMiden/protocol/issues/3514