### PR TITLE
fix(standards): return `get_schema_commitment` at the required stack depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Fixed `input_note::remove_asset` succeeding when asked to remove an empty or malformed asset ID instead of reporting the asset as not found ([#3592](https://github.com/0xMiden/protocol/pull/3607)).
 - Faucet asset-callback procedure roots are now verified against the faucet's account code before dispatch, so a misconfigured callback root can no longer make an asset nontransferable ([#3612](https://github.com/0xMiden/protocol/pull/3612)).
 - [BREAKING] Enforced the limit of 1024 per asset delta op for added and removed account vault deltas inside and outside the tx kernel ([#3623](https://github.com/0xMiden/protocol/pull/3623)).
-- Fixed `AccountSchemaCommitment`'s `get_schema_commitment` returning above the 16-element stack depth ([#3639](https://github.com/0xMiden/protocol/pull/3639)).
+- Fixed `AccountSchemaCommitment`'s `get_schema_commitment` returning above the 16-element stack depth ([#3645](https://github.com/0xMiden/protocol/pull/3645)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fixed `input_note::remove_asset` succeeding when asked to remove an empty or malformed asset ID instead of reporting the asset as not found ([#3592](https://github.com/0xMiden/protocol/pull/3607)).
 - Faucet asset-callback procedure roots are now verified against the faucet's account code before dispatch, so a misconfigured callback root can no longer make an asset nontransferable ([#3612](https://github.com/0xMiden/protocol/pull/3612)).
 - [BREAKING] Enforced the limit of 1024 per asset delta op for added and removed account vault deltas inside and outside the tx kernel ([#3623](https://github.com/0xMiden/protocol/pull/3623)).
+- Fixed `AccountSchemaCommitment`'s `get_schema_commitment` returning above the 16-element stack depth ([#3639](https://github.com/0xMiden/protocol/pull/3639)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/crates/miden-standards/asm/standards/inspection/storage_schema.masm
+++ b/crates/miden-standards/asm/standards/inspection/storage_schema.masm
@@ -10,12 +10,21 @@ use miden::protocol::active_account
 # The slot in this component's storage layout where the account storage schema commitment is stored
 const SCHEMA_COMMITMENT_SLOT = word("miden::standards::inspection::storage_schema::commitment")
 
-# TODO(call invocation)
+#! Returns the commitment to the storage schema of the active account.
+#!
+#! Inputs:  [pad(16)]
+#! Outputs: [SCHEMA_COMMITMENT, pad(12)]
+#!
+#! Where:
+#! - SCHEMA_COMMITMENT is the commitment to the active account's storage schema.
+#!
+#! Invocation: call
 @account_procedure
 pub proc get_schema_commitment
-    dropw
-    # => [pad(16)]
-
     push.SCHEMA_COMMITMENT_SLOT[0..2] exec.active_account::get_item
     # => [SCHEMA_COMMITMENT, pad(16)]
+
+    # drop the excess padding to restore the stack depth for the call boundary
+    swapw dropw
+    # => [SCHEMA_COMMITMENT, pad(12)]
 end

--- a/crates/miden-testing/tests/scripts/mod.rs
+++ b/crates/miden-testing/tests/scripts/mod.rs
@@ -19,6 +19,7 @@ mod p2ide;
 mod pausable;
 mod pswap;
 pub(crate) mod rbac;
+mod schema_commitment;
 mod send_note;
 mod swap;
 pub(crate) mod transfer_policy;

--- a/crates/miden-testing/tests/scripts/schema_commitment.rs
+++ b/crates/miden-testing/tests/scripts/schema_commitment.rs
@@ -1,0 +1,70 @@
+extern crate alloc;
+
+use miden_protocol::account::{Account, AccountBuilder, AccountType};
+use miden_standards::account::inspection::AccountSchemaCommitment;
+use miden_standards::account::wallets::BasicWallet;
+use miden_standards::code_builder::CodeBuilder;
+use miden_testing::{Auth, MockChain};
+
+// HELPERS
+// ================================================================================================
+
+/// Builds an account exposing the `BasicWallet` and `AccountSchemaCommitment` components.
+fn create_schema_committed_account() -> anyhow::Result<Account> {
+    let builder = AccountBuilder::new([1; 32])
+        .account_type(AccountType::Public)
+        .with_components(Auth::IncrNonce)
+        .with_component(BasicWallet);
+
+    // Mirrors `build_with_schema_commitment`, but builds an existing account so the mock chain can
+    // hold it without a seed.
+    let schema_commitment = AccountSchemaCommitment::new(builder.storage_schemas())?;
+
+    Ok(builder.with_component(schema_commitment).build_existing()?)
+}
+
+// TESTS
+// ================================================================================================
+
+/// `AccountSchemaCommitment::get_schema_commitment`, invoked via `call` from a transaction script,
+/// returns the commitment to the account's storage schema and honours the 16-felt call ABI.
+#[tokio::test]
+async fn schema_commitment_get_schema_commitment() -> anyhow::Result<()> {
+    let account = create_schema_committed_account()?;
+    let expected_schema_commitment =
+        account.storage().get_item(AccountSchemaCommitment::schema_commitment_slot())?;
+
+    // The getter expects `[pad(16)]`, so the script pads the stack before the call.
+    let tx_script_code = format!(
+        r#"
+        use miden::standards::components::inspection::schema_commitment
+
+        @transaction_script
+        pub proc main
+            padw padw padw padw
+            call.schema_commitment::get_schema_commitment
+            # => [SCHEMA_COMMITMENT, pad(12), pad(16)]
+            push.{expected_schema_commitment}
+            assert_eqw.err="get_schema_commitment returned an unexpected commitment or violated the call ABI"
+            dropw dropw dropw
+        end
+        "#
+    );
+
+    let mut builder = MockChain::builder();
+    builder.add_account(account.clone())?;
+    let mock_chain = builder.build()?;
+
+    let tx_script = CodeBuilder::default()
+        .with_dynamically_linked_package(AccountSchemaCommitment::code())?
+        .compile_tx_script(tx_script_code)?;
+
+    mock_chain
+        .build_transaction(account.id())
+        .tx_script(tx_script)
+        .build()?
+        .execute()
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
After https://github.com/0xMiden/protocol/pull/3470 is merged there is also `get_schema_commitment` to be fixed. This PR fixes the issue accordingly.