### PR TITLE
refactor: reshape TransactionKernel around package-first access

### DIFF
--- a/crates/miden-protocol/src/transaction/kernel/mod.rs
+++ b/crates/miden-protocol/src/transaction/kernel/mod.rs
@@ -97,6 +97,36 @@ static TX_SCRIPT_MAIN_DEBUG_INFO: LazyLock<Option<Arc<PackageDebugInfo>>> =
 // TRANSACTION KERNEL
 // ================================================================================================
 
+/// One of the kernel's embedded programs, paired with everything a package-debug execution API
+/// needs to run it.
+///
+/// The program, its debug info and its entrypoint source node are only meaningful together: the
+/// entrypoint node is an index into that package's debug info, and a program whose package
+/// carried no debug sections still needs an empty [`PackageDebugInfo`] to execute against.
+/// Returning them as a unit keeps callers from having to know that.
+pub struct KernelProgram {
+    program: Program,
+    debug_info: Arc<PackageDebugInfo>,
+    entrypoint_source_node: Option<DebugSourceNodeId>,
+}
+
+impl KernelProgram {
+    /// Returns the executable program.
+    pub fn program(&self) -> &Program {
+        &self.program
+    }
+
+    /// Returns the package-owned debug info, which is empty when the package carried none.
+    pub fn debug_info(&self) -> &PackageDebugInfo {
+        &self.debug_info
+    }
+
+    /// Returns the source/debug occurrence for the program's entrypoint.
+    pub fn entrypoint_source_node(&self) -> Option<DebugSourceNodeId> {
+        self.entrypoint_source_node
+    }
+}
+
 pub struct TransactionKernel;
 
 impl TransactionKernel {
@@ -122,17 +152,20 @@ impl TransactionKernel {
         KERNEL_MAIN.clone()
     }
 
-    /// Returns package-owned debug information for the transaction kernel executable program.
+    /// Returns the transaction kernel executable program together with its package-owned debug
+    /// info, ready to hand to a package-debug execution API.
     ///
     /// # Panics
     /// Panics if the embedded transaction kernel package contains malformed debug information.
-    pub fn main_debug_info() -> Option<Arc<PackageDebugInfo>> {
-        KERNEL_MAIN_DEBUG_INFO.clone()
-    }
-
-    /// Returns the source/debug occurrence for the transaction kernel executable entrypoint.
-    pub fn main_entrypoint_source_node() -> Option<DebugSourceNodeId> {
-        package_entrypoint_source_node(&KERNEL_MAIN_PACKAGE, KERNEL_MAIN_DEBUG_INFO.as_deref())
+    pub fn main_program() -> KernelProgram {
+        KernelProgram {
+            program: Self::main(),
+            debug_info: KERNEL_MAIN_DEBUG_INFO.clone().unwrap_or_else(empty_debug_info),
+            entrypoint_source_node: package_entrypoint_source_node(
+                &KERNEL_MAIN_PACKAGE,
+                KERNEL_MAIN_DEBUG_INFO.as_deref(),
+            ),
+        }
     }
 
     /// Returns an AST of the transaction script executor program.
@@ -143,21 +176,21 @@ impl TransactionKernel {
         TX_SCRIPT_MAIN.clone()
     }
 
-    /// Returns package-owned debug information for the transaction script executor program.
+    /// Returns the transaction script executor program together with its package-owned debug
+    /// info, ready to hand to a package-debug execution API.
     ///
     /// # Panics
     /// Panics if the embedded transaction script executor package contains malformed debug
     /// information.
-    pub fn tx_script_main_debug_info() -> Option<Arc<PackageDebugInfo>> {
-        TX_SCRIPT_MAIN_DEBUG_INFO.clone()
-    }
-
-    /// Returns the source/debug occurrence for the transaction script executor entrypoint.
-    pub fn tx_script_main_entrypoint_source_node() -> Option<DebugSourceNodeId> {
-        package_entrypoint_source_node(
-            &TX_SCRIPT_MAIN_PACKAGE,
-            TX_SCRIPT_MAIN_DEBUG_INFO.as_deref(),
-        )
+    pub fn tx_script_main_program() -> KernelProgram {
+        KernelProgram {
+            program: Self::tx_script_main(),
+            debug_info: TX_SCRIPT_MAIN_DEBUG_INFO.clone().unwrap_or_else(empty_debug_info),
+            entrypoint_source_node: package_entrypoint_source_node(
+                &TX_SCRIPT_MAIN_PACKAGE,
+                TX_SCRIPT_MAIN_DEBUG_INFO.as_deref(),
+            ),
+        }
     }
 
     /// Returns [ProgramInfo] for the transaction kernel executable program.
@@ -467,6 +500,13 @@ impl TransactionKernel {
     pub fn to_commitment(&self) -> Word {
         <Self as SequentialCommit>::to_commitment(self)
     }
+}
+
+/// Shared empty debug info, used when a package carries no debug sections.
+fn empty_debug_info() -> Arc<PackageDebugInfo> {
+    static EMPTY: LazyLock<Arc<PackageDebugInfo>> =
+        LazyLock::new(|| Arc::new(PackageDebugInfo::default()));
+    EMPTY.clone()
 }
 
 fn package_debug_info(package: &Package, package_name: &str) -> Option<Arc<PackageDebugInfo>> {

--- a/crates/miden-tx/src/executor/mod.rs
+++ b/crates/miden-tx/src/executor/mod.rs
@@ -19,7 +19,7 @@ use miden_protocol::transaction::{
     TransactionKernel,
     TransactionScript,
 };
-use miden_protocol::vm::{PackageDebugInfo, StackOutputs};
+use miden_protocol::vm::StackOutputs;
 use miden_protocol::{Felt, MAX_TX_EXECUTION_CYCLES, MIN_TX_EXECUTION_CYCLES};
 
 use super::TransactionExecutorError;
@@ -203,14 +203,12 @@ where
         // sections. This enables package-owned debug info for dynamically loaded scripts.
         let processor = EXEC::new(stack_inputs, advice_inputs, self.exec_options);
 
-        let program = TransactionKernel::main();
-        let kernel_debug_info = TransactionKernel::main_debug_info();
-        let fallback_debug_info = PackageDebugInfo::default();
+        let kernel = TransactionKernel::main_program();
         let output = processor
             .execute_with_package_debug_info(
-                &program,
-                kernel_debug_info.as_deref().unwrap_or(&fallback_debug_info),
-                TransactionKernel::main_entrypoint_source_node(),
+                kernel.program(),
+                kernel.debug_info(),
+                kernel.entrypoint_source_node(),
                 &mut host,
             )
             .await
@@ -253,14 +251,12 @@ where
         let (mut host, stack_inputs, advice_inputs) = self.prepare_transaction(&tx_inputs).await?;
 
         let processor = EXEC::new(stack_inputs, advice_inputs, self.exec_options);
-        let program = TransactionKernel::tx_script_main();
-        let kernel_debug_info = TransactionKernel::tx_script_main_debug_info();
-        let fallback_debug_info = PackageDebugInfo::default();
+        let kernel = TransactionKernel::tx_script_main_program();
         let output = processor
             .execute_with_package_debug_info(
-                &program,
-                kernel_debug_info.as_deref().unwrap_or(&fallback_debug_info),
-                TransactionKernel::tx_script_main_entrypoint_source_node(),
+                kernel.program(),
+                kernel.debug_info(),
+                kernel.entrypoint_source_node(),
                 &mut host,
             )
             .await

--- a/crates/miden-tx/src/executor/notes_checker.rs
+++ b/crates/miden-tx/src/executor/notes_checker.rs
@@ -13,7 +13,6 @@ use miden_protocol::transaction::{
     TransactionInputs,
     TransactionKernel,
 };
-use miden_protocol::vm::PackageDebugInfo;
 use miden_standards::note::{NoteConsumptionStatus, StandardNote};
 
 use super::{ProgramExecutor, TransactionExecutor};
@@ -437,14 +436,12 @@ where
                 .map_err(TransactionCheckerError::TransactionPreparation)?;
 
         let processor = EXEC::new(stack_inputs, advice_inputs, self.0.exec_options);
-        let program = TransactionKernel::main();
-        let kernel_debug_info = TransactionKernel::main_debug_info();
-        let fallback_debug_info = PackageDebugInfo::default();
+        let kernel = TransactionKernel::main_program();
         let result = processor
             .execute_with_package_debug_info(
-                &program,
-                kernel_debug_info.as_deref().unwrap_or(&fallback_debug_info),
-                TransactionKernel::main_entrypoint_source_node(),
+                kernel.program(),
+                kernel.debug_info(),
+                kernel.entrypoint_source_node(),
                 &mut host,
             )
             .await


### PR DESCRIPTION
Closes #3194

Draft while I wait to be assigned on the issue.

## Rationale

#3146 left `TransactionKernel` exposing four separate values per program — the program, its package debug info, and its entrypoint source node — so each caller had to know how to pair them, and had to supply its own `PackageDebugInfo::default()` for the case where the embedded package carries no debug sections.

All three call sites in `miden-tx` repeated the same five lines:

```rust
let program = TransactionKernel::main();
let kernel_debug_info = TransactionKernel::main_debug_info();
let fallback_debug_info = PackageDebugInfo::default();
processor.execute_with_package_debug_info(
    &program,
    kernel_debug_info.as_deref().unwrap_or(&fallback_debug_info),
    TransactionKernel::main_entrypoint_source_node(),
    &mut host,
)
```

## Changes

Adds `KernelProgram`, holding the three values together, and replaces the four accessors with `main_program()` and `tx_script_main_program()`. Call sites become:

```rust
let kernel = TransactionKernel::main_program();
processor.execute_with_package_debug_info(
    kernel.program(),
    kernel.debug_info(),
    kernel.entrypoint_source_node(),
    &mut host,
)
```

Two details worth flagging:

- `debug_info()` returns `&PackageDebugInfo` rather than an `Option`. An empty `PackageDebugInfo` is what the execution API wants when a package has no debug sections, so making the caller unwrap into a locally-owned fallback was pushing a kernel concern outward. The empty value now sits behind a shared `LazyLock` instead of being allocated fresh on every execution.
- `main()` and `tx_script_main()` stay. The prover uses the bare program and has no use for debug info, so removing them would have been a regression rather than a simplification.

The clearest signal that the boundary landed in the right place: both caller files stopped importing `PackageDebugInfo` entirely.

## Test plan

```
cargo test -p miden-protocol --lib
cargo check -p miden-protocol -p miden-tx --all-targets
cargo clippy -p miden-protocol -p miden-tx --all-targets
```

This is a pure refactor with no behaviour change — the same three values reach `execute_with_package_debug_info` in the same order — so it is covered by the existing suite rather than new tests.

## Results

`cargo test -p miden-protocol --lib` passes (429 tests). Clippy reports nothing new; the two `Option::filter` suggestions it emits are pre-existing in `account/component/storage/toml/`, untouched here.

One caveat on formatting: `make format` uses `cargo +nightly fmt` and I only have stable, so I could not run the project formatter. I kept added lines within the configured widths and matched the surrounding style by hand — please flag anything it would move.
