### PR TITLE
docs(protocol): correct stale mint panic conditions in faucet docs

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction-core/src/faucet.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/faucet.masm
@@ -23,6 +23,10 @@ const ACCOUNT_VAULT_BEFORE_BURN_ASSET_EVENT =
 
 #! Mint an asset from the faucet the transaction is being executed against.
 #!
+#! Note that this procedure only adds the asset to the input vault; it does not enforce a maximum
+#! issuance for fungible assets or uniqueness for non-fungible assets across transactions - those
+#! invariants must be enforced by the faucet's account component.
+#!
 #! Inputs:  [ASSET_ID, ASSET_VALUE]
 #! Outputs: []
 #!
@@ -33,9 +37,6 @@ const ACCOUNT_VAULT_BEFORE_BURN_ASSET_EVENT =
 #! Panics if:
 #! - the asset issuer is not the faucet the transaction is being executed against.
 #! - the asset is not well formed.
-#! - For fungible faucets if the total issuance after minting is greater than the maximum amount
-#!   allowed.
-#! - For non-fungible faucets if the non-fungible asset being minted already exists.
 pub proc mint
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/faucet.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/faucet.masm
@@ -23,10 +23,6 @@ const ACCOUNT_VAULT_BEFORE_BURN_ASSET_EVENT =
 
 #! Mint an asset from the faucet the transaction is being executed against.
 #!
-#! Note that this procedure only adds the asset to the input vault; it does not enforce a maximum
-#! issuance for fungible assets or uniqueness for non-fungible assets across transactions - those
-#! invariants must be enforced by the faucet's account component.
-#!
 #! Inputs:  [ASSET_ID, ASSET_VALUE]
 #! Outputs: []
 #!

--- a/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
@@ -931,10 +931,6 @@ end
 
 #! Mint an asset from the faucet the transaction is being executed against.
 #!
-#! Note that this procedure only adds the asset to the input vault; it does not enforce a maximum
-#! issuance for fungible assets or uniqueness for non-fungible assets across transactions - those
-#! invariants must be enforced by the faucet's account component.
-#!
 #! Inputs:  [ASSET_ID, ASSET_VALUE, pad(8)]
 #! Outputs: [pad(16)]
 #!

--- a/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
@@ -931,6 +931,10 @@ end
 
 #! Mint an asset from the faucet the transaction is being executed against.
 #!
+#! Note that this procedure only adds the asset to the input vault; it does not enforce a maximum
+#! issuance for fungible assets or uniqueness for non-fungible assets across transactions - those
+#! invariants must be enforced by the faucet's account component.
+#!
 #! Inputs:  [ASSET_ID, ASSET_VALUE, pad(8)]
 #! Outputs: [pad(16)]
 #!
@@ -943,10 +947,6 @@ end
 #! - the current active account is not the native account of the transaction.
 #! - the asset issuer is not the faucet the transaction is being executed against.
 #! - the asset is not well formed.
-#! - For fungible faucets:
-#!   - if the total issuance after minting is greater than the maximum amount allowed.
-#! - For non-fungible faucets:
-#!   - if the non-fungible asset being minted already exists.
 #!
 #! Invocation: dynexec
 pub proc faucet_mint_asset

--- a/crates/miden-protocol/asm/protocol/src/faucet.masm
+++ b/crates/miden-protocol/asm/protocol/src/faucet.masm
@@ -3,6 +3,10 @@ use {Asset} from miden::protocol::types
 
 #! Mint an asset from the faucet the transaction is being executed against.
 #!
+#! Note that this procedure only adds the asset to the input vault; it does not enforce a maximum
+#! issuance for fungible assets or uniqueness for non-fungible assets across transactions - those
+#! invariants must be enforced by the faucet's account component.
+#!
 #! Inputs:  [ASSET_ID, ASSET_VALUE]
 #! Outputs: []
 #!
@@ -13,9 +17,6 @@ use {Asset} from miden::protocol::types
 #! Panics if:
 #! - the asset issuer is not the faucet the transaction is being executed against.
 #! - the asset is not well formed.
-#! - for fungible faucets if the total issuance after minting is greater than the maximum amount
-#!   allowed.
-#! - for non-fungible faucets if the non-fungible asset being minted already exists.
 #!
 #! Invocation: exec
 pub proc mint(asset: Asset)

--- a/crates/miden-protocol/asm/protocol/src/faucet.masm
+++ b/crates/miden-protocol/asm/protocol/src/faucet.masm
@@ -3,10 +3,6 @@ use {Asset} from miden::protocol::types
 
 #! Mint an asset from the faucet the transaction is being executed against.
 #!
-#! Note that this procedure only adds the asset to the input vault; it does not enforce a maximum
-#! issuance for fungible assets or uniqueness for non-fungible assets across transactions - those
-#! invariants must be enforced by the faucet's account component.
-#!
 #! Inputs:  [ASSET_ID, ASSET_VALUE]
 #! Outputs: []
 #!


### PR DESCRIPTION
## Summary

Corrects three `mint` doc comments (kernel dispatcher, syscall wrapper, and library proc) that claimed the kernel enforces maximum fungible issuance and non-fungible uniqueness.

Those invariants are enforced by the faucet's account component (`standards`), not the kernel `mint` procedure. Documentation only.

Closes #3597
