### PR TITLE
fix: return Result from Address::encode and correct amount/docs drift

### DIFF
--- a/crates/miden-protocol/src/address/mod.rs
+++ b/crates/miden-protocol/src/address/mod.rs
@@ -141,17 +141,21 @@ impl Address {
     /// - If routing parameters are present:
     ///   - Append the [`Address::SEPARATOR`] to that string.
     ///   - Append the encoded routing parameters to that string.
-    pub fn encode(&self, network_id: NetworkId) -> String {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if encoding the routing parameters to bech32 fails.
+    pub fn encode(&self, network_id: NetworkId) -> Result<String, AddressError> {
         let mut encoded = match self.id {
             AddressId::AccountId(id) => id.to_bech32(network_id),
         };
 
         if let Some(routing_params) = &self.routing_params {
             encoded.push(Self::SEPARATOR);
-            encoded.push_str(&routing_params.encode_to_string());
+            encoded.push_str(&routing_params.encode_to_string()?);
         }
 
-        encoded
+        Ok(encoded)
     }
 
     /// Decodes an address string into the [`NetworkId`] and an [`Address`].
@@ -245,7 +249,7 @@ mod tests {
                 // Encode/Decode without routing parameters should be valid.
                 let mut address = Address::new(account_id);
 
-                let bech32_string = address.encode(network_id.clone());
+                let bech32_string = address.encode(network_id.clone())?;
                 assert!(
                     !bech32_string.contains(Address::SEPARATOR),
                     "separator should not be present in address without routing params"
@@ -264,7 +268,7 @@ mod tests {
                         .with_note_tag_len(NoteTag::MAX_ACCOUNT_TARGET_TAG_LENGTH)?,
                 );
 
-                let bech32_string = address.encode(network_id.clone());
+                let bech32_string = address.encode(network_id.clone())?;
                 assert!(
                     bech32_string.contains(Address::SEPARATOR),
                     "separator should be present in address without routing params"
@@ -287,7 +291,7 @@ mod tests {
         let id = AccountIdBuilder::new().build_with_rng(&mut rand::rng());
 
         let address = Address::new(id);
-        let mut encoded_address = address.encode(NetworkId::Devnet);
+        let mut encoded_address = address.encode(NetworkId::Devnet)?;
         encoded_address.push(Address::SEPARATOR);
 
         let err = Address::decode(&encoded_address).unwrap_err();
@@ -305,7 +309,7 @@ mod tests {
             RoutingParameters::new(AddressInterface::BasicWallet).with_note_tag_len(14)?,
         );
 
-        let bech32_string = address.encode(network_id);
+        let bech32_string = address.encode(network_id)?;
         let mut invalid_bech32_1 = bech32_string.clone();
         invalid_bech32_1.remove(0);
         let mut invalid_bech32_2 = bech32_string.clone();
@@ -450,7 +454,7 @@ mod tests {
         );
 
         // Encode and decode
-        let encoded = address.encode(NetworkId::Mainnet);
+        let encoded = address.encode(NetworkId::Mainnet)?;
         let (decoded_network, decoded_address) = Address::decode(&encoded)?;
 
         assert_eq!(decoded_network, NetworkId::Mainnet);

--- a/crates/miden-protocol/src/address/routing_parameters.rs
+++ b/crates/miden-protocol/src/address/routing_parameters.rs
@@ -153,18 +153,25 @@ impl RoutingParameters {
     }
 
     /// Encodes [`RoutingParameters`] to a bech32 string _without_ the leading hrp and separator.
-    pub(crate) fn encode_to_string(&self) -> String {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if bech32 encoding fails.
+    pub(crate) fn encode_to_string(&self) -> Result<String, AddressError> {
         let encoded = self.encode_to_bytes();
 
-        let bech32_str =
-            bech32::encode::<Bech32m>(*ROUTING_PARAMETERS_HRP, &encoded).expect("TODO");
-        let encoded_str = bech32_str
-            .strip_prefix(ROUTING_PARAMETERS_HRP.as_str())
-            .expect("bech32 str should start with the hrp");
-        let encoded_str = encoded_str
-            .strip_prefix(BECH32_SEPARATOR)
-            .expect("encoded str should start with bech32 separator `1`");
-        encoded_str.to_owned()
+        let bech32_str = bech32::encode::<Bech32m>(*ROUTING_PARAMETERS_HRP, &encoded).map_err(
+            |source| {
+                AddressError::Bech32EncodeError(Bech32Error::EncodeError(source.to_string().into()))
+            },
+        )?;
+        let encoded_str = bech32_str.strip_prefix(ROUTING_PARAMETERS_HRP.as_str()).ok_or_else(
+            || AddressError::decode_error("bech32 str should start with the hrp"),
+        )?;
+        let encoded_str = encoded_str.strip_prefix(BECH32_SEPARATOR).ok_or_else(|| {
+            AddressError::decode_error("encoded str should start with bech32 separator `1`")
+        })?;
+        Ok(encoded_str.to_owned())
     }
 
     /// Decodes [`RoutingParameters`] from a bech32 string _without_ the leading hrp and separator.
@@ -447,7 +454,7 @@ mod tests {
     fn routing_parameters_bech32_encode_decode_roundtrip() -> anyhow::Result<()> {
         // Test case 1: No explicit tag length
         let params_no_tag = RoutingParameters::new(AddressInterface::BasicWallet);
-        let encoded = params_no_tag.encode_to_string();
+        let encoded = params_no_tag.encode_to_string()?;
         let decoded = RoutingParameters::decode(encoded)?;
         assert_eq!(params_no_tag, decoded);
         assert_eq!(decoded.note_tag_len(), None);
@@ -455,7 +462,7 @@ mod tests {
         // Test case 2: Explicit tag length 0
         let params_tag_0 =
             RoutingParameters::new(AddressInterface::BasicWallet).with_note_tag_len(0)?;
-        let encoded = params_tag_0.encode_to_string();
+        let encoded = params_tag_0.encode_to_string()?;
         let decoded = RoutingParameters::decode(encoded)?;
         assert_eq!(params_tag_0, decoded);
         assert_eq!(decoded.note_tag_len(), Some(0));
@@ -463,7 +470,7 @@ mod tests {
         // Test case 3: Explicit tag length 6
         let params_tag_6 =
             RoutingParameters::new(AddressInterface::BasicWallet).with_note_tag_len(6)?;
-        let encoded = params_tag_6.encode_to_string();
+        let encoded = params_tag_6.encode_to_string()?;
         let decoded = RoutingParameters::decode(encoded)?;
         assert_eq!(params_tag_6, decoded);
         assert_eq!(decoded.note_tag_len(), Some(6));
@@ -471,7 +478,7 @@ mod tests {
         // Test case 4: Explicit tag length set to max
         let params_tag_max = RoutingParameters::new(AddressInterface::BasicWallet)
             .with_note_tag_len(NoteTag::MAX_ACCOUNT_TARGET_TAG_LENGTH)?;
-        let encoded = params_tag_max.encode_to_string();
+        let encoded = params_tag_max.encode_to_string()?;
         let decoded = RoutingParameters::decode(encoded)?;
         assert_eq!(params_tag_max, decoded);
         assert_eq!(decoded.note_tag_len(), Some(NoteTag::MAX_ACCOUNT_TARGET_TAG_LENGTH));
@@ -525,7 +532,7 @@ mod tests {
                 .with_encryption_key(encryption_key.clone());
 
             // Test bech32 encoding/decoding
-            let encoded = routing_params.encode_to_string();
+            let encoded = routing_params.encode_to_string()?;
             let decoded = RoutingParameters::decode(encoded)?;
             assert_eq!(routing_params, decoded);
             assert_eq!(decoded.encryption_key(), Some(&encryption_key));

--- a/crates/miden-protocol/src/asset/fungible.rs
+++ b/crates/miden-protocol/src/asset/fungible.rs
@@ -19,7 +19,8 @@ use crate::utils::serde::{
 /// A fungible asset.
 ///
 /// A fungible asset consists of a faucet ID of the faucet which issued the asset as well as the
-/// asset amount. Asset amount is guaranteed to be 2^63 - 1 or smaller.
+/// asset amount. Asset amount is guaranteed to be at most [`FungibleAsset::MAX_AMOUNT`]
+/// (`2^63 - 2^31`).
 ///
 /// Whether the asset triggers callbacks to the faucet is an immutable property of the faucet's
 /// [`AccountId`], see [`AccountId::asset_callback_flag`].
@@ -151,7 +152,7 @@ impl FungibleAsset {
     /// # Errors
     /// Returns an error if:
     /// - The assets do not have the same asset ID (i.e. different faucet).
-    /// - The total value of assets is greater than or equal to 2^63.
+    /// - The total value of assets would exceed [`FungibleAsset::MAX_AMOUNT`] (`2^63 - 2^31`).
     #[allow(clippy::should_implement_trait)]
     pub fn add(self, other: Self) -> Result<Self, AssetError> {
         if !self.is_same(&other) {

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -354,6 +354,8 @@ pub enum AddressError {
     AccountIdDecodeError(#[source] AccountIdError),
     #[error("address separator must not be included without routing parameters")]
     TrailingSeparator,
+    #[error("failed to encode address to a bech32 string")]
+    Bech32EncodeError(#[source] Bech32Error),
     #[error("failed to decode bech32 string into an address")]
     Bech32DecodeError(#[source] Bech32Error),
     #[error("{error_msg}")]
@@ -394,6 +396,8 @@ impl AddressError {
 pub enum Bech32Error {
     #[error(transparent)]
     DecodeError(Box<dyn Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    EncodeError(Box<dyn Error + Send + Sync + 'static>),
     #[error("found unknown address type {0} which is not the expected {account_addr} account ID address type",
       account_addr = AddressType::AccountId as u8
     )]

--- a/crates/miden-standards/asm/standards/attachments/network_account_target.masm
+++ b/crates/miden-standards/asm/standards/attachments/network_account_target.masm
@@ -73,7 +73,7 @@ end
 #! Where:
 #! - account_id_{suffix,prefix} are the suffix and prefix felts of an account ID.
 #! - exec_hint_tag is the encoded execution hint for the note with its tag.
-#! - attachment_scheme is the attachment scheme (1) for use with `output_note::add_word_attachment`.
+#! - attachment_scheme is the attachment scheme (2) for use with `output_note::add_word_attachment`.
 #!
 #! Invocation: exec
 pub proc new

--- a/crates/miden-standards/asm/standards/notes/p2id.masm
+++ b/crates/miden-standards/asm/standards/notes/p2id.masm
@@ -37,8 +37,8 @@ const TARGET_ACCOUNT_ID_PREFIX_PTR = STORAGE_PTR + 1
 #! - Account does not expose miden::standards::wallets::basic::receive_asset procedure.
 #! - Account ID of executing account is not equal to the Account ID specified via note storage.
 #! - The same non-fungible asset already exists in the account.
-#! - Adding a fungible asset would result in amount overflow, i.e., the total amount would be
-#!   greater than 2^63.
+#! - Adding a fungible asset would result in amount overflow, i.e., the total amount would exceed
+#!   FUNGIBLE_ASSET_MAX_AMOUNT (2^63 - 2^31).
 @note_script
 pub proc main
     # store the note storage to memory starting at address 0

--- a/crates/miden-standards/asm/standards/notes/p2ide.masm
+++ b/crates/miden-standards/asm/standards/notes/p2ide.masm
@@ -124,8 +124,8 @@ end
 #! - At and after reclaim block height: the account ID of the executing account is not equal to
 #!   the target account ID or reclaimer account ID.
 #! - The same non-fungible asset already exists in the account.
-#! - Adding a fungible asset would result in an amount overflow, i.e., the total amount would be
-#!   greater than 2^63.
+#! - Adding a fungible asset would result in an amount overflow, i.e., the total amount would exceed
+#!   FUNGIBLE_ASSET_MAX_AMOUNT (2^63 - 2^31).
 @note_script
 pub proc main
     # store the note storage to memory starting at STORAGE_PTR

--- a/crates/miden-standards/asm/standards/notes/pswap.masm
+++ b/crates/miden-standards/asm/standards/notes/pswap.masm
@@ -142,7 +142,7 @@ end
 #! u128 via `u64::widening_mul`, then divided by `fill_reference` (extended to
 #! u128) via `u128::div`. This gives exact integer precision with one floor
 #! division at the end, each input is safe
-#! up to `FungibleAsset::MAX ≈ 2^63`, and the resulting quotient
+#! up to `FungibleAsset::MAX` (2^63 - 2^31), and the resulting quotient
 #! `payout ≤ offered` always fits back in u64 (asserted via the upper-half
 #! limb check below).
 #!

--- a/crates/miden-standards/asm/standards/notes/swap.masm
+++ b/crates/miden-standards/asm/standards/notes/swap.masm
@@ -60,8 +60,8 @@ const ERR_SWAP_WRONG_NUMBER_OF_ASSETS="SWAP script requires exactly 1 note asset
 #! Panics if:
 #! - account does not expose the required wallet procedures.
 #! - account vault does not contain the requested asset.
-#! - adding a fungible asset would result in amount overflow, i.e., the total amount would be
-#!   greater than 2^63.
+#! - adding a fungible asset would result in amount overflow, i.e., the total amount would exceed
+#!   FUNGIBLE_ASSET_MAX_AMOUNT (2^63 - 2^31).
 @note_script
 pub proc main
     # drop note args

--- a/crates/miden-standards/asm/standards/notes/tx_fee.masm
+++ b/crates/miden-standards/asm/standards/notes/tx_fee.masm
@@ -44,8 +44,8 @@ const ERR_TX_FEE_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS = "TX_FEE note expects exact
 #! - the note carries a non-zero number of storage items.
 #! - the account does not expose miden::standards::wallets::basic::receive_asset procedure.
 #! - the same non-fungible asset already exists in the account.
-#! - adding a fungible asset would result in amount overflow, i.e., the total amount would be
-#!   greater than 2^63.
+#! - adding a fungible asset would result in amount overflow, i.e., the total amount would exceed
+#!   FUNGIBLE_ASSET_MAX_AMOUNT (2^63 - 2^31).
 @note_script
 pub proc main
     # make sure the note carries no storage items

--- a/crates/miden-standards/asm/standards/wallets/basic.masm
+++ b/crates/miden-standards/asm/standards/wallets/basic.masm
@@ -21,7 +21,7 @@ pub use {create_note} from miden::standards::note::note_creator
 #! Panics if:
 #! - the same non-fungible asset already exists in the account.
 #! - adding a fungible asset would result in amount overflow, i.e.,
-#!   the total amount would be greater than 2^63.
+#!   the total amount would exceed FUNGIBLE_ASSET_MAX_AMOUNT (2^63 - 2^31).
 #!
 #! Invocation: call
 @account_procedure

--- a/crates/miden-standards/src/note/p2ide.rs
+++ b/crates/miden-standards/src/note/p2ide.rs
@@ -134,7 +134,10 @@ impl P2ideNote {
         self.storage
     }
 
-    /// Returns the account ID of the note's target (the only account that can consume it).
+    /// Returns the account ID of the note's target.
+    ///
+    /// Before the reclaim height (or when reclaim is disabled), only this account can consume the
+    /// note. At and after the reclaim height, the [reclaimer](Self::reclaimer) may also consume it.
     pub fn target(&self) -> AccountId {
         self.storage.target()
     }


### PR DESCRIPTION
## Summary
- Replace the placeholder `bech32::encode(...).expect("TODO")` path with proper `Result` handling (`Address::encode` / routing-parameter encoding now return `AddressError::Bech32EncodeError`).
- Fix P2IDE `target()` docs to mention reclaim/reclaimer consumption.
- Correct `NetworkAccountTarget` attachment-scheme comment (`1` → `2`).
- Align fungible max-amount wording with `FUNGIBLE_ASSET_MAX_AMOUNT` (`2^63 - 2^31`) in note/wallet docs and `FungibleAsset` Rust docs.

## Breaking change
- `Address::encode` signature: `String` → `Result<String, AddressError>`.

## Test plan
- [x] `cargo test -p miden-protocol --lib address::`
- [x] `cargo test -p miden-protocol --lib asset::fungible`
- [x] `cargo test -p miden-standards --lib note::`