### PR TITLE
test(protocol): pin RoleSymbol encoded-value constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [BREAKING] Extracted the shared `MastForestScript` type and `MastForestScriptError` backing `NoteScript` / `TransactionScript`, moving `TransactionScript` into `transaction::script` ([#3516](https://github.com/0xMiden/protocol/pull/3516)).
 - Documented the RBAC freeze-only actor pattern on `Authority` and added test coverage pinning that a `FREEZER` can trip the emergency switch but can never unfreeze the account ([#3520](https://github.com/0xMiden/protocol/pull/3520)).
 - [BREAKING] Moved the internal shared helpers of `miden::protocol::input_note`, `miden::protocol::active_note`, and the note memory-write helpers into private `input_note_internal` and `note_internal` modules ([#3501](https://github.com/0xMiden/protocol/pull/3501)).
+- Added test coverage pinning `RoleSymbol`'s encoded-value constants and its decode range ([#3549](https://github.com/0xMiden/protocol/issues/3549)).
 
 ### Fixes
 

--- a/crates/miden-protocol/src/account/access.rs
+++ b/crates/miden-protocol/src/account/access.rs
@@ -158,4 +158,40 @@ mod tests {
         assert!(ab > b);
         assert!(b < ab);
     }
+
+    /// Utility test just to make sure that the [`RoleSymbol::MAX_ENCODED_VALUE`] constant still
+    /// represents the maximum possible encoded value.
+    #[test]
+    fn test_role_symbol_max_value() {
+        let role_symbol = RoleSymbol::new("____________").unwrap();
+
+        assert_eq!(role_symbol.as_element().as_canonical_u64(), RoleSymbol::MAX_ENCODED_VALUE);
+    }
+
+    /// Utility test just to make sure that the [`RoleSymbol::MIN_ENCODED_VALUE`] constant still
+    /// represents the minimum possible encoded value.
+    #[test]
+    fn test_role_symbol_min_value() {
+        let role_symbol = RoleSymbol::new("A").unwrap();
+
+        assert_eq!(role_symbol.as_element().as_canonical_u64(), RoleSymbol::MIN_ENCODED_VALUE);
+    }
+
+    /// Checks that decoding rejects a value below [`RoleSymbol::MIN_ENCODED_VALUE`].
+    #[test]
+    fn test_role_symbol_underflow() {
+        let err = RoleSymbol::try_from(Felt::ZERO).unwrap_err();
+
+        assert_matches!(err, RoleSymbolError::ValueTooSmall(0));
+    }
+
+    /// Checks that decoding rejects a value above [`RoleSymbol::MAX_ENCODED_VALUE`].
+    #[test]
+    fn test_role_symbol_overflow() {
+        let too_large = Felt::new_unchecked(RoleSymbol::MAX_ENCODED_VALUE + 1);
+
+        let err = RoleSymbol::try_from(too_large).unwrap_err();
+
+        assert_matches!(err, RoleSymbolError::ValueTooLarge(_));
+    }
 }


### PR DESCRIPTION
Closes #3549.

### Problem

`RoleSymbol` and `TokenSymbol` are the same shape: both wrap `ShortCapitalString`, both declare hand-written `MIN_ENCODED_VALUE`/`MAX_ENCODED_VALUE` constants, and both pass those constants into `ShortCapitalString::try_from_encoded_felt` as the accepted decode range.

`TokenSymbol` pins both constants to the encoding they describe (`test_token_symbol_max_value`, `test_token_symbol_min_value`) and covers the lower range check (`test_token_symbol_underflow`). `RoleSymbol` covered round-tripping, length and character validation, and `Ord`, but nothing tied either constant to the encoder.

That matters because `MAX_ENCODED_VALUE` is a function of the alphabet size and `ShortCapitalString::MAX_LENGTH`. `RoleSymbol::ALPHABET` holds 27 symbols (`A-Z` plus `_`) against `TokenSymbol`'s 26, so the two constants are different 19-digit numbers and neither can be checked by inspection. If the alphabet or the maximum length changes, the constant silently stops matching the encoder, and the result is either rejecting valid role symbols or accepting felts that cannot decode.

### Change

Adds the three `RoleSymbol` counterparts of the existing `TokenSymbol` tests, and additionally covers the upper range check, which neither type tested:

- `test_role_symbol_max_value` - `"____________"` encodes to `MAX_ENCODED_VALUE`
- `test_role_symbol_min_value` - `"A"` encodes to `MIN_ENCODED_VALUE`
- `test_role_symbol_underflow` - `Felt::ZERO` is rejected with `ValueTooSmall`
- `test_role_symbol_overflow` - `MAX_ENCODED_VALUE + 1` is rejected with `ValueTooLarge`

No production code changes.

### Test plan

```
cargo test -p miden-protocol --lib account::access
```

The four tests above plus the two that already existed.

### Verification

The constants are correct today, so these tests pass as written rather than exposing anything. I confirmed the expected values independently by reimplementing `ShortCapitalString::as_element` in isolation and comparing against the declared constants:

```
RoleSymbol  "A"            -> 1                    == MIN_ENCODED_VALUE
RoleSymbol  "____________" -> 4052555153018976252  == MAX_ENCODED_VALUE
TokenSymbol "A"            -> 1                    == MIN_ENCODED_VALUE
TokenSymbol "ZZZZZZZZZZZZ" -> 2481152873203736562  == MAX_ENCODED_VALUE
```

I cannot run the suite locally: `miden-core-lib`'s build script fails on Windows with `invalid root module path 'mod.masm'`, unrelated to this change, and there is no Windows job in CI. Nightly `rustfmt --check` is clean on the modified file, and I am relying on CI for the compile and test run.

### Notes

I followed the CHANGELOG wording of #3520, which recorded a comparable "added test coverage pinning ..." change under Changes rather than Fixes.

I opened #3549 for this and, per CONTRIBUTING, am happy to wait for it to be assigned before this gets review time.
