### PR TITLE
feat: ensure account procedure uniqueness and sorting in tx kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [BREAKING] Moved the internal shared helpers of `miden::protocol::input_note`, `miden::protocol::active_note`, and the note memory-write helpers into private `input_note_internal` and `note_internal` modules ([#3501](https://github.com/0xMiden/protocol/pull/3501)).
 - [BREAKING] Sorted the procedures of `AccountCode` after the authentication procedure at index 0, making the account code commitment independent of the order in which components are provided ([#2961](https://github.com/0xMiden/protocol/issues/2961)).
+- The transaction kernel now validates that a new account's procedures are sorted and unique ([#3567](https://github.com/0xMiden/protocol/pull/3567)).
 - [BREAKING] Changed asset callbacks into validation-only interfaces that return no asset value; the transaction kernel retains and uses the original value, preventing callbacks from modifying it. The kernel commitment changes ([#3505](https://github.com/0xMiden/protocol/issues/3505), [#3513](https://github.com/0xMiden/protocol/pull/3513)).
 - [BREAKING] Extracted the shared `MastForestScript` type and `MastForestScriptError` backing `NoteScript` / `TransactionScript`, moving `TransactionScript` into `transaction::script` ([#3516](https://github.com/0xMiden/protocol/pull/3516)).
 - Documented the RBAC freeze-only actor pattern on `Authority` and added test coverage pinning that a `FREEZER` can trip the emergency switch but can never unfreeze the account ([#3520](https://github.com/0xMiden/protocol/pull/3520)).

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -42,6 +42,12 @@ const ERR_ACCOUNT_PROC_NOT_AUTH_PROC =
 const ERR_ACCOUNT_STORAGE_SLOTS_MUST_BE_SORTED_AND_UNIQUE =
     "slot IDs must be unique and sorted in ascending order"
 
+const ERR_ACCOUNT_PROCEDURES_MUST_BE_SORTED_AND_UNIQUE =
+    "account procedures following the authentication procedure must be unique and sorted in ascending order"
+
+const ERR_ACCOUNT_AUTH_PROCEDURE_MUST_NOT_BE_DUPLICATED =
+    "the root of the authentication procedure must not appear among the account's other procedures"
+
 const ERR_ACCOUNT_UNKNOWN_STORAGE_SLOT_NAME = "storage slot with the provided name does not exist"
 
 const ERR_ACCOUNT_CODE_COMMITMENT_MISMATCH =
@@ -1026,6 +1032,79 @@ pub proc is_slot_id_lt
     # determines the outcome
     and or
     # => [is_prev_lt_curr]
+end
+
+#! Validates that the account procedures following the authentication procedure at index 0 are
+#! sorted in ascending order and that no procedure root appears more than once.
+#!
+#! The authentication procedure is exempt from the ordering requirement because the transaction
+#! kernel expects it at index 0.
+#!
+#! This procedure is public so it can be tested.
+#!
+#! Inputs:  []
+#! Outputs: []
+#!
+#! Panics if:
+#! - a procedure root is not strictly greater than the root preceding it.
+#!    - this ensures sorting and uniqueness among the procedures following the auth procedure.
+#! - the root of the auth procedure appears at an index other than 0.
+pub proc validate_procedures
+    exec.memory::get_num_account_procedures sub.1
+    # => [curr_proc_idx]
+
+    # keep the auth procedure root on the stack since every procedure is compared against it
+    push.0 exec.get_procedure_root
+    # => [AUTH_PROC_ROOT, curr_proc_idx]
+
+    dup.4 exec.get_procedure_root
+    # => [CURR_PROC_ROOT, AUTH_PROC_ROOT, curr_proc_idx]
+
+    # save_account_procedure_data guarantees that the account has at least MIN_NUM_PROCEDURES
+    # procedures, so curr_proc_idx is at least 1. the procedure at index 1 is handled after the loop
+    # because it has no predecessor to be compared against.
+    dup.8 neq.1
+    # => [should_loop, CURR_PROC_ROOT, AUTH_PROC_ROOT, curr_proc_idx]
+
+    while.true
+        # assert the current proc root is not the auth proc root
+        exec.word::test_eq
+        # => [is_auth_proc_dup, CURR_PROC_ROOT, AUTH_PROC_ROOT, curr_proc_idx]
+
+        assertz.err=ERR_ACCOUNT_AUTH_PROCEDURE_MUST_NOT_BE_DUPLICATED
+        # => [CURR_PROC_ROOT, AUTH_PROC_ROOT, curr_proc_idx]
+
+        # step to the preceding procedure, whose root becomes the current one of the next iteration
+        movup.8 sub.1 movdn.8
+        # => [CURR_PROC_ROOT, AUTH_PROC_ROOT, prev_proc_idx]
+
+        dup.8 exec.get_procedure_root
+        # => [PREV_PROC_ROOT, CURR_PROC_ROOT, AUTH_PROC_ROOT, prev_proc_idx]
+
+        dupw movupw.2
+        # => [CURR_PROC_ROOT, PREV_PROC_ROOT, PREV_PROC_ROOT, AUTH_PROC_ROOT, prev_proc_idx]
+
+        # word::lt returns whether PREV_PROC_ROOT is strictly less than CURR_PROC_ROOT, so this
+        # rejects duplicates as well as procedures that are out of order
+        exec.word::lt
+        # => [is_prev_lt_curr, PREV_PROC_ROOT, AUTH_PROC_ROOT, prev_proc_idx]
+
+        assert.err=ERR_ACCOUNT_PROCEDURES_MUST_BE_SORTED_AND_UNIQUE
+        # => [PREV_PROC_ROOT, AUTH_PROC_ROOT, prev_proc_idx]
+
+        # continue if prev_proc_idx != 1
+        dup.8 neq.1
+        # => [should_continue, PREV_PROC_ROOT, AUTH_PROC_ROOT, prev_proc_idx]
+    end
+    # => [PROC_ROOT_1, AUTH_PROC_ROOT, proc_idx = 1]
+
+    # the procedure at index 1 is the only one the loop did not compare against the auth procedure
+    exec.word::eq
+    # => [is_auth_proc_dup, proc_idx]
+
+    assertz.err=ERR_ACCOUNT_AUTH_PROCEDURE_MUST_NOT_BE_DUPLICATED
+    drop
+    # => []
 end
 
 # DATA LOADERS

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -1046,8 +1046,8 @@ end
 #! Outputs: []
 #!
 #! Panics if:
-#! - a procedure root is not strictly greater than the root preceding it.
-#!    - this ensures sorting and uniqueness among the procedures following the auth procedure.
+#! - the procedure roots are not sorted.
+#! - the procedure roots are not unique.
 #! - the root of the auth procedure appears at an index other than 0.
 pub proc validate_procedures
     exec.memory::get_num_account_procedures sub.1

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
@@ -292,6 +292,11 @@ end
 #! - assert that the account vault is empty.
 #! - assert that the account nonce is set to 0.
 #! - read the account seed from the advice provider and assert it satisfies seed requirements.
+#! - assert that the storage slots and the account procedures are sorted and unique.
+#!
+#! Validating storage and procedures for new accounts is sufficient because the storage and code
+#! commitments of an existing account are bound to its committed state, which was produced by the
+#! transaction that created the account and therefore already passed this validation.
 #!
 #! Inputs:  []
 #! Outputs: []
@@ -325,6 +330,11 @@ proc validate_new_account
     # Assert the storage slots are sorted and unique.
     # ---------------------------------------------------------------------------------------------
     exec.account::validate_storage
+    # => []
+
+    # Assert the account procedures are sorted and unique.
+    # ---------------------------------------------------------------------------------------------
+    exec.account::validate_procedures
     # => []
 end
 

--- a/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
@@ -221,6 +221,9 @@ end
 #!
 #! Invocation: dynexec
 pub proc account_upgrade
+    # TODO(code_upgrades): Account upgrades must ensure the same conditions hold for an upgraded
+    # account as validated in account::{validate_storage, validate_procedures}.
+
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [CODE_UPGRADE_COMMITMENT, STORAGE_UPGRADE_COMMITMENT, pad(8)]

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use assert_matches::assert_matches;
 use miden_crypto::rand::test_utils::rand_value;
+use miden_crypto::rand::{FeltRng, RandomCoin};
 use miden_processor::{ExecutionError, Word};
 use miden_protocol::account::auth::AuthScheme;
 use miden_protocol::account::component::AccountComponentMetadata;
@@ -15,6 +16,7 @@ use miden_protocol::account::{
     AccountCode,
     AccountComponent,
     AccountId,
+    AccountProcedureRoot,
     AccountStorage,
     AccountType,
     StorageMap,
@@ -32,11 +34,13 @@ use miden_protocol::assembly::diagnostics::reporting::PrintDiagnostic;
 use miden_protocol::assembly::{DefaultSourceManager, Linkage, ModuleKind, ModuleParser, Path};
 use miden_protocol::asset::{Asset, AssetId, FungibleAsset};
 use miden_protocol::errors::tx_kernel::{
+    ERR_ACCOUNT_AUTH_PROCEDURE_MUST_NOT_BE_DUPLICATED,
     ERR_ACCOUNT_ID_SUFFIX_LEAST_SIGNIFICANT_BYTE_MUST_BE_ZERO,
     ERR_ACCOUNT_ID_SUFFIX_MOST_SIGNIFICANT_BIT_MUST_BE_ZERO,
     ERR_ACCOUNT_ID_UNKNOWN_VERSION,
     ERR_ACCOUNT_NONCE_AT_MAX,
     ERR_ACCOUNT_NONCE_CAN_ONLY_BE_INCREMENTED_ONCE,
+    ERR_ACCOUNT_PROCEDURES_MUST_BE_SORTED_AND_UNIQUE,
     ERR_ACCOUNT_UNKNOWN_STORAGE_SLOT_NAME,
 };
 use miden_protocol::field::PrimeField64;
@@ -71,6 +75,7 @@ use crate::{
     ExecError,
     MockChain,
     TestTransactionBuilder,
+    assert_execution_error,
     assert_transaction_executor_error,
 };
 
@@ -696,6 +701,142 @@ async fn test_is_slot_id_lt() -> anyhow::Result<()> {
 
         CodeExecutor::with_default_host().run(&code).await?;
     }
+
+    Ok(())
+}
+
+/// Returns the requested number of distinct procedure roots sorted in ascending order.
+fn sorted_procedure_roots(num_procedures: usize) -> Vec<AccountProcedureRoot> {
+    let mut rng = RandomCoin::new([num_procedures as u32, 0, 0, 0].into());
+    let mut roots = (0..num_procedures as u32)
+        .map(|_| AccountProcedureRoot::from_raw(rng.draw_word()))
+        .collect::<Vec<_>>();
+    roots.sort_unstable();
+
+    roots
+}
+
+/// Returns a program that writes the provided procedure roots into the native account's procedure
+/// section and validates them.
+fn validate_procedures_program(procedure_roots: &[AccountProcedureRoot]) -> String {
+    let procedure_writes = procedure_roots
+        .iter()
+        .enumerate()
+        .map(|(index, root)| {
+            format!(
+                "push.{root}
+                exec.memory::get_account_procedures_section_ptr add.{offset} mem_storew_le dropw",
+                offset = index * Word::NUM_ELEMENTS
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"
+        use miden::tx_kernel_core::account
+        use miden::tx_kernel_core::memory
+
+        begin
+            exec.memory::set_active_account_data_ptr_to_native_account
+
+            push.{num_procedures} exec.memory::set_num_account_procedures
+
+            {procedure_writes}
+
+            exec.account::validate_procedures
+        end
+        "#,
+        num_procedures = procedure_roots.len()
+    )
+}
+
+/// The auth procedure at index 0 is exempt from the ordering, so it is validated against roots that
+/// sort before, in between and after the other procedures.
+#[rstest::rstest]
+#[case::minimum_number_of_procedures(2, 0)]
+#[case::auth_procedure_sorts_first(8, 0)]
+#[case::auth_procedure_sorts_in_between(8, 4)]
+#[case::auth_procedure_sorts_last(8, 7)]
+#[tokio::test]
+async fn test_validate_procedures_accepts_sorted_and_unique_procedures(
+    #[case] num_procedures: usize,
+    #[case] auth_procedure_index: usize,
+) -> anyhow::Result<()> {
+    let mut procedure_roots = sorted_procedure_roots(num_procedures);
+    let auth_procedure_root = procedure_roots.remove(auth_procedure_index);
+    procedure_roots.insert(0, auth_procedure_root);
+
+    CodeExecutor::with_default_host()
+        .run(&validate_procedures_program(&procedure_roots))
+        .await?;
+
+    Ok(())
+}
+
+#[rstest::rstest]
+#[case::first_pair_swapped(1, 2)]
+#[case::last_pair_swapped(6, 7)]
+#[case::first_and_last_swapped(1, 7)]
+#[tokio::test]
+async fn test_validate_procedures_rejects_unsorted_procedures(
+    #[case] left_index: usize,
+    #[case] right_index: usize,
+) -> anyhow::Result<()> {
+    let mut procedure_roots = sorted_procedure_roots(8);
+    procedure_roots.swap(left_index, right_index);
+
+    let result = CodeExecutor::with_default_host()
+        .run(&validate_procedures_program(&procedure_roots))
+        .await;
+
+    assert_execution_error!(result, ERR_ACCOUNT_PROCEDURES_MUST_BE_SORTED_AND_UNIQUE);
+
+    Ok(())
+}
+
+/// The duplicated procedure is always the one preceding it, which must be at index 1 or greater so
+/// the duplicate does not involve the auth procedure at index 0.
+#[rstest::rstest]
+#[case::first_procedure(2)]
+#[case::middle_procedure(4)]
+#[case::last_procedure(7)]
+#[tokio::test]
+async fn test_validate_procedures_rejects_duplicated_procedure(
+    #[case] duplicated_index: usize,
+) -> anyhow::Result<()> {
+    let mut procedure_roots = sorted_procedure_roots(8);
+    procedure_roots[duplicated_index] = procedure_roots[duplicated_index - 1];
+
+    let result = CodeExecutor::with_default_host()
+        .run(&validate_procedures_program(&procedure_roots))
+        .await;
+
+    assert_execution_error!(result, ERR_ACCOUNT_PROCEDURES_MUST_BE_SORTED_AND_UNIQUE);
+
+    Ok(())
+}
+
+/// A duplicated auth procedure is not caught by the ordering check, since the auth procedure is
+/// exempt from it, so it must be rejected by the explicit comparison against the root at index 0.
+#[rstest::rstest]
+#[case::minimum_number_of_procedures(2, 1)]
+#[case::first_procedure(8, 1)]
+#[case::middle_procedure(8, 4)]
+#[case::last_procedure(8, 7)]
+#[tokio::test]
+async fn test_validate_procedures_rejects_duplicated_auth_procedure(
+    #[case] num_procedures: usize,
+    #[case] duplicated_index: usize,
+) -> anyhow::Result<()> {
+    let mut procedure_roots = sorted_procedure_roots(num_procedures);
+    procedure_roots[0] = procedure_roots[duplicated_index];
+
+    let result = CodeExecutor::with_default_host()
+        .run(&validate_procedures_program(&procedure_roots))
+        .await;
+
+    assert_execution_error!(result, ERR_ACCOUNT_AUTH_PROCEDURE_MUST_NOT_BE_DUPLICATED);
 
     Ok(())
 }


### PR DESCRIPTION
## Describe your changes

Stacked on https://github.com/0xMiden/protocol/pull/3565, should be merged as a stack.

Proves the account procedure sorting invariant inside the transaction kernel, so that it holds against a malicious host and not only against the Rust constructors. `assert_procedure_in_account` resolves a procedure root to an index supplied by the host and only checks that the root stored at that index matches, so if the same root appears twice the host picks which index gets marked as called. That defeats procedure call tracking and everything layered on it. Checking uniqueness over an unsorted array needs host help, but over the sorted array produced by the preceding change it is a strictly-increasing adjacent-pair scan.

Closes #3418

- `account::validate_procedures` walks the procedures from the last index down, asserting with `word::lt` that each root is strictly greater than its predecessor, which rejects out-of-order roots and duplicates in one comparison. The auth procedure root is loaded once, kept on the stack and compared against every other root with `word::test_eq`, since the auth procedure sits at index 0 and is exempt from the ordering. Each root is read from memory once and carried into the next iteration.
- Called from `validate_new_account` in the prologue, alongside `validate_storage`. Validating only new accounts is sufficient because the code commitment of an existing account is bound to state that was produced by the transaction which created it, and that transaction already ran this check. Account code upgrades are the one gap, so `account_upgrade` carries a TODO; it is still a no-op that only records commitments.
- `validate_procedures` is public so it can be tested directly, following `is_slot_id_lt`. The tests set up the native account's procedure section from MASM and call the procedure with crafted roots. Roots vary in all four elements and are ordered with the Rust `Word` ordering, so the accepting cases also pin that `Ord for Word` and the kernel's `word::lt` agree on the reverse-element canonical-u64 convention.

## Notes

`sorted_array::assert_sorted_words` is not reused for the ordering scan because it is non-decreasing and therefore admits exactly the duplicates this check exists to reject. `sorted_array::find_word` could prove the auth root's absence in constant time instead of one comparison per procedure, but at roughly 286 cycles it only pays off past about 18 procedures and it would add a dependency on `LOWERBOUND_ARRAY_EVENT` advice.
