### PR TITLE
fix: validate deserialized protocol inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,20 @@ We expect to keep making changes (including breaking changes) to all components.
 | [bench-note-checker](bin/bench-note-checker) | Note consumability benchmarks for the transaction executor. |
 | [bench-transaction](bin/bench-transaction) | Transaction execution and proving benchmarks. |
 
+## Getting started
+
+Install the Rust toolchain listed in [rust-toolchain.toml](rust-toolchain.toml), then clone the repository and initialize its submodules if your workflow requires them:
+
+```shell
+git clone https://github.com/0xMiden/protocol.git
+cd protocol
+```
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. The [Makefile](Makefile) contains the supported build, test, lint, and documentation commands.
+
 ## Make commands
 
-We use `make` to automate building, testing, and other processes. In most cases, `make` commands are just wrappers around `cargo` commands with specific arguments. You can view the list of available commands in the [Makefile](Makefile), or just run the following command:
+We use `make` to automate building, testing, and other processes. In most cases, `make` commands are just wrappers around `cargo` commands with specific arguments. You can view the list of available commands in the [Makefile](Makefile), or run the default target to list them:
 
 ```shell
 make
@@ -78,7 +89,9 @@ Some of the functions in this project are computationally intensive and may take
 
 ## Documentation
 
-The documentation in the `docs/` folder is built using Docusaurus and is automatically absorbed into the main [miden-docs](https://docs.miden.xyz/protocol/) repository for the main documentation website. Changes to the `next` branch trigger an automated deployment workflow. The docs folder requires npm packages to be installed before building.
+The Rust API documentation is generated from the workspace crates. The contributor documentation in `docs/` is built with Docusaurus and is automatically absorbed into the main [Miden documentation](https://docs.miden.xyz/protocol/) site. Changes to the `next` branch trigger an automated deployment workflow. The docs folder requires npm packages to be installed before building.
+
+For crate-specific guidance, start with the relevant crate README in the [project structure](#project-structure) table. Keep public API changes and protocol behavior changes documented in the appropriate crate or Docusaurus page.
 
 ## License
 

--- a/crates/miden-protocol/src/account/access.rs
+++ b/crates/miden-protocol/src/account/access.rs
@@ -127,6 +127,17 @@ mod tests {
     use crate::errors::RoleSymbolError;
 
     #[test]
+    fn test_role_symbol_encoded_value_boundaries() {
+        let min = RoleSymbol::new("A").unwrap();
+        let max = RoleSymbol::new("____________").unwrap();
+
+        assert_eq!(min.as_element().as_canonical_u64(), RoleSymbol::MIN_ENCODED_VALUE);
+        assert_eq!(max.as_element().as_canonical_u64(), RoleSymbol::MAX_ENCODED_VALUE);
+        assert_eq!(RoleSymbol::try_from(Felt::new(RoleSymbol::MIN_ENCODED_VALUE)).unwrap(), min);
+        assert_eq!(RoleSymbol::try_from(Felt::new(RoleSymbol::MAX_ENCODED_VALUE)).unwrap(), max);
+    }
+
+    #[test]
     fn test_role_symbol_roundtrip_and_validation() {
         let role_symbols = ["MINTER", "BURNER", "MINTER_ADMIN", "A", "A_B_C"];
         for role_symbol in role_symbols {

--- a/crates/miden-protocol/src/account/storage/partial.rs
+++ b/crates/miden-protocol/src/account/storage/partial.rs
@@ -150,9 +150,8 @@ impl Deserializable for PartialStorage {
         let header: AccountStorageHeader = source.read()?;
         let map_smts: BTreeMap<Word, PartialStorageMap> = source.read()?;
 
-        let commitment = header.to_commitment();
-
-        Ok(PartialStorage { header, maps: map_smts, commitment })
+        PartialStorage::new(header, map_smts.into_values())
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }
 

--- a/crates/miden-protocol/src/block/block_signatures.rs
+++ b/crates/miden-protocol/src/block/block_signatures.rs
@@ -146,7 +146,7 @@ impl Serializable for BlockSignatures {
 impl Deserializable for BlockSignatures {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let signatures = Vec::<Signature>::read_from(source)?;
-        Ok(Self { signatures })
+        Self::new(signatures).map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }
 

--- a/crates/miden-protocol/src/transaction/inputs/mod.rs
+++ b/crates/miden-protocol/src/transaction/inputs/mod.rs
@@ -506,16 +506,15 @@ impl Deserializable for TransactionInputs {
         let foreign_account_slot_names =
             BTreeMap::<StorageSlotId, StorageSlotName>::read_from(source)?;
 
-        Ok(TransactionInputs {
-            account,
-            block_header,
-            blockchain,
-            input_notes,
-            tx_args,
-            advice_inputs,
-            foreign_account_code,
-            foreign_account_slot_names,
-        })
+        TransactionInputs::new(account, block_header, blockchain, input_notes)
+            .map(|inputs| {
+                inputs
+                    .with_tx_args(tx_args)
+                    .with_advice_inputs(advice_inputs)
+                    .with_foreign_account_code(foreign_account_code)
+                    .with_foreign_account_slot_names(foreign_account_slot_names)
+            })
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }
 


### PR DESCRIPTION
Closes #3494
Closes #3533
Closes #3535
Closes #3549 
Closes #3530 

## Summary

This batch preserves validation invariants during deserialization and refreshes contributor documentation:

- Validate `BlockSignatures` through its constructor so oversized signature vectors are rejected during deserialization.
- - Validate `PartialStorage` map roots through `PartialStorage::new`.
- - Validate `TransactionInputs` chain commitments, lengths, and authenticated note proofs during deserialization while restoring serialized fields.
- - Add boundary tests for `RoleSymbol` encoded-value constants.
- - Refresh the root README with setup, contribution, testing, and documentation guidance.
## Validation

`git diff --check` passed. Cargo formatting and tests were unavailable locally because Cargo is not installed in the sandbox.