### PR TITLE
fix(protocol): verify faucet callback root against account code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixes
 
+- Verified faucet asset-callback procedure roots against the faucet's account code before dispatch, so a misconfigured callback root can no longer make an asset untransferable ([#3590](https://github.com/0xMiden/protocol/issues/3590)).
 - Fixed the authentication procedure not ending up at index 0 of an account's code when its MAST root was already exported by another component ([#3566](https://github.com/0xMiden/protocol/pull/3566)).
 - [BREAKING] Foreign procedure invocation now requires the provided procedure root to be part of the foreign account's code, so a caller can no longer execute arbitrary code under a foreign account's identity ([#3575](https://github.com/0xMiden/protocol/pull/3575)).
 - Fixed `PrivateOutputNote` construction and deserialization accepting attachment data that is not committed by the note header ([#3556](https://github.com/0xMiden/protocol/issues/3556)).

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/callbacks.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/callbacks.masm
@@ -24,6 +24,12 @@ pub const ON_BEFORE_ASSET_ADDED_TO_NOTE_PROC_ROOT_SLOT =
         "miden::protocol::faucet::callback::on_before_asset_added_to_note"
     )
 
+# ERRORS
+# ==================================================================================================
+
+const ERR_FAUCET_CALLBACK_PROC_ROOT_NOT_PART_OF_ACCOUNT_CODE =
+    "the faucet callback procedure root is not part of the faucet's account code"
+
 # PROCEDURES
 # ==================================================================================================
 
@@ -118,6 +124,10 @@ proc invoke_callback
 
     # only invoke the callback if the procedure root is not the empty word
     if.true
+        # verify the callback root is part of the faucet's account code before invoking it
+        dupw exec.account::has_procedure assert.err=ERR_FAUCET_CALLBACK_PROC_ROOT_NOT_PART_OF_ACCOUNT_CODE
+        # => [PROC_ROOT, ASSET_ID, ASSET_VALUE, custom_data, was_foreign_context_started]
+
         # prepare for dyncall by storing procedure root in local memory
         loc_storew_le.CALLBACK_PROC_ROOT_LOC dropw
         # => [ASSET_ID, ASSET_VALUE, custom_data, was_foreign_context_started]

--- a/crates/miden-testing/src/kernel_tests/tx/test_callbacks.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_callbacks.rs
@@ -299,6 +299,72 @@ async fn test_faucet_without_callback_slot_skips_callback(
     Ok(())
 }
 
+/// The expected error when the faucet's callback slot holds a root that is not part of its code.
+const ERR_FAUCET_CALLBACK_PROC_ROOT_NOT_PART_OF_ACCOUNT_CODE: MasmError =
+    MasmError::from_static_str(
+        "the faucet callback procedure root is not part of the faucet's account code",
+    );
+
+/// Tests that consuming a callbacks-enabled asset fails when the issuing faucet's callback slot
+/// holds a procedure root that is not part of the faucet's account code.
+#[tokio::test]
+async fn test_faucet_with_invalid_callback_root_fails() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+
+    let target_account = builder.add_existing_wallet(Auth::IncrNonce)?;
+
+    // Create a faucet whose ID enables callbacks and whose callback slot holds an arbitrary root
+    // that does not correspond to any of the faucet's procedures.
+    let arbitrary_root = Word::from([1u32, 2, 3, 4]);
+    let name = "miden::testing::callbacks";
+    let slots = AssetCallbacks::new()
+        .on_before_asset_added_to_account(arbitrary_root)
+        .into_storage_slots();
+    let component = AccountComponent::new(
+        CodeBuilder::new().compile_component_code(name, "pub proc dummy nop end")?,
+        slots,
+        AccountComponentMetadata::mock(name),
+    )?;
+
+    let account_builder = AccountBuilder::new([45u8; 32])
+        .account_type(AccountType::Public)
+        .with_asset_callbacks(AssetCallbackFlag::Enabled)
+        .with_component(MockFaucetComponent)
+        .with_component(component);
+
+    let faucet = builder.add_account_from_builder(
+        Auth::BasicAuth {
+            auth_scheme: AuthScheme::Falcon512Poseidon2,
+        },
+        account_builder,
+        AccountState::Exists,
+    )?;
+
+    let asset = Asset::from(FungibleAsset::new(faucet.id(), 100)?);
+    let note =
+        builder.add_p2id_note(faucet.id(), target_account.id(), &[asset], NoteType::Public)?;
+
+    let mut mock_chain = builder.build()?;
+    mock_chain.prove_next_block()?;
+
+    let faucet_inputs = mock_chain.get_foreign_account_inputs(faucet.id())?;
+
+    let result = mock_chain
+        .build_transaction(target_account.id())
+        .authenticated_input_note(note.id())
+        .foreign_accounts(vec![faucet_inputs])
+        .build()?
+        .execute()
+        .await;
+
+    assert_transaction_executor_error!(
+        result,
+        ERR_FAUCET_CALLBACK_PROC_ROOT_NOT_PART_OF_ACCOUNT_CODE
+    );
+
+    Ok(())
+}
+
 // ON_ASSET_ADDED_TO_ACCOUNT TESTS
 // ================================================================================================
 


### PR DESCRIPTION
## Summary

The faucet asset-callback dispatcher invoked the procedure root stored in the faucet's callback slot without verifying it belongs to the faucet's account code, so an arbitrary root would break every transfer of that asset via failed dynamic dispatch. Adds an `account::has_procedure` check (asserting `ERR_FAUCET_CALLBACK_PROC_ROOT_NOT_PART_OF_ACCOUNT_CODE`) after the faucet callback context is established and before the `dyncall`, plus a regression test.

Closes #3590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
