### PR TITLE
fix(protocol): correct AddressInterface bit budget to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [BREAKING] Extracted the shared `MastForestScript` type and `MastForestScriptError` backing `NoteScript` / `TransactionScript`, moving `TransactionScript` into `transaction::script` ([#3516](https://github.com/0xMiden/protocol/pull/3516)).
 - Documented the RBAC freeze-only actor pattern on `Authority` and added test coverage pinning that a `FREEZER` can trip the emergency switch but can never unfreeze the account ([#3520](https://github.com/0xMiden/protocol/pull/3520)).
 - [BREAKING] Moved the internal shared helpers of `miden::protocol::input_note`, `miden::protocol::active_note`, and the note memory-write helpers into private `input_note_internal` and `note_internal` modules ([#3501](https://github.com/0xMiden/protocol/pull/3501)).
+- Corrected the documented bit budget of `AddressInterface` from 11 to 10 bits and enforced it with a compile-time assertion ([#3554](https://github.com/0xMiden/protocol/issues/3554)).
 
 ### Fixes
 

--- a/crates/miden-protocol/src/address/interface.rs
+++ b/crates/miden-protocol/src/address/interface.rs
@@ -13,8 +13,9 @@ use crate::errors::AddressError;
 ///
 /// ## Guarantees
 ///
-/// An interface encodes to a `u16`, but is guaranteed to take up at most 11 of its bits. This
-/// constraint allows encoding the interface into an address efficiently.
+/// An interface encodes to a `u16`, but is guaranteed to take up at most 10 of its bits. This
+/// constraint allows encoding the interface into an address efficiently, sharing the remaining
+/// bits with the note tag length.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u16)]
 #[non_exhaustive]
@@ -24,9 +25,22 @@ pub enum AddressInterface {
 }
 
 impl AddressInterface {
+    /// The number of bits an encoded interface occupies in an address' receiver profile.
+    ///
+    /// The remaining bits of that profile carry the note tag length, so a variant that does not
+    /// fit into this budget would corrupt both fields.
+    pub(crate) const ENCODED_BITS: u32 = 10;
+
     // Constants for internal use only.
     const BASIC_WALLET: u16 = 0;
 }
+
+// The encoder guards this budget with a `debug_assert`, which is compiled out in release builds,
+// so the discriminants are checked here at compile time as well.
+const _: () = assert!(
+    AddressInterface::BASIC_WALLET < (1u16 << AddressInterface::ENCODED_BITS),
+    "address interface discriminants must fit into ENCODED_BITS bits",
+);
 
 impl TryFrom<u16> for AddressInterface {
     type Error = AddressError;

--- a/crates/miden-protocol/src/address/routing_parameters.rs
+++ b/crates/miden-protocol/src/address/routing_parameters.rs
@@ -268,11 +268,16 @@ fn encode_receiver_profile(interface: AddressInterface, note_tag_len: Option<u8>
     let note_tag_len = note_tag_len.unwrap_or(ABSENT_NOTE_TAG_LEN);
 
     let interface = interface as u16;
-    debug_assert_eq!(interface >> 10, 0, "address interface should fit into 10 bits");
+    debug_assert_eq!(
+        interface >> AddressInterface::ENCODED_BITS,
+        0,
+        "address interface should fit into {} bits",
+        AddressInterface::ENCODED_BITS,
+    );
 
-    // The interface takes up 10 bits and the tag length 6 bits, so we can merge them
-    // together.
-    let tag_len = (note_tag_len as u16) << 10;
+    // The interface takes up the low bits and the tag length the remaining high ones, so we can
+    // merge them together.
+    let tag_len = (note_tag_len as u16) << AddressInterface::ENCODED_BITS;
     let receiver_profile: u16 = tag_len | interface;
     receiver_profile.to_be_bytes()
 }
@@ -289,7 +294,7 @@ fn decode_receiver_profile(
     let byte1 = byte_iter.next().expect("byte1 should exist");
     let receiver_profile = u16::from_be_bytes([byte0, byte1]);
 
-    let tag_len = (receiver_profile >> 10) as u8;
+    let tag_len = (receiver_profile >> AddressInterface::ENCODED_BITS) as u8;
     let note_tag_len = match tag_len {
         ABSENT_NOTE_TAG_LEN => None,
         0..=32 => Some(tag_len),
@@ -298,7 +303,7 @@ fn decode_receiver_profile(
         },
     };
 
-    let addr_interface = receiver_profile & 0b0000_0011_1111_1111;
+    let addr_interface = receiver_profile & ((1u16 << AddressInterface::ENCODED_BITS) - 1);
     let addr_interface = AddressInterface::try_from(addr_interface).map_err(|err| {
         AddressError::decode_error_with_source("failed to decode address interface", err)
     })?;


### PR DESCRIPTION
Closes #3554.

### Problem

`AddressInterface` documented a guarantee of "at most 11 of its bits", but the receiver profile reserves 10. Four places in the encoder and decoder agree on 10: the inline comment ("the interface takes up 10 bits and the tag length 6 bits"), the `debug_assert`, the `<< 10` shift that places the tag length, and the `& 0b0000_0011_1111_1111` mask that recovers the interface.

The documented number is also arithmetically impossible. The profile is a single `u16` shared with the note tag length, and `ABSENT_NOTE_TAG_LEN = 63` shows that field is 6 bits wide. `10 + 6 = 16` fits exactly; `11 + 6 = 17` does not.

This matters because the type is `#[non_exhaustive]` and its documentation explicitly invites new variants, so the bit budget is the contract a future variant is written against. The encoder guards it only with a `debug_assert`, which is compiled out in release builds.

### Change

- Corrects the documented budget and expresses it as `AddressInterface::ENCODED_BITS`.
- Adds a `const _: () = assert!(...)` so a discriminant that exceeds the budget fails to compile rather than depending on a `debug_assert`. This repo already uses that pattern in `constants.rs` and `transaction/kernel/memory.rs`.
- Derives the shift and the mask in `routing_parameters.rs` from that constant, so encoder, decoder and documentation share one source of truth instead of three hand-written `10`s and a hand-written mask.

No behaviour change: `ENCODED_BITS` is 10, which is what the code already did.

### Test plan

```
cargo test -p miden-protocol --lib address
```

The existing address encode/decode tests cover this path and should be unchanged.

### Verification

I cannot build this workspace locally (`miden-core-lib`'s build script fails on Windows with `invalid root module path 'mod.masm'`, unrelated to this change, and there is no Windows job in CI), so I verified the arithmetic in isolation instead.

Reimplementing both the old and the new form of `encode_receiver_profile`/`decode_receiver_profile` and comparing them over every valid input:

```
mask: old=1023 new=1023 -> identical
encode/decode compared over 65536 (interface, tag_len) pairs -> 0 mismatches
```

The same harness demonstrates the corruption the documented budget invites. Encoding an "11-bit" interface (`1024`) with `tag_len = 5`:

```
encode -> 0x1400
decode -> interface=0 (expected 1024), tag_len=5
```

The interface decodes as `BasicWallet` instead of the variant that was encoded. With `tag_len = 0` the tag length is corrupted too, since bit 10 of the interface lands in that field.

I also ran the workflows on my fork. The full `lint` set passes there: `clippy`, `clippy no_std`, `doc`, `rustfmt`, `cargo-deny`, `check for unused dependencies`, `spellcheck`, `toml formatting`, `workspace inheritance`, `claude hooks pytest`. `build` and `test` are still queued on the fork's shared runners; I will follow up if either surfaces anything.

### Notes

I kept the `debug_assert` in the encoder rather than removing it: it still gives a clearer message at the call site if a value is ever constructed outside the enum.

I opened #3554 for this and, per CONTRIBUTING, am happy to wait for it to be assigned before this gets review time.
