### PR TITLE
chore: address batch kernel review comments

### DIFF
--- a/crates/miden-protocol/asm/kernels/batch/lib/epilogue.masm
+++ b/crates/miden-protocol/asm/kernels/batch/lib/epilogue.masm
@@ -30,13 +30,20 @@ const ERR_BATCH_NOTE_CONSUMED_BEFORE_CREATED="an erased input note was consumed 
 #! Outputs: []
 proc assert_all_output_notes_created
     exec.memory::get_num_output_notes
+    # => [num_output_notes]
     push.0
+    # => [idx, num_output_notes]
     dup.1 dup.1 neq
+    # => [should_loop, idx, num_output_notes]
     while.true
         dup exec.memory::output_note_flags_ptr add.OUTPUT_NOTE_IS_CREATED_OFFSET mem_load
+        # => [is_created, idx, num_output_notes]
         assert.err=ERR_BATCH_OUTPUT_NOTE_NOT_CREATED
+        # => [idx, num_output_notes]
         add.1
+        # => [idx+1, num_output_notes]
         dup.1 dup.1 neq
+        # => [should_loop, idx+1, num_output_notes]
     end
     drop drop
 end
@@ -64,6 +71,37 @@ proc absorb_input_entry
     drop drop
 end
 
+#! Processes one input-note list entry: asserts the entry was consumed exactly once and is not
+#! left expected-to-be-erased, then absorbs it into the batch hasher unless it was erased.
+#!
+#! The absorbed_count is only incremented by 1 if the entry was not erased (erasure != 2).
+#!
+#! Inputs:  [idx, absorbed_count, num]
+#! Outputs: [idx + 1, absorbed_count, num]
+proc process_input_entry
+    # Assert this entry was consumed exactly once and is not left expected-to-be-erased.
+    dup exec.memory::input_note_flags_ptr
+    # => [flags_ptr, idx, absorbed_count, num]
+    dup add.INPUT_NOTE_CONSUMPTION_OFFSET mem_load
+    # => [consumption, flags_ptr, idx, absorbed_count, num]
+    assert.err=ERR_BATCH_INPUT_NOTE_NOT_CONSUMED
+    # => [flags_ptr, idx, absorbed_count, num]
+    mem_load
+    # => [erasure, idx, absorbed_count, num]
+    dup neq.1 assert.err=ERR_BATCH_NOTE_CONSUMED_BEFORE_CREATED
+    # => [erasure, idx, absorbed_count, num]
+
+    # Absorb the entry unless it was erased (created-and-consumed in this batch).
+    neq.2
+    # => [not_erased, idx, absorbed_count, num]
+    if.true
+        dup exec.absorb_input_entry
+        swap add.1 swap
+        # => [idx, absorbed_count+1, num]
+    end
+    add.1
+end
+
 #! Computes INPUT_NOTES_COMMITMENT as the sequential poseidon2 hash of the non-erased
 #! `(NULLIFIER, NOTE_ID_OR_EMPTY)` entries of the nullifier-sorted input-note list (entries with
 #! erasure flag == 2 are skipped).
@@ -85,29 +123,10 @@ proc compute_input_notes_commitment
     dup dup.3 neq
     # => [should_loop, idx, absorbed_count, num]
     while.true
-        # Assert this entry was consumed exactly once and is not left expected-to-be-erased.
-        dup exec.memory::input_note_flags_ptr
-        # => [flags_ptr, idx, absorbed_count, num]
-        dup add.INPUT_NOTE_CONSUMPTION_OFFSET mem_load
-        # => [consumption, flags_ptr, idx, absorbed_count, num]
-        assert.err=ERR_BATCH_INPUT_NOTE_NOT_CONSUMED
-        # => [flags_ptr, idx, absorbed_count, num]
-        mem_load
-        # => [erasure, idx, absorbed_count, num]
-        dup neq.1 assert.err=ERR_BATCH_NOTE_CONSUMED_BEFORE_CREATED
-        # => [erasure, idx, absorbed_count, num]
-
-        # Absorb the entry unless it was erased (created-and-consumed in this batch).
-        neq.2
-        # => [not_erased, idx, absorbed_count, num]
-        if.true
-            dup exec.absorb_input_entry
-            swap add.1 swap
-            # => [idx, absorbed_count+1, num]
-        end
-        add.1
+        exec.process_input_entry
+        # => [idx+1, absorbed_count, num] (absorbed_count + 1 if entry was not erased)
         dup dup.3 neq
-        # => [should_loop, idx, absorbed_count, num]
+        # => [should_loop, idx+1, absorbed_count, num]
     end
     # => [idx, absorbed_count, num]
     drop swap drop

--- a/crates/miden-protocol/src/batch/kernel.rs
+++ b/crates/miden-protocol/src/batch/kernel.rs
@@ -6,8 +6,8 @@ use miden_core::utils::hash_string_to_word;
 
 use crate::batch::{BatchId, ProposedBatch};
 use crate::errors::ProvenBatchError;
-use crate::note::{NoteId, Nullifier};
-use crate::transaction::{OrderedTransactionHeaders, TransactionId};
+use crate::note::Nullifier;
+use crate::transaction::{OrderedTransactionHeaders, TransactionCommitments};
 use crate::utils::serde::Deserializable;
 use crate::utils::sync::LazyLock;
 use crate::vm::{AdviceInputs, Package, Program, ProgramInfo, StackInputs};
@@ -28,16 +28,11 @@ static KERNEL_MAIN: LazyLock<Program> = LazyLock::new(|| {
 });
 
 // Advice-map keys under which the sorted (pre-erasure) note lists are provided to the kernel.
-const INPUT_NOTE_LIST_KEY_MESSAGE: &str = "miden::batch_kernel::input_note_list";
-const OUTPUT_NOTE_LIST_KEY_MESSAGE: &str = "miden::batch_kernel::output_note_list";
+pub static INPUT_NOTE_LIST_KEY: LazyLock<Word> =
+    LazyLock::new(|| hash_string_to_word("miden::batch_kernel::input_note_list"));
 
-fn input_note_list_key() -> Word {
-    hash_string_to_word(INPUT_NOTE_LIST_KEY_MESSAGE)
-}
-
-fn output_note_list_key() -> Word {
-    hash_string_to_word(OUTPUT_NOTE_LIST_KEY_MESSAGE)
-}
+pub static OUTPUT_NOTE_LIST_KEY: LazyLock<Word> =
+    LazyLock::new(|| hash_string_to_word("miden::batch_kernel::output_note_list"));
 
 // BATCH KERNEL
 // ================================================================================================
@@ -80,35 +75,33 @@ impl BatchKernel {
         (stack_inputs, advice_inputs)
     }
 
-    /// Rejects a [`ProposedBatch`] the batch kernel cannot yet correctly prove, surfacing a clear
-    /// error early instead of an opaque in-kernel failure. Both cases are temporary limitations:
+    /// Rejects a [`ProposedBatch`] the batch kernel cannot yet correctly prove.
     ///
-    /// - An input note authenticated within the batch (an unauthenticated note converted to
-    ///   authenticated via a supplied inclusion proof). The kernel reconstructs its commitment from
-    ///   the per-transaction `(NULLIFIER, NOTE_ID)` tuples, whereas the batch commits `(NULLIFIER,
-    ///   EMPTY)` for such a note, so the two commitments diverge. Proper support needs in-kernel
-    ///   note authentication (the TODO in `asm/kernels/batch/main.masm`).
-    /// - A pre-erasure note union larger than `MAX_INPUT_NOTES_PER_BATCH` /
-    ///   `MAX_OUTPUT_NOTES_PER_BATCH`. The kernel stores the pre-erasure lists in fixed-size
-    ///   regions, so it rejects such a batch even when it is valid post-erasure. Tracked in
+    /// Two temporary limitations:
+    /// - Authenticated input notes (converted from unauthenticated via inclusion proof). The kernel
+    ///   reconstructs their commitment from per-transaction `(NULLIFIER, NOTE_ID)` tuples, whereas
+    ///   the batch commits `(NULLIFIER, EMPTY)` for such notes, so the two commitments diverge.
+    /// - Pre-erasure note union exceeding `MAX_INPUT_NOTES_PER_BATCH` / `MAX_OUTPUT_NOTES_PER_BATCH`.
+    ///   The kernel stores the pre-erasure lists in fixed-size regions, so it rejects such batches
+    ///   even when valid post-erasure. Tracked in
     ///   <https://github.com/0xMiden/protocol/issues/3184>.
     pub fn ensure_supported(proposed_batch: &ProposedBatch) -> Result<(), ProvenBatchError> {
         // The pre-erasure note unions must fit the kernel's fixed-size note regions.
-        let input_notes: usize = proposed_batch
+        let num_input_notes = proposed_batch
             .transactions()
             .iter()
             .map(|tx| usize::from(tx.input_notes().num_notes()))
             .sum();
-        if input_notes > MAX_INPUT_NOTES_PER_BATCH {
-            return Err(ProvenBatchError::TooManyPreErasureInputNotes(input_notes));
+        if num_input_notes > MAX_INPUT_NOTES_PER_BATCH {
+            return Err(ProvenBatchError::TooManyPreErasureInputNotes(num_input_notes));
         }
-        let output_notes: usize = proposed_batch
+        let num_output_notes = proposed_batch
             .transactions()
             .iter()
             .map(|tx| tx.output_notes().num_notes())
             .sum();
-        if output_notes > MAX_OUTPUT_NOTES_PER_BATCH {
-            return Err(ProvenBatchError::TooManyPreErasureOutputNotes(output_notes));
+        if num_output_notes > MAX_OUTPUT_NOTES_PER_BATCH {
+            return Err(ProvenBatchError::TooManyPreErasureOutputNotes(num_output_notes));
         }
 
         // An input note that some transaction consumed as unauthenticated but which the batch
@@ -118,15 +111,16 @@ impl BatchKernel {
             .transactions()
             .iter()
             .flat_map(|tx| tx.input_notes().iter())
-            .filter(|note| note.header().is_some())
-            .map(|note| note.nullifier())
+            .filter_map(|note| note.header().is_some().then_some(note.nullifier()))
             .collect();
-        for note in proposed_batch.input_notes().iter() {
-            if note.header().is_none() && consumed_unauthenticated.contains(&note.nullifier()) {
-                return Err(ProvenBatchError::UnsupportedInBatchAuthenticatedNote(
-                    note.nullifier(),
-                ));
-            }
+        let unsupported_note = proposed_batch
+            .input_notes()
+            .iter()
+            .filter(|note| note.header().is_none())
+            .find(|note| consumed_unauthenticated.contains(&note.nullifier()));
+
+        if let Some(note) = unsupported_note {
+            return Err(ProvenBatchError::UnsupportedInBatchAuthenticatedNote(note.nullifier()));
         }
 
         Ok(())
@@ -161,14 +155,14 @@ impl BatchKernel {
     /// - `BATCH_ID` -> the `(tx_id, account_id)` tuple list (matching
     ///   `OrderedTransactionHeaders::hash_input_elements`).
     /// - each `tx_id` -> the transaction header felt sequence (matching
-    ///   `TransactionId::input_elements`).
+    ///   [`TransactionCommitments::elements`]).
     /// - each per-tx `INPUT_NOTES_COMMITMENT` -> the `(NULLIFIER, NOTE_ID_OR_EMPTY)` tuples.
     /// - each per-tx `OUTPUT_NOTES_COMMITMENT` -> the `(DETAILS_COMMITMENT, METADATA_COMMITMENT)`
     ///   tuples (the kernel derives each output `NoteId` from these via `poseidon2::merge`).
     ///
     /// It also provides two sorted lists: the pre-erasure union of every transaction's input
-    /// notes, sorted by nullifier (keyed by [`input_note_list_key`]), and of their output notes,
-    /// sorted by note id (keyed by [`output_note_list_key`]). The kernel binds every entry of
+    /// notes, sorted by nullifier (keyed by [`INPUT_NOTE_LIST_KEY`]), and of their output notes,
+    /// sorted by note id (keyed by [`OUTPUT_NOTE_LIST_KEY`]). The kernel binds every entry of
     /// these lists to the per-transaction notes above (so the host cannot inject, omit, or
     /// duplicate notes), derives erasure by cross-referencing the two lists, and hashes the
     /// non-erased input notes in nullifier order to reproduce
@@ -185,24 +179,19 @@ impl BatchKernel {
         // Pre-erasure union of every transaction's notes, collected while walking the per-tx
         // layers and sorted below: input notes by nullifier, output notes by note id, matching
         // `ProposedBatch`.
-        let mut input_list: Vec<(Nullifier, Word)> = Vec::new(); // (nullifier, note_id_or_empty)
-        let mut output_list: Vec<NoteId> = Vec::new();
+        let mut input_list = Vec::new(); // (nullifier, note_id_or_empty)
+        let mut output_list = Vec::new();
 
         for tx in proposed_batch.transactions().iter() {
             // Layer 2: tx_id -> the felt sequence TransactionId::new hashes.
-            let header_data = TransactionId::input_elements(
-                tx.account_update().initial_state_commitment(),
-                tx.account_update().final_state_commitment(),
-                tx.input_notes().commitment(),
-                tx.output_notes().commitment(),
-            );
+            let header_data = TransactionCommitments::from(tx.as_ref()).elements();
             advice_inputs.map.extend([(tx.id().as_word(), header_data.to_vec())]);
 
             // Layer 3a: per-tx INPUT_NOTES_COMMITMENT -> [NULLIFIER, NOTE_ID_OR_EMPTY] tuples.
             // This must reproduce `build_input_note_commitment` exactly.
             let input_notes_commitment = tx.input_notes().commitment();
             if input_notes_commitment != Word::empty() {
-                let mut preimage_data: Vec<Felt> =
+                let mut preimage_data =
                     Vec::with_capacity(usize::from(tx.input_notes().num_notes()) * 8);
                 for note_commit in tx.input_notes().iter() {
                     let nullifier = note_commit.nullifier();
@@ -220,8 +209,7 @@ impl BatchKernel {
             // each output NoteId as `merge(details_commitment, metadata_commitment)`.
             let output_notes_commitment = tx.output_notes().commitment();
             if output_notes_commitment != Word::empty() {
-                let mut preimage_data: Vec<Felt> =
-                    Vec::with_capacity(tx.output_notes().num_notes() * 8);
+                let mut preimage_data = Vec::with_capacity(tx.output_notes().num_notes() * 8);
                 for note in tx.output_notes().iter() {
                     preimage_data
                         .extend_from_slice(note.details_commitment().as_word().as_elements());
@@ -240,35 +228,22 @@ impl BatchKernel {
         output_list.sort_unstable();
 
         // INPUT_NOTE_LIST_KEY -> [NULLIFIER, NOTE_ID_OR_EMPTY] (8 felts per note).
-        let mut input_blob: Vec<Felt> = Vec::with_capacity(input_list.len() * 8);
+        let mut input_blob = Vec::with_capacity(input_list.len() * 8);
         for (nullifier, note_id_or_empty) in &input_list {
             input_blob.extend_from_slice(nullifier.as_word().as_elements());
             input_blob.extend_from_slice(note_id_or_empty.as_elements());
         }
-        advice_inputs.map.extend([(input_note_list_key(), input_blob)]);
+        advice_inputs.map.extend([(*INPUT_NOTE_LIST_KEY, input_blob)]);
 
         // OUTPUT_NOTE_LIST_KEY -> [NOTE_ID, 0, 0, 0, 0] (8 felts per note; the VALUE word
         // is unused, present only so the entries fit `sorted_array`'s KEY+VALUE layout).
-        let mut output_blob: Vec<Felt> = Vec::with_capacity(output_list.len() * 8);
+        let mut output_blob = Vec::with_capacity(output_list.len() * 8);
         for note_id in &output_list {
             output_blob.extend_from_slice(note_id.as_word().as_elements());
             output_blob.extend_from_slice(Word::empty().as_elements());
         }
-        advice_inputs.map.extend([(output_note_list_key(), output_blob)]);
+        advice_inputs.map.extend([(*OUTPUT_NOTE_LIST_KEY, output_blob)]);
 
         advice_inputs
-    }
-}
-
-#[cfg(any(feature = "testing", test))]
-impl BatchKernel {
-    /// The input-note list advice-map key.
-    pub fn input_note_list_key() -> Word {
-        input_note_list_key()
-    }
-
-    /// The output-note list advice-map key.
-    pub fn output_note_list_key() -> Word {
-        output_note_list_key()
     }
 }

--- a/crates/miden-protocol/src/batch/mod.rs
+++ b/crates/miden-protocol/src/batch/mod.rs
@@ -19,7 +19,7 @@ pub use ordered_batches::OrderedBatches;
 pub(super) mod note_tracker;
 
 mod kernel;
-pub use kernel::BatchKernel;
+pub use kernel::{BatchKernel, INPUT_NOTE_LIST_KEY, OUTPUT_NOTE_LIST_KEY};
 
 mod output;
 pub use output::BatchOutputs;

--- a/crates/miden-protocol/src/transaction/executed_tx.rs
+++ b/crates/miden-protocol/src/transaction/executed_tx.rs
@@ -9,6 +9,7 @@ use super::{
     NoteId,
     RawOutputNotes,
     TransactionArgs,
+    TransactionCommitments,
     TransactionId,
     TransactionOutputs,
 };
@@ -64,12 +65,12 @@ impl ExecutedTransaction {
 
         // we create the id from the content, so we cannot construct the
         // `id` value after construction `Self {..}` without moving
-        let id = TransactionId::new(
+        let id = TransactionId::new(TransactionCommitments::new(
             tx_inputs.account().initial_commitment(),
             tx_outputs.account().to_commitment(),
             tx_inputs.input_notes().commitment(),
             tx_outputs.output_notes().commitment(),
-        );
+        ));
 
         Self {
             id,

--- a/crates/miden-protocol/src/transaction/mod.rs
+++ b/crates/miden-protocol/src/transaction/mod.rs
@@ -36,7 +36,7 @@ pub use outputs::{
 pub use partial_blockchain::PartialBlockchain;
 pub use proven_tx::{InputNoteCommitment, ProvenTransaction, TxAccountUpdate};
 pub use script::{TRANSACTION_SCRIPT_ATTRIBUTE, TransactionScript, TransactionScriptRoot};
-pub use transaction_id::TransactionId;
+pub use transaction_id::{TransactionCommitments, TransactionId};
 pub use tx_args::TransactionArgs;
 pub use tx_header::TransactionHeader;
 pub use tx_summary::{TransactionSummary, TransactionSummaryUserParams};

--- a/crates/miden-protocol/src/transaction/proven_tx.rs
+++ b/crates/miden-protocol/src/transaction/proven_tx.rs
@@ -12,6 +12,7 @@ use crate::transaction::{
     Nullifier,
     OutputNote,
     OutputNotes,
+    TransactionCommitments,
     TransactionId,
 };
 use crate::utils::serde::{
@@ -217,12 +218,12 @@ impl ProvenTransaction {
             }
         }
 
-        let id = TransactionId::new(
+        let id = TransactionId::new(TransactionCommitments::new(
             account_update.initial_state_commitment(),
             account_update.final_state_commitment(),
             input_notes.commitment(),
             output_notes.commitment(),
-        );
+        ));
 
         Ok(Self {
             id,

--- a/crates/miden-protocol/src/transaction/transaction_id.rs
+++ b/crates/miden-protocol/src/transaction/transaction_id.rs
@@ -2,7 +2,7 @@ use core::fmt::{Debug, Display};
 
 use miden_crypto_derive::WordWrapper;
 
-use super::{Felt, Hasher, ProvenTransaction, WORD_SIZE, Word, ZERO};
+use super::{ExecutedTransaction, Felt, Hasher, ProvenTransaction, WORD_SIZE, Word, ZERO};
 use crate::utils::serde::{
     ByteReader,
     ByteWriter,
@@ -10,6 +10,96 @@ use crate::utils::serde::{
     DeserializationError,
     Serializable,
 };
+
+// TRANSACTION COMMITMENTS
+// ================================================================================================
+
+/// The four commitments that make up the preimage of the corresponding [`TransactionId`].
+#[derive(Clone, Copy)]
+pub struct TransactionCommitments {
+    init_account_commitment: Word,
+    final_account_commitment: Word,
+    input_notes_commitment: Word,
+    output_notes_commitment: Word,
+}
+
+impl TransactionCommitments {
+    /// Length of the felt sequence returned by [`Self::elements`].
+    pub const ELEMENTS_LEN: usize = 4 * WORD_SIZE;
+
+    /// Returns a new [`TransactionCommitments`] from the four commitment words.
+    pub fn new(
+        init_account_commitment: Word,
+        final_account_commitment: Word,
+        input_notes_commitment: Word,
+        output_notes_commitment: Word,
+    ) -> Self {
+        Self {
+            init_account_commitment,
+            final_account_commitment,
+            input_notes_commitment,
+            output_notes_commitment,
+        }
+    }
+
+    /// Returns the transaction commitments as a felt sequence.
+    ///
+    /// The layout is:
+    ///   `[INIT[4], FINAL[4], INPUT_NOTES_COMMITMENT[4], OUTPUT_NOTES_COMMITMENT[4]]`
+    ///
+    /// The batch kernel pipes this same felt sequence from the advice provider to memory and
+    /// asserts the resulting hash matches a previously-verified `tx_id`.
+    pub fn elements(&self) -> [Felt; Self::ELEMENTS_LEN] {
+        let mut elements = [ZERO; Self::ELEMENTS_LEN];
+        elements[..4].copy_from_slice(self.init_account_commitment.as_elements());
+        elements[4..8].copy_from_slice(self.final_account_commitment.as_elements());
+        elements[8..12].copy_from_slice(self.input_notes_commitment.as_elements());
+        elements[12..16].copy_from_slice(self.output_notes_commitment.as_elements());
+        elements
+    }
+
+    /// Returns the initial account commitment.
+    pub fn init_account_commitment(&self) -> Word {
+        self.init_account_commitment
+    }
+
+    /// Returns the final account commitment.
+    pub fn final_account_commitment(&self) -> Word {
+        self.final_account_commitment
+    }
+
+    /// Returns the input notes commitment.
+    pub fn input_notes_commitment(&self) -> Word {
+        self.input_notes_commitment
+    }
+
+    /// Returns the output notes commitment.
+    pub fn output_notes_commitment(&self) -> Word {
+        self.output_notes_commitment
+    }
+}
+
+impl From<&ProvenTransaction> for TransactionCommitments {
+    fn from(tx: &ProvenTransaction) -> Self {
+        Self {
+            init_account_commitment: tx.account_update().initial_state_commitment(),
+            final_account_commitment: tx.account_update().final_state_commitment(),
+            input_notes_commitment: tx.input_notes().commitment(),
+            output_notes_commitment: tx.output_notes().commitment(),
+        }
+    }
+}
+
+impl From<&ExecutedTransaction> for TransactionCommitments {
+    fn from(tx: &ExecutedTransaction) -> Self {
+        Self {
+            init_account_commitment: tx.initial_account().initial_commitment(),
+            final_account_commitment: tx.final_account().to_commitment(),
+            input_notes_commitment: tx.input_notes().commitment(),
+            output_notes_commitment: tx.output_notes().commitment(),
+        }
+    }
+}
 
 // TRANSACTION ID
 // ================================================================================================
@@ -23,7 +113,6 @@ use crate::utils::serde::{
 ///     FINAL_ACCOUNT_COMMITMENT,
 ///     INPUT_NOTES_COMMITMENT,
 ///     OUTPUT_NOTES_COMMITMENT,
-///     FEE_ASSET,
 /// )
 ///
 /// This achieves the following properties:
@@ -33,43 +122,9 @@ use crate::utils::serde::{
 pub struct TransactionId(Word);
 
 impl TransactionId {
-    /// Length of the felt sequence hashed by [`Self::new`] / [`Self::input_elements`].
-    pub(crate) const INPUT_ELEMENTS_LEN: usize = 4 * WORD_SIZE;
-
-    /// Returns a new [TransactionId] instantiated from the provided transaction components.
-    pub fn new(
-        init_account_commitment: Word,
-        final_account_commitment: Word,
-        input_notes_commitment: Word,
-        output_notes_commitment: Word,
-    ) -> Self {
-        Self(Hasher::hash_elements(&Self::input_elements(
-            init_account_commitment,
-            final_account_commitment,
-            input_notes_commitment,
-            output_notes_commitment,
-        )))
-    }
-
-    /// Returns the felt sequence that [`Self::new`] hashes to produce a [`TransactionId`].
-    ///
-    /// The layout is:
-    ///   `[INIT[4], FINAL[4], INPUT_NOTES_COMMITMENT[4], OUTPUT_NOTES_COMMITMENT[4]]`
-    ///
-    /// The batch kernel pipes this same felt sequence from the advice provider to memory and
-    /// asserts the resulting hash matches a previously-verified `tx_id`.
-    pub(crate) fn input_elements(
-        init_account_commitment: Word,
-        final_account_commitment: Word,
-        input_notes_commitment: Word,
-        output_notes_commitment: Word,
-    ) -> [Felt; Self::INPUT_ELEMENTS_LEN] {
-        let mut elements = [ZERO; Self::INPUT_ELEMENTS_LEN];
-        elements[..4].copy_from_slice(init_account_commitment.as_elements());
-        elements[4..8].copy_from_slice(final_account_commitment.as_elements());
-        elements[8..12].copy_from_slice(input_notes_commitment.as_elements());
-        elements[12..16].copy_from_slice(output_notes_commitment.as_elements());
-        elements
+    /// Returns a new [TransactionId] from the given [`TransactionCommitments`].
+    pub fn new(commitments: TransactionCommitments) -> Self {
+        Self(Hasher::hash_elements(&commitments.elements()))
     }
 }
 
@@ -90,12 +145,7 @@ impl Display for TransactionId {
 
 impl From<&ProvenTransaction> for TransactionId {
     fn from(tx: &ProvenTransaction) -> Self {
-        Self::new(
-            tx.account_update().initial_state_commitment(),
-            tx.account_update().final_state_commitment(),
-            tx.input_notes().commitment(),
-            tx.output_notes().commitment(),
-        )
+        Self::new(TransactionCommitments::from(tx))
     }
 }
 

--- a/crates/miden-protocol/src/transaction/tx_header.rs
+++ b/crates/miden-protocol/src/transaction/tx_header.rs
@@ -9,6 +9,7 @@ use crate::transaction::{
     InputNotes,
     ProvenTransaction,
     RawOutputNotes,
+    TransactionCommitments,
     TransactionId,
 };
 use crate::utils::serde::{
@@ -60,12 +61,12 @@ impl TransactionHeader {
         let input_notes_commitment = input_notes.commitment();
         let output_notes_commitment = RawOutputNotes::compute_commitment(output_notes.iter());
 
-        let id = TransactionId::new(
+        let id = TransactionId::new(TransactionCommitments::new(
             initial_state_commitment,
             final_state_commitment,
             input_notes_commitment,
             output_notes_commitment,
-        );
+        ));
 
         Self {
             id,

--- a/crates/miden-testing/src/kernel_tests/batch/test_batch_kernel.rs
+++ b/crates/miden-testing/src/kernel_tests/batch/test_batch_kernel.rs
@@ -3,7 +3,12 @@ use alloc::vec::Vec;
 use std::collections::BTreeMap;
 
 use anyhow::Context;
-use miden_protocol::batch::{BatchKernel, ProposedBatch};
+use miden_protocol::batch::{
+    BatchKernel,
+    INPUT_NOTE_LIST_KEY,
+    OUTPUT_NOTE_LIST_KEY,
+    ProposedBatch,
+};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::errors::{MasmError, ProvenBatchError, batch_kernel};
 use miden_protocol::transaction::RawOutputNote;
@@ -251,8 +256,7 @@ fn batch_kernel_rejects_input_note_missing_from_list() -> anyhow::Result<()> {
 
     let mut blob = input_note_list_blob(&batch);
     blob.truncate(blob.len() - FELTS_PER_NOTE_ENTRY); // drop the last (highest-nullifier) note
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::input_note_list_key(), blob)]);
+    let override_advice = AdviceInputs::default().with_map([(*INPUT_NOTE_LIST_KEY, blob)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_INPUT_NOTE_NOT_IN_LIST);
@@ -270,8 +274,7 @@ fn batch_kernel_rejects_duplicated_input_note_list_entry() -> anyhow::Result<()>
     // Prepend a copy of the first entry, so two equal nullifiers are adjacent.
     let mut duplicated: Vec<Felt> = blob[0..FELTS_PER_NOTE_ENTRY].to_vec();
     duplicated.extend_from_slice(&blob);
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::input_note_list_key(), duplicated)]);
+    let override_advice = AdviceInputs::default().with_map([(*INPUT_NOTE_LIST_KEY, duplicated)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_NOTE_LIST_NOT_SORTED);
@@ -289,8 +292,7 @@ fn batch_kernel_rejects_input_note_list_id_mismatch() -> anyhow::Result<()> {
     let mut blob = input_note_list_blob(&batch);
     // Corrupt the first entry's note-id word only, so the entry is still found by nullifier.
     blob[4] += Felt::from(1u32);
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::input_note_list_key(), blob)]);
+    let override_advice = AdviceInputs::default().with_map([(*INPUT_NOTE_LIST_KEY, blob)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_INPUT_NOTE_ID_MISMATCH);
@@ -324,8 +326,7 @@ fn batch_kernel_rejects_output_note_missing_from_list() -> anyhow::Result<()> {
 
     let mut blob = output_note_list_blob(&batch);
     blob.truncate(blob.len() - FELTS_PER_NOTE_ENTRY); // drop the last (highest-note-id) output note
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::output_note_list_key(), blob)]);
+    let override_advice = AdviceInputs::default().with_map([(*OUTPUT_NOTE_LIST_KEY, blob)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_OUTPUT_NOTE_NOT_IN_LIST);
@@ -355,8 +356,7 @@ fn batch_kernel_rejects_consume_before_create() -> anyhow::Result<()> {
         blob.extend_from_slice(note_id.as_elements());
         blob.extend_from_slice(Word::empty().as_elements());
     }
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::output_note_list_key(), blob)]);
+    let override_advice = AdviceInputs::default().with_map([(*OUTPUT_NOTE_LIST_KEY, blob)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_NOTE_CONSUMED_BEFORE_CREATED);
@@ -388,8 +388,7 @@ fn batch_kernel_rejects_unconsumed_input_note() -> anyhow::Result<()> {
         blob.extend_from_slice(nullifier.as_elements());
         blob.extend_from_slice(note_id_or_empty.as_elements());
     }
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::input_note_list_key(), blob)]);
+    let override_advice = AdviceInputs::default().with_map([(*INPUT_NOTE_LIST_KEY, blob)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_INPUT_NOTE_NOT_CONSUMED);
@@ -418,8 +417,7 @@ fn batch_kernel_rejects_uncreated_output_note() -> anyhow::Result<()> {
         blob.extend_from_slice(note_id.as_elements());
         blob.extend_from_slice(Word::empty().as_elements());
     }
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::output_note_list_key(), blob)]);
+    let override_advice = AdviceInputs::default().with_map([(*OUTPUT_NOTE_LIST_KEY, blob)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_OUTPUT_NOTE_NOT_CREATED);
@@ -435,8 +433,7 @@ fn batch_kernel_rejects_oversized_input_note_list() -> anyhow::Result<()> {
     let batch = two_tx_batch(&mut setup)?;
 
     let blob = vec![Felt::from(0u32); (MAX_INPUT_NOTES_PER_BATCH + 1) * FELTS_PER_NOTE_ENTRY];
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::input_note_list_key(), blob)]);
+    let override_advice = AdviceInputs::default().with_map([(*INPUT_NOTE_LIST_KEY, blob)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_NOTE_LIST_TOO_LONG);
@@ -451,8 +448,7 @@ fn batch_kernel_rejects_oversized_output_note_list() -> anyhow::Result<()> {
     let batch = two_tx_batch(&mut setup)?;
 
     let blob = vec![Felt::from(0u32); (MAX_OUTPUT_NOTES_PER_BATCH + 1) * FELTS_PER_NOTE_ENTRY];
-    let override_advice =
-        AdviceInputs::default().with_map([(BatchKernel::output_note_list_key(), blob)]);
+    let override_advice = AdviceInputs::default().with_map([(*OUTPUT_NOTE_LIST_KEY, blob)]);
 
     let result = BatchExecutor::new().execute(batch, override_advice);
     assert_kernel_error(result, batch_kernel::ERR_BATCH_NOTE_LIST_TOO_LONG);


### PR DESCRIPTION
Should be merged on top of #2905.

Addresses most review comments left in https://github.com/0xMiden/protocol/pull/2905#pullrequestreview-4904378531:

- Extracted loop body into `process_input_entry` MASM helper
- Introduced `TransactionCommitments` newtype, simplified `TransactionId::new` to take it
- Replaced key functions with `pub static LazyLock<Word>` constants
- Rewrote `ensure_supported` doc comment and renamed local variables for clarity
- Collapsed `filter`+`map` into `filter_map`; refactored authenticated-note check into `.filter().find()`
- Added MASM stack traces to `assert_all_output_notes_created`
- Removed redundant type annotations on `Vec` locals