### PR TITLE
refactor(protocol): use native accessors in native-only account procedures

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -878,10 +878,6 @@ end
 #! 1. Compute the hash of (SEED, CODE_COMMITMENT, STORAGE_COMMITMENT, EMPTY_WORD).
 #! 2. Assert the two least significant elements of the digest are equal to the native account ID.
 #!
-#! This procedure runs in the prologue, where the active account is always the native account.
-#! It therefore reads the code and storage commitments through the active accessors, which resolve
-#! to the native account's state.
-#!
 #! Inputs:
 #!   Operand stack: []
 #!   Advice map: { ACCOUNT_ID_KEY: [SEED] }

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -1718,12 +1718,9 @@ end
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
 proc find_storage_slot
-    # construct the end pointer of the storage slots section in which we will search
-    dup.1 mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH dup.1 add
-    # => [storage_slots_end_ptr, storage_slots_start_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
-
-    # drop the now-consumed slot count
-    movup.2 drop
+    # construct the end pointer of the storage slots section in which we will search, moving the
+    # slot count into place rather than duplicating and later dropping it
+    swap mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH dup.1 add
     # => [storage_slots_end_ptr, storage_slots_start_ptr, slot_id_suffix, slot_id_prefix]
 
     swap movup.3 movup.3

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -1718,8 +1718,7 @@ end
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
 proc find_storage_slot
-    # construct the end pointer of the storage slots section in which we will search, moving the
-    # slot count into place rather than duplicating and later dropping it
+    # construct the end pointer of the storage slots section in which we will search
     swap mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH dup.1 add
     # => [storage_slots_end_ptr, storage_slots_start_ptr, slot_id_suffix, slot_id_prefix]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -339,9 +339,10 @@ pub use {get_init_native_account_vault_root as get_initial_vault_root}
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
 pub proc get_item
-    # get account storage slots section offset
+    # get the active account storage slots section offset and its slot count
+    exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
-    # => [acct_storage_slots_section_offset, slot_id_suffix, slot_id_prefix]
+    # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
 
     exec.get_storage_slot_ptr
     # => [slot_ptr]
@@ -366,9 +367,10 @@ end
 #! - is_found is 1 if the slot was found, 0 otherwise.
 #! - VALUE is the value of the item, or the empty word if the slot was not found.
 pub proc find_item
-    # get account storage slots section offset
+    # get the active account storage slots section offset and its slot count
+    exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
-    # => [acct_storage_slots_section_offset, slot_id_suffix, slot_id_prefix]
+    # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
 
     exec.find_storage_slot
     # => [is_found, slot_ptr]
@@ -399,9 +401,10 @@ end
 #!   the first two felts of the hashed slot name.
 #! - has_slot is 1 if a slot with the provided slot ID exists, 0 otherwise.
 pub proc has_storage_slot
-    # get account storage slots section offset
+    # get the active account storage slots section offset and its slot count
+    exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
-    # => [acct_storage_slots_section_offset, slot_id_suffix, slot_id_prefix]
+    # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
 
     exec.find_storage_slot
     # => [has_slot, slot_ptr]
@@ -425,9 +428,10 @@ end
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
 pub proc get_typed_item
-    # get account storage slots section offset
+    # get the active account storage slots section offset and its slot count
+    exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
-    # => [acct_storage_slots_section_offset, slot_id_suffix, slot_id_prefix]
+    # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
 
     exec.get_storage_slot_ptr
     # => [slot_ptr]
@@ -453,9 +457,10 @@ end
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
 pub proc get_initial_item
-    # get native account initial storage slots section offset
+    # get the native account initial storage slots section offset and the native slot count
+    exec.memory::get_native_num_storage_slots
     exec.memory::get_native_account_initial_storage_slots_ptr
-    # => [native_account_initial_storage_slots_ptr, slot_id_suffix, slot_id_prefix]
+    # => [native_account_initial_storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
 
     exec.get_storage_slot_ptr
     # => [slot_ptr]
@@ -483,8 +488,9 @@ pub proc set_item
     emit.ACCOUNT_STORAGE_BEFORE_SET_ITEM_EVENT
     # => [slot_id_suffix, slot_id_prefix, VALUE]
 
+    exec.memory::get_native_num_storage_slots
     exec.memory::get_native_account_active_storage_slots_ptr
-    # => [storage_slots_ptr, slot_id_suffix, slot_id_prefix, VALUE]
+    # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix, VALUE]
 
     exec.get_storage_slot_ptr
     # => [slot_ptr, VALUE]
@@ -531,8 +537,9 @@ end
 #! - a slot with the provided slot ID does not exist in account storage.
 #! - the requested storage slot type is not map.
 pub proc get_map_item
+    exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
-    # => [storage_slots_ptr, slot_id_suffix, slot_id_prefix, KEY]
+    # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix, KEY]
 
     exec.get_map_item_raw
 end
@@ -552,8 +559,9 @@ end
 #! - a slot with the provided slot ID does not exist in account storage.
 #! - the requested storage slot type is not map.
 pub proc get_initial_map_item
+    exec.memory::get_native_num_storage_slots
     exec.memory::get_native_account_initial_storage_slots_ptr
-    # => [native_initial_storage_slots_ptr, slot_id_suffix, slot_id_prefix, KEY]
+    # => [native_initial_storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix, KEY]
 
     exec.get_map_item_raw
 end
@@ -577,8 +585,9 @@ end
 #! - the storage slot type is not map.
 #! - no map with the root of the slot is found.
 pub proc set_map_item
+    exec.memory::get_native_num_storage_slots
     exec.memory::get_native_account_active_storage_slots_ptr
-    # => [storage_slots_ptr, slot_id_suffix, slot_id_prefix, KEY, NEW_VALUE]
+    # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix, KEY, NEW_VALUE]
 
     # resolve the slot name to its pointer
     exec.get_storage_slot_ptr
@@ -656,7 +665,7 @@ pub proc add_asset_to_vault
     # => [ASSET_ID, ASSET_VALUE, ASSET_ID]
 
     # push the account vault root ptr
-    exec.memory::get_account_vault_root_ptr movdn.8
+    exec.memory::get_native_account_vault_root_ptr movdn.8
     # => [ASSET_ID, ASSET_VALUE, account_vault_root_ptr, ASSET_ID]
 
     # emit event to signal that an asset is going to be added to the account vault
@@ -698,7 +707,7 @@ pub proc remove_asset_from_vault
     # => [ASSET_ID, ASSET_VALUE, ASSET_ID]
 
     # push the vault root ptr
-    exec.memory::get_account_vault_root_ptr movdn.8
+    exec.memory::get_native_account_vault_root_ptr movdn.8
     # => [ASSET_ID, ASSET_VALUE, account_vault_root_ptr, ASSET_ID]
 
     # emit event to signal that an asset is going to be removed from the account vault
@@ -867,8 +876,11 @@ end
 #!
 #! Validation is performed via the following steps:
 #! 1. Compute the hash of (SEED, CODE_COMMITMENT, STORAGE_COMMITMENT, EMPTY_WORD).
-#! 2. Assert the two least significant elements of the digest are equal to the account ID of the
-#!    account the transaction is being executed against.
+#! 2. Assert the two least significant elements of the digest are equal to the native account ID.
+#!
+#! This procedure runs in the prologue, where the active account is always the native account.
+#! It therefore reads the code and storage commitments through the active accessors, which resolve
+#! to the native account's state.
 #!
 #! Inputs:
 #!   Operand stack: []
@@ -919,7 +931,7 @@ pub proc validate_seed
     movup.2 drop movup.2 drop
     # => [hashed_account_id_suffix, hashed_account_id_prefix]
 
-    exec.memory::get_account_id movdn.3 movdn.3
+    exec.memory::get_native_account_id movdn.3 movdn.3
     # => [hashed_account_id_suffix, hashed_account_id_prefix, account_id_suffix, account_id_prefix]
 
     # shape suffix of hashed id by setting the lower 8 bits to zero
@@ -1280,7 +1292,7 @@ end
 #! Inputs:  []
 #! Outputs: []
 pub proc insert_new_storage
-    exec.memory::get_num_storage_slots
+    exec.memory::get_native_num_storage_slots
     # => [num_slots]
 
     # loop if there are storage slots
@@ -1329,7 +1341,7 @@ end
 #! Outputs: []
 proc insert_and_validate_storage_map
     mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH
-    exec.memory::get_account_active_storage_slots_section_ptr
+    exec.memory::get_native_account_active_storage_slots_ptr
     add
     # => [slot_ptr]
 
@@ -1649,11 +1661,12 @@ end
 #! Finds the storage map root in the storage slot with the provided name in the provided storage
 #! slots section and returns the VALUE associated with the KEY in the corresponding map.
 #!
-#! Inputs:  [storage_slots_ptr, slot_id_suffix, slot_id_prefix, KEY]
+#! Inputs:  [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix, KEY]
 #! Outputs: [VALUE]
 #!
 #! Where:
 #! - storage_slots_ptr is the pointer to the storage slots section in which to look up the slot.
+#! - num_storage_slots is the number of slots contained in the storage slots section.
 #! - KEY is the key to look up in the map.
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
@@ -1698,18 +1711,26 @@ end
 #! Finds the slot identified by the key [_, _, slot_id_suffix, slot_id_prefix] and returns a flag
 #! indicating whether the slot was found and the pointer to that slot.
 #!
-#! Inputs:  [storage_slots_ptr, slot_id_suffix, slot_id_prefix]
+#! The caller provides both the section base pointer and the number of slots it contains, so that
+#! the section being searched and its extent always belong to the same account.
+#!
+#! Inputs:  [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
 #! Outputs: [is_found, slot_ptr]
 #!
 #! Where:
 #! - storage_slots_ptr is the pointer to the storage slots section.
+#! - num_storage_slots is the number of slots contained in the storage slots section.
 #! - is_found is 1 if the slot was found, 0 otherwise.
 #! - slot_ptr is the pointer to the resolved storage slot.
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
 proc find_storage_slot
-    # construct the start and end pointers of the storage slot section in which we will search
-    dup exec.memory::get_num_storage_slots mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH add
+    # construct the end pointer of the storage slots section in which we will search
+    dup.1 mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH dup.1 add
+    # => [storage_slots_end_ptr, storage_slots_start_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
+
+    # drop the now-consumed slot count
+    movup.2 drop
     # => [storage_slots_end_ptr, storage_slots_start_ptr, slot_id_suffix, slot_id_prefix]
 
     swap movup.3 movup.3
@@ -1726,11 +1747,12 @@ end
 #! Finds the slot identified by the key [_, _, slot_id_suffix, slot_id_prefix] and returns the
 #! pointer to that slot.
 #!
-#! Inputs:  [storage_slots_ptr, slot_id_suffix, slot_id_prefix]
+#! Inputs:  [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
 #! Outputs: [slot_ptr]
 #!
 #! Where:
 #! - storage_slots_ptr is the pointer to the storage slots section.
+#! - num_storage_slots is the number of slots contained in the storage slots section.
 #! - slot_ptr is the pointer to the resolved storage slot.
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
@@ -1757,7 +1779,7 @@ end
 #! - slot_ptr is the pointer to a "current" storage slot in the native account's memory section.
 #! - slot_idx is the index of the storage slot.
 proc slot_ptr_to_index
-    exec.memory::get_account_active_storage_slots_section_ptr
+    exec.memory::get_native_account_active_storage_slots_ptr
     sub
     # => [slot_offset]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -1711,9 +1711,6 @@ end
 #! Finds the slot identified by the key [_, _, slot_id_suffix, slot_id_prefix] and returns a flag
 #! indicating whether the slot was found and the pointer to that slot.
 #!
-#! The caller provides both the section base pointer and the number of slots it contains, so that
-#! the section being searched and its extent always belong to the same account.
-#!
 #! Inputs:  [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix]
 #! Outputs: [is_found, slot_ptr]
 #!

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
@@ -123,7 +123,7 @@ pub proc compute_patch_commitment
 
     # get the nonce of the account and assume it is the final nonce
     # we later assert that the nonce was incremented (unless the patch is empty)
-    exec.memory::get_account_nonce
+    exec.memory::get_native_account_nonce
     push.DOMAIN_PATCH
     # => [domain_patch, final_nonce, native_account_id_suffix, native_account_id_prefix, EMPTY_WORD, CAPACITY]
     # => [ID_AND_NONCE, EMPTY_WORD, CAPACITY]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/epilogue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/epilogue.masm
@@ -99,7 +99,7 @@ end
 #! Outputs: []
 proc build_output_vault
     # copy final account vault root to output account vault root
-    exec.memory::get_account_vault_root exec.memory::set_output_vault_root dropw
+    exec.memory::get_native_account_vault_root exec.memory::set_output_vault_root dropw
     # => []
 
     # get the number of output notes from memory

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
@@ -1154,6 +1154,28 @@ pub proc set_account_vault_root
     mem_storew_le
 end
 
+#! Returns the memory pointer to the native account's vault root.
+#!
+#! Inputs:  []
+#! Outputs: [account_vault_root_ptr]
+#!
+#! Where:
+#! - account_vault_root_ptr is the memory pointer to the native account's asset vault root.
+pub proc get_native_account_vault_root_ptr
+    push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_VAULT_ROOT_OFFSET
+end
+
+#! Returns the native account's vault root.
+#!
+#! Inputs:  []
+#! Outputs: [ACCT_VAULT_ROOT]
+#!
+#! Where:
+#! - ACCT_VAULT_ROOT is the native account's asset vault root.
+pub proc get_native_account_vault_root
+    padw exec.get_native_account_vault_root_ptr mem_loadw_le
+end
+
 ### ACCOUNT CODE #################################################
 
 #! Returns the code commitment of the account.
@@ -1441,7 +1463,7 @@ pub proc mem_copy_native_account_initial_storage_slots
     # => [active_storage_slots_ptr, initial_storage_slots_ptr]
 
     # each slot takes up two words
-    exec.get_num_storage_slots mul.2
+    exec.get_native_num_storage_slots mul.2
     # => [num_storage_slot_words, active_storage_slots_ptr, initial_storage_slots_ptr]
 
     exec.mem::memcopy_words


### PR DESCRIPTION
## Summary

Corrects several native-only transaction-kernel procedures that mixed ACTIVE and NATIVE account accessors so each reads only the native account's state, e.g. `find_storage_slot` now take the section's slot count from the caller alongside its base pointer, so a section can no longer be searched using _another_ account's length;

Closes #3596
