### PR TITLE
chore: remove stale doc references, rename procedure

### DIFF
--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -791,7 +791,7 @@ end
 #! - the procedure root is not part of the account code.
 pub proc authenticate_procedure
     # verify that the procedure is part of the account code and get its index
-    exec.assert_procedure_in_account
+    exec.assert_procedure_in_active_account
     # => [proc_idx]
 
     # the call is tracked only if the active account is the native account and the epilogue is not
@@ -812,8 +812,8 @@ pub proc authenticate_procedure
     end
 end
 
-#! Verifies that the procedure root is part of the account code and returns its index, WITHOUT
-#! tracking the call.
+#! Verifies that the procedure root is part of the active account's code and returns its index,
+#! WITHOUT tracking the call.
 #!
 #! Inputs:  [PROC_ROOT]
 #! Outputs: [proc_idx]
@@ -823,8 +823,8 @@ end
 #! - proc_idx is the index of the requested account procedure.
 #!
 #! Panics if:
-#! - the procedure root is not part of the account code.
-pub proc assert_procedure_in_account
+#! - the procedure root is not part of the active account's code.
+pub proc assert_procedure_in_active_account
     # load procedure index
     emit.ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT adv_push
     # => [proc_idx, PROC_ROOT]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
@@ -1137,8 +1137,7 @@ end
 #!   Advice map: {
 #!      PARTIAL_BLOCKCHAIN_COMMITMENT: [MMR_PEAKS],
 #!      INPUT_NOTES_COMMITMENT: [NOTE_DATA],
-#!      TX_KERNEL_COMMITMENT: [KERNEL_COMMITMENTS],
-#!      KERNEL_COMMITMENT: [KERNEL_PROCEDURE_ROOTS],
+#!      TX_KERNEL_COMMITMENT: [KERNEL_PROCEDURE_ROOTS],
 #!      ACCOUNT_CODE_COMMITMENT: [ACCOUNT_PROCEDURE_DATA],
 #!      ACCOUNT_STORAGE_COMMITMENT: [ACCOUNT_STORAGE_SLOT_DATA],
 #!   }
@@ -1153,7 +1152,7 @@ end
 #! - INITIAL_ACCOUNT_COMMITMENT is the account state prior to the transaction, EMPTY_WORD for new
 #!   accounts.
 #! - INPUT_NOTES_COMMITMENT, see `transaction::api::get_input_notes_commitment`.
-#! - TX_KERNEL_COMMITMENT is the sequential hash from all kernel commitments.
+#! - TX_KERNEL_COMMITMENT is the sequential hash of the kernel procedures.
 #! - PREV_BLOCK_COMMITMENT is the commitment to the previous block.
 #! - PARTIAL_BLOCKCHAIN_COMMITMENT is the sequential hash of the reference MMR.
 #! - ACCOUNT_ROOT is the root of the tree with latest account states for all accounts.

--- a/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
@@ -1992,7 +1992,7 @@ pub proc tx_exec_foreign_proc
     # part of the foreign account's code. This is NOT the same as the account procedure
     # authentication the kernel already does. Without this, the called procedure could dyncall into
     # a genuine procedure of the account and it would pass.
-    exec.account::assert_procedure_in_account drop
+    exec.account::assert_procedure_in_active_account drop
     # => [foreign_procedure_inputs(16)]
 
     # get the pointer to the foreign procedure root to perform the dyncall

--- a/crates/miden-protocol/src/block/header.rs
+++ b/crates/miden-protocol/src/block/header.rs
@@ -28,7 +28,7 @@ use crate::{Felt, Hasher, Word, ZERO};
 /// - `note_root` is a commitment to all notes created in the current block.
 /// - `tx_commitment` is a commitment to the set of transaction IDs which affected accounts in the
 ///   block.
-/// - `tx_kernel_commitment` a commitment to all transaction kernels supported by this block.
+/// - `tx_kernel_commitment` is the sequential hash of the kernel procedures.
 /// - `validator_keys` is the set of validator public keys authorized to sign the *next* block.
 /// - `fee_parameters` are the parameters defining the base fees and the fee faucet ID, see
 ///   [`FeeParameters`] for more details.

--- a/crates/miden-protocol/src/note/metadata.rs
+++ b/crates/miden-protocol/src/note/metadata.rs
@@ -147,7 +147,7 @@ impl Deserializable for PartialNoteMetadata {
 /// - 3rd felt: Max value is `0xFFFEFFFE_FFFEFFFE` (schemes capped at 65534), which is less than
 ///   `p`.
 ///
-/// The version is hardcoded to 0 and is reserved for forward compatibility.
+/// The version is hardcoded to 1 and is reserved for forward compatibility.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct NoteMetadata {
     partial_metadata: PartialNoteMetadata,

--- a/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
+++ b/crates/miden-protocol/src/transaction/kernel/advice_inputs.rs
@@ -145,7 +145,6 @@ impl TransactionAdviceInputs {
     ///     [0, verification_base_fee, fee_faucet_id_suffix, fee_faucet_id_prefix]
     ///     [0, 0, 0, 0]
     ///     NOTE_ROOT,
-    ///     kernel_version
     ///     [account_nonce, 0, account_id_suffix, account_id_prefix],
     ///     ACCOUNT_VAULT_ROOT,
     ///     ACCOUNT_STORAGE_COMMITMENT,

--- a/crates/miden-standards/src/note/constant_fee_policy_config.rs
+++ b/crates/miden-standards/src/note/constant_fee_policy_config.rs
@@ -166,7 +166,7 @@ impl ConstantFeePolicyConfigNote {
 
     /// Returns the account ID of the managed account: the account the note is tagged for and bound
     /// to via its `NetworkAccountTarget` attachment (only this account can consume the note).
-    pub fn account(&self) -> AccountId {
+    pub fn target(&self) -> AccountId {
         self.target
     }
 
@@ -313,7 +313,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(note.sender(), sender);
-        assert_eq!(note.account(), account);
+        assert_eq!(note.target(), account);
 
         let note = Note::from(note);
         assert_eq!(note.metadata().note_type(), NoteType::Public);

--- a/crates/miden-standards/src/note/faucet_policy_config.rs
+++ b/crates/miden-standards/src/note/faucet_policy_config.rs
@@ -212,7 +212,7 @@ impl FaucetPolicyConfigNote {
     }
 
     /// Returns the account ID of the managed faucet (the account the note is tagged for).
-    pub fn account(&self) -> AccountId {
+    pub fn target(&self) -> AccountId {
         self.target
     }
 
@@ -329,7 +329,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(note.sender(), sender);
-        assert_eq!(note.account(), faucet);
+        assert_eq!(note.target(), faucet);
 
         let note = Note::from(note);
         assert_eq!(note.metadata().note_type(), NoteType::Public);

--- a/crates/miden-standards/src/note/network_account_config.rs
+++ b/crates/miden-standards/src/note/network_account_config.rs
@@ -221,7 +221,7 @@ impl NetworkAccountConfigNote {
     }
 
     /// Returns the account ID of the managed network account (the account the note is tagged for).
-    pub fn account(&self) -> AccountId {
+    pub fn target(&self) -> AccountId {
         self.target
     }
 
@@ -349,7 +349,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(note.sender(), sender);
-        assert_eq!(note.account(), account);
+        assert_eq!(note.target(), account);
 
         let note = Note::from(note);
         assert_eq!(note.metadata().note_type(), NoteType::Public);

--- a/crates/miden-standards/src/note/owner_config.rs
+++ b/crates/miden-standards/src/note/owner_config.rs
@@ -205,7 +205,7 @@ impl OwnerConfigNote {
     }
 
     /// Returns the account ID of the managed account (the account the note is tagged for).
-    pub fn account(&self) -> AccountId {
+    pub fn target(&self) -> AccountId {
         self.target
     }
 
@@ -331,7 +331,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(note.sender(), owner);
-        assert_eq!(note.account(), managed);
+        assert_eq!(note.target(), managed);
 
         let note = Note::from(note);
         assert_eq!(note.metadata().note_type(), NoteType::Public);

--- a/crates/miden-standards/src/note/pause_config.rs
+++ b/crates/miden-standards/src/note/pause_config.rs
@@ -181,7 +181,7 @@ impl PauseConfigNote {
     }
 
     /// Returns the account ID of the managed account (the account the note is tagged for).
-    pub fn account(&self) -> AccountId {
+    pub fn target(&self) -> AccountId {
         self.target
     }
 
@@ -294,7 +294,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(note.sender(), sender);
-        assert_eq!(note.account(), managed);
+        assert_eq!(note.target(), managed);
 
         let note = Note::from(note);
         assert_eq!(note.metadata().note_type(), NoteType::Public);

--- a/crates/miden-standards/src/note/rbac_config.rs
+++ b/crates/miden-standards/src/note/rbac_config.rs
@@ -230,7 +230,7 @@ impl RbacConfigNote {
     }
 
     /// Returns the account ID of the managed account (the account the note is tagged for).
-    pub fn account(&self) -> AccountId {
+    pub fn target(&self) -> AccountId {
         self.target
     }
 
@@ -360,7 +360,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(note.sender(), admin);
-        assert_eq!(note.account(), managed);
+        assert_eq!(note.target(), managed);
 
         let note = Note::from(note);
         assert_eq!(note.metadata().note_type(), NoteType::Public);


### PR DESCRIPTION
Housekeeping:
- Remove stale docs referencing the no longer implemented multi-kernel commitment scheme.
- Rename procedure `assert_procedure_in_account` to `assert_procedure_in_active_account` as suggested in https://github.com/0xMiden/protocol/pull/3575#discussion_r3786320129.
- make getter names consistent with field names in config notes