### PR TITLE
docs(standards): document the freeze-only actor pattern for the emergency switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changes
 
+- Documented the RBAC freeze-only actor pattern on `Authority` and added test coverage pinning that a `FREEZER` can trip the emergency switch but can never unfreeze the account ([#3520](https://github.com/0xMiden/protocol/pull/3520)).
+
 ### Fixes
 
 ## v0.16.0 (2026-08-06)

--- a/crates/miden-standards/src/account/access/authority.rs
+++ b/crates/miden-standards/src/account/access/authority.rs
@@ -110,6 +110,49 @@ const RBAC_CONTROLLED: u8 = 2;
 /// This flag has no effect under [`Authority::AuthControlled`], where `freeze` / `unfreeze` panic
 /// (there is no owner and no role graph).
 ///
+/// # Freeze-only actor (incident-response "panic button")
+///
+/// A second actor that can freeze the account in an incident but can never re-open it, or authorize
+/// anything else, needs no dedicated component: it is a plain [`Authority::RbacControlled`] role
+/// assignment. Map `freeze` to a role of its own, map `unfreeze` to a *different* role, and grant
+/// the incident responder only the former:
+///
+/// ```no_run
+/// use std::collections::BTreeMap;
+///
+/// use miden_protocol::account::{AccountBuilder, RoleSymbol};
+/// use miden_standards::account::access::{AccessControl, Authority};
+/// # let admin: miden_protocol::account::AccountId = unimplemented!();
+/// # let init_seed = [0u8; 32];
+///
+/// let procedure_roles = BTreeMap::from([
+///     (Authority::freeze_root(), RoleSymbol::new("FREEZER")?),
+///     (Authority::unfreeze_root(), RoleSymbol::new("UNFREEZER")?),
+/// ]);
+///
+/// AccountBuilder::new(init_seed).with_components(AccessControl::Rbac { admin, procedure_roles });
+///
+/// // Then grant `FREEZER` to the incident responder and `UNFREEZER` to the recovery authority
+/// // through the `RoleBasedAccessControl` component's `grant_role`.
+/// # Ok::<(), miden_protocol::errors::RoleSymbolError>(())
+/// ```
+///
+/// This yields the intended asymmetry: freezing is available to the `FREEZER`, re-opening is not.
+/// A compromised freeze-only actor can at worst deny service by freezing the account; it can never
+/// keep the account open, grant roles, move assets, or invoke any other gated procedure.
+///
+/// Two things to get right when wiring this up:
+///
+/// - Map `unfreeze` explicitly, or leave it unmapped and keep the freeze-only actor out of `ADMIN`.
+///   An unmapped procedure falls back to the `ADMIN` role, so a freeze-only actor that also holds
+///   `ADMIN` could re-open the account and defeat the asymmetry.
+/// - The pattern requires `RbacControlled`. Under [`Authority::OwnerControlled`] the owner is the
+///   only emergency authority, and under [`Authority::AuthControlled`] there is no switch at all,
+///   so an account that wants a freeze-only actor must use RBAC.
+///
+/// The same shape generalizes to any "can stop, cannot start" authority: give the cancelling or
+/// pausing procedure its own role and keep the resuming procedure on a separate one.
+///
 /// Storage layout:
 /// - Value slot: `[authority, is_frozen, 0, 0]`.
 /// - Map slot (only under RBAC): `procedure_root` → `[role_symbol, 0, 0, 0]`.

--- a/crates/miden-standards/src/account/access/mod.rs
+++ b/crates/miden-standards/src/account/access/mod.rs
@@ -55,12 +55,12 @@ pub enum AccessControl {
     /// for the administration model.
     ///
     /// `procedure_roles` assigns a role to individual authority-gated procedures, keyed by
-    /// procedure root (e.g. `PausableManager::pause_root()` → `PAUSER`, `unpause_root()` →
-    /// `UNPAUSER`, and optionally `Authority::freeze_root()` → `FREEZER`). A gated procedure
-    /// without an entry in `procedure_roles` falls back to the `ADMIN` role. The emergency
-    /// `freeze` / `unfreeze` switch resolves its role the same way, defaulting to `ADMIN`. Role
-    /// membership is managed through the standard RBAC API on the [`RoleBasedAccessControl`]
-    /// component.
+    /// procedure root (e.g. [`PausableManager::pause_root`] → `PAUSER`,
+    /// [`PausableManager::unpause_root`] → `UNPAUSER`, and optionally [`Authority::freeze_root`] →
+    /// `FREEZER` with [`Authority::unfreeze_root`] → `UNFREEZER`). A gated procedure without an
+    /// entry in `procedure_roles` falls back to the `ADMIN` role. The emergency `freeze` /
+    /// `unfreeze` switch resolves its role the same way, defaulting to `ADMIN`. Role membership is
+    /// managed through the standard RBAC API on the [`RoleBasedAccessControl`] component.
     Rbac {
         admin: AccountId,
         procedure_roles: BTreeMap<AccountProcedureRoot, RoleSymbol>,

--- a/crates/miden-testing/tests/scripts/authority.rs
+++ b/crates/miden-testing/tests/scripts/authority.rs
@@ -366,3 +366,87 @@ async fn freeze_and_unfreeze_use_distinct_roles() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// An actor holding only the `FREEZER` authorization, capable of nothing but freezing,
+/// can flip the kill switch; it can never unfreeze the account, nor authorize any other
+/// protected procedure.
+#[tokio::test]
+async fn freezer_can_freeze_but_cannot_unfreeze_or_authorize() -> anyhow::Result<()> {
+    let freezer = test_account_id(25);
+    let unfreezer = test_account_id(26);
+
+    // `freeze` is the freezer's only reachable procedure: `unfreeze` carries its own role and
+    // `pause` is unmapped, so it falls back to ADMIN.
+    let roles = BTreeMap::from([
+        (Authority::freeze_root(), role("FREEZER")),
+        (Authority::unfreeze_root(), role("UNFREEZER")),
+    ]);
+
+    let admin = *ADMIN_ID;
+    let mut builder = MockChain::builder();
+    let faucet = add_rbac_faucet(&mut builder, admin, roles, 66)?;
+
+    let grant_freezer = build_grant_role_note(admin, &role("FREEZER"), freezer)?;
+    let grant_unfreezer = build_grant_role_note(admin, &role("UNFREEZER"), unfreezer)?;
+    let freezer_pause_note = build_pause_note(freezer)?;
+    let freezer_freeze_note = build_freeze_note(freezer)?;
+    let freezer_unfreeze_note = build_unfreeze_note(freezer)?;
+    let admin_unfreeze_note = build_unfreeze_note(admin)?;
+    let unfreezer_unfreeze_note = build_unfreeze_note(unfreezer)?;
+    for note in [
+        &grant_freezer,
+        &grant_unfreezer,
+        &freezer_pause_note,
+        &freezer_freeze_note,
+        &freezer_unfreeze_note,
+        &admin_unfreeze_note,
+        &unfreezer_unfreeze_note,
+    ] {
+        builder.add_output_note(RawOutputNote::Full(note.clone()));
+    }
+
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    execute_note_on_faucet(&mut mock_chain, faucet.id(), &grant_freezer).await?;
+    execute_note_on_faucet(&mut mock_chain, faucet.id(), &grant_unfreezer).await?;
+
+    // The freezer holds no other role, so ordinary gated procedures stay out of reach.
+    let freezer_pause_result = mock_chain
+        .build_transaction(faucet.id())
+        .authenticated_input_note(freezer_pause_note.id())
+        .build()?
+        .execute()
+        .await;
+    assert_transaction_executor_error!(freezer_pause_result, ERR_SENDER_LACKS_ROLE);
+
+    // The freezer trips the emergency switch.
+    execute_note_on_faucet(&mut mock_chain, faucet.id(), &freezer_freeze_note).await?;
+    assert!(is_frozen(&mock_chain, faucet.id())?);
+
+    // But it cannot re-open the account: `unfreeze` requires UNFREEZER.
+    let freezer_unfreeze_result = mock_chain
+        .build_transaction(faucet.id())
+        .authenticated_input_note(freezer_unfreeze_note.id())
+        .build()?
+        .execute()
+        .await;
+    assert_transaction_executor_error!(freezer_unfreeze_result, ERR_SENDER_LACKS_ROLE);
+    assert!(is_frozen(&mock_chain, faucet.id())?);
+
+    // Neither can the ADMIN, since `unfreeze` is explicitly mapped and so never falls back to it.
+    let admin_unfreeze_result = mock_chain
+        .build_transaction(faucet.id())
+        .authenticated_input_note(admin_unfreeze_note.id())
+        .build()?
+        .execute()
+        .await;
+    assert_transaction_executor_error!(admin_unfreeze_result, ERR_SENDER_LACKS_ROLE);
+    assert!(is_frozen(&mock_chain, faucet.id())?);
+
+    // Only the UNFREEZER re-opens the account.
+    execute_note_on_faucet(&mut mock_chain, faucet.id(), &unfreezer_unfreeze_note).await?;
+    assert!(!is_frozen(&mock_chain, faucet.id())?);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes: https://github.com/0xMiden/protocol/issues/3519