### PR TITLE
feat(fees): support account issued fee assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features
 
+- [BREAKING] Added an account issued fee asset mode to `FeePolicyManager`, allowing a network faucet
+  to charge fees in its own fungible asset without embedding its account ID in initial storage
+  ([#3584](https://github.com/0xMiden/protocol/issues/3584)).
+
 ### Changes
 
 - [BREAKING] AggLayer bridge and faucet account builders now take a concrete `BasicConstantFeePolicy` and fee faucet ID, constructing their `FeePolicyManager` internally ([#3583](https://github.com/0xMiden/protocol/pull/3583)).

--- a/crates/miden-standards/asm/standards/fees/fee_manager.masm
+++ b/crates/miden-standards/asm/standards/fees/fee_manager.masm
@@ -16,6 +16,7 @@ use miden::protocol::active_account
 use miden::protocol::native_account
 
 use miden::standards::access::authority
+use miden::standards::assets::fungible_asset
 
 use {AccountProcedureRoot, Asset, AssetId, NoteRecipient} from miden::protocol::types
 use {ONE_WORD, ZERO_WORD} from miden::standards::utils
@@ -34,7 +35,8 @@ const ACTIVE_FEE_POLICY_PROC_ROOT_SLOT = word("miden::standards::auth::network_a
 # Allowlist map slot for fee policy roots. Map entries: [PROC_ROOT] -> [1, 0, 0, 0]
 const ALLOWED_FEE_POLICY_PROC_ROOTS_SLOT = word("miden::standards::auth::network_account::allowed_fee_policy_proc_roots")
 
-# Slot holding the ID of the asset fees are charged in. Layout: [FEE_ASSET_ID]
+# Slot holding the ID of the asset fees are charged in. The empty word selects the fungible asset
+# issued by the active account. Layout: [FEE_ASSET_ID]
 const FEE_ASSET_ID_SLOT = word("miden::standards::auth::network_account::fee_asset_id")
 
 # Map entry value marking a fee policy root as allowed.
@@ -344,7 +346,8 @@ proc get_fee_policy_root() -> AccountProcedureRoot
     # => [FEE_POLICY_ROOT]
 end
 
-#! Reads the fee asset ID from storage.
+#! Returns the fee asset ID configured in storage. An empty stored value resolves to the fungible
+#! asset issued by the active account.
 #!
 #! Inputs:  []
 #! Outputs: [FEE_ASSET_ID]
@@ -352,6 +355,18 @@ end
 #! Invocation: exec
 pub proc read_fee_asset_id() -> AssetId
     push.FEE_ASSET_ID_SLOT[0..2] exec.active_account::get_item
+    # => [STORED_FEE_ASSET_ID]
+
+    exec.word::testz
+    # => [is_account_issued, STORED_FEE_ASSET_ID]
+
+    if.true
+        dropw
+        # => []
+
+        exec.active_account::get_id exec.fungible_asset::create_id
+        # => [FEE_ASSET_ID]
+    end
     # => [FEE_ASSET_ID]
 end
 

--- a/crates/miden-standards/src/account/fees/fee_policy_manager.rs
+++ b/crates/miden-standards/src/account/fees/fee_policy_manager.rs
@@ -51,11 +51,11 @@ static FEE_ASSET_ID_SLOT_NAME: LazyLock<StorageSlotName> = LazyLock::new(|| {
 /// need to be installed separately. The [`FeePolicyManager`] is not an account component itself and
 /// only exists to configure the auth component it is contained in.
 ///
-/// Construct via [`Self::builder`]. The builder requires the fee faucet and the active fee policy.
-/// Additional allowed policies for runtime switching may be registered.
+/// Construct via [`Self::builder`]. The builder requires a fee asset selection and the active fee
+/// policy. Additional allowed policies for runtime switching may be registered.
 #[derive(Debug, Clone)]
 pub struct FeePolicyManager {
-    fee_asset_id: AssetId,
+    fee_asset_id: Option<AssetId>,
     active_fee_policy_root: AccountProcedureRoot,
     policies: BTreeMap<AccountProcedureRoot, Vec<AccountComponent>>,
 }
@@ -64,17 +64,17 @@ pub struct FeePolicyManager {
 impl FeePolicyManager {
     /// Builder constructor for [`FeePolicyManager`].
     ///
-    /// The `fee_faucet_id` setter is required and sets the faucet issuing the fungible asset
-    /// fees are charged in. The `active_fee_policy` setter is required and registers the policy
-    /// the manager dispatches to. Each `allowed_fee_policy` setter registers an additional
-    /// reserved alternative for runtime switching via the `set_fee_policy` procedure.
+    /// Select the fee asset with either `fee_faucet_id` or
+    /// [`FeePolicyManagerBuilder::account_issued_fee_asset`]. The `active_fee_policy` setter is
+    /// also required and registers the policy the manager dispatches to. Each
+    /// `allowed_fee_policy` setter registers an additional reserved alternative for runtime
+    /// switching via the `set_fee_policy` procedure.
     #[builder]
     pub fn new(
         #[builder(field)] allowed_fee_policies: BTreeMap<AccountProcedureRoot, FeePolicy>,
-        fee_faucet_id: AccountId,
+        #[builder(required, setters(vis = ""))] fee_asset_id: Option<AssetId>,
         active_fee_policy: FeePolicy,
     ) -> Self {
-        let fee_asset_id = AssetId::new_fungible(fee_faucet_id);
         let active_fee_policy_root = active_fee_policy.root();
 
         let mut policies: BTreeMap<AccountProcedureRoot, Vec<AccountComponent>> = BTreeMap::new();
@@ -101,12 +101,33 @@ impl<S: fee_policy_manager_builder::State> FeePolicyManagerBuilder<S> {
     }
 }
 
+impl<S: fee_policy_manager_builder::State> FeePolicyManagerBuilder<S>
+where
+    S::FeeAssetId: fee_policy_manager_builder::IsUnset,
+{
+    /// Configures fees in the fungible asset issued by `fee_faucet_id`.
+    pub fn fee_faucet_id(
+        self,
+        fee_faucet_id: AccountId,
+    ) -> FeePolicyManagerBuilder<fee_policy_manager_builder::SetFeeAssetId<S>> {
+        self.fee_asset_id(Some(AssetId::new_fungible(fee_faucet_id)))
+    }
+
+    /// Configures fees in the fungible asset issued by the account carrying this manager.
+    pub fn account_issued_fee_asset(
+        self,
+    ) -> FeePolicyManagerBuilder<fee_policy_manager_builder::SetFeeAssetId<S>> {
+        self.fee_asset_id(None)
+    }
+}
+
 impl FeePolicyManager {
     // ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the [`AssetId`] of the fungible asset fees are charged in.
-    pub fn fee_asset_id(&self) -> AssetId {
+    /// Returns the explicit [`AssetId`] fees are charged in, or `None` when the asset is issued by
+    /// the account carrying the manager.
+    pub fn fee_asset_id(&self) -> Option<AssetId> {
         self.fee_asset_id
     }
 
@@ -138,7 +159,7 @@ impl FeePolicyManager {
         &ALLOWED_FEE_POLICY_PROC_ROOTS_SLOT_NAME
     }
 
-    /// Returns the storage slot holding the ID of the asset fees are charged in.
+    /// Returns the storage slot holding the explicit fee asset ID or the account issued marker.
     pub fn fee_asset_id_slot() -> &'static StorageSlotName {
         &FEE_ASSET_ID_SLOT_NAME
     }
@@ -168,7 +189,7 @@ impl FeePolicyManager {
             (
                 FEE_ASSET_ID_SLOT_NAME.clone(),
                 StorageSlotSchema::value(
-                    "ID of the asset fees are charged in",
+                    "Explicit fee asset ID, or an empty word for the account issued asset",
                     SchemaType::native_word(),
                 ),
             ),
@@ -198,7 +219,10 @@ impl FeePolicyManager {
                 self.active_fee_policy().as_word(),
             ),
             StorageSlot::with_map(ALLOWED_FEE_POLICY_PROC_ROOTS_SLOT_NAME.clone(), allowed_map),
-            StorageSlot::with_value(FEE_ASSET_ID_SLOT_NAME.clone(), self.fee_asset_id().to_word()),
+            StorageSlot::with_value(
+                FEE_ASSET_ID_SLOT_NAME.clone(),
+                self.fee_asset_id.map_or_else(Word::empty, |asset_id| asset_id.to_word()),
+            ),
         ]
     }
 }
@@ -271,5 +295,26 @@ mod tests {
                 .any(|component| component.has_procedure(AuthNetworkAccount::get_fee_policy_root())),
             "the fee-policy procedures are exported by the auth component, not by the manager"
         );
+    }
+
+    /// Explicit fee assets retain their asset ID encoding, while the account issued mode stores an
+    /// empty marker so account construction does not depend on the ID being derived.
+    #[test]
+    fn fee_asset_storage_encoding_distinguishes_both_modes() {
+        let explicit_manager = FeePolicyManager::builder()
+            .fee_faucet_id(fee_faucet_id())
+            .active_fee_policy(BasicConstantFeePolicy::new().into())
+            .build();
+        let account_issued_manager = FeePolicyManager::builder()
+            .account_issued_fee_asset()
+            .active_fee_policy(BasicConstantFeePolicy::new().into())
+            .build();
+
+        let expected_asset_id = AssetId::new_fungible(fee_faucet_id());
+        assert_eq!(explicit_manager.fee_asset_id(), Some(expected_asset_id));
+        assert_eq!(explicit_manager.to_storage_slots()[2].value(), expected_asset_id.to_word());
+
+        assert_eq!(account_issued_manager.fee_asset_id(), None);
+        assert_eq!(account_issued_manager.to_storage_slots()[2].value(), Word::empty());
     }
 }

--- a/crates/miden-testing/tests/auth/fee_payment/network.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/network.rs
@@ -1,13 +1,26 @@
 use std::collections::BTreeSet;
 
+use miden_protocol::Felt;
 use miden_protocol::account::{Account, AccountBuilder, AccountType};
-use miden_protocol::asset::{Asset, AssetAmount, FungibleAsset};
+use miden_protocol::asset::{Asset, AssetAmount, AssetVault, FungibleAsset, TokenSymbol};
 use miden_protocol::errors::tx_kernel::ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW;
 use miden_protocol::note::{Note, NoteScriptRoot, NoteType};
 use miden_protocol::testing::account_id::{ACCOUNT_ID_FEE_FAUCET, ACCOUNT_ID_SENDER};
 use miden_protocol::transaction::{ExecutedTransaction, RawOutputNote};
+use miden_standards::account::access::AccessControl;
 use miden_standards::account::auth::AuthNetworkAccount;
+use miden_standards::account::faucets::{
+    FungibleFaucet,
+    TokenName,
+    create_network_fungible_faucet,
+};
 use miden_standards::account::fees::{BasicConstantFeePolicy, FeePolicyManager};
+use miden_standards::account::policies::{
+    BurnPolicy,
+    MintPolicy,
+    TokenPolicyManager,
+    TransferPolicy,
+};
 use miden_standards::account::wallets::BasicWallet;
 use miden_standards::note::{NetworkAccountConfigNote, TxFeeNote};
 use miden_standards::testing::note::NoteBuilder;
@@ -136,6 +149,68 @@ async fn network_account_pays_fee_note() -> anyhow::Result<()> {
         .build()?
         .into();
     assert_eq!(output_note.id(), expected_note.id());
+
+    Ok(())
+}
+
+/// A network faucet can derive its account ID without embedding that ID in initial storage, then
+/// resolve the account issued asset at runtime and pay a nonzero chain fee in that asset.
+#[tokio::test]
+async fn network_faucet_pays_fee_in_its_own_asset() -> anyhow::Result<()> {
+    let fee_policy_manager = FeePolicyManager::builder()
+        .account_issued_fee_asset()
+        .active_fee_policy(BasicConstantFeePolicy::new().into())
+        .build();
+    let faucet = FungibleFaucet::builder()
+        .name(TokenName::new("Native fee asset")?)
+        .symbol(TokenSymbol::new("NFA")?)
+        .decimals(6)
+        .max_supply(AssetAmount::new(1_000_000)?)
+        .build()?;
+    let token_policy_manager = TokenPolicyManager::builder()
+        .active_mint_policy(MintPolicy::allow_all())
+        .active_burn_policy(BurnPolicy::allow_all())
+        .active_send_policy(TransferPolicy::allow_all())
+        .active_receive_policy(TransferPolicy::allow_all())
+        .build();
+    let new_faucet = create_network_fungible_faucet(
+        [10; 32],
+        faucet,
+        AccessControl::Ownable2Step { owner: ACCOUNT_ID_SENDER.try_into()? },
+        token_policy_manager,
+        fee_policy_manager,
+    )?;
+    assert!(new_faucet.is_new());
+
+    // Genesis funding happens after the ID is known. Rewrap the new account as an existing account
+    // with a balance in the asset it issues, matching how a network faucet is initialized on chain.
+    let fee_faucet_id = new_faucet.id();
+    let fee_asset: Asset = FungibleAsset::new(fee_faucet_id, 1_000_000)?.into();
+    let (id, _vault, storage, code, _nonce, _seed) = new_faucet.into_parts();
+    let faucet_account =
+        Account::new(id, AssetVault::new(&[fee_asset])?, storage, code, Felt::ONE, None)?;
+
+    let mut builder = MockChain::builder()
+        .fee_faucet_id(fee_faucet_id)
+        .verification_base_fee(VERIFICATION_BASE_FEE);
+    builder.add_account(faucet_account)?;
+    let mock_chain = builder.build()?;
+
+    let executed_transaction =
+        mock_chain.build_transaction(fee_faucet_id).build()?.execute().await?;
+    assert_eq!(executed_transaction.output_notes().num_notes(), 1);
+
+    let output_note = executed_transaction.output_notes().get_note(0);
+    assert_eq!(output_note.metadata().note_type(), NoteType::Public);
+    assert_eq!(output_note.assets().num_assets(), 1);
+    let paid_asset = output_note.assets().iter().next().expect("fee note should carry an asset");
+    let Asset::Fungible(paid_asset) = paid_asset else {
+        panic!("fee note asset should be fungible");
+    };
+
+    assert_eq!(output_note.metadata().tag(), TxFeeNote::TAG);
+    assert_eq!(paid_asset.faucet_id(), fee_faucet_id);
+    assert!(paid_asset.amount() >= executed_transaction.compute_fee());
 
     Ok(())
 }

--- a/crates/miden-tx/src/pricer.rs
+++ b/crates/miden-tx/src/pricer.rs
@@ -382,7 +382,9 @@ mod tests {
         assert_eq!(manager.active_fee_policy(), BasicConstantFeePolicy::root());
         assert_eq!(
             manager.fee_asset_id(),
-            miden_protocol::asset::AssetId::new_fungible(pricer.fee_parameters().fee_faucet_id())
+            Some(miden_protocol::asset::AssetId::new_fungible(
+                pricer.fee_parameters().fee_faucet_id()
+            ))
         );
     }
 


### PR DESCRIPTION
## Summary

* add `account_issued_fee_asset()` to `FeePolicyManagerBuilder`
* encode this mode without embedding the account ID in initial storage
* resolve the fee asset at runtime from the active account ID
* preserve the existing explicit fee faucet mode
* cover a network fungible faucet paying a nonzero chain fee in its own asset

Closes #3584.