### PR TITLE
fix(protocol): enforce invariants in TransactionInputs::read_from (#3535)

### DIFF
--- a/crates/miden-protocol/src/transaction/inputs/mod.rs
+++ b/crates/miden-protocol/src/transaction/inputs/mod.rs
@@ -80,33 +80,7 @@ impl TransactionInputs {
         blockchain: PartialBlockchain,
         input_notes: InputNotes<InputNote>,
     ) -> Result<Self, TransactionInputError> {
-        // Check that the partial blockchain and block header are consistent.
-        if blockchain.chain_length() != block_header.block_num() {
-            return Err(TransactionInputError::InconsistentChainLength {
-                expected: block_header.block_num(),
-                actual: blockchain.chain_length(),
-            });
-        }
-        if blockchain.peaks().hash_peaks() != block_header.chain_commitment() {
-            return Err(TransactionInputError::InconsistentChainCommitment {
-                expected: block_header.chain_commitment(),
-                actual: blockchain.peaks().hash_peaks(),
-            });
-        }
-        // Validate the authentication paths of the input notes.
-        for note in input_notes.iter() {
-            if let InputNote::Authenticated { note, proof } = note {
-                let note_block_num = proof.location().block_num();
-                let block_header = if note_block_num == block_header.block_num() {
-                    &block_header
-                } else {
-                    blockchain.get_block(note_block_num).ok_or(
-                        TransactionInputError::InputNoteBlockNotInPartialBlockchain(note.id()),
-                    )?
-                };
-                validate_is_in_block(note, proof, block_header)?;
-            }
-        }
+        validate_transaction_inputs(&block_header, &blockchain, &input_notes)?;
 
         Ok(Self {
             account,
@@ -506,6 +480,9 @@ impl Deserializable for TransactionInputs {
         let foreign_account_slot_names =
             BTreeMap::<StorageSlotId, StorageSlotName>::read_from(source)?;
 
+        validate_transaction_inputs(&block_header, &blockchain, &input_notes)
+            .map_err(|err| DeserializationError::InvalidValue(format!("{err}")))?;
+
         Ok(TransactionInputs {
             account,
             block_header,
@@ -521,6 +498,42 @@ impl Deserializable for TransactionInputs {
 
 // HELPER FUNCTIONS
 // ================================================================================================
+
+fn validate_transaction_inputs(
+    block_header: &BlockHeader,
+    blockchain: &PartialBlockchain,
+    input_notes: &InputNotes<InputNote>,
+) -> Result<(), TransactionInputError> {
+    // Check that the partial blockchain and block header are consistent.
+    if blockchain.chain_length() != block_header.block_num() {
+        return Err(TransactionInputError::InconsistentChainLength {
+            expected: block_header.block_num(),
+            actual: blockchain.chain_length(),
+        });
+    }
+    if blockchain.peaks().hash_peaks() != block_header.chain_commitment() {
+        return Err(TransactionInputError::InconsistentChainCommitment {
+            expected: block_header.chain_commitment(),
+            actual: blockchain.peaks().hash_peaks(),
+        });
+    }
+    // Validate the authentication paths of the input notes.
+    for note in input_notes.iter() {
+        if let InputNote::Authenticated { note, proof } = note {
+            let note_block_num = proof.location().block_num();
+            let block_header = if note_block_num == block_header.block_num() {
+                block_header
+            } else {
+                blockchain.get_block(note_block_num).ok_or(
+                    TransactionInputError::InputNoteBlockNotInPartialBlockchain(note.id()),
+                )?
+            };
+            validate_is_in_block(note, proof, block_header)?;
+        }
+    }
+
+    Ok(())
+}
 
 /// Validates whether the provided note belongs to the note tree of the specified block.
 fn validate_is_in_block(

--- a/crates/miden-protocol/src/transaction/inputs/tests.rs
+++ b/crates/miden-protocol/src/transaction/inputs/tests.rs
@@ -4,6 +4,8 @@ use alloc::vec;
 use std::collections::BTreeMap;
 use std::vec::Vec;
 
+use miden_crypto::merkle::SparseMerklePath;
+
 use crate::account::{
     AccountCode,
     AccountHeader,
@@ -18,12 +20,13 @@ use crate::account::{
 use crate::asset::PartialVault;
 use crate::block::account_tree::AccountIdKey;
 use crate::errors::TransactionInputsExtractionError;
+use crate::note::NoteInclusionProof;
 use crate::testing::account_id::{
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE,
     ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE_2,
 };
-use crate::transaction::TransactionInputs;
-use crate::utils::serde::{Deserializable, Serializable};
+use crate::transaction::{InputNote, PartialBlockchain, TransactionInputs};
+use crate::utils::serde::{Deserializable, DeserializationError, Serializable};
 use crate::{Felt, Word};
 
 #[test]
@@ -372,4 +375,86 @@ fn test_transaction_inputs_serialization_with_foreign_slot_names() {
 
     // Verify the entire structure is identical.
     assert_eq!(original_tx_inputs, deserialized);
+}
+
+#[test]
+fn test_transaction_inputs_deserialization_validates_invariants() {
+    let mut chain_length_mismatch = test_transaction_inputs();
+    chain_length_mismatch.blockchain.add_block(
+        &crate::block::BlockHeader::mock(0, None, None, &[], Word::default()),
+        false,
+    );
+    let error = TransactionInputs::read_from_bytes(&chain_length_mismatch.to_bytes()).unwrap_err();
+    assert_matches!(
+        error,
+        DeserializationError::InvalidValue(message)
+            if message == "partial blockchain has length 1 which does not match block number 0"
+    );
+
+    let mut chain_commitment_mismatch = test_transaction_inputs();
+    chain_commitment_mismatch.block_header = crate::block::BlockHeader::mock(
+        0,
+        Some(Word::new([Felt::ONE; 4])),
+        None,
+        &[],
+        Word::default(),
+    );
+    let error =
+        TransactionInputs::read_from_bytes(&chain_commitment_mismatch.to_bytes()).unwrap_err();
+    assert_matches!(
+        error,
+        DeserializationError::InvalidValue(message)
+            if message.starts_with("partial blockchain has commitment ")
+                && message.contains("which does not match the block header's chain commitment")
+    );
+
+    let mut invalid_note_proof = test_transaction_inputs();
+    let note = crate::testing::note::Note::mock_noop(Word::new([Felt::ONE; 4]));
+    let proof = NoteInclusionProof::new(0, 0, SparseMerklePath::default()).unwrap();
+    invalid_note_proof.input_notes = crate::transaction::InputNotes::new(vec![
+        InputNote::Authenticated { note: note.clone(), proof },
+    ])
+    .unwrap();
+    let error = TransactionInputs::read_from_bytes(&invalid_note_proof.to_bytes()).unwrap_err();
+    assert_matches!(
+        error,
+        DeserializationError::InvalidValue(message)
+            if message == format!("input note with id {} was not created in block 0", note.id())
+    );
+}
+
+fn test_transaction_inputs() -> TransactionInputs {
+    let account_id =
+        AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
+    let code = AccountCode::mock();
+    let storage_header = AccountStorageHeader::new(vec![]).unwrap();
+    let partial_storage = PartialStorage::new(storage_header, []).unwrap();
+    let partial_account = PartialAccount::new(
+        account_id,
+        Felt::new_unchecked(10),
+        code,
+        partial_storage,
+        PartialVault::new(Word::default()),
+        None,
+    )
+    .unwrap();
+    let blockchain = PartialBlockchain::default();
+    let block_header = crate::block::BlockHeader::mock(
+        0,
+        Some(blockchain.peaks().hash_peaks()),
+        None,
+        &[],
+        Word::default(),
+    );
+
+    TransactionInputs {
+        account: partial_account,
+        block_header,
+        blockchain,
+        input_notes: crate::transaction::InputNotes::new(vec![]).unwrap(),
+        tx_args: crate::transaction::TransactionArgs::default(),
+        advice_inputs: crate::vm::AdviceInputs::default(),
+        foreign_account_code: Vec::new(),
+        foreign_account_slot_names: BTreeMap::new(),
+    }
 }


### PR DESCRIPTION
Fixes #3535

## Summary
`TransactionInputs::read_from` was bypassing the three invariant checks enforced by `TransactionInputs::new`. This PR updates `read_from` to enforce the same validation logic and adds regression tests.

## Changes Made
- Updated `TransactionInputs::read_from` in `crates/miden-protocol/src/transaction/inputs/mod.rs` to validate:
  1. `blockchain.chain_length() == block_header.block_num()`
  2. `blockchain.peaks().hash_peaks() == block_header.chain_commitment()`
  3. Proof validity for every `InputNote::Authenticated` via `validate_is_in_block`.
- Added regression test in `tests.rs` verifying that deserialization fails when these invariants are violated.

*Note: Submitted the complete fix and tests to help accelerate resolution. @mehmetkr-31 / maintainers, please feel free to close if already handled elsewhere.*