### PR TITLE
fix(protocol): enforce asset delta limits consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fixed `PrivateOutputNote` construction and deserialization accepting attachment data that is not committed by the note header ([#3556](https://github.com/0xMiden/protocol/issues/3556)).
 - Fixed the authentication procedure not ending up at index 0 of an account's code when its MAST root was already exported by another component ([#3566](https://github.com/0xMiden/protocol/pull/3566)).
 - [BREAKING] Foreign procedure invocation now requires the provided procedure root to be part of the foreign account's code, so a caller can no longer execute arbitrary code under a foreign account's identity ([#3575](https://github.com/0xMiden/protocol/pull/3575)).
+- Enforced the 1024-asset operation limit consistently for added and removed account vault deltas, including deserialization boundaries ([#3595](https://github.com/0xMiden/protocol/issues/3595)).
 
 ## v0.16.0 (2026-08-06)
 
@@ -491,7 +492,7 @@ Added a new `INPUT_NOTE_INDEX_LOOKUP_EVENT` that lets transaction hosts provide 
 
 ### Changes
 
-- [BREAKING] Renamed `NoteInputs` to `NoteStorage` to better reflect that values are stored data associated with a note rather than inputs ([#1662](https://github.com/0xMiden/miden-base/issues/1662), [#2316](https://github.com/0xMiden/miden-base/issues/2316)).
+- [BREAKING] Renamed `NoteInputs` to `NoteStorage` to better reflect that values are stored data associated with a note rather than inputs ([#1662](https://github.com/0xMiden/miden-base/issues/1662), [#2316](https://github.com/0xMiden/miden-base/pull/2316)).
 - Introduced NOTE_MAX_SIZE (256 KiB) and enforce it on individual output notes ([#2205](https://github.com/0xMiden/miden-base/pull/2205), [#2651](https://github.com/0xMiden/miden-base/pull/2651)).
 - Restructured `miden-agglayer/asm` directory to separate bridge and faucet into per-component libraries, preventing cross-component procedure exposure ([#2294](https://github.com/0xMiden/miden-base/issues/2294)).
 - Skip requests to the `DataStore` for asset vault witnesses which are already in transaction inputs ([#2298](https://github.com/0xMiden/miden-base/pull/2298)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,7 +456,7 @@ Added a new `INPUT_NOTE_INDEX_LOOKUP_EVENT` that lets transaction hosts provide 
 - Added `Ownable2Step` account component with two-step ownership transfer (`transfer_ownership`, `accept_ownership`, `renounce_ownership`) and `owner`, `nominated_owner` procedures ([#2292](https://github.com/0xMiden/miden-base/pull/2292)).
 - Added double-word array data structure abstraction over storage maps ([#2299](https://github.com/0xMiden/miden-base/pull/2299)).
 - Added `BlockNumber::MAX` constant to represent the maximum block number ([#2324](https://github.com/0xMiden/miden-base/pull/2324)).
-- Introduced `TokenMetadata` type to encapsulate fungible faucet metadata ([#2344](https://github.com/0xMiden/protocol/issues/2344)).
+- Introduced `TokenMetadata` type to encapsulate fungible faucet metadata ([#2344](https://github.com/0xMiden/miden-base/issues/2344)).
 - Added `PackageKind` and `ProcedureExport` ([#2358](https://github.com/0xMiden/miden-base/pull/2358)).
 - Added `AccountTargetNetworkNote` type and `NetworkNoteExt` trait with `is_network_note()` / `as_account_target_network_note()` helpers ([#2365](https://github.com/0xMiden/miden-base/pull/2365)).
 - [BREAKING] Added `get_asset` and `get_initial_asset` kernel procedures and removed `get_balance`, `get_initial_balance` and `has_non_fungible_asset` kernel procedures ([#2369](https://github.com/0xMiden/miden-base/pull/2369)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,7 +456,7 @@ Added a new `INPUT_NOTE_INDEX_LOOKUP_EVENT` that lets transaction hosts provide 
 - Added `Ownable2Step` account component with two-step ownership transfer (`transfer_ownership`, `accept_ownership`, `renounce_ownership`) and `owner`, `nominated_owner` procedures ([#2292](https://github.com/0xMiden/miden-base/pull/2292)).
 - Added double-word array data structure abstraction over storage maps ([#2299](https://github.com/0xMiden/miden-base/pull/2299)).
 - Added `BlockNumber::MAX` constant to represent the maximum block number ([#2324](https://github.com/0xMiden/miden-base/pull/2324)).
-- Introduced `TokenMetadata` type to encapsulate fungible faucet metadata ([#2344](https://github.com/0xMiden/miden-base/issues/2344)).
+- Introduced `TokenMetadata` type to encapsulate fungible faucet metadata ([#2344](https://github.com/0xMiden/protocol/issues/2344)).
 - Added `PackageKind` and `ProcedureExport` ([#2358](https://github.com/0xMiden/miden-base/pull/2358)).
 - Added `AccountTargetNetworkNote` type and `NetworkNoteExt` trait with `is_network_note()` / `as_account_target_network_note()` helpers ([#2365](https://github.com/0xMiden/miden-base/pull/2365)).
 - [BREAKING] Added `get_asset` and `get_initial_asset` kernel procedures and removed `get_balance`, `get_initial_balance` and `has_non_fungible_asset` kernel procedures ([#2369](https://github.com/0xMiden/miden-base/pull/2369)).
@@ -492,7 +492,7 @@ Added a new `INPUT_NOTE_INDEX_LOOKUP_EVENT` that lets transaction hosts provide 
 
 ### Changes
 
-- [BREAKING] Renamed `NoteInputs` to `NoteStorage` to better reflect that values are stored data associated with a note rather than inputs ([#1662](https://github.com/0xMiden/miden-base/issues/1662), [#2316](https://github.com/0xMiden/miden-base/pull/2316)).
+- [BREAKING] Renamed `NoteInputs` to `NoteStorage` to better reflect that values are stored data associated with a note rather than inputs ([#1662](https://github.com/0xMiden/miden-base/issues/1662), [#2316](https://github.com/0xMiden/miden-base/issues/2316)).
 - Introduced NOTE_MAX_SIZE (256 KiB) and enforce it on individual output notes ([#2205](https://github.com/0xMiden/miden-base/pull/2205), [#2651](https://github.com/0xMiden/miden-base/pull/2651)).
 - Restructured `miden-agglayer/asm` directory to separate bridge and faucet into per-component libraries, preventing cross-component procedure exposure ([#2294](https://github.com/0xMiden/miden-base/issues/2294)).
 - Skip requests to the `DataStore` for asset vault witnesses which are already in transaction inputs ([#2298](https://github.com/0xMiden/miden-base/pull/2298)).

--- a/changelog/3621.md
+++ b/changelog/3621.md
@@ -1,0 +1,1 @@
+- Enforced the 1024-asset operation limit consistently for added and removed account vault deltas, including deserialization boundaries ([#3621](https://github.com/0xMiden/protocol/pull/3621)).

--- a/changelog/3621.md
+++ b/changelog/3621.md
@@ -1,1 +1,0 @@
-- Enforced the 1024-asset operation limit consistently for added and removed account vault deltas, including deserialization boundaries ([#3621](https://github.com/0xMiden/protocol/pull/3621)).

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
@@ -17,6 +17,9 @@ const ERR_ACCOUNT_DELTA_NONCE_MUST_BE_INCREMENTED_IF_VAULT_OR_STORAGE_CHANGED =
 const ERR_ACCOUNT_PATCH_NONCE_MUST_BE_INCREMENTED_IF_VAULT_OR_STORAGE_CHANGED =
     "final nonce in patch must have been incremented if account vault or account storage changed"
 
+const ERR_ACCOUNT_DELTA_TOO_MANY_ADDED_ASSETS =
+    "number of added assets in the transaction exceeds the maximum limit of 1024"
+
 const ERR_ACCOUNT_DELTA_TOO_MANY_REMOVED_ASSETS =
     "number of removed assets in the transaction exceeds the maximum limit of 1024"
 
@@ -93,7 +96,7 @@ const COMMIT_ASSET_PATCH_NUM_CHANGED_LOC = 2
 #!
 #! This limit is arbitrary and can be increased accordingly with the number of locals of
 #! commit_asset_delta.
-const COMMIT_ASSET_DELTA_MAX_REMOVED_ASSETS = 1024
+const COMMIT_ASSET_DELTA_MAX_ASSETS_PER_OPERATION = 1024
 
 # PROCEDURES
 # =================================================================================================
@@ -476,7 +479,7 @@ end
 #! - 1: iter
 #! - 2: num_added_assets
 #! - 3: num_removed_assets
-#! - 4..8196: removed_assets (COMMIT_ASSET_DELTA_MAX_REMOVED_ASSETS * ASSET_SIZE elements)
+#! - 4..8196: removed_assets (COMMIT_ASSET_DELTA_MAX_ASSETS_PER_OPERATION * ASSET_SIZE elements)
 @locals(8196)
 proc commit_asset_delta
     # initialize num_added_assets = 0 and num_removed_assets = 0
@@ -526,8 +529,11 @@ proc commit_asset_delta
             # => [is_addition, ASSET_ID, DELTA_ASSET_VALUE, RATE0, RATE1, CAPACITY]
 
             if.true
-                # increment num_added_assets
                 loc_load.COMMIT_ASSET_DELTA_NUM_ADDED_LOC
+                dup neq.COMMIT_ASSET_DELTA_MAX_ASSETS_PER_OPERATION
+                assert.err=ERR_ACCOUNT_DELTA_TOO_MANY_ADDED_ASSETS
+
+                # increment num_added_assets
                 add.1
                 loc_store.COMMIT_ASSET_DELTA_NUM_ADDED_LOC
                 # => [ASSET_ID, DELTA_ASSET_VALUE, RATE0, RATE1, CAPACITY]
@@ -543,7 +549,7 @@ proc commit_asset_delta
                 # => [num_removed_assets, ASSET_ID, DELTA_ASSET_VALUE, RATE0, RATE1, CAPACITY]
 
                 # make sure we do not write outside the assigned number of locals
-                dup neq.COMMIT_ASSET_DELTA_MAX_REMOVED_ASSETS
+                dup neq.COMMIT_ASSET_DELTA_MAX_ASSETS_PER_OPERATION
                 assert.err=ERR_ACCOUNT_DELTA_TOO_MANY_REMOVED_ASSETS
                 # => [num_removed_assets, ASSET_ID, DELTA_ASSET_VALUE, RATE0, RATE1, CAPACITY]
 

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -102,8 +102,10 @@ impl AccountVaultDelta {
             }
         }
 
-        let num_added_assets =
-            delta.values().filter(|asset| asset.delta_op() == AssetDeltaOperation::Add).count();
+        let num_added_assets = delta
+            .values()
+            .filter(|asset| asset.delta_op() == AssetDeltaOperation::Add)
+            .count();
         if num_added_assets > Self::MAX_ASSETS_PER_OPERATION {
             return Err(AccountDeltaError::TooManyVaultAssetDeltas {
                 operation: "added",
@@ -112,8 +114,10 @@ impl AccountVaultDelta {
             });
         }
 
-        let num_removed_assets =
-            delta.values().filter(|asset| asset.delta_op() == AssetDeltaOperation::Remove).count();
+        let num_removed_assets = delta
+            .values()
+            .filter(|asset| asset.delta_op() == AssetDeltaOperation::Remove)
+            .count();
         if num_removed_assets > Self::MAX_ASSETS_PER_OPERATION {
             return Err(AccountDeltaError::TooManyVaultAssetDeltas {
                 operation: "removed",

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -79,6 +79,9 @@ impl AccountVaultDelta {
     /// Domain separator for assets in the account delta commitment.
     pub(in crate::account) const DOMAIN: Felt = Felt::new_unchecked(3);
 
+    /// Maximum number of added or removed assets representable by the transaction kernel.
+    pub const MAX_ASSETS_PER_OPERATION: usize = 1024;
+
     /// Validates and creates an [`AccountVaultDelta`] from the given asset deltas.
     ///
     /// # Errors
@@ -91,15 +94,34 @@ impl AccountVaultDelta {
 
         for asset_delta in asset_deltas {
             match delta.entry(asset_delta.asset_id()) {
-                Entry::Vacant(entry) => {
+                alloc::collections::btree_map::Entry::Vacant(entry) => {
                     entry.insert(asset_delta);
                 },
-                Entry::Occupied(entry) => {
-                    return Err(AccountDeltaError::DuplicateAssetDelta(*entry.key()));
+                alloc::collections::btree_map::Entry::Occupied(_) => {
+                    return Err(AccountDeltaError::DuplicateAssetDelta(asset_delta.asset_id()));
                 },
             }
         }
 
+        let num_added_assets =
+            delta.values().filter(|asset| asset.delta_op() == AssetDeltaOperation::Add).count();
+        if num_added_assets > Self::MAX_ASSETS_PER_OPERATION {
+            return Err(AccountDeltaError::TooManyVaultAssetDeltas {
+                operation: "added",
+                count: num_added_assets,
+                max: Self::MAX_ASSETS_PER_OPERATION,
+            });
+        }
+
+        let num_removed_assets =
+            delta.values().filter(|asset| asset.delta_op() == AssetDeltaOperation::Remove).count();
+        if num_removed_assets > Self::MAX_ASSETS_PER_OPERATION {
+            return Err(AccountDeltaError::TooManyVaultAssetDeltas {
+                operation: "removed",
+                count: num_removed_assets,
+                max: Self::MAX_ASSETS_PER_OPERATION,
+            });
+        }
         Ok(Self { delta })
     }
 
@@ -198,6 +220,16 @@ impl Serializable for AccountVaultDelta {
 impl Deserializable for AccountVaultDelta {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let num_added_assets = source.read_usize()?;
+        if num_added_assets > Self::MAX_ASSETS_PER_OPERATION {
+            return Err(DeserializationError::InvalidValue(
+                AccountDeltaError::TooManyVaultAssetDeltas {
+                    operation: "added",
+                    count: num_added_assets,
+                    max: Self::MAX_ASSETS_PER_OPERATION,
+                }
+                .to_string(),
+            ));
+        }
         // The capacity is not reserved upfront since the number of assets is not yet validated
         // against the remaining bytes at this point.
         let mut asset_deltas = Vec::new();
@@ -206,6 +238,16 @@ impl Deserializable for AccountVaultDelta {
         }
 
         let num_removed_assets = source.read_usize()?;
+        if num_removed_assets > Self::MAX_ASSETS_PER_OPERATION {
+            return Err(DeserializationError::InvalidValue(
+                AccountDeltaError::TooManyVaultAssetDeltas {
+                    operation: "removed",
+                    count: num_removed_assets,
+                    max: Self::MAX_ASSETS_PER_OPERATION,
+                }
+                .to_string(),
+            ));
+        }
         for asset in source.read_many_iter::<Asset>(num_removed_assets)? {
             asset_deltas.push(AssetDelta::new(AssetDeltaOperation::Remove, asset?));
         }
@@ -250,6 +292,41 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn account_vault_delta_deserialization_rejects_too_many_added_assets() {
+        let mut bytes = Vec::new();
+        bytes.write_usize(AccountVaultDelta::MAX_ASSETS_PER_OPERATION + 1);
+
+        let error = AccountVaultDelta::read_from_bytes(&bytes)
+            .expect_err("delta with too many added assets should not deserialize");
+
+        let expected = AccountDeltaError::TooManyVaultAssetDeltas {
+            operation: "added",
+            count: AccountVaultDelta::MAX_ASSETS_PER_OPERATION + 1,
+            max: AccountVaultDelta::MAX_ASSETS_PER_OPERATION,
+        }
+        .to_string();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) if message == expected);
+    }
+    #[test]
+    fn account_vault_delta_deserialization_rejects_too_many_removed_assets() {
+        let mut bytes = Vec::new();
+        bytes.write_usize(0);
+        bytes.write_usize(AccountVaultDelta::MAX_ASSETS_PER_OPERATION + 1);
+
+        let error = AccountVaultDelta::read_from_bytes(&bytes)
+            .expect_err("delta with too many removed assets should not deserialize");
+
+        let expected = AccountDeltaError::TooManyVaultAssetDeltas {
+            operation: "removed",
+            count: AccountVaultDelta::MAX_ASSETS_PER_OPERATION + 1,
+            max: AccountVaultDelta::MAX_ASSETS_PER_OPERATION,
+        }
+        .to_string();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) if message == expected);
+    }
     /// A crafted byte stream that changes the same asset in both the added and the removed section
     /// must be rejected rather than silently collapsing into a single entry.
     #[test]

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -1,5 +1,4 @@
 use alloc::collections::BTreeMap;
-use alloc::collections::btree_map::Entry;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 

--- a/crates/miden-protocol/src/errors/mod.rs
+++ b/crates/miden-protocol/src/errors/mod.rs
@@ -425,6 +425,14 @@ pub enum AccountDeltaError {
     #[error("asset {0} is changed by more than one asset delta")]
     DuplicateAssetDelta(AssetId),
     #[error(
+        "number of {operation} assets in account vault delta is {count} but max possible number is {max}"
+    )]
+    TooManyVaultAssetDeltas {
+        operation: &'static str,
+        count: usize,
+        max: usize,
+    },
+    #[error(
         "account update of type `{left_update_type}` cannot be merged with account update of type `{right_update_type}`"
     )]
     IncompatibleAccountUpdates {


### PR DESCRIPTION
## Summary
- mirror the transaction-kernel asset-delta limit in `AccountVaultDelta` for both added and removed assets
- reject over-limit counts at deserialization boundaries before reading asset payloads
- enforce the same 1024-item cap for added assets in the transaction kernel, while preserving the existing removed-assets bound
- add regression coverage for over-limit added/removed deserialization counts
- add the corresponding changelog entry under v0.17.0 fixes

Closes #3595

## Validation
- the previous CI run showed build and test passing
- the rustfmt-only lint failure was fixed
- the changelog now updates `CHANGELOG.md` directly
- final diff was rechecked to keep the changelog change scoped to a single new entry

Replaces closed PR #3621 with the corrected branch state.