### PR TITLE
fix(protocol): validate note inclusion proof index against note path depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixes
 
+- Enforced that a note inclusion proof's index addresses a leaf of its Merkle path ([#3544](https://github.com/0xMiden/protocol/issues/3544)).
+
 ## v0.16.0 (2026-08-06)
 
 ### Features

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -754,6 +754,14 @@ pub enum NoteError {
         block_note_tree_index: u16,
         highest_index: usize,
     },
+    #[error(
+        "block note tree index {block_note_tree_index} does not address a leaf of a note path \
+         of depth {path_depth}"
+    )]
+    NoteInclusionProofIndexNotInPath {
+        block_note_tree_index: u16,
+        path_depth: u8,
+    },
     #[error("note network execution requires a public note but note is of type {0}")]
     NetworkExecutionRequiresPublicNote(NoteType),
     #[error("failed to assemble note script:\n{}", PrintDiagnostic::new(.0))]

--- a/crates/miden-protocol/src/note/location.rs
+++ b/crates/miden-protocol/src/note/location.rs
@@ -1,4 +1,6 @@
-use miden_crypto::merkle::SparseMerklePath;
+use alloc::string::ToString;
+
+use miden_crypto::merkle::{NodeIndex, SparseMerklePath};
 
 use super::{
     ByteReader,
@@ -54,6 +56,12 @@ pub struct NoteInclusionProof {
 
 impl NoteInclusionProof {
     /// Returns a new [NoteInclusionProof].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - `block_note_tree_index` is out of bounds of the block note tree.
+    /// - `block_note_tree_index` does not address a leaf of `note_path` at its depth.
     pub fn new(
         block_num: BlockNumber,
         block_note_tree_index: u16,
@@ -64,6 +72,15 @@ impl NoteInclusionProof {
             return Err(NoteError::BlockNoteTreeIndexOutOfBounds {
                 block_note_tree_index,
                 highest_index: HIGHEST_INDEX,
+            });
+        }
+
+        // `authenticated_nodes` uses `block_note_tree_index` as a leaf position within
+        // `note_path`, so the index must be addressable at that path's depth.
+        if NodeIndex::new(note_path.depth(), block_note_tree_index.into()).is_err() {
+            return Err(NoteError::NoteInclusionProofIndexNotInPath {
+                block_note_tree_index,
+                path_depth: note_path.depth(),
             });
         }
 
@@ -89,7 +106,8 @@ impl NoteInclusionProof {
     /// Returns an iterator over inner nodes of this proof assuming that `note_id` is the value of
     /// the node to which this proof opens.
     pub fn authenticated_nodes(&self, note_id: NoteId) -> impl Iterator<Item = InnerNodeInfo> {
-        // SAFETY: expect() is fine here because we check index consistency in the constructor
+        // SAFETY: every construction path verifies that `block_note_tree_index` addresses a leaf
+        // of `note_path`, which is exactly the bound checked here.
         self.note_path
             .authenticated_nodes(self.location.block_note_tree_index().into(), note_id.as_word())
             .expect("note index is not out of bounds")
@@ -127,6 +145,76 @@ impl Deserializable for NoteInclusionProof {
         let location = NoteLocation::read_from(source)?;
         let note_path = SparseMerklePath::read_from(source)?;
 
-        Ok(Self { location, note_path })
+        Self::new(location.block_num, location.block_note_tree_index, note_path)
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use assert_matches::assert_matches;
+
+    use super::*;
+    use crate::{BLOCK_NOTE_TREE_DEPTH, Word};
+
+    /// Builds a path of the given depth. A zero mask means every node along the path is non-empty,
+    /// so the depth equals the number of nodes.
+    fn path_of_depth(depth: u8) -> SparseMerklePath {
+        SparseMerklePath::from_parts(0, vec![Word::default(); depth as usize])
+            .expect("a zero mask with `depth` nodes describes a valid path")
+    }
+
+    #[test]
+    fn new_accepts_index_addressable_at_path_depth() {
+        // 1000 < 2^10, so the index addresses a leaf of a depth-10 path.
+        assert!(NoteInclusionProof::new(BlockNumber::GENESIS, 1000, path_of_depth(10)).is_ok());
+    }
+
+    #[test]
+    fn new_accepts_zero_index_with_empty_path() {
+        // A depth-0 path opens to the root, whose only leaf position is 0.
+        assert!(NoteInclusionProof::new(BlockNumber::GENESIS, 0, path_of_depth(0)).is_ok());
+    }
+
+    #[test]
+    fn new_rejects_index_beyond_path_depth() {
+        // 1000 is a valid block note tree index, but no leaf of a depth-5 path carries it.
+        let err = NoteInclusionProof::new(BlockNumber::GENESIS, 1000, path_of_depth(5))
+            .expect_err("index 1000 is not addressable at depth 5");
+
+        assert_matches!(
+            err,
+            NoteError::NoteInclusionProofIndexNotInPath { block_note_tree_index, path_depth }
+                if block_note_tree_index == 1000 && path_depth == 5
+        );
+    }
+
+    #[test]
+    fn read_from_rejects_index_beyond_path_depth() {
+        // `new` rejects this combination, so the bytes are encoded field by field.
+        let mut bytes = Vec::new();
+        NoteLocation {
+            block_num: BlockNumber::GENESIS,
+            block_note_tree_index: 1000,
+        }
+        .write_into(&mut bytes);
+        path_of_depth(5).write_into(&mut bytes);
+
+        assert!(NoteInclusionProof::read_from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn valid_proof_round_trips() {
+        let path = path_of_depth(BLOCK_NOTE_TREE_DEPTH);
+        let proof = NoteInclusionProof::new(BlockNumber::GENESIS, 7, path).unwrap();
+
+        let decoded = NoteInclusionProof::read_from_bytes(&proof.to_bytes()).unwrap();
+
+        assert_eq!(proof, decoded);
     }
 }


### PR DESCRIPTION
Closes #3544.

### Problem

`NoteInclusionProof::authenticated_nodes` treats `block_note_tree_index` as a leaf position within `note_path` and unwraps the result:

```rust
self.note_path
    .authenticated_nodes(self.location.block_note_tree_index().into(), note_id.as_word())
    .expect("note index is not out of bounds")
```

Neither `new` nor the `Deserializable` impl enforced that invariant:

- `new`'s only check compared `block_note_tree_index` against `HIGHEST_INDEX`, which evaluates to `MAX_BATCHES_PER_BLOCK * MAX_OUTPUT_NOTES_PER_BATCH - 1 = 64 * 1024 - 1 = 65535`. That is exactly `u16::MAX`, so the comparison can never be true and the check is dead code.
- `read_from` did not route through `new` at all.

Because proofs are converted straight from RPC responses (`TryFrom<proto::note::NoteInclusionInBlockProof>` in `rust-sdk`) and then consumed while assembling transaction advice inputs, a proof whose path depth does not match its index reached a panic rather than a typed error.

### Change

- `NoteInclusionProof::new` rejects an index that is not addressable at `note_path.depth()`, reusing the same `NodeIndex::new` bound that `authenticated_nodes` relies on, and returns the new `NoteError::NoteInclusionProofIndexNotInPath`.
- `NoteInclusionProof`'s `Deserializable` impl routes through `new`, so deserialization enforces the same invariant and reports `DeserializationError::InvalidValue`.
- Corrected the `SAFETY` comment on `authenticated_nodes`, which asserted that the constructor checked index consistency.

The new check bounds the index by the path's own depth rather than requiring `BLOCK_NOTE_TREE_DEPTH`. That is the exact precondition `authenticated_nodes` needs, and it keeps the existing placeholder proofs that are built from an empty path with index `0` working - `miden-standards` and `miden-testing` both construct proofs that way.

### Test plan

```
cargo test -p miden-protocol --lib note::location
```

Five unit tests:

- `new_accepts_index_addressable_at_path_depth`
- `new_accepts_zero_index_with_empty_path` - pins that the placeholder proofs built in `miden-standards` and `miden-testing` keep working
- `new_rejects_index_beyond_path_depth`
- `read_from_rejects_index_beyond_path_depth`
- `valid_proof_round_trips`

To observe the panic this prevents, drop the `NodeIndex::new` check from `new` and call `authenticated_nodes` on a proof built from `SparseMerklePath::default()` with index `1`.

### Verification

I cannot build this workspace locally: `miden-core-lib`'s build script fails on Windows with `invalid root module path 'mod.masm'`, unrelated to this change, and there is no Windows job in CI. To avoid asking for review on unverified work I ran the workflows on my fork instead.

Passing there: `clippy`, `clippy no_std`, `rustfmt`, `doc`, `build for no-std`, `Check benchmarks compilation`, `cargo-deny`, `check for unused dependencies`, `changelog`, `spellcheck`, `toml formatting`, `workspace inheritance`.

Still queued on the fork's shared runners: `test`, `doc-tests`, `check all feature combinations`. I will follow up if any of them surfaces something.

### Notes

Two things worth a maintainer's call:

- This adds a variant to `NoteError`. I followed the precedent of #3415, which tightened validation in the same way, and left the CHANGELOG entry untagged rather than marking it `[BREAKING]` - happy to change that.
- The now-redundant `HIGHEST_INDEX` check is left in place to keep the diff minimal. It can be removed if you would rather not carry a bound that cannot trigger.

I also opened #3544 for this and, per CONTRIBUTING, am happy to wait for it to be assigned before this gets review time.
