### PR TITLE
fix(kernels): reject ambiguous non-fungible asset delta entries in update_asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixed `input_note::remove_asset` succeeding when asked to remove an empty or malformed asset ID instead of reporting the asset as not found ([#3592](https://github.com/0xMiden/protocol/pull/3607)).
 - Faucet asset-callback procedure roots are now verified against the faucet's account code before dispatch, so a misconfigured callback root can no longer make an asset nontransferable ([#3612](https://github.com/0xMiden/protocol/pull/3612)).
 - [BREAKING] Enforced the limit of 1024 per asset delta op for added and removed account vault deltas inside and outside the tx kernel ([#3623](https://github.com/0xMiden/protocol/pull/3623)).
+- [BREAKING] The transaction kernel now rejects removing a non-fungible asset and adding a different value under the same asset ID within one transaction, which the account delta would have encoded incorrectly as a pure removal ([#3600](https://github.com/0xMiden/protocol/issues/3600)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
@@ -23,6 +23,9 @@ const ERR_ACCOUNT_DELTA_TOO_MANY_ADDED_ASSETS =
 const ERR_ACCOUNT_DELTA_TOO_MANY_REMOVED_ASSETS =
     "number of removed assets in the transaction exceeds the maximum limit of 1024"
 
+const ERR_ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_REPLACEMENT =
+    "removing a non-fungible asset and adding a different value under the same asset ID within one transaction is not supported as the account delta cannot encode the replacement"
+
 # EVENTS
 # =================================================================================================
 
@@ -788,6 +791,12 @@ end
 #! - ASSET_ID is the asset ID of the asset that is added.
 #! - INITIAL_ASSET_VALUE is the value of the asset before the update.
 #! - FINAL_ASSET_VALUE is the value of the asset after the update.
+#!
+#! Panics if:
+#! - the asset's composition is none and the update would leave the patch entry with two distinct
+#!   non-empty values, i.e. the value under the asset ID was removed and a different value was
+#!   added within the same transaction. The account delta cannot encode such a replacement (see
+#!   compute_asset_delta).
 pub proc update_asset
     swapw dupw.1 push.ACCOUNT_UPDATE_ASSET_PTR
     # => [asset_delta_map_ptr, ASSET_ID, INITIAL_ASSET_VALUE, ASSET_ID, FINAL_ASSET_VALUE]
@@ -810,6 +819,37 @@ pub proc update_asset
     cdropw
     # => [NEW_INITIAL_VALUE, ASSET_ID, FINAL_ASSET_VALUE]
 
+    # For an asset whose composition is none, the entry can only encode an addition (empty
+    # initial value), a removal (empty final value) or a no-op (equal values). Reject an entry
+    # holding two distinct non-empty values: compute_asset_delta would encode such a
+    # replacement incorrectly as a pure removal of the initial value.
+    dupw.1 exec.asset::id_into_composition eq.COMPOSITION_NONE
+    # => [is_composition_none, NEW_INITIAL_VALUE, ASSET_ID, FINAL_ASSET_VALUE]
+
+    if.true
+        swapw movdnw.2
+        # => [NEW_INITIAL_VALUE, FINAL_ASSET_VALUE, ASSET_ID]
+
+        exec.word::test_eq movdn.8
+        # => [NEW_INITIAL_VALUE, FINAL_ASSET_VALUE, are_values_equal, ASSET_ID]
+
+        exec.word::testz movdn.9
+        # => [NEW_INITIAL_VALUE, FINAL_ASSET_VALUE, are_values_equal, is_initial_empty, ASSET_ID]
+
+        swapw exec.word::testz
+        # => [is_final_empty, FINAL_ASSET_VALUE, NEW_INITIAL_VALUE, are_values_equal, is_initial_empty, ASSET_ID]
+
+        movup.9 or movup.9 or
+        # => [is_encodable, FINAL_ASSET_VALUE, NEW_INITIAL_VALUE, ASSET_ID]
+
+        assert.err=ERR_ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_REPLACEMENT
+        # => [FINAL_ASSET_VALUE, NEW_INITIAL_VALUE, ASSET_ID]
+
+        movdnw.2
+        # => [NEW_INITIAL_VALUE, ASSET_ID, FINAL_ASSET_VALUE]
+    end
+    # => [NEW_INITIAL_VALUE, ASSET_ID, FINAL_ASSET_VALUE]
+
     swapw push.ACCOUNT_UPDATE_ASSET_PTR
     # => [asset_delta_map_ptr, ASSET_ID, NEW_INITIAL_VALUE, FINAL_ASSET_VALUE]
 
@@ -825,8 +865,9 @@ end
 #! - If the composition of the asset is none:
 #!   - If the initial value is the empty word, the final value must be non-empty, so the asset was
 #!     added.
-#!   - Conversely, if the initial value is not the empty word, the final value must be empty
-#!     according to the asset vault guarantees, so the asset was removed.
+#!   - Conversely, if the initial value is not the empty word, the final value must be empty, so
+#!     the asset was removed. This holds because update_asset rejects entries holding two distinct
+#!     non-empty values and this procedure is only called when the values are not equal.
 #! - If the composition is not none:
 #!   - Compute the delta as `GREATER_ASSET_VALUE - LESSER_ASSET_VALUE` using `asset::lt` to find
 #!     the larger value and `asset::split` for the computation itself.

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
@@ -30,17 +30,24 @@ use miden_protocol::account::{
     StorageValuePatch,
 };
 use miden_protocol::asset::{Asset, FungibleAsset, NonFungibleAsset, NonFungibleAssetDetails};
+use miden_protocol::errors::tx_kernel::ERR_ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_REPLACEMENT;
 use miden_protocol::note::{NoteTag, NoteType};
 use miden_protocol::testing::account_id::AccountIdBuilder;
 use miden_protocol::testing::storage::{MOCK_MAP_SLOT, MOCK_VALUE_SLOT0};
 use miden_protocol::transaction::TransactionScript;
 use miden_protocol::{EMPTY_WORD, Felt, Word, ZERO};
 use miden_standards::code_builder::CodeBuilder;
-use miden_standards::testing::account_component::MockAccountComponent;
+use miden_standards::testing::account_component::{MockAccountComponent, MockFaucetComponent};
 use miden_tx::{LocalTransactionProver, TransactionExecutorError};
 use rand::RngExt;
 
-use crate::{Auth, MockChain, TestTransactionBuilder};
+use crate::{
+    AccountState,
+    Auth,
+    MockChain,
+    TestTransactionBuilder,
+    assert_transaction_executor_error,
+};
 
 // ACCOUNT DELTA TESTS
 //
@@ -545,6 +552,96 @@ async fn non_fungible_asset_delta() -> anyhow::Result<()> {
     }
     .execute()
     .await
+}
+
+/// Tests that replacing a non-fungible asset with a different value under the same asset ID within
+/// one transaction is rejected.
+///
+/// A non-fungible asset ID binds only the first two elements of the asset value, so an issuer can
+/// craft two distinct values V1 and V2 that share one asset ID. Removing V1 and then adding V2
+/// would leave the asset patch entry with two distinct non-empty values, which the account delta
+/// cannot encode: the update would be encoded incorrectly as a pure removal of V1, omitting the
+/// addition of V2. The kernel must reject the mutation that creates such an entry, even in a
+/// transaction that balances the vaults by burning V1 and minting V2.
+#[tokio::test]
+async fn non_fungible_asset_replacement_is_rejected() -> anyhow::Result<()> {
+    let auth = Auth::IncrNonce;
+    let faucet_builder = || {
+        AccountBuilder::new([7; 32])
+            .with_component(MockFaucetComponent)
+            .with_component(MockAccountComponent::with_empty_slots())
+    };
+
+    // The asset names the faucet as its origin, but the faucet must also hold it in its vault.
+    // Since the ID of an existing account does not depend on its vault, it can be taken from an
+    // asset-less build of the same faucet.
+    let (auth_components, _) = auth.build_components();
+    let faucet_id = faucet_builder().with_components(auth_components).build_existing()?.id();
+
+    // Craft two distinct asset values sharing one asset ID: changing the last element of the
+    // value yields a different value under the same ID.
+    let asset_v1 = NonFungibleAsset::new(&NonFungibleAssetDetails::new(faucet_id, vec![42]));
+    let v1_value = asset_v1.to_value_word();
+    let v2_value = Word::from([v1_value[0], v1_value[1], v1_value[2], v1_value[3] + Felt::ONE]);
+    let asset_v2 = NonFungibleAsset::from_parts(faucet_id, v2_value);
+    assert_eq!(asset_v1.to_id_word(), asset_v2.to_id_word());
+    assert_ne!(asset_v1.to_value_word(), asset_v2.to_value_word());
+
+    let mut chain_builder = MockChain::builder();
+    let faucet = chain_builder.add_account_from_builder(
+        auth,
+        faucet_builder().with_assets([Asset::from(asset_v1)]),
+        AccountState::Exists,
+    )?;
+    let mock_chain = chain_builder.build()?;
+
+    let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(format!(
+        "
+    use mock::account as mock_account
+    use mock::faucet as mock_faucet
+
+    @transaction_script
+    pub proc main
+        # remove V1 from the account vault; the asset patch entry becomes (V1, EMPTY_WORD)
+        push.{V1_VALUE}
+        push.{ASSET_ID}
+        call.mock_account::remove_asset dropw
+        # => []
+
+        # burn V1 and mint V2 so that the transaction's vaults balance
+        push.{V1_VALUE}
+        push.{ASSET_ID}
+        call.mock_faucet::burn
+        # => []
+
+        push.{V2_VALUE}
+        push.{ASSET_ID}
+        call.mock_faucet::mint
+        # => []
+
+        # adding V2 must fail: the asset patch entry would hold two distinct non-empty values,
+        # which the account delta cannot encode
+        push.{V2_VALUE}
+        push.{ASSET_ID}
+        call.mock_account::add_asset dropw
+        # => []
+    end
+    ",
+        ASSET_ID = asset_v1.to_id_word(),
+        V1_VALUE = asset_v1.to_value_word(),
+        V2_VALUE = asset_v2.to_value_word(),
+    ))?;
+
+    let result = mock_chain
+        .build_transaction(faucet)
+        .tx_script(tx_script)
+        .build()?
+        .execute()
+        .await;
+
+    assert_transaction_executor_error!(result, ERR_ACCOUNT_DELTA_NON_FUNGIBLE_ASSET_REPLACEMENT);
+
+    Ok(())
 }
 
 /// Tests that storage value/map updates combined with vault asset additions and removals are


### PR DESCRIPTION
## Summary

Closes #3600.

A non-fungible asset ID binds only the first two elements of the 4-element asset value, so an issuer can craft two distinct values V1 and V2 sharing one asset ID. Removing V1 from the account vault and then adding V2 left the asset patch entry with two non-empty values `(V1, V2)`, and `compute_asset_delta` infers the operation solely from whether the initial value is empty: it reported "V1 removed" and silently omitting the V2 addition. The doc justified this with an "asset vault guarantees" claim that only holds per operation, not across two operations. Balancing the transaction by burning V1 and minting V2 made the whole route prove and verify with a wrong committed delta.

Per the maintainer decision in the issue, the check is added in [`update_asset`](https://github.com/0xMiden/protocol/blob/ca1f54079db7154d2a76e2502a32ae5f422d458e/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm#L800), so the transaction fails at the exact mutation that would create the unencodable entry.

## Changes

- `update_asset` now asserts, for assets whose composition is none, that a patch entry never holds two distinct non-empty values; an addition (empty initial), a removal (empty final) and the remove-then-re-add-same-value no-op (equal values) all still pass, and fungible partial updates are unaffected since the check is scoped to composition-none assets.
