### PR TITLE
fix(protocol): validate private output note attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixes
 
+- Fixed `PrivateOutputNote` construction and deserialization accepting attachment data that is not committed by the note header ([#3556](https://github.com/0xMiden/protocol/issues/3556)).
+
 ## v0.16.0 (2026-08-06)
 
 ### Features

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -945,6 +945,10 @@ pub enum TransactionOutputError {
 /// [`PrivateOutputNote`](crate::transaction::PrivateOutputNote).
 #[derive(Debug, Error)]
 pub enum OutputNoteError {
+    #[error("attachment headers do not match attachments for private note with id {0}")]
+    AttachmentHeadersMismatch(NoteId),
+    #[error("attachments commitment does not match attachments for private note with id {0}")]
+    AttachmentsCommitmentMismatch(NoteId),
     #[error("note with id {0} is private but expected a public note")]
     NoteIsPrivate(NoteId),
     #[error("note with id {0} is public but expected a private note")]

--- a/crates/miden-protocol/src/transaction/outputs/notes.rs
+++ b/crates/miden-protocol/src/transaction/outputs/notes.rs
@@ -580,9 +580,19 @@ impl PrivateOutputNote {
     /// # Errors
     /// Returns an error if:
     /// - The provided header is for a public note.
+    /// - The attachment headers in the provided header do not match the provided attachments.
+    /// - The attachments commitment in the provided header does not match the provided attachments.
     pub fn new(header: NoteHeader, attachments: NoteAttachments) -> Result<Self, OutputNoteError> {
         if header.metadata().is_public() {
             return Err(OutputNoteError::NoteIsPublic(header.id()));
+        }
+
+        if header.metadata().attachment_headers() != &attachments.to_headers() {
+            return Err(OutputNoteError::AttachmentHeadersMismatch(header.id()));
+        }
+
+        if header.metadata().attachments_commitment() != attachments.to_commitment() {
+            return Err(OutputNoteError::AttachmentsCommitmentMismatch(header.id()));
         }
 
         Ok(Self { header, attachments })

--- a/crates/miden-protocol/src/transaction/outputs/tests.rs
+++ b/crates/miden-protocol/src/transaction/outputs/tests.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 
 use assert_matches::assert_matches;
 
-use super::{PublicOutputNote, RawOutputNote, RawOutputNotes};
+use super::{PrivateOutputNote, PublicOutputNote, RawOutputNote, RawOutputNotes};
 use crate::account::AccountId;
 use crate::assembly::mast::{ExternalNodeBuilder, JoinNodeBuilder, MastForest};
 use crate::asset::FungibleAsset;
@@ -11,6 +11,12 @@ use crate::errors::{OutputNoteError, TransactionOutputError};
 use crate::note::{
     Note,
     NoteAssets,
+    NoteAttachment,
+    NoteAttachmentScheme,
+    NoteAttachments,
+    NoteDetailsCommitment,
+    NoteHeader,
+    NoteMetadata,
     NoteRecipient,
     NoteScript,
     NoteStorage,
@@ -23,7 +29,7 @@ use crate::testing::account_id::{
     ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET,
     ACCOUNT_ID_SENDER,
 };
-use crate::utils::serde::Serializable;
+use crate::utils::serde::{Deserializable, DeserializationError, Serializable};
 use crate::{Felt, Word};
 
 #[test]
@@ -75,6 +81,61 @@ fn output_note_size_hint_matches_serialized_length() -> anyhow::Result<()> {
     assert_eq!(bytes.len(), output_note.get_size_hint());
 
     Ok(())
+}
+
+#[test]
+fn private_output_note_rejects_attachment_header_mismatch() -> anyhow::Result<()> {
+    let committed_attachments = note_attachments(1, Word::from([1, 2, 3, 4u32]));
+    let provided_attachments = note_attachments(2, Word::from([1, 2, 3, 4u32]));
+    let header = private_note_header(&committed_attachments);
+
+    let error = PrivateOutputNote::new(header, provided_attachments).unwrap_err();
+
+    assert_matches!(error, OutputNoteError::AttachmentHeadersMismatch(note_id) if note_id == header.id());
+
+    Ok(())
+}
+
+#[test]
+fn private_output_note_rejects_attachments_commitment_mismatch() -> anyhow::Result<()> {
+    let committed_attachments = note_attachments(1, Word::from([1, 2, 3, 4u32]));
+    let provided_attachments = note_attachments(1, Word::from([5, 6, 7, 8u32]));
+    let header = private_note_header(&committed_attachments);
+
+    let error = PrivateOutputNote::new(header, provided_attachments).unwrap_err();
+
+    assert_matches!(error, OutputNoteError::AttachmentsCommitmentMismatch(note_id) if note_id == header.id());
+
+    Ok(())
+}
+
+#[test]
+fn private_output_note_deserialization_rejects_uncommitted_attachments() -> anyhow::Result<()> {
+    let committed_attachments = note_attachments(1, Word::from([1, 2, 3, 4u32]));
+    let provided_attachments = note_attachments(1, Word::from([5, 6, 7, 8u32]));
+    let header = private_note_header(&committed_attachments);
+    let mut bytes = header.to_bytes();
+    bytes.extend_from_slice(&provided_attachments.to_bytes());
+
+    let error = PrivateOutputNote::read_from_bytes(&bytes).unwrap_err();
+
+    assert_matches!(error, DeserializationError::InvalidValue(message) if message.contains("attachments commitment does not match"));
+
+    Ok(())
+}
+
+fn note_attachments(scheme: u16, content: Word) -> NoteAttachments {
+    let scheme = NoteAttachmentScheme::new(scheme).expect("test attachment scheme should be valid");
+    NoteAttachment::with_word(scheme, content).into()
+}
+
+fn private_note_header(attachments: &NoteAttachments) -> NoteHeader {
+    let sender_id = ACCOUNT_ID_SENDER.try_into().expect("test account ID should be valid");
+    let partial_metadata = PartialNoteMetadata::new(sender_id, NoteType::Private);
+    let metadata = NoteMetadata::new(partial_metadata, attachments);
+    let details_commitment =
+        NoteDetailsCommitment::from_raw_commitments(Word::empty(), Word::empty());
+    NoteHeader::new(details_commitment, metadata)
 }
 
 // Construct a public note whose serialized size exceeds NOTE_MAX_SIZE by building a MastForest with

--- a/crates/miden-protocol/src/transaction/outputs/tests.rs
+++ b/crates/miden-protocol/src/transaction/outputs/tests.rs
@@ -90,8 +90,11 @@ fn private_output_note_rejects_attachment_header_mismatch() -> anyhow::Result<()
     let header = private_note_header(&committed_attachments);
 
     let error = PrivateOutputNote::new(header, provided_attachments).unwrap_err();
-
-    assert_matches!(error, OutputNoteError::AttachmentHeadersMismatch(note_id) if note_id == header.id());
+    let note_id = match error {
+        OutputNoteError::AttachmentHeadersMismatch(note_id) => note_id,
+        error => panic!("expected attachment headers mismatch, got {error:?}"),
+    };
+    assert_eq!(note_id, header.id());
 
     Ok(())
 }
@@ -103,8 +106,11 @@ fn private_output_note_rejects_attachments_commitment_mismatch() -> anyhow::Resu
     let header = private_note_header(&committed_attachments);
 
     let error = PrivateOutputNote::new(header, provided_attachments).unwrap_err();
-
-    assert_matches!(error, OutputNoteError::AttachmentsCommitmentMismatch(note_id) if note_id == header.id());
+    let note_id = match error {
+        OutputNoteError::AttachmentsCommitmentMismatch(note_id) => note_id,
+        error => panic!("expected attachments commitment mismatch, got {error:?}"),
+    };
+    assert_eq!(note_id, header.id());
 
     Ok(())
 }

--- a/crates/miden-protocol/src/transaction/outputs/tests.rs
+++ b/crates/miden-protocol/src/transaction/outputs/tests.rs
@@ -90,11 +90,7 @@ fn private_output_note_rejects_attachment_header_mismatch() -> anyhow::Result<()
     let header = private_note_header(&committed_attachments);
 
     let error = PrivateOutputNote::new(header, provided_attachments).unwrap_err();
-    let note_id = match error {
-        OutputNoteError::AttachmentHeadersMismatch(note_id) => note_id,
-        error => panic!("expected attachment headers mismatch, got {error:?}"),
-    };
-    assert_eq!(note_id, header.id());
+    assert_matches!(error, OutputNoteError::AttachmentHeadersMismatch(_));
 
     Ok(())
 }
@@ -106,11 +102,7 @@ fn private_output_note_rejects_attachments_commitment_mismatch() -> anyhow::Resu
     let header = private_note_header(&committed_attachments);
 
     let error = PrivateOutputNote::new(header, provided_attachments).unwrap_err();
-    let note_id = match error {
-        OutputNoteError::AttachmentsCommitmentMismatch(note_id) => note_id,
-        error => panic!("expected attachments commitment mismatch, got {error:?}"),
-    };
-    assert_eq!(note_id, header.id());
+    assert_matches!(error, OutputNoteError::AttachmentsCommitmentMismatch(_));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- validate that `PrivateOutputNote` attachment headers match the provided attachments
- validate that the attachments commitment matches the provided attachment contents
- reject mismatched serialized private output notes through the existing constructor path

Closes #3556.