### PR TITLE
feat: sort account procedures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changes
 
 - [BREAKING] Moved the internal shared helpers of `miden::protocol::input_note`, `miden::protocol::active_note`, and the note memory-write helpers into private `input_note_internal` and `note_internal` modules ([#3501](https://github.com/0xMiden/protocol/pull/3501)).
+- [BREAKING] Sorted the procedures of `AccountCode` after the authentication procedure at index 0, making the account code commitment independent of the order in which components are provided ([#2961](https://github.com/0xMiden/protocol/issues/2961)).
 - [BREAKING] Changed asset callbacks into validation-only interfaces that return no asset value; the transaction kernel retains and uses the original value, preventing callbacks from modifying it. The kernel commitment changes ([#3505](https://github.com/0xMiden/protocol/issues/3505), [#3513](https://github.com/0xMiden/protocol/pull/3513)).
 - [BREAKING] Extracted the shared `MastForestScript` type and `MastForestScriptError` backing `NoteScript` / `TransactionScript`, moving `TransactionScript` into `transaction::script` ([#3516](https://github.com/0xMiden/protocol/pull/3516)).
 - Documented the RBAC freeze-only actor pattern on `Authority` and added test coverage pinning that a `FREEZER` can trip the emergency switch but can never unfreeze the account ([#3520](https://github.com/0xMiden/protocol/pull/3520)).

--- a/crates/miden-protocol/src/account/builder/mod.rs
+++ b/crates/miden-protocol/src/account/builder/mod.rs
@@ -53,10 +53,10 @@ use crate::{Felt, Word};
 ///
 /// **Account Procedure Order**
 ///
-/// Note that the procedure in each components code are merged together in the same order as
-/// `with_component` is called, except for the auth component. The auth procedure is always moved to
-/// the first position, since the tx kernel assume procedure index 0 is the auth procedure within an
-/// [`AccountCode`].
+/// Note that the auth procedure is always moved to the first position, since the tx kernel assumes
+/// procedure index 0 is the auth procedure within an [`AccountCode`]. The procedures of all other
+/// components are merged and sorted, so the order in which `with_component` is called does not
+/// affect the resulting account code commitment.
 #[derive(Debug, Clone)]
 pub struct AccountBuilder {
     #[cfg(any(feature = "testing", test))]
@@ -118,7 +118,8 @@ impl AccountBuilder {
     /// All components will be merged to form the final code and storage of the built account.
     /// Exactly one of the added components must be an authentication component (see
     /// [`AccountComponent::is_auth_component`]); it is identified and moved to the front of the
-    /// procedure list automatically when [`Self::build`] is called.
+    /// procedure list automatically when [`Self::build`] is called, while all other procedures are
+    /// sorted.
     ///
     /// For composite configurations that expand into multiple components (such as
     /// `AccessControl` or `TokenPolicyManager`), use [`Self::with_components`].

--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -1,7 +1,7 @@
-use alloc::collections::BTreeSet;
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::cmp::Ordering;
 
 use miden_core::mast::MastForest;
 use miden_core::prettier::PrettyPrint;
@@ -33,9 +33,10 @@ use procedure::{AccountProcedureRoot, PrintableProcedure};
 /// An account's public interface consists of a set of account procedures, each of which is
 /// identified and committed to by a MAST root. They are represented by [`AccountProcedureRoot`].
 ///
-/// The set of procedures has an arbitrary order, i.e. they are not sorted. The only exception is
-/// the authentication procedure of the account, which is always at index 0. This procedure is
-/// automatically called at the end of a transaction to validate an account's state transition.
+/// The authentication procedure of the account is always at index 0. It is automatically called at
+/// the end of a transaction to validate an account's state transition. The remaining procedures are
+/// sorted in ascending order, which makes the code commitment independent of the order in which the
+/// account's components were provided.
 ///
 /// The code commits to the entire account interface by building a sequential hash of all procedure
 /// MAST roots. Specifically, each procedure contributes exactly 4 field elements to the sequence of
@@ -72,6 +73,8 @@ impl AccountCode {
     ///
     /// Returns an error if:
     /// - The number of procedures is smaller than 2 or greater than 256.
+    /// - The procedures after the authentication procedure at index 0 are not sorted in ascending
+    ///   order.
     /// - The procedure roots are not unique.
     /// - Any provided procedure root is not in the provided [`MastForest`].
     pub fn from_parts(
@@ -85,11 +88,22 @@ impl AccountCode {
             return Err(AccountError::AccountCodeTooManyProcedures(procedures.len()));
         }
 
-        let mut unique_roots = BTreeSet::new();
-        for procedure in &procedures {
-            if !unique_roots.insert(procedure.as_word()) {
-                return Err(AccountError::AccountCodeDuplicateProcedureRoot(procedure.as_word()));
+        // The authentication procedure at index 0 is exempt from the ordering invariant, so the
+        // remaining procedures are checked to be strictly increasing, which also makes them unique.
+        let (auth_proc, other_procs) = procedures.split_first().expect("at least two procedures");
+        for pair in other_procs.windows(2) {
+            match pair[0].cmp(&pair[1]) {
+                Ordering::Less => {},
+                Ordering::Equal => {
+                    return Err(AccountError::AccountCodeDuplicateProcedureRoot(pair[0].as_word()));
+                },
+                Ordering::Greater => return Err(AccountError::AccountCodeProceduresNotSorted),
             }
+        }
+
+        // The authentication procedure must not appear a second time among the sorted procedures.
+        if other_procs.binary_search(auth_proc).is_ok() {
+            return Err(AccountError::AccountCodeDuplicateProcedureRoot(auth_proc.as_word()));
         }
 
         // make sure that all account procedures are in the MAST forest
@@ -160,11 +174,9 @@ impl AccountCode {
 
         let procedures = builder.build()?;
 
-        Ok(Self {
-            commitment: build_procedure_commitment(&procedures),
-            procedures,
-            mast: Arc::new(merged_mast_forest),
-            package_debug_info,
+        Self::from_parts(Arc::new(merged_mast_forest), procedures).map(|mut code| {
+            code.package_debug_info = package_debug_info;
+            code
         })
     }
 
@@ -363,7 +375,8 @@ impl PrettyPrint for AccountCode {
 
 /// A helper type for building the set of account procedures from account components.
 ///
-/// In particular, this ensures that the auth procedure ends up at index 0.
+/// In particular, this ensures that the auth procedure ends up at index 0 and that the remaining
+/// procedures are sorted.
 struct AccountProcedureBuilder {
     procedures: Vec<AccountProcedureRoot>,
 }
@@ -415,14 +428,13 @@ impl AccountProcedureBuilder {
         }
     }
 
-    fn build(self) -> Result<Vec<AccountProcedureRoot>, AccountError> {
-        if self.procedures.len() < AccountCode::MIN_NUM_PROCEDURES {
-            Err(AccountError::AccountCodeNoProcedures)
-        } else if self.procedures.len() > AccountCode::MAX_NUM_PROCEDURES {
-            Err(AccountError::AccountCodeTooManyProcedures(self.procedures.len()))
-        } else {
-            Ok(self.procedures)
-        }
+    fn build(mut self) -> Result<Vec<AccountProcedureRoot>, AccountError> {
+        // Sorting makes the account code commitment independent of the order in which components
+        // were provided. The auth procedure at index 0 is excluded from the sort so it keeps the
+        // position the transaction kernel expects.
+        self.procedures[1..].sort_unstable();
+
+        Ok(self.procedures)
     }
 }
 
@@ -617,5 +629,86 @@ mod tests {
             err,
             DeserializationError::InvalidValue(msg) if msg.contains("duplicate procedure with root")
         );
+    }
+
+    #[test]
+    fn account_code_procedures_are_sorted_after_the_auth_procedure() {
+        let code = AccountCode::mock();
+
+        assert!(code.procedures()[1..].is_sorted());
+    }
+
+    #[test]
+    fn account_code_commitment_is_independent_of_component_order() -> anyhow::Result<()> {
+        let first = mock_component("test-account-code-first", "test::first", 1);
+        let second = mock_component("test-account-code-second", "test::second", 2);
+
+        let mut components = vec![NoopAuthComponent.into(), first.clone(), second.clone()];
+
+        let code = AccountCode::from_components(&components)?;
+        components.reverse();
+        let reversed_code = AccountCode::from_components(&components)?;
+
+        assert_eq!(code.commitment(), reversed_code.commitment());
+        assert_eq!(
+            code.procedures()[0],
+            reversed_code.procedures()[0],
+            "the auth procedure should stay at index 0"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn account_code_from_parts_rejects_unsorted_procedures() -> anyhow::Result<()> {
+        let code = AccountCode::mock();
+        let procedures = code.procedures();
+
+        // the procedures of the mock code are sorted, so swapping two of them breaks the invariant
+        let unsorted = vec![procedures[0], procedures[2], procedures[1]];
+        let err = AccountCode::from_parts(code.mast(), unsorted).unwrap_err();
+
+        assert_matches!(err, AccountError::AccountCodeProceduresNotSorted);
+
+        Ok(())
+    }
+
+    #[test]
+    fn account_code_from_parts_rejects_duplicated_auth_procedure() -> anyhow::Result<()> {
+        let code = AccountCode::mock();
+        let procedures = code.procedures();
+
+        // the auth procedure must not reappear among the sorted procedures
+        let mut duplicated_auth = vec![procedures[0], procedures[1], procedures[0]];
+        duplicated_auth[1..].sort_unstable();
+        let err = AccountCode::from_parts(code.mast(), duplicated_auth).unwrap_err();
+
+        assert_matches!(
+            err,
+            AccountError::AccountCodeDuplicateProcedureRoot(root) if root == procedures[0].as_word()
+        );
+
+        Ok(())
+    }
+
+    /// Creates a component exporting a single account procedure whose MAST root is made unique by
+    /// the provided value.
+    fn mock_component(
+        package_name: &str,
+        module_path: &str,
+        unique_value: u32,
+    ) -> AccountComponent {
+        let code = format!(
+            "
+            @account_procedure
+            pub proc account_procedure
+                push.{unique_value} drop
+            end
+            "
+        );
+        let package = assemble_test_package(package_name, module_path, &code);
+        let metadata = AccountComponentMetadata::new(module_path);
+
+        AccountComponent::new(package, vec![], metadata).expect("component should be valid")
     }
 }

--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -90,20 +90,29 @@ impl AccountCode {
 
         // The authentication procedure at index 0 is exempt from the ordering invariant, so the
         // remaining procedures are checked to be strictly increasing, which also makes them unique.
-        let (auth_proc, other_procs) = procedures.split_first().expect("at least two procedures");
-        for pair in other_procs.windows(2) {
-            match pair[0].cmp(&pair[1]) {
-                Ordering::Less => {},
-                Ordering::Equal => {
-                    return Err(AccountError::AccountCodeDuplicateProcedureRoot(pair[0].as_word()));
-                },
-                Ordering::Greater => return Err(AccountError::AccountCodeProceduresNotSorted),
-            }
-        }
+        // Each of them is also compared against the authentication procedure, which must not appear
+        // a second time.
+        let (auth_proc, other_procs) = procedures
+            .split_first()
+            .expect("account code should contain at least two procedures");
 
-        // The authentication procedure must not appear a second time among the sorted procedures.
-        if other_procs.binary_search(auth_proc).is_ok() {
-            return Err(AccountError::AccountCodeDuplicateProcedureRoot(auth_proc.as_word()));
+        let mut previous_proc: Option<&AccountProcedureRoot> = None;
+        for procedure in other_procs {
+            if procedure == auth_proc {
+                return Err(AccountError::AccountCodeDuplicateProcedureRoot(*procedure));
+            }
+
+            if let Some(previous_proc) = previous_proc {
+                match previous_proc.cmp(procedure) {
+                    Ordering::Less => {},
+                    Ordering::Equal => {
+                        return Err(AccountError::AccountCodeDuplicateProcedureRoot(*procedure));
+                    },
+                    Ordering::Greater => return Err(AccountError::AccountCodeProceduresUnsorted),
+                }
+            }
+
+            previous_proc = Some(procedure);
         }
 
         // make sure that all account procedures are in the MAST forest
@@ -591,7 +600,7 @@ mod tests {
 
         assert_matches!(
             err,
-            AccountError::AccountCodeDuplicateProcedureRoot(root) if root == procedures[1].as_word()
+            AccountError::AccountCodeDuplicateProcedureRoot(root) if root == procedures[1]
         );
     }
 
@@ -668,7 +677,7 @@ mod tests {
         let unsorted = vec![procedures[0], procedures[2], procedures[1]];
         let err = AccountCode::from_parts(code.mast(), unsorted).unwrap_err();
 
-        assert_matches!(err, AccountError::AccountCodeProceduresNotSorted);
+        assert_matches!(err, AccountError::AccountCodeProceduresUnsorted);
 
         Ok(())
     }
@@ -685,7 +694,7 @@ mod tests {
 
         assert_matches!(
             err,
-            AccountError::AccountCodeDuplicateProcedureRoot(root) if root == procedures[0].as_word()
+            AccountError::AccountCodeDuplicateProcedureRoot(root) if root == procedures[0]
         );
 
         Ok(())

--- a/crates/miden-protocol/src/account/code/mod.rs
+++ b/crates/miden-protocol/src/account/code/mod.rs
@@ -442,6 +442,12 @@ impl AccountProcedureBuilder {
     }
 
     fn build(mut self) -> Result<Vec<AccountProcedureRoot>, AccountError> {
+        if self.procedures.len() < AccountCode::MIN_NUM_PROCEDURES {
+            return Err(AccountError::AccountCodeNoProcedures);
+        } else if self.procedures.len() > AccountCode::MAX_NUM_PROCEDURES {
+            return Err(AccountError::AccountCodeTooManyProcedures(self.procedures.len()));
+        }
+
         // Sorting makes the account code commitment independent of the order in which components
         // were provided. The auth procedure at index 0 is excluded from the sort so it keeps the
         // position the transaction kernel expects.

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -123,6 +123,10 @@ pub enum AccountError {
     AccountCodeTooManyProcedures(usize),
     #[error("account code contains a duplicate procedure with root {0}")]
     AccountCodeDuplicateProcedureRoot(Word),
+    #[error(
+        "account code procedures following the authentication procedure are not sorted in ascending order"
+    )]
+    AccountCodeProceduresNotSorted,
     #[error("failed to assemble account component:\n{}", PrintDiagnostic::new(.0))]
     AccountComponentAssemblyError(Report),
     #[error("failed to merge components into one account code mast forest")]

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -122,11 +122,11 @@ pub enum AccountError {
     #[error("account code contains {0} procedures but it may contain at most {max} procedures", max = AccountCode::MAX_NUM_PROCEDURES)]
     AccountCodeTooManyProcedures(usize),
     #[error("account code contains a duplicate procedure with root {0}")]
-    AccountCodeDuplicateProcedureRoot(Word),
+    AccountCodeDuplicateProcedureRoot(AccountProcedureRoot),
     #[error(
         "account code procedures following the authentication procedure are not sorted in ascending order"
     )]
-    AccountCodeProceduresNotSorted,
+    AccountCodeProceduresUnsorted,
     #[error("failed to assemble account component:\n{}", PrintDiagnostic::new(.0))]
     AccountComponentAssemblyError(Report),
     #[error("failed to merge components into one account code mast forest")]

--- a/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_fpi.rs
@@ -2,6 +2,7 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 
+use anyhow::Context;
 use miden_processor::advice::{AdviceInputs, AdviceStack};
 use miden_processor::{EMPTY_WORD, ExecutionError, ExecutionOutput, Felt};
 use miden_protocol::account::component::AccountComponentMetadata;
@@ -100,6 +101,14 @@ async fn test_fpi_memory_single_account() -> anyhow::Result<()> {
         AccountComponentMetadata::mock("test::foreign_account"),
     )?;
 
+    let get_item_foreign_root = foreign_account_component
+        .get_procedure_root_by_path("test::foreign_account::get_item_foreign")
+        .context("proc should be present")?;
+
+    let get_map_item_foreign_root = foreign_account_component
+        .get_procedure_root_by_path("test::foreign_account::get_map_item_foreign")
+        .context("proc should be present")?;
+
     let foreign_account = AccountBuilder::new(rand::random())
         .with_components(Auth::IncrNonce)
         .with_component(foreign_account_component)
@@ -130,8 +139,6 @@ async fn test_fpi_memory_single_account() -> anyhow::Result<()> {
     // --------------------------------------------------------------------------------------------
     // Check the correctness of the memory layout after `get_item_foreign` account procedure
     // invocation
-
-    let get_item_foreign_root = foreign_account.code().procedures()[1].mast_root();
 
     let code = format!(
         r#"
@@ -185,8 +192,6 @@ async fn test_fpi_memory_single_account() -> anyhow::Result<()> {
     // GET MAP ITEM
     // --------------------------------------------------------------------------------------------
     // Check the correctness of the memory layout after `get_map_item` account procedure invocation
-
-    let get_map_item_foreign_root = foreign_account.code().procedures()[2].mast_root();
 
     let code = format!(
         r#"
@@ -268,7 +273,7 @@ async fn test_fpi_memory_single_account() -> anyhow::Result<()> {
             push.MOCK_VALUE_SLOT0[0..2]
 
             # get the hash of the `get_item_foreign` procedure of the foreign account
-            push.{get_item_foreign_hash}
+            push.{get_item_foreign_root}
 
             # push the foreign account ID
             push.{foreign_prefix} push.{foreign_suffix}
@@ -287,7 +292,7 @@ async fn test_fpi_memory_single_account() -> anyhow::Result<()> {
             push.MOCK_VALUE_SLOT0[0..2]
 
             # get the hash of the `get_item_foreign` procedure of the foreign account
-            push.{get_item_foreign_hash}
+            push.{get_item_foreign_root}
 
             # push the foreign account ID
             push.{foreign_prefix} push.{foreign_suffix}
@@ -303,7 +308,6 @@ async fn test_fpi_memory_single_account() -> anyhow::Result<()> {
         mock_value_slot0 = mock_value_slot0.name(),
         foreign_prefix = foreign_account.id().prefix().as_felt(),
         foreign_suffix = foreign_account.id().suffix(),
-        get_item_foreign_hash = foreign_account.code().procedures()[1].mast_root(),
     );
 
     let exec_output = &mock_tx.execute_code(&code).await?;
@@ -1032,6 +1036,10 @@ async fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
             .expect("failed to get foreign account inputs"),
     ];
 
+    let get_item_foreign_root = first_foreign_account_component
+        .get_procedure_root_by_path("first_foreign_account::get_item_foreign")
+        .context("proc should be present")?;
+
     // push the hashes of the foreign procedures and account IDs to the advice stack to be able to
     // call them dynamically.
     let mut advice_stack = AdviceStack::new();
@@ -1041,7 +1049,7 @@ async fn test_nested_fpi_cyclic_invocation() -> anyhow::Result<()> {
             second_foreign_account.id().prefix().as_felt(),
             second_foreign_account.id().suffix(),
         ])
-        .append_elements(*first_foreign_account.code().procedures()[2].mast_root())
+        .append_elements(*get_item_foreign_root.mast_root())
         .append_elements([
             first_foreign_account.id().prefix().as_felt(),
             first_foreign_account.id().suffix(),


### PR DESCRIPTION
## Describe your changes

Sorts the procedures of `AccountCode` in ascending order, so that the same set of components produces the same account code commitment regardless of the order in which they were provided. The authentication procedure stays at index 0 and is exempt from the sort, since the transaction kernel hardcodes that position; the invariant therefore only holds over the range `1..`. Closes #2961.

- `AccountProcedureBuilder::build` sorts everything after the auth procedure. This is the only place the final procedure list is produced, so all construction paths inherit the ordering.
- `AccountCode::from_parts` enforces the invariant rather than assuming it, which also covers `Deserializable::read_from` and makes the serialized form canonical. A strictly-increasing check over `procedures[1..]` replaces the previous `BTreeSet` uniqueness scan, since strictness gives uniqueness over the tail for free, and a `binary_search` additionally rejects the auth root reappearing among the sorted procedures. This mirrors what `AccountStorage` already does for slot IDs.
- `from_components_unchecked` now builds through `from_parts` instead of instantiating the struct directly, so the count, ordering, uniqueness and MAST-membership checks all live in one place.
- All `AccountCode` construction now goes through `from_parts` making it the only place the struct is instantiated, which makes it easier to understand what invariants are always enforced. Due to that change, the (now) duplicate min/max procedure count check from `AccountProcedureBuilder` was removed.

This unblocks the remaining part of #3418 which is implementing the uniqueness check in the tx kernel. This will be a follow-up PR.
