### PR TITLE
docs: add README docs build commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+- Documented the root README commands for building and previewing the docs site locally ([#3536](https://github.com/0xMiden/protocol/pull/3536)).
 - [BREAKING] Changed asset callbacks into validation-only interfaces that return no asset value; the transaction kernel retains and uses the original value, preventing callbacks from modifying it. The kernel commitment changes ([#3505](https://github.com/0xMiden/protocol/issues/3505), [#3513](https://github.com/0xMiden/protocol/pull/3513)).
 - [BREAKING] Extracted the shared `MastForestScript` type and `MastForestScriptError` backing `NoteScript` / `TransactionScript`, moving `TransactionScript` into `transaction::script` ([#3516](https://github.com/0xMiden/protocol/pull/3516)).
 - Documented the RBAC freeze-only actor pattern on `Authority` and added test coverage pinning that a `FREEZER` can trip the emergency switch but can never unfreeze the account ([#3520](https://github.com/0xMiden/protocol/pull/3520)).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,17 @@ Some of the functions in this project are computationally intensive and may take
 
 ## Documentation
 
-The documentation in the `docs/` folder is built using Docusaurus and is automatically absorbed into the main [miden-docs](https://docs.miden.xyz/protocol/) repository for the main documentation website. Changes to the `next` branch trigger an automated deployment workflow. The docs folder requires npm packages to be installed before building.
+The documentation in the `docs/` folder is built using Docusaurus and is automatically absorbed into the main [miden-docs](https://docs.miden.xyz/protocol/) repository for the main documentation website. Changes to the `next` branch trigger an automated deployment workflow.
+
+To build the docs locally:
+
+```shell
+cd docs
+npm ci
+npm run build:dev
+```
+
+To preview the docs locally, run `make serve-docs` from the repository root or `npm run start:dev` from the `docs/` folder.
 
 ## License
 


### PR DESCRIPTION
Refs #3530.

Added the local docs build and preview commands to the root README. The commands match the existing Docusaurus scripts and the `build-docs` workflow, so someone reading the README does not have to jump into `docs/package.json` or CI to find the right setup.

Also added the required changelog entry for this docs update.

Validation:
- `git diff --check -- README.md CHANGELOG.md`
- `BASE_REF=next NO_CHANGELOG_LABEL=false ./scripts/check-changelog.sh`
- Checked the commands against `docs/package.json`, `Makefile`, and `.github/workflows/build-docs.yml`.