### PR TITLE
fix(protocol): route BlockSignatures::read_from through new()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixes
 
+- Fixed `BlockSignatures::read_from` skipping the `TooManySignatures` validation by routing deserialization through `BlockSignatures::new` ([#3494](https://github.com/0xMiden/protocol/issues/3494)).
+
 ## v0.16.0 (2026-08-06)
 
 ### Features

--- a/crates/miden-protocol/src/block/block_signatures.rs
+++ b/crates/miden-protocol/src/block/block_signatures.rs
@@ -146,7 +146,7 @@ impl Serializable for BlockSignatures {
 impl Deserializable for BlockSignatures {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let signatures = Vec::<Signature>::read_from(source)?;
-        Ok(Self { signatures })
+        Self::new(signatures).map_err(|err| DeserializationError::InvalidValue(format!("{err}")))
     }
 }
 
@@ -214,6 +214,26 @@ mod tests {
             signatures.verify_against(commitment, &other_keys),
             Err(SignatureVerificationError::SignatureCountMismatch { expected: 4, actual: 3 })
         ));
+    }
+
+    #[test]
+    fn read_from_rejects_too_many_signatures() {
+        // Manually serialize more than ValidatorKeys::MAX signatures.
+        let commitment = Word::empty();
+        let signatures: Vec<Signature> = (0..ValidatorKeys::MAX + 1)
+            .map(|_| random_secret_key().sign(commitment))
+            .collect();
+
+        // Serializing raw: write count + each signature.
+        let mut bytes = Vec::new();
+        signatures.write_into(&mut bytes);
+
+        let err = BlockSignatures::read_from_bytes(&bytes)
+            .expect_err("deserializing more than MAX signatures must fail");
+        assert!(
+            matches!(err, DeserializationError::InvalidValue(_)),
+            "expected InvalidValue, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Route `BlockSignatures::read_from` through `Self::new().map_err(...)` so the `TooManySignatures` length check is enforced during deserialization, matching the existing `ValidatorKeys::read_from` pattern.
- Add regression test `read_from_rejects_too_many_signatures`.
- Add CHANGELOG entry.

## Rationale

`BlockSignatures::read_from` constructed the struct directly with `Ok(Self { signatures })`, bypassing the `TooManySignatures` validation that `new()` enforces. A crafted payload with more than `ValidatorKeys::MAX` (5) signatures would deserialize without error. This is the same pattern PhilippGackstatter flagged in [#3516 (comment)](https://github.com/0xMiden/protocol/pull/3516#discussion_r3517073671).

## Test plan

- `read_from_rejects_too_many_signatures`: serializes 6 signatures (MAX + 1), deserializes, asserts `InvalidValue` error.
- All existing `block_signatures` tests pass (6/6).

Closes #3494