### PR TITLE
 chore: name fungible value to amount conversion APIs consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@
 - Documented the RBAC freeze-only actor pattern on `Authority` and added test coverage pinning that a `FREEZER` can trip the emergency switch but can never unfreeze the account ([#3520](https://github.com/0xMiden/protocol/pull/3520)).
 - [BREAKING] Moved the internal shared helpers of `miden::protocol::input_note`, `miden::protocol::active_note`, and the note memory-write helpers into private `input_note_internal` and `note_internal` modules ([#3501](https://github.com/0xMiden/protocol/pull/3501)).
 - [BREAKING] Refactored `AccountVaultDelta` to track generic assets. `FungibleAssetDelta`, `NonFungibleAssetDelta` and `NonFungibleDeltaAction` were removed ([3485](https://github.com/0xMiden/protocol/pull/3485)).
-- [BREAKING] Renamed the fungible asset amount extraction procedures so the unsuffixed name is the validating one: `miden::protocol::asset::fungible_value_into_amount` to `fungible_value_into_amount_unchecked`, `miden::standards::assets::fungible_asset::value_into_amount` to `value_into_amount_unchecked`, `to_amount` to `to_amount_unchecked`, and `try_value_to_amount` to `value_into_amount` ([#3576](https://github.com/0xMiden/protocol/pull/3576)).
+- [BREAKING] Renamed the fungible asset amount extraction procedures so the unsuffixed name is the validating one ([#3576](https://github.com/0xMiden/protocol/pull/3576)):
+  - `miden::protocol::asset::fungible_value_into_amount` -> `fungible_value_into_amount_unchecked`.
+  - `miden::standards::assets::fungible_asset::value_into_amount` to `value_into_amount_unchecked`.
+  - `to_amount` to `to_amount_unchecked`.
+  - `try_value_to_amount` to `value_into_amount`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Documented the RBAC freeze-only actor pattern on `Authority` and added test coverage pinning that a `FREEZER` can trip the emergency switch but can never unfreeze the account ([#3520](https://github.com/0xMiden/protocol/pull/3520)).
 - [BREAKING] Moved the internal shared helpers of `miden::protocol::input_note`, `miden::protocol::active_note`, and the note memory-write helpers into private `input_note_internal` and `note_internal` modules ([#3501](https://github.com/0xMiden/protocol/pull/3501)).
 - [BREAKING] Refactored `AccountVaultDelta` to track generic assets. `FungibleAssetDelta`, `NonFungibleAssetDelta` and `NonFungibleDeltaAction` were removed ([3485](https://github.com/0xMiden/protocol/pull/3485)).
+- [BREAKING] Renamed the fungible asset amount extraction procedures so the unsuffixed name is the validating one: `miden::protocol::asset::fungible_value_into_amount` to `fungible_value_into_amount_unchecked`, `miden::standards::assets::fungible_asset::value_into_amount` to `value_into_amount_unchecked`, `to_amount` to `to_amount_unchecked`, and `try_value_to_amount` to `value_into_amount` ([#3576](https://github.com/0xMiden/protocol/pull/3576)).
 
 ### Fixes
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -296,7 +296,7 @@ end
 #!
 #! Invocation: exec
 proc convert_asset
-    swapw exec.fungible_asset::value_into_amount movdn.4
+    swapw exec.fungible_asset::value_into_amount_unchecked movdn.4
     # => [ASSET_ID, amount]
 
     exec.asset::id_into_faucet_id

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/asset.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/asset.masm
@@ -19,7 +19,7 @@ const ERR_FAUCET_IS_NOT_ASSET_ORIGIN = "the faucet is not the origin of the asse
 # CONSTANT ACCESSORS
 # =================================================================================================
 
-pub use {ASSET_SIZE, ASSET_VALUE_MEMORY_OFFSET, COMPOSITION_CUSTOM, COMPOSITION_FUNGIBLE, COMPOSITION_NONE, FUNGIBLE_ASSET_MAX_AMOUNT, id_to_faucet_id, id_into_faucet_id, id_to_asset_class, id_into_asset_class, id_to_composition, id_into_composition, load, store, validate_metadata, fungible_value_into_amount}
+pub use {ASSET_SIZE, ASSET_VALUE_MEMORY_OFFSET, COMPOSITION_CUSTOM, COMPOSITION_FUNGIBLE, COMPOSITION_NONE, FUNGIBLE_ASSET_MAX_AMOUNT, id_to_faucet_id, id_into_faucet_id, id_to_asset_class, id_into_asset_class, id_to_composition, id_into_composition, load, store, validate_metadata, fungible_value_into_amount_unchecked}
     from miden::protocol_utils::asset
 
 # PROCEDURES

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/fungible_asset.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/fungible_asset.masm
@@ -50,7 +50,7 @@ const ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW =
 #! - adding the two asset values would exceed MAX_AMOUNT.
 pub proc merge
     # extract amounts from assets
-    exec.asset::fungible_value_into_amount movdn.4 exec.asset::fungible_value_into_amount
+    exec.asset::fungible_value_into_amount_unchecked movdn.4 exec.asset::fungible_value_into_amount_unchecked
     # => [amount_1, amount_0]
 
     # compute max_add_amount = MAX_AMOUNT - amount_0
@@ -88,7 +88,7 @@ end
 #! - ASSET_VALUE_0 does not contain at least the amount of ASSET_VALUE_1.
 pub proc split
     # extract amounts from assets
-    exec.asset::fungible_value_into_amount movdn.4 exec.asset::fungible_value_into_amount swap
+    exec.asset::fungible_value_into_amount_unchecked movdn.4 exec.asset::fungible_value_into_amount_unchecked swap
     # => [amount_1, amount_0]
 
     # assert amount_1 <= amount_0 so we can safely subtract
@@ -118,7 +118,7 @@ end
 #! - ASSET_VALUE_{0, 1} are the assets to compare.
 #! - is_lt is 1 if ASSET_VALUE_0 is less than ASSET_VALUE_1.
 pub proc lt
-    exec.asset::fungible_value_into_amount movdn.4 exec.asset::fungible_value_into_amount swap
+    exec.asset::fungible_value_into_amount_unchecked movdn.4 exec.asset::fungible_value_into_amount_unchecked swap
     # => [amount_1, amount_0]
 
     lt

--- a/crates/miden-protocol/asm/protocol/src/asset.masm
+++ b/crates/miden-protocol/asm/protocol/src/asset.masm
@@ -1,5 +1,5 @@
 # RE-EXPORTS
 # =================================================================================================
 
-pub use {ASSET_SIZE, ASSET_VALUE_MEMORY_OFFSET, COMPOSITION_CUSTOM, COMPOSITION_FUNGIBLE, COMPOSITION_NONE, FUNGIBLE_ASSET_MAX_AMOUNT, id_to_faucet_id, id_into_faucet_id, id_to_asset_class, id_into_asset_class, id_to_composition, id_into_composition, load, store, fungible_value_into_amount}
+pub use {ASSET_SIZE, ASSET_VALUE_MEMORY_OFFSET, COMPOSITION_CUSTOM, COMPOSITION_FUNGIBLE, COMPOSITION_NONE, FUNGIBLE_ASSET_MAX_AMOUNT, id_to_faucet_id, id_into_faucet_id, id_to_asset_class, id_into_asset_class, id_to_composition, id_into_composition, load, store, fungible_value_into_amount_unchecked}
     from miden::protocol_utils::asset

--- a/crates/miden-protocol/asm/protocol_utils/src/asset.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/asset.masm
@@ -296,7 +296,7 @@ end
 #! Where:
 #! - ASSET_VALUE is the fungible asset from which to extract the balance.
 #! - balance is the amount of the fungible asset.
-pub proc fungible_value_into_amount
+pub proc fungible_value_into_amount_unchecked
     movdn.3 drop drop drop
     # => [balance]
 end

--- a/crates/miden-standards/asm/standards/assets/fungible_asset.masm
+++ b/crates/miden-standards/asm/standards/assets/fungible_asset.masm
@@ -7,7 +7,7 @@ pub use {FUNGIBLE_ASSET_MAX_AMOUNT as MAX_AMOUNT} from miden::protocol::asset
 # RE-EXPORTS
 # ================================================================================================
 
-pub use {fungible_value_into_amount as value_into_amount} from miden::protocol::asset
+pub use {fungible_value_into_amount_unchecked as value_into_amount_unchecked} from miden::protocol::asset
 
 # ERRORS
 # ================================================================================================
@@ -123,7 +123,7 @@ pub proc get_initial_native_account_balance
     # => [ASSET_VALUE]
 
     # extract the asset's balance
-    exec.value_into_amount
+    exec.value_into_amount_unchecked
     # => [balance]
 end
 
@@ -152,7 +152,7 @@ pub proc get_active_account_balance
     # => [ASSET_VALUE]
 
     # extract the asset's balance
-    exec.value_into_amount
+    exec.value_into_amount_unchecked
     # => [balance]
 end
 
@@ -168,16 +168,13 @@ end
 #! - amount is the amount of the fungible asset.
 #!
 #! Invocation: exec
-pub proc to_amount
+pub proc to_amount_unchecked
     # => [ASSET_ID, [amount, 0, 0, 0]]
     dup.4
     # => [amount, ASSET_ID, ASSET_VALUE]
 end
 
-#! Validates the provided asset value and returns its amount.
-#!
-#! This procedure checks that the provided asset value is well-formed (first, second and third
-#! elements are zeros) and checks that the amount doesn't exceed the maximum.
+#! Validates the given fungible asset value and returns its amount, consuming it.
 #!
 #! Inputs:  [ASSET_VALUE]
 #! Outputs: [amount]
@@ -191,7 +188,7 @@ end
 #! - the asset amount exceeds maximum allowed amount.
 #!
 #! Invocation: exec
-pub proc try_value_to_amount
+pub proc value_into_amount
     # assert the amount does not exceed the maximum fungible asset amount
     dup lte.MAX_AMOUNT assert.err=ERR_FUNGIBLE_ASSET_AMOUNT_EXCEEDS_MAX_ALLOWED_AMOUNT
     # => [amount, e1, e2, e3]

--- a/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
@@ -151,8 +151,6 @@ pub proc set_procedure_policy
         # => [is_delayed_threshold_zero, PROC_ROOT]
 
         if.true
-            # `eq.0 assert` produces the proper error when note_restrictions is non-zero;
-            # `assertz` would surface a generic "binary value expected" error for values 2 or 3.
             loc_load.NOTE_RESTRICTIONS_LOC eq.0 assert.err=ERR_NOTE_RESTRICTIONS_REQUIRE_THRESHOLD
             # => [PROC_ROOT]
         end

--- a/crates/miden-standards/asm/standards/faucets/fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/fungible.masm
@@ -411,7 +411,7 @@ pub proc receive_and_burn
     # Burn the asset from the transaction vault
     # ---------------------------------------------------------------------------------------------
 
-    exec.fungible_asset::to_amount movdn.8
+    exec.fungible_asset::to_amount_unchecked movdn.8
     # => [ASSET_ID, ASSET_VALUE, amount, pad(8)]
 
     # burn the asset

--- a/crates/miden-standards/asm/standards/faucets/policies/burn/min_burn_amount.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/burn/min_burn_amount.masm
@@ -44,7 +44,7 @@ pub proc check_policy
     dropw
     # => [ASSET_VALUE, pad(12)]
 
-    exec.fungible_asset::value_into_amount
+    exec.fungible_asset::value_into_amount_unchecked
     # => [amount, pad(15)]
 
     push.MIN_BURN_AMOUNT_SLOT[0..2] exec.active_account::get_item

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -510,7 +510,7 @@ proc estimate_input_note_fee
 
     # the manager asserts the estimate is denominated in its configured fee asset, so only the
     # fee amount is needed here
-    dropw exec.fungible_asset::value_into_amount
+    dropw exec.fungible_asset::value_into_amount_unchecked
     # => [required_fee_amount]
 end
 
@@ -543,7 +543,7 @@ proc move_sponsored_fee_to_vault
     movupw.2 exec.word::eq assert.err=ERR_FEE_MANAGER_SPONSORSHIP_WRONG_ASSET
     # => [ASSET_VALUE]
 
-    exec.fungible_asset::value_into_amount
+    exec.fungible_asset::value_into_amount_unchecked
     # => [fee_amount]
 end
 
@@ -642,7 +642,7 @@ proc create_network_note_sponsorship(
     exec.compute_sponsorship_fee
     # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx]
 
-    exec.fungible_asset::to_amount
+    exec.fungible_asset::to_amount_unchecked
     # => [fee_amount, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx]
 
     movdn.10 dup.10 eq.0

--- a/crates/miden-standards/asm/standards/fees/policies/constant_fee_manager.masm
+++ b/crates/miden-standards/asm/standards/fees/policies/constant_fee_manager.masm
@@ -76,7 +76,7 @@ pub proc set_note_fee(note_lookup_key: word, fee_asset: Asset)
     # => [FEE_ASSET_VALUE, NOTE_LOOKUP_KEY, pad(8)]
 
     # Extract the asset amount from the value and assert that it was well-formed
-    exec.fungible_asset::try_value_to_amount
+    exec.fungible_asset::value_into_amount
     # => [amount, NOTE_LOOKUP_KEY, pad(11)]
 
     # build the fee schedule entry [amount, 0, 0, 1] with the set-marker as the last element

--- a/crates/miden-standards/asm/standards/notes/pswap.masm
+++ b/crates/miden-standards/asm/standards/notes/pswap.masm
@@ -595,7 +595,7 @@ proc execute_pswap
     # => [ASSET_ID, ASSET_VALUE]
 
     # Extract offered amount
-    exec.fungible_asset::to_amount
+    exec.fungible_asset::to_amount_unchecked
     # => [amount, ASSET_ID, ASSET_VALUE]
 
     loc_store.EXEC_AMT_OFFERED


### PR DESCRIPTION


## Changes

`miden::standards::assets::fungible_asset` offered two ways to extract an amount from an `ASSET_VALUE`, and the names gave no hint which one validated: the unchecked `value_into_amount` (a re-export of the protocol procedure) and the validating `try_value_to_amount`. The unchecked variant had the shorter, more inviting name, so it was the one a caller reached for by default. The renames make the unsuffixed name the safe one and mark the unchecked variant explicitly, using the conventional `_unchecked` suffix we use in many other places.

Similarly, `to` becomes `into` for APIs that consume a value to give a hint (like `to` MASM procedures extract rather than consume).

- `miden::protocol::asset::fungible_value_into_amount` becomes `fungible_value_into_amount_unchecked`, with its re-export lists and the kernel `merge` / `split` / `lt` call sites following. MAST digests do not depend on procedure names, so the kernel commitment is unchanged.
- The standards alias becomes `value_into_amount_unchecked`, and every existing caller gains the suffix so it keeps unchecked semantics: the two balance getters, the AggLayer bridge-out asset conversion, the minimum-burn-amount policy, and fee estimation and sponsorship collection.
- `to_amount`, which peeks at the amount rather than consuming the value, is likewise unchecked and becomes `to_amount_unchecked`, along with its callers in the fungible faucet burn path, sponsorship fee computation, and pSWAP.
- `try_value_to_amount` takes over the freed `value_into_amount` name. Its body and error constants are unchanged, and `ConstantFeeManager::set_note_fee` is its only caller.
- Removed a stale comment in `multisig_smart` claiming that `assertz` surfaces a generic "binary value expected" error instead of its own error code. This no longer holds on the current toolchain, which reports the supplied error code for non-binary operands.

## Notes

Breaking for MASM consumers. The rename is not a mechanical find-and-replace: a call site left as `value_into_amount` silently switches from the unchecked procedure to the validating one.
