### PR TITLE
ci: add weekly benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,48 @@
+# Runs benchmarks on a weekly schedule to track performance over time.
+
+name: bench
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    name: run benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Never save from this workflow: scheduled runs would otherwise evict
+          # the caches that build/test/lint rely on (github has a 10GB limit).
+          save-if: "false"
+      - name: Install rust
+        run: rustup update --no-self-update
+      - name: Run note checker benchmarks
+        run: make bench-note-checker
+      - name: Run transaction execution benchmarks
+        # Proving benchmarks are excluded: a single sample takes seconds, and the
+        # full suite does not complete within a reasonable time on a hosted runner.
+        run: cargo bench --bin bench-transaction --bench time_counting_benchmarks --features concurrent -- "^Execute transaction"
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: criterion-results
+          path: target/criterion/
+          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- Added a weekly scheduled workflow that runs the note checker and transaction execution benchmarks and uploads the results as an artifact ([#1671](https://github.com/0xMiden/protocol/issues/1671)).
+
 ### Changes
 
 - [BREAKING] Changed asset callbacks into validation-only interfaces that return no asset value; the transaction kernel retains and uses the original value, preventing callbacks from modifying it. The kernel commitment changes ([#3505](https://github.com/0xMiden/protocol/issues/3505), [#3513](https://github.com/0xMiden/protocol/pull/3513)).


### PR DESCRIPTION
Closes #1671.

Adds a `bench` workflow that runs on a weekly schedule and can also be triggered manually via `workflow_dispatch`. Results are uploaded as a `criterion-results` artifact with 90 day retention.

### Scope

The issue asks for two things: running benchmarks periodically, and reporting anomalous results. This PR only implements the first. Anomaly reporting needs a baseline store and a regression threshold, and I did not want to guess at either without maintainer input. Happy to follow up in a second PR.

### Which benchmarks run

- `bench-note-checker` in full.
- `bench-transaction`, filtered to the `Execute transaction` group.

The `Execute and prove` group is excluded. Each sample takes seconds, and on my machine (Apple silicon) the group did not finish within 10 minutes. On a hosted runner it would be considerably slower. Including it would likely need a self hosted runner, which felt like a separate discussion.

Measured runtimes locally, excluding compilation:

| Suite | Runtime |
| --- | --- |
| `bench-note-checker` | ~35s |
| `bench-transaction` (execute only) | ~4m15s |

`timeout-minutes: 90` leaves room for a cold compile on a hosted runner.

### On anomaly detection

While measuring, I ran the same suite twice on the same commit with no code changes. Criterion reported `Performance has regressed` at +2.33% for `falcon/two-p2id-notes`, and `-3.36%` for `b2agg-note` in the same run. The direction was not even consistent between runs. A shared runner will be noisier still, so a threshold picked without data would produce weekly false alarms. Collecting artifacts first gives something concrete to calibrate against.

### Notes

- `save-if: "false"` on the cache step, so scheduled runs never evict the caches that `build`, `test` and `lint` depend on.
- `if: always()` on the upload, so a failing benchmark still leaves results behind.
- `actionlint` and `zizmor` (with `zizmor.yml`) both pass locally.
