### PR TITLE
feat: stable `exec_kernel_proc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Moved the transaction kernel API procedures into the kernel's `api` submodule, leaving `exec_kernel_proc` as the only `syscall`-invocable kernel procedure ([#3646](https://github.com/0xMiden/protocol/pull/3646)).
 - [BREAKING] Added the `miden::standards::expiration` MASM module with `apply_default` and used it to apply a default 20-block transaction expiration limit to the standard allowlist and blocklist transfer policies and the fee manager's `estimate_note_fee` procedure ([#3512](https://github.com/0xMiden/protocol/pull/3512)).
+- [BREAKING] Moved the kernel data section of the transaction kernel memory to address `0`, so that `exec_kernel_proc` becomes reusable across multiple kernels ([#3655](https://github.com/0xMiden/protocol/pull/3655)).
 - [BREAKING] Moved the internal shared helpers of `miden::protocol::input_note`, `miden::protocol::active_note`, and the note memory-write helpers into private `input_note_internal` and `note_internal` modules ([#3501](https://github.com/0xMiden/protocol/pull/3501)).
 - [BREAKING] Sorted the procedures of `AccountCode` after the authentication procedure at index 0, making the account code commitment independent of the order in which components are provided ([#2961](https://github.com/0xMiden/protocol/issues/2961)).
 - The transaction kernel now validates that a new account's procedures are sorted and unique ([#3567](https://github.com/0xMiden/protocol/pull/3567)).

--- a/bin/bench-transaction/bench-tx.json
+++ b/bin/bench-transaction/bench-tx.json
@@ -1,98 +1,98 @@
 {
   "consume single P2ID note with Falcon signing": {
     "prologue": 4282,
-    "notes_processing": 2200,
+    "notes_processing": 2194,
     "note_execution": {
-      "0xc25b14d93ecdf5862c785dd72734b5da948d8f4d7897a59395584d929b8c8e68": 2158
+      "0x5166fb09b1ba37e20ca5cbdeb2ce8b3d0c7a0b045007f792bebb3d1b2b041aea": 2152
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 73757,
-      "auth_procedure": 72646
+      "total": 73741,
+      "auth_procedure": 72631
     },
     "trace": {
-      "core_rows": 80325,
-      "chiplets_rows": 11331,
-      "range_rows": 20583,
+      "core_rows": 80302,
+      "chiplets_rows": 11270,
+      "range_rows": 20695,
       "chiplets_shape": {
         "hasher_rows": 8272,
         "bitwise_rows": 584,
         "memory_rows": 2412,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume single P2ID note with ECDSA signing": {
     "prologue": 4282,
-    "notes_processing": 2200,
+    "notes_processing": 2194,
     "note_execution": {
-      "0xe656d46bd533644247871e32ee4ed150301b60c623cf3a4956758513bc459d4f": 2158
+      "0x58a1dea9f42bafeedf8714b36a4aaa3a3578bb6b16ee62809aaa161c75e531f5": 2152
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 6119,
-      "auth_procedure": 5008
+      "total": 6103,
+      "auth_procedure": 4993
     },
     "trace": {
-      "core_rows": 12687,
-      "chiplets_rows": 5588,
-      "range_rows": 1867,
+      "core_rows": 12664,
+      "chiplets_rows": 5527,
+      "range_rows": 1895,
       "chiplets_shape": {
         "hasher_rows": 3920,
         "bitwise_rows": 840,
         "memory_rows": 765,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume two P2ID notes with Falcon signing": {
     "prologue": 5025,
-    "notes_processing": 4582,
+    "notes_processing": 4570,
     "note_execution": {
-      "0x55856c817efd90a535e6245b8b9e39dc27e2dac5dd466ae5eb11257eef40c15a": 2158,
-      "0x8381b9aecd5eb2f220cfda02977f18c5d92b28926313900dc5e021bb89c18a2d": 2373
+      "0xa0e74e49449bb191ff2634814ee96b269f29ccde0dd9f15fb08c1d44d47fd2f3": 2367,
+      "0xf1a2a585b29a07684a88d02bcc763c7981d409c9784c7f0fa25bab85677d7d67": 2152
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 73685,
-      "auth_procedure": 72610
+      "total": 73669,
+      "auth_procedure": 72595
     },
     "trace": {
-      "core_rows": 83378,
-      "chiplets_rows": 13299,
-      "range_rows": 20355,
+      "core_rows": 83349,
+      "chiplets_rows": 13238,
+      "range_rows": 20353,
       "chiplets_shape": {
         "hasher_rows": 9776,
         "bitwise_rows": 928,
         "memory_rows": 2532,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume two P2ID notes with ECDSA signing": {
     "prologue": 5025,
-    "notes_processing": 4582,
+    "notes_processing": 4570,
     "note_execution": {
-      "0x55856c817efd90a535e6245b8b9e39dc27e2dac5dd466ae5eb11257eef40c15a": 2158,
-      "0x8381b9aecd5eb2f220cfda02977f18c5d92b28926313900dc5e021bb89c18a2d": 2373
+      "0xa0e74e49449bb191ff2634814ee96b269f29ccde0dd9f15fb08c1d44d47fd2f3": 2367,
+      "0xf1a2a585b29a07684a88d02bcc763c7981d409c9784c7f0fa25bab85677d7d67": 2152
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 6047,
-      "auth_procedure": 4972
+      "total": 6031,
+      "auth_procedure": 4957
     },
     "trace": {
-      "core_rows": 15740,
-      "chiplets_rows": 7556,
-      "range_rows": 1491,
+      "core_rows": 15711,
+      "chiplets_rows": 7495,
+      "range_rows": 1483,
       "chiplets_shape": {
         "hasher_rows": 5424,
         "bitwise_rows": 1184,
         "memory_rows": 885,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
@@ -101,20 +101,20 @@
     "prologue": 1881,
     "notes_processing": 35,
     "note_execution": {},
-    "tx_script_processing": 1910,
+    "tx_script_processing": 1904,
     "epilogue": {
-      "total": 75287,
-      "auth_procedure": 73249
+      "total": 75268,
+      "auth_procedure": 73231
     },
     "trace": {
-      "core_rows": 79157,
-      "chiplets_rows": 10902,
-      "range_rows": 20279,
+      "core_rows": 79132,
+      "chiplets_rows": 10841,
+      "range_rows": 20345,
       "chiplets_shape": {
         "hasher_rows": 7992,
         "bitwise_rows": 544,
         "memory_rows": 2303,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
@@ -123,909 +123,909 @@
     "prologue": 1881,
     "notes_processing": 35,
     "note_execution": {},
-    "tx_script_processing": 1910,
+    "tx_script_processing": 1904,
     "epilogue": {
-      "total": 7649,
-      "auth_procedure": 5611
+      "total": 7630,
+      "auth_procedure": 5593
     },
     "trace": {
-      "core_rows": 11519,
-      "chiplets_rows": 5159,
-      "range_rows": 1345,
+      "core_rows": 11494,
+      "chiplets_rows": 5106,
+      "range_rows": 1317,
       "chiplets_shape": {
-        "hasher_rows": 3640,
+        "hasher_rows": 3648,
         "bitwise_rows": 800,
         "memory_rows": 656,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L1 to Miden)": {
     "prologue": 4033,
-    "notes_processing": 28630,
+    "notes_processing": 28611,
     "note_execution": {
-      "0x7011215795b6dba5c82c896bb172b879a33aa64269846fabbd9c0c2577b7a756": 28588
+      "0x7bea021213b295ee78576f67b78275a36ee5383a2fefa3ad65b5aa76d54ae854": 28569
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 16906,
-      "auth_procedure": 11851
+      "total": 16862,
+      "auth_procedure": 11808
     },
     "trace": {
-      "core_rows": 49655,
-      "chiplets_rows": 19608,
-      "range_rows": 3431,
+      "core_rows": 49591,
+      "chiplets_rows": 19555,
+      "range_rows": 3471,
       "chiplets_shape": {
-        "hasher_rows": 12712,
+        "hasher_rows": 12720,
         "bitwise_rows": 2752,
         "memory_rows": 4081,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L2 to Miden)": {
     "prologue": 4033,
-    "notes_processing": 38792,
+    "notes_processing": 38773,
     "note_execution": {
-      "0x0b5ae157c63e7f16c93614f30657bee63562c825b3829023dd35325fcb51285a": 38750
+      "0x0b5ac42d7096eab566b98f2a4347b6723be173d3142833418efb059e7708a3bd": 38731
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 16906,
-      "auth_procedure": 11851
+      "total": 16862,
+      "auth_procedure": 11808
     },
     "trace": {
-      "core_rows": 59817,
-      "chiplets_rows": 22358,
-      "range_rows": 3643,
+      "core_rows": 59753,
+      "chiplets_rows": 22305,
+      "range_rows": 3633,
       "chiplets_shape": {
-        "hasher_rows": 14264,
+        "hasher_rows": 14272,
         "bitwise_rows": 3008,
         "memory_rows": 5023,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out)": {
     "prologue": 4957,
-    "notes_processing": 118067,
+    "notes_processing": 117975,
     "note_execution": {
-      "0x53d05c66c8fdf38e31fcf003bf35b60e3800fed66ce19aa7d584fbd4bbeacc69": 118025
+      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 117933
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 26673,
-      "auth_procedure": 11936
+      "total": 26629,
+      "auth_procedure": 11893
     },
     "trace": {
-      "core_rows": 149783,
-      "chiplets_rows": 70673,
-      "range_rows": 4625,
+      "core_rows": 149646,
+      "chiplets_rows": 70620,
+      "range_rows": 4681,
       "chiplets_shape": {
-        "hasher_rows": 56544,
+        "hasher_rows": 56552,
         "bitwise_rows": 3528,
         "memory_rows": 10538,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31 leaves)": {
     "prologue": 4957,
-    "notes_processing": 116360,
+    "notes_processing": 116268,
     "note_execution": {
-      "0x53d05c66c8fdf38e31fcf003bf35b60e3800fed66ce19aa7d584fbd4bbeacc69": 116318
+      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 116226
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 26385,
-      "auth_procedure": 11936
+      "total": 26341,
+      "auth_procedure": 11893
     },
     "trace": {
-      "core_rows": 147788,
-      "chiplets_rows": 69686,
-      "range_rows": 4735,
+      "core_rows": 147651,
+      "chiplets_rows": 69633,
+      "range_rows": 4691,
       "chiplets_shape": {
-        "hasher_rows": 55688,
+        "hasher_rows": 55696,
         "bitwise_rows": 3528,
         "memory_rows": 10407,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31-1 leaves)": {
     "prologue": 4957,
-    "notes_processing": 61711,
+    "notes_processing": 61619,
     "note_execution": {
-      "0x53d05c66c8fdf38e31fcf003bf35b60e3800fed66ce19aa7d584fbd4bbeacc69": 61669
+      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 61577
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 17745,
-      "auth_procedure": 11936
+      "total": 17701,
+      "auth_procedure": 11893
     },
     "trace": {
-      "core_rows": 84499,
-      "chiplets_rows": 39588,
-      "range_rows": 3635,
+      "core_rows": 84362,
+      "chiplets_rows": 39535,
+      "range_rows": 3653,
       "chiplets_shape": {
-        "hasher_rows": 29520,
+        "hasher_rows": 29528,
         "bitwise_rows": 3528,
         "memory_rows": 6477,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2ID note (network account)": {
     "prologue": 3719,
-    "notes_processing": 2200,
+    "notes_processing": 2194,
     "note_execution": {
-      "0x2fc9fa5f7c6db2669cdeaf6af782e1cd2e24a8026cdd4faf95b74453c0f939f8": 2158
+      "0x6495b4e27e12699e75ff36925212c87fec735ed3fd368ea3d149f57c2cbf7b70": 2152
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 12728,
-      "auth_procedure": 9555
+      "total": 12694,
+      "auth_procedure": 9522
     },
     "trace": {
-      "core_rows": 18733,
-      "chiplets_rows": 8316,
-      "range_rows": 1499,
+      "core_rows": 18692,
+      "chiplets_rows": 8263,
+      "range_rows": 1449,
       "chiplets_shape": {
-        "hasher_rows": 6328,
+        "hasher_rows": 6336,
         "bitwise_rows": 824,
         "memory_rows": 1101,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2ID note (16 assets, network account)": {
     "prologue": 11894,
-    "notes_processing": 29859,
+    "notes_processing": 29838,
     "note_execution": {
-      "0x0568c989f8b4f74472a76cef4fac6f51c17fa69c38e5041dd73944c72df91bc1": 29817
+      "0x26b9d5425af9d8aab3e4a5e3ab4d358ad779f0aead666bdb4ce0a2f8a7c31232": 29796
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 15207,
-      "auth_procedure": 9874
+      "total": 15173,
+      "auth_procedure": 9841
     },
     "trace": {
-      "core_rows": 57046,
-      "chiplets_rows": 32498,
-      "range_rows": 3613,
+      "core_rows": 56990,
+      "chiplets_rows": 32445,
+      "range_rows": 3593,
       "chiplets_shape": {
-        "hasher_rows": 24720,
+        "hasher_rows": 24728,
         "bitwise_rows": 4784,
         "memory_rows": 2931,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (claim, network account)": {
     "prologue": 3719,
-    "notes_processing": 2325,
+    "notes_processing": 2318,
     "note_execution": {
-      "0x943339b21513253f8df4b3afcf5903347f84ba03df23ec1518d1d164a3863eba": 2283
+      "0xcba9e1f5fcd0ef144f503fa91f0cf56a2b8e187a993af184265e624e96bf3eca": 2276
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 12728,
-      "auth_procedure": 9555
+      "total": 12694,
+      "auth_procedure": 9522
     },
     "trace": {
-      "core_rows": 18858,
-      "chiplets_rows": 8352,
-      "range_rows": 1467,
+      "core_rows": 18816,
+      "chiplets_rows": 8291,
+      "range_rows": 1473,
       "chiplets_shape": {
         "hasher_rows": 6360,
         "bitwise_rows": 824,
         "memory_rows": 1105,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (claim, 16 assets, network account)": {
     "prologue": 11894,
-    "notes_processing": 29984,
+    "notes_processing": 29962,
     "note_execution": {
-      "0x991129c34019d8612646f8209d36a40b5d0ec46ac487e10f9a39e168e8371129": 29942
+      "0x892585dcabda6b524b99bfea1a67784809df641574326d175447082d821c329a": 29920
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 15207,
-      "auth_procedure": 9874
+      "total": 15173,
+      "auth_procedure": 9841
     },
     "trace": {
-      "core_rows": 57171,
-      "chiplets_rows": 32534,
-      "range_rows": 3595,
+      "core_rows": 57114,
+      "chiplets_rows": 32481,
+      "range_rows": 3621,
       "chiplets_shape": {
-        "hasher_rows": 24752,
+        "hasher_rows": 24760,
         "bitwise_rows": 4784,
         "memory_rows": 2935,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (reclaim, network account)": {
     "prologue": 3822,
-    "notes_processing": 2377,
+    "notes_processing": 2370,
     "note_execution": {
-      "0x7f2daf1d1282ddbfd5feea9246fc7c90d45edfbb321dda3246b4b141380098df": 2335
+      "0xc19feee7c5779c4cd9618e0938246740f54a1880bdbc5a81ef4f346d93bac041": 2328
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 12728,
-      "auth_procedure": 9555
+      "total": 12694,
+      "auth_procedure": 9522
     },
     "trace": {
-      "core_rows": 19013,
-      "chiplets_rows": 8383,
-      "range_rows": 1479,
+      "core_rows": 18971,
+      "chiplets_rows": 8322,
+      "range_rows": 1461,
       "chiplets_shape": {
         "hasher_rows": 6384,
         "bitwise_rows": 824,
         "memory_rows": 1112,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume SWAP note (public payback, network account)": {
     "prologue": 3719,
-    "notes_processing": 4594,
+    "notes_processing": 4583,
     "note_execution": {
-      "0x5ac2969fe0ea6bc33421d9df0d015da7761323c0f0f4233a450178b8e6e777ec": 4552
+      "0x831f0b151ca2841de114e5fbf49ce0cc0f2757fb0d61bc922ecc03a7dc46c926": 4541
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 14391,
-      "auth_procedure": 10095
+      "total": 14354,
+      "auth_procedure": 10059
     },
     "trace": {
-      "core_rows": 22790,
-      "chiplets_rows": 10358,
-      "range_rows": 1737,
+      "core_rows": 22741,
+      "chiplets_rows": 10305,
+      "range_rows": 1759,
       "chiplets_shape": {
-        "hasher_rows": 7896,
+        "hasher_rows": 7904,
         "bitwise_rows": 1144,
         "memory_rows": 1255,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume SWAP note (private payback, network account)": {
     "prologue": 3719,
-    "notes_processing": 4074,
+    "notes_processing": 4064,
     "note_execution": {
-      "0x2a8487a87546bf9fbc85b0cf0d215adfb2cc8a0c559852b7fdb39ffdfe2408a4": 4032
+      "0xbf0594a8a71ed5b2cb9967bfccdb15e435f5ffedd781db5f5ef86320ec3a7bf3": 4022
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 14391,
-      "auth_procedure": 10095
+      "total": 14354,
+      "auth_procedure": 10059
     },
     "trace": {
-      "core_rows": 22270,
-      "chiplets_rows": 10237,
-      "range_rows": 1763,
+      "core_rows": 22222,
+      "chiplets_rows": 10184,
+      "range_rows": 1757,
       "chiplets_shape": {
-        "hasher_rows": 7792,
+        "hasher_rows": 7800,
         "bitwise_rows": 1144,
         "memory_rows": 1238,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume PSWAP note (full fill, network account)": {
     "prologue": 3719,
-    "notes_processing": 7156,
+    "notes_processing": 7143,
     "note_execution": {
-      "0xd4e6cc16194c18f021ad0d9333e548a059e412a2629e8ef948a26b67cd36e831": 7114
+      "0x5b49ce1dd31c9fc1e6660d5ce57602d43bd3d0727cbc74b290567fe510cee9d1": 7101
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 14427,
-      "auth_procedure": 10095
+      "total": 14390,
+      "auth_procedure": 10059
     },
     "trace": {
-      "core_rows": 25388,
-      "chiplets_rows": 11102,
-      "range_rows": 1801,
+      "core_rows": 25337,
+      "chiplets_rows": 11049,
+      "range_rows": 1759,
       "chiplets_shape": {
-        "hasher_rows": 8344,
+        "hasher_rows": 8352,
         "bitwise_rows": 1264,
         "memory_rows": 1431,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume PSWAP note (partial fill, network account)": {
     "prologue": 3719,
-    "notes_processing": 9770,
+    "notes_processing": 9749,
     "note_execution": {
-      "0xd4e6cc16194c18f021ad0d9333e548a059e412a2629e8ef948a26b67cd36e831": 9728
+      "0x5b49ce1dd31c9fc1e6660d5ce57602d43bd3d0727cbc74b290567fe510cee9d1": 9707
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 15841,
-      "auth_procedure": 10318
+      "total": 15801,
+      "auth_procedure": 10279
     },
     "trace": {
-      "core_rows": 29416,
-      "chiplets_rows": 12850,
-      "range_rows": 1975,
+      "core_rows": 29354,
+      "chiplets_rows": 12797,
+      "range_rows": 1979,
       "chiplets_shape": {
-        "hasher_rows": 9552,
+        "hasher_rows": 9560,
         "bitwise_rows": 1640,
         "memory_rows": 1595,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume MINT note (fungible faucet, network account)": {
     "prologue": 5447,
-    "notes_processing": 10151,
+    "notes_processing": 8806,
     "note_execution": {
-      "0x50bdfdf93aacd5c8e8d16ffe9d8263f282bf2ba393449ea6be218b038fd46144": 10109
+      "0xa0d1aa4c9e5a3c18eebc8023934763769e278133a9afdceb00a6eba5557e98e9": 8764
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 19218,
-      "auth_procedure": 9850
+      "total": 19181,
+      "auth_procedure": 9814
     },
     "trace": {
-      "core_rows": 34902,
-      "chiplets_rows": 13260,
-      "range_rows": 2899,
+      "core_rows": 33519,
+      "chiplets_rows": 12925,
+      "range_rows": 2807,
       "chiplets_shape": {
-        "hasher_rows": 9928,
+        "hasher_rows": 9680,
         "bitwise_rows": 1144,
-        "memory_rows": 2125,
-        "kernel_rom_rows": 62,
+        "memory_rows": 2099,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume MINT note (non-fungible faucet, network account)": {
     "prologue": 5496,
-    "notes_processing": 13432,
+    "notes_processing": 11832,
     "note_execution": {
-      "0xaa85a3062c540b3c77c23e6ac179b02b4c23e0929daeff8fdbba3d2cab85f9bd": 13390
+      "0xdd8a2ea724860b76cdb00db7c255fb112b25d37412bcfa63b1221fd668636d6d": 11790
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 19483,
-      "auth_procedure": 9859
+      "total": 19446,
+      "auth_procedure": 9823
     },
     "trace": {
-      "core_rows": 38497,
-      "chiplets_rows": 14456,
-      "range_rows": 2993,
+      "core_rows": 36859,
+      "chiplets_rows": 14060,
+      "range_rows": 2965,
       "chiplets_shape": {
-        "hasher_rows": 11080,
+        "hasher_rows": 10776,
         "bitwise_rows": 1048,
-        "memory_rows": 2265,
-        "kernel_rom_rows": 62,
+        "memory_rows": 2234,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume BURN note (network account)": {
     "prologue": 6046,
-    "notes_processing": 5399,
+    "notes_processing": 5439,
     "note_execution": {
-      "0x025dc248f3d076d0cf118ce8a6bb19030e2ac2ecad7ebc02661901c2a9247e86": 5357
+      "0x2ee00ed0d857480af3d474d6eb4ddb4ee721b734a609b343f3992b3fb73292e3": 5397
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 17960,
-      "auth_procedure": 9629
+      "total": 17926,
+      "auth_procedure": 9596
     },
     "trace": {
-      "core_rows": 29491,
-      "chiplets_rows": 11604,
-      "range_rows": 2637,
+      "core_rows": 29496,
+      "chiplets_rows": 11560,
+      "range_rows": 2571,
       "chiplets_shape": {
-        "hasher_rows": 8760,
+        "hasher_rows": 8776,
         "bitwise_rows": 880,
-        "memory_rows": 1901,
-        "kernel_rom_rows": 62,
+        "memory_rows": 1902,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume FAUCET_POLICY_CONFIG note (network account)": {
     "prologue": 5400,
-    "notes_processing": 5072,
+    "notes_processing": 4398,
     "note_execution": {
-      "0xc3b3d962dd17d38d28b8bd514edd4672c2081966baedb44d83e1020d7bbd7c6e": 5030
+      "0x5ee6b7875961eb6cf45f6b867ef596485916493175744d96c2becc73a009279d": 4356
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 17813,
-      "auth_procedure": 9620
+      "total": 17779,
+      "auth_procedure": 9587
     },
     "trace": {
-      "core_rows": 28371,
-      "chiplets_rows": 10345,
-      "range_rows": 2561,
+      "core_rows": 27662,
+      "chiplets_rows": 10143,
+      "range_rows": 2517,
       "chiplets_shape": {
-        "hasher_rows": 7936,
+        "hasher_rows": 7808,
         "bitwise_rows": 560,
-        "memory_rows": 1786,
-        "kernel_rom_rows": 62,
+        "memory_rows": 1773,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume FAUCET_METADATA_CONFIG note (network account)": {
     "prologue": 4824,
-    "notes_processing": 6316,
+    "notes_processing": 6298,
     "note_execution": {
-      "0xd2b2c699be28d271aab1bb21f381e3c7498d8fecf5fc53fa6f92fdc0d30d4e33": 6274
+      "0x70cebe3a3c700b76e269c95d9a4d221e1ea47dc3b5cd94872b376202ad0a6cba": 6256
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 16468,
-      "auth_procedure": 9539
+      "total": 16434,
+      "auth_procedure": 9506
     },
     "trace": {
-      "core_rows": 27694,
-      "chiplets_rows": 10186,
-      "range_rows": 2401,
+      "core_rows": 27641,
+      "chiplets_rows": 10125,
+      "range_rows": 2395,
       "chiplets_shape": {
         "hasher_rows": 7720,
         "bitwise_rows": 568,
         "memory_rows": 1835,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume MIN_BURN_AMOUNT_CONFIG note (network account)": {
     "prologue": 5457,
-    "notes_processing": 2536,
+    "notes_processing": 2527,
     "note_execution": {
-      "0x4cd6e558a92ce936614debbfd28096a4eb5aed56c0b0a7923f4967b5d64b96ba": 2494
+      "0x4f24c4fecad6adcd971a9a73443f8785dc88d59860a29d46ec8611e4f042afae": 2485
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 17960,
-      "auth_procedure": 9629
+      "total": 17926,
+      "auth_procedure": 9596
     },
     "trace": {
-      "core_rows": 26039,
-      "chiplets_rows": 9665,
-      "range_rows": 2461,
+      "core_rows": 25995,
+      "chiplets_rows": 9612,
+      "range_rows": 2421,
       "chiplets_shape": {
-        "hasher_rows": 7328,
+        "hasher_rows": 7336,
         "bitwise_rows": 560,
         "memory_rows": 1714,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume ALLOWLIST_CONFIG note (network account)": {
     "prologue": 5457,
-    "notes_processing": 3110,
+    "notes_processing": 3101,
     "note_execution": {
-      "0x1f3f7daaf0d7a78a35608b5974358387f5d79e758180c4c8414a2b4f4819eb62": 3068
+      "0xa12cccb957dc237ce3a5daf2844fafee3d43229b5c09b9e3cc744729e64378b5": 3059
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 18136,
-      "auth_procedure": 9629
+      "total": 18102,
+      "auth_procedure": 9596
     },
     "trace": {
-      "core_rows": 26789,
-      "chiplets_rows": 10293,
-      "range_rows": 2449,
+      "core_rows": 26745,
+      "chiplets_rows": 10240,
+      "range_rows": 2447,
       "chiplets_shape": {
-        "hasher_rows": 7880,
+        "hasher_rows": 7888,
         "bitwise_rows": 560,
         "memory_rows": 1790,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume BLOCKLIST_CONFIG note (network account)": {
     "prologue": 5457,
-    "notes_processing": 3110,
+    "notes_processing": 3101,
     "note_execution": {
-      "0xbe15db131bf98497e7eedf764f77b10e901f86126819245b04c0b162ed84076f": 3068
+      "0x310c085efd662ab82f78d98744827ea2056f9105b93d8a4a803cfce478555bc2": 3059
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 18136,
-      "auth_procedure": 9629
+      "total": 18102,
+      "auth_procedure": 9596
     },
     "trace": {
-      "core_rows": 26789,
-      "chiplets_rows": 10293,
-      "range_rows": 2443,
+      "core_rows": 26745,
+      "chiplets_rows": 10240,
+      "range_rows": 2451,
       "chiplets_shape": {
-        "hasher_rows": 7880,
+        "hasher_rows": 7888,
         "bitwise_rows": 560,
         "memory_rows": 1790,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume PAUSE_CONFIG note (network account)": {
     "prologue": 3327,
-    "notes_processing": 2551,
+    "notes_processing": 2542,
     "note_execution": {
-      "0x5037f39eb4150307e04b9b9ef5019518832f92f041fa1754abdb6db88a57a95a": 2509
+      "0x8ced3f952199688034cb25cc6e74d04f3c2bd80b7d0f1fbcfed3f0b21f59a64c": 2500
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 12775,
-      "auth_procedure": 9314
+      "total": 12741,
+      "auth_procedure": 9281
     },
     "trace": {
-      "core_rows": 18739,
-      "chiplets_rows": 7477,
-      "range_rows": 1515,
+      "core_rows": 18695,
+      "chiplets_rows": 7424,
+      "range_rows": 1547,
       "chiplets_shape": {
-        "hasher_rows": 5704,
+        "hasher_rows": 5712,
         "bitwise_rows": 560,
         "memory_rows": 1150,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume OWNER_CONFIG note (network account)": {
     "prologue": 3186,
-    "notes_processing": 2580,
+    "notes_processing": 2571,
     "note_execution": {
-      "0x9f882e6a06d58d867c57b456e39bc2ebe4a93392dc9bfc262d5bbefc55146aee": 2538
+      "0x866357dfcef38b790d5e4f36bcdfde152219052cf36cd936fff970ec2d8f22f3": 2529
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 12481,
-      "auth_procedure": 9296
+      "total": 12447,
+      "auth_procedure": 9263
     },
     "trace": {
-      "core_rows": 18333,
-      "chiplets_rows": 7365,
-      "range_rows": 1533,
+      "core_rows": 18289,
+      "chiplets_rows": 7312,
+      "range_rows": 1509,
       "chiplets_shape": {
-        "hasher_rows": 5608,
+        "hasher_rows": 5616,
         "bitwise_rows": 576,
         "memory_rows": 1118,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume RBAC_CONFIG note (network account)": {
     "prologue": 3365,
-    "notes_processing": 5444,
+    "notes_processing": 5432,
     "note_execution": {
-      "0xe1d05837d388654ca1c418dbcc5778ae217d6b34ddf05117411f6a5ff0c51a1c": 5402
+      "0x035211253a92572f63e9dff299426456a88dbd7ff57a77b6c628f9acb6ee81ef": 5390
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 13302,
-      "auth_procedure": 9323
+      "total": 13268,
+      "auth_procedure": 9290
     },
     "trace": {
-      "core_rows": 22197,
-      "chiplets_rows": 9821,
-      "range_rows": 1733,
+      "core_rows": 22150,
+      "chiplets_rows": 9768,
+      "range_rows": 1685,
       "chiplets_shape": {
-        "hasher_rows": 7744,
+        "hasher_rows": 7752,
         "bitwise_rows": 576,
         "memory_rows": 1438,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume NETWORK_ACCOUNT_CONFIG note (network account)": {
     "prologue": 3270,
-    "notes_processing": 3083,
+    "notes_processing": 3074,
     "note_execution": {
-      "0x4519f7da7cc74cfa1cee1233966ed40b0e1e67d540f6342e7a962742fd10ed9a": 3041
+      "0x74c16ef12e615b835dd41dcc8b3760cf093c530773d3567c8e87179b0bc41a37": 3032
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 12794,
-      "auth_procedure": 9305
+      "total": 12760,
+      "auth_procedure": 9272
     },
     "trace": {
-      "core_rows": 19233,
-      "chiplets_rows": 8023,
-      "range_rows": 1565,
+      "core_rows": 19189,
+      "chiplets_rows": 7970,
+      "range_rows": 1575,
       "chiplets_shape": {
-        "hasher_rows": 6200,
+        "hasher_rows": 6208,
         "bitwise_rows": 560,
         "memory_rows": 1200,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CONSTANT_FEE_POLICY_CONFIG note (network account)": {
     "prologue": 3317,
-    "notes_processing": 3804,
+    "notes_processing": 3793,
     "note_execution": {
-      "0xc1bb01823b4f2eeab6fc870d34791fea2bf9b2b17a59e783f4748b5e08366fce": 3762
+      "0x0d576089fb4f0ac6ecbd22ad77330b06c3481f9e603ca1e222c95242d264876f": 3751
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 12941,
-      "auth_procedure": 9314
+      "total": 12907,
+      "auth_procedure": 9281
     },
     "trace": {
-      "core_rows": 20148,
-      "chiplets_rows": 8307,
-      "range_rows": 1551,
+      "core_rows": 20102,
+      "chiplets_rows": 8246,
+      "range_rows": 1543,
       "chiplets_shape": {
         "hasher_rows": 6408,
         "bitwise_rows": 560,
         "memory_rows": 1276,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume FEE_SPONSORSHIP note with feature note (network account)": {
     "prologue": 4775,
-    "notes_processing": 1201,
+    "notes_processing": 1196,
     "note_execution": {
-      "0x0878e4f039a63ef94a6aea1b5170fa5a155acd70ed72f17d9e9054f86f7254e1": 676,
-      "0x30e133565785ae090e4920c05bb4adac8004adba6ba51e887396e0082197e1e7": 474
+      "0x38b367dcdad68d422859f08b8cc2994f6b8168f5d7f9a95c7e6aa4bae442060e": 472,
+      "0xc66d02bd1583a26b36b48d0648dde8b721325db0113054b61a894a3fdc53ffea": 673
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 15503,
-      "auth_procedure": 12474
+      "total": 15460,
+      "auth_procedure": 12432
     },
     "trace": {
-      "core_rows": 21565,
-      "chiplets_rows": 9371,
-      "range_rows": 1585,
+      "core_rows": 21516,
+      "chiplets_rows": 9318,
+      "range_rows": 1577,
       "chiplets_shape": {
-        "hasher_rows": 7200,
+        "hasher_rows": 7208,
         "bitwise_rows": 888,
         "memory_rows": 1220,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume FEE_SPONSORSHIP note (reclaim)": {
     "prologue": 3605,
-    "notes_processing": 2959,
+    "notes_processing": 2950,
     "note_execution": {
-      "0xf98abceec1f290ee4de60d305d4d4631e83ef11732a89c99868e31bb8524c9ea": 2917
+      "0xc9a85e5d49decb62e8e7273c1481deae65578c7144e274a66bf8def2a612e1c0": 2908
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 10475,
-      "auth_procedure": 8261
+      "total": 10451,
+      "auth_procedure": 8238
     },
     "trace": {
-      "core_rows": 17125,
-      "chiplets_rows": 7725,
+      "core_rows": 17091,
+      "chiplets_rows": 7672,
       "range_rows": 1587,
       "chiplets_shape": {
-        "hasher_rows": 5648,
+        "hasher_rows": 5656,
         "bitwise_rows": 1144,
         "memory_rows": 870,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L1 to Miden, with fee payment)": {
     "prologue": 4033,
-    "notes_processing": 28630,
+    "notes_processing": 28611,
     "note_execution": {
-      "0x7011215795b6dba5c82c896bb172b879a33aa64269846fabbd9c0c2577b7a756": 28588
+      "0x7bea021213b295ee78576f67b78275a36ee5383a2fefa3ad65b5aa76d54ae854": 28569
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 21056,
-      "auth_procedure": 14619
+      "total": 21004,
+      "auth_procedure": 14568
     },
     "trace": {
-      "core_rows": 53805,
-      "chiplets_rows": 21728,
-      "range_rows": 3583,
+      "core_rows": 53733,
+      "chiplets_rows": 21675,
+      "range_rows": 3595,
       "chiplets_shape": {
-        "hasher_rows": 14344,
+        "hasher_rows": 14352,
         "bitwise_rows": 3088,
         "memory_rows": 4233,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L2 to Miden, with fee payment)": {
     "prologue": 4033,
-    "notes_processing": 38792,
+    "notes_processing": 38773,
     "note_execution": {
-      "0x0b5ae157c63e7f16c93614f30657bee63562c825b3829023dd35325fcb51285a": 38750
+      "0x0b5ac42d7096eab566b98f2a4347b6723be173d3142833418efb059e7708a3bd": 38731
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 21056,
-      "auth_procedure": 14619
+      "total": 21004,
+      "auth_procedure": 14568
     },
     "trace": {
-      "core_rows": 63967,
-      "chiplets_rows": 24478,
-      "range_rows": 3803,
+      "core_rows": 63895,
+      "chiplets_rows": 24425,
+      "range_rows": 3789,
       "chiplets_shape": {
-        "hasher_rows": 15896,
+        "hasher_rows": 15904,
         "bitwise_rows": 3344,
         "memory_rows": 5175,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, with fee payment)": {
     "prologue": 4957,
-    "notes_processing": 118067,
+    "notes_processing": 117975,
     "note_execution": {
-      "0x53d05c66c8fdf38e31fcf003bf35b60e3800fed66ce19aa7d584fbd4bbeacc69": 118025
+      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 117933
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 30823,
-      "auth_procedure": 14704
+      "total": 30771,
+      "auth_procedure": 14653
     },
     "trace": {
-      "core_rows": 153933,
-      "chiplets_rows": 72785,
-      "range_rows": 4841,
+      "core_rows": 153788,
+      "chiplets_rows": 72732,
+      "range_rows": 4883,
       "chiplets_shape": {
-        "hasher_rows": 58168,
+        "hasher_rows": 58176,
         "bitwise_rows": 3864,
         "memory_rows": 10690,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31-1 leaves, with fee payment)": {
     "prologue": 4957,
-    "notes_processing": 61711,
+    "notes_processing": 61619,
     "note_execution": {
-      "0x53d05c66c8fdf38e31fcf003bf35b60e3800fed66ce19aa7d584fbd4bbeacc69": 61669
+      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 61577
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 21895,
-      "auth_procedure": 14704
+      "total": 21843,
+      "auth_procedure": 14653
     },
     "trace": {
-      "core_rows": 88649,
-      "chiplets_rows": 41708,
-      "range_rows": 3761,
+      "core_rows": 88504,
+      "chiplets_rows": 41655,
+      "range_rows": 3799,
       "chiplets_shape": {
-        "hasher_rows": 31152,
+        "hasher_rows": 31160,
         "bitwise_rows": 3864,
         "memory_rows": 6629,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CONFIG_AGG_BRIDGE note (with fee payment)": {
     "prologue": 4341,
-    "notes_processing": 13752,
+    "notes_processing": 13728,
     "note_execution": {
-      "0x9485384774b3136244540201ff43c707d0bf5b623dbd67181e5e642af3d09fc0": 13710
+      "0x2b6789ea1f4051b038115581fc45fe5ef5640ddca84a5b4376bd64747646cbd8": 13686
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 16330,
-      "auth_procedure": 9467
+      "total": 16296,
+      "auth_procedure": 9434
     },
     "trace": {
-      "core_rows": 34509,
-      "chiplets_rows": 15065,
-      "range_rows": 2471,
+      "core_rows": 34450,
+      "chiplets_rows": 15012,
+      "range_rows": 2443,
       "chiplets_shape": {
-        "hasher_rows": 12000,
+        "hasher_rows": 12008,
         "bitwise_rows": 616,
         "memory_rows": 2386,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume DEREGISTER_AGG_FAUCET note (with fee payment)": {
     "prologue": 4400,
-    "notes_processing": 12991,
+    "notes_processing": 12971,
     "note_execution": {
-      "0xfd9bae702d6f3a8178a014308c751da579760feeecfdef8db24091460f353d52": 12949
+      "0x6d5162b070084e53389394472579ec1fdfee66744b0186f48b4e6adc189bd4c3": 12929
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 16330,
-      "auth_procedure": 9467
+      "total": 16296,
+      "auth_procedure": 9434
     },
     "trace": {
-      "core_rows": 33807,
-      "chiplets_rows": 14715,
-      "range_rows": 2333,
+      "core_rows": 33752,
+      "chiplets_rows": 14654,
+      "range_rows": 2325,
       "chiplets_shape": {
         "hasher_rows": 11784,
         "bitwise_rows": 608,
         "memory_rows": 2260,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume UPDATE_GER note (with fee payment)": {
     "prologue": 4341,
-    "notes_processing": 4526,
+    "notes_processing": 4514,
     "note_execution": {
-      "0xdc19b5cbbf8cc228a899a3476b76360e5e4e2ea30f779f03e03967618d2842a8": 4484
+      "0x647f3a0b261d5527584bc401839b229a52f25b9251df7823c8809fe48a60a3aa": 4472
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 15530,
-      "auth_procedure": 9467
+      "total": 15496,
+      "auth_procedure": 9434
     },
     "trace": {
-      "core_rows": 24483,
-      "chiplets_rows": 9920,
-      "range_rows": 2101,
+      "core_rows": 24436,
+      "chiplets_rows": 9867,
+      "range_rows": 2055,
       "chiplets_shape": {
-        "hasher_rows": 7648,
+        "hasher_rows": 7656,
         "bitwise_rows": 560,
         "memory_rows": 1649,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume REMOVE_GER note (with fee payment)": {
     "prologue": 4400,
-    "notes_processing": 5590,
+    "notes_processing": 5576,
     "note_execution": {
-      "0xa0a89dec6b5c425ff4b4361d6ffb3bf27effdd0fa0890f0c8dcaf7509628213c": 5548
+      "0x50fe02a4740223ab69567829530c755b42b5e096de41fbeb3029b95595eeb663": 5534
     },
-    "tx_script_processing": 42,
+    "tx_script_processing": 41,
     "epilogue": {
-      "total": 15566,
-      "auth_procedure": 9467
+      "total": 15532,
+      "auth_procedure": 9434
     },
     "trace": {
-      "core_rows": 25642,
-      "chiplets_rows": 10240,
-      "range_rows": 2131,
+      "core_rows": 25593,
+      "chiplets_rows": 10187,
+      "range_rows": 2089,
       "chiplets_shape": {
-        "hasher_rows": 7880,
+        "hasher_rows": 7888,
         "bitwise_rows": 560,
         "memory_rows": 1737,
-        "kernel_rom_rows": 62,
+        "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }

--- a/crates/miden-agglayer/src/costs/table.rs
+++ b/crates/miden-agglayer/src/costs/table.rs
@@ -2,20 +2,20 @@
 // Values are maxima across the benchmarked paths; see `miden_standards::note::costs` for the
 // caveats on what they do and do not cover.
 
-/// Cycles of consuming a CLAIM note: L1 origin 53761, L2 origin 63923 (maximum).
-pub const CLAIM_CONSUMPTION_CYCLES: u32 = 63923;
+/// Cycles of consuming a CLAIM note: L1 origin 53689, L2 origin 63851 (maximum).
+pub const CLAIM_CONSUMPTION_CYCLES: u32 = 63851;
 
-/// Cycles of consuming a B2AGG note: empty frontier 153889 (maximum), 2^31-1 leaves 88605.
-pub const B2AGG_CONSUMPTION_CYCLES: u32 = 153889;
+/// Cycles of consuming a B2AGG note: empty frontier 153744 (maximum), 2^31-1 leaves 88460.
+pub const B2AGG_CONSUMPTION_CYCLES: u32 = 153744;
 
 /// Cycles of consuming a CONFIG_AGG_BRIDGE note (single benchmarked path).
-pub const CONFIG_AGG_BRIDGE_CONSUMPTION_CYCLES: u32 = 34465;
+pub const CONFIG_AGG_BRIDGE_CONSUMPTION_CYCLES: u32 = 34406;
 
 /// Cycles of consuming a DEREGISTER_AGG_FAUCET note (single benchmarked path).
-pub const DEREGISTER_AGG_FAUCET_CONSUMPTION_CYCLES: u32 = 33763;
+pub const DEREGISTER_AGG_FAUCET_CONSUMPTION_CYCLES: u32 = 33708;
 
 /// Cycles of consuming an UPDATE_GER note (single benchmarked path).
-pub const UPDATE_GER_CONSUMPTION_CYCLES: u32 = 24439;
+pub const UPDATE_GER_CONSUMPTION_CYCLES: u32 = 24392;
 
 /// Cycles of consuming a REMOVE_GER note (single benchmarked path).
-pub const REMOVE_GER_CONSUMPTION_CYCLES: u32 = 25598;
+pub const REMOVE_GER_CONSUMPTION_CYCLES: u32 = 25549;

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
@@ -23,132 +23,148 @@ const ERR_LINK_MAP_MAX_ENTRIES_EXCEEDED = "number of link map entries exceeds ma
 # MEMORY ADDRESS CONSTANTS
 # =================================================================================================
 
+# KERNEL DATA
+# -------------------------------------------------------------------------------------------------
+
+# The memory address at which the hashes of kernel procedures begin.
+#
+# This section is placed at address 0 so that the dispatcher can turn a procedure offset into a
+# procedure pointer with a single multiplication. The root of the dispatcher is part of the kernel
+# commitment, so it must not change when the rest of the memory layout changes.
+pub const KERNEL_PROCEDURES_PTR = 0
+
+# The maximum number of procedures which the transaction kernel can have.
+const MAX_KERNEL_PROCEDURES = 255
+
+# The memory address at which the number of the kernel procedures is stored.
+pub const NUM_KERNEL_PROCEDURES_PTR = MAX_KERNEL_PROCEDURES * WORD_NUM_ELEMENTS
+
 # BOOK KEEPING
 # -------------------------------------------------------------------------------------------------
 
 # The memory address at which a pointer to the currently active input note is stored.
-const ACTIVE_INPUT_NOTE_PTR = 0
+const ACTIVE_INPUT_NOTE_PTR = 1200
 
 # The memory address at which the number of output notes is stored.
-const NUM_OUTPUT_NOTES_PTR = 1
+const NUM_OUTPUT_NOTES_PTR = 1201
 
 # The memory address at which the absolute expiration block number is stored.
-const TX_EXPIRATION_BLOCK_NUM_PTR = 2
+const TX_EXPIRATION_BLOCK_NUM_PTR = 1202
 
 # The memory address at which the dirty flag of the storage commitment of the native account is
 # stored.
 #
 # This binary flag specifies whether the commitment is outdated: it holds 1 if some changes were
 # made to the account storage since the last re-computation, and 0 otherwise.
-const NATIVE_ACCT_STORAGE_COMMITMENT_DIRTY_FLAG_PTR = 3
+const NATIVE_ACCT_STORAGE_COMMITMENT_DIRTY_FLAG_PTR = 1203
 
 # The memory address at which the input vault root is stored.
-pub const INPUT_VAULT_ROOT_PTR = 4
+pub const INPUT_VAULT_ROOT_PTR = 1204
 
 # The memory address at which the output vault root is stored.
-pub const OUTPUT_VAULT_ROOT_PTR = 8
+pub const OUTPUT_VAULT_ROOT_PTR = 1208
 
 # Pointer to the prefix and suffix of the ID of the foreign account which will be loaded during the
 # upcoming FPI call. This ID is updated during the `prepare_fpi_call` kernel procedure.
-const UPCOMING_FOREIGN_ACCOUNT_SUFFIX_PTR = 12
+const UPCOMING_FOREIGN_ACCOUNT_SUFFIX_PTR = 1212
 const UPCOMING_FOREIGN_ACCOUNT_PREFIX_PTR = UPCOMING_FOREIGN_ACCOUNT_SUFFIX_PTR + 1
 
 # Pointer to the 16th input value (with index 15) of the foreign procedure which will be loaded
 # during the upcoming FPI call. This "buffer" value helps to work around the 15 value limitation of
 # the `exec_kernel_proc` kernel procedure, so that any account procedure, even if it has 16 input
 # values, could be executed as foreign.
-pub const UPCOMING_FOREIGN_PROC_INPUT_VALUE_15_PTR = 14
+pub const UPCOMING_FOREIGN_PROC_INPUT_VALUE_15_PTR = 1214
 
 # The memory address at which the flag indicating that the epilogue is running the account's
 # authentication procedure is stored.
-const EPILOGUE_AUTH_IN_PROGRESS_FLAG_PTR = 15
+const EPILOGUE_AUTH_IN_PROGRESS_FLAG_PTR = 1215
 
 # Pointer to the root of the foreign procedure which will be executed during the upcoming FPI call.
 # This root is updated during the `prepare_fpi_call` kernel procedure.
-pub const UPCOMING_FOREIGN_PROCEDURE_PTR = 16
+pub const UPCOMING_FOREIGN_PROCEDURE_PTR = 1216
 
 # The memory address at which the pointer to the account stack element containing the pointer to the
 # currently accessing account (active account) data is stored.
-const ACCOUNT_STACK_TOP_PTR = 20
+const ACCOUNT_STACK_TOP_PTR = 1220
 
 # Pointer to the first element on the account stack.
-const MIN_ACCOUNT_STACK_PTR = 21
+const MIN_ACCOUNT_STACK_PTR = 1221
 
 # Pointer to the last element on the account stack.
-const MAX_ACCOUNT_STACK_PTR = 84
+const MAX_ACCOUNT_STACK_PTR = 1284
 
 # GLOBAL INPUTS
 # -------------------------------------------------------------------------------------------------
 
 # The memory address at which the global inputs section begins.
-const GLOBAL_INPUTS_SECTION_OFFSET = 400
+const GLOBAL_INPUTS_SECTION_OFFSET = 1600
 
 # The memory address at which the transaction reference block's commitment is stored.
-const BLOCK_COMMITMENT_PTR = 400
+const BLOCK_COMMITMENT_PTR = 1600
 
 # The memory address at which the native account ID provided as a global transaction input is
 # stored.
-const GLOBAL_ACCOUNT_ID_SUFFIX_PTR = 404
+const GLOBAL_ACCOUNT_ID_SUFFIX_PTR = 1604
 const GLOBAL_ACCOUNT_ID_PREFIX_PTR = GLOBAL_ACCOUNT_ID_SUFFIX_PTR + 1
 
 # The memory address at which the initial account commitment is stored.
-const INIT_ACCOUNT_COMMITMENT_PTR = 408
+const INIT_ACCOUNT_COMMITMENT_PTR = 1608
 
 # The memory address at which the initial nonce is stored.
-const INIT_NONCE_PTR = 412
+const INIT_NONCE_PTR = 1612
 
 # The memory address at which the initial vault root of the native account is stored.
-const INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR = 416
+const INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR = 1616
 
 # The memory address at which the initial storage commitment of the native account is stored.
-const INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT_PTR = 420
+const INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT_PTR = 1620
 
 # The memory address at which the input notes commitment is stored.
-const INPUT_NOTES_COMMITMENT_PTR = 424
+const INPUT_NOTES_COMMITMENT_PTR = 1624
 
 # The memory address at which the transaction script mast root is stored.
-pub const TX_SCRIPT_ROOT_PTR = 428
+pub const TX_SCRIPT_ROOT_PTR = 1628
 
 # The memory address at which the transaction script arguments are stored.
-const TX_SCRIPT_ARGS_PTR = 432
+const TX_SCRIPT_ARGS_PTR = 1632
 
 # The memory address at which the auth procedure arguments are stored.
-const AUTH_ARGS_PTR = 436
+const AUTH_ARGS_PTR = 1636
 
 # GLOBAL BLOCK DATA
 # -------------------------------------------------------------------------------------------------
 
 # The memory address at which the block data section begins
-pub const BLOCK_DATA_SECTION_OFFSET = 800
+pub const BLOCK_DATA_SECTION_OFFSET = 2000
 
 # The memory address at which the previous block commitment is stored
-const PREV_BLOCK_COMMITMENT_PTR = 800
+const PREV_BLOCK_COMMITMENT_PTR = 2000
 
 # The memory address at which the chain commitment is stored
-const CHAIN_COMMITMENT_PTR = 804
+const CHAIN_COMMITMENT_PTR = 2004
 
 # The memory address at which the account root is stored
-const ACCT_DB_ROOT_PTR = 808
+const ACCT_DB_ROOT_PTR = 2008
 
 # The memory address at which the nullifier root is stored
-const NULLIFIER_ROOT_PTR = 812
+const NULLIFIER_ROOT_PTR = 2012
 
 # The memory address at which the tx commitment is stored
-const TX_COMMITMENT_PTR = 816
+const TX_COMMITMENT_PTR = 2016
 
 # The memory address at which the kernel commitment is stored
-const TX_KERNEL_COMMITMENT_PTR = 820
+const TX_KERNEL_COMMITMENT_PTR = 2020
 
 # The memory address at which the proof commitment is stored
-const VALIDATOR_KEY_COMMITMENT_PTR = 824
+const VALIDATOR_KEY_COMMITMENT_PTR = 2024
 
 # The memory address at which the block metadata is stored [block_number, version, timestamp, 0]
-const BLOCK_METADATA_PTR = 828
+const BLOCK_METADATA_PTR = 2028
 
 # The memory address at which the fee parameters are stored. These occupy a double word.
 # [0, verification_base_fee, fee_faucet_id_suffix, fee_faucet_id_prefix]
 # [0, 0, 0, 0]
-const FEE_PARAMETERS_PTR = 832
+const FEE_PARAMETERS_PTR = 2032
 
 # The memory address at which the verification base fee is stored.
 const VERIFICATION_BASE_FEE_PTR = FEE_PARAMETERS_PTR + 1
@@ -158,28 +174,19 @@ const FEE_FAUCET_ID_SUFFIX_PTR = FEE_PARAMETERS_PTR + 2
 const FEE_FAUCET_ID_PREFIX_PTR = FEE_PARAMETERS_PTR + 3
 
 # The memory address at which the note root is stored
-const NOTE_ROOT_PTR = 840
+const NOTE_ROOT_PTR = 2040
 
 # PARTIAL BLOCKCHAIN
 # -------------------------------------------------------------------------------------------------
 
 # The memory address at which the chain data section begins
-pub const PARTIAL_BLOCKCHAIN_PTR = 1200
+pub const PARTIAL_BLOCKCHAIN_PTR = 2400
 
 # The memory address at which the total number of leaves in the partial blockchain is stored
-const PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR = 1200
+const PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR = 2400
 
 # The memory address at which the partial blockchain peaks are stored
-const PARTIAL_BLOCKCHAIN_PEAKS_PTR = 1204
-
-# KERNEL DATA
-# -------------------------------------------------------------------------------------------------
-
-# The memory address at which the number of the kernel procedures is stored.
-const NUM_KERNEL_PROCEDURES_PTR = 1600
-
-# The memory address at which the hashes of kernel procedures begin.
-pub const KERNEL_PROCEDURES_PTR = 1604
+const PARTIAL_BLOCKCHAIN_PEAKS_PTR = 2404
 
 # ACCOUNT DATA
 # -------------------------------------------------------------------------------------------------
@@ -2097,17 +2104,6 @@ end
 #! - num_kernel_procedures is the number of the procedures of the selected kernel.
 pub proc set_num_kernel_procedures
     mem_store.NUM_KERNEL_PROCEDURES_PTR
-end
-
-#! Returns the number of the procedures of the selected kernel.
-#!
-#! Inputs:  []
-#! Outputs: [num_kernel_procedures]
-#!
-#! Where:
-#! - num_kernel_procedures is the number of the procedures of the selected kernel.
-pub proc get_num_kernel_procedures
-    mem_load.NUM_KERNEL_PROCEDURES_PTR
 end
 
 # LINK MAP

--- a/crates/miden-protocol/asm/kernels/transaction/lib/dispatcher.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/dispatcher.masm
@@ -5,9 +5,7 @@
 
 pub mod api
 
-use miden::tx_kernel_core::memory
-
-use {KERNEL_PROCEDURES_PTR} from miden::tx_kernel_core::memory
+use {NUM_KERNEL_PROCEDURES_PTR} from miden::tx_kernel_core::memory
 use {WORD_NUM_ELEMENTS} from miden::tx_kernel_core::constants
 
 # ERRORS
@@ -42,13 +40,22 @@ const ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS =
 #! Invocation: syscall
 pub proc exec_kernel_proc
     # check that the provided procedure offset is within expected bounds
-    dup exec.memory::get_num_kernel_procedures
-    lt assert.err=ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS
+    #
+    # the number of procedures is read from memory here instead of through a `memory` accessor so
+    # that the root of this procedure does not depend on the code of any other module
+    dup mem_load.NUM_KERNEL_PROCEDURES_PTR
+    # => [num_kernel_procedures, procedure_offset, procedure_offset, <procedure_inputs>, <pad>]
+
+    # assert procedure_offset < num_kernel_procedures
+    u32assert2.err=ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS
+    u32lt assert.err=ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS
     # => [procedure_offset, <procedure_inputs>, <pad>]
 
     # compute the memory pointer at which desired procedure is stored
-    mul.WORD_NUM_ELEMENTS add.KERNEL_PROCEDURES_PTR
-    # => [procedure_pointer, <procedure_inputs>, <pad>]
+    #
+    # no base address is added because the kernel procedures section starts at address 0
+    mul.WORD_NUM_ELEMENTS
+    # => [procedure_ptr, <procedure_inputs>, <pad>]
 
     # execute loaded procedure
     dynexec

--- a/crates/miden-protocol/src/transaction/kernel/memory.rs
+++ b/crates/miden-protocol/src/transaction/kernel/memory.rs
@@ -1,3 +1,7 @@
+use miden_core::program::KernelDescriptor;
+
+use crate::WORD_SIZE;
+
 // TYPE ALIASES
 // ================================================================================================
 
@@ -12,20 +16,21 @@ pub type StorageSlot = u8;
 
 // General layout
 //
-// | Section            | Start address | Size in elements | Comment                                    |
-// | ------------------ | ------------- | ---------------- | ------------------------------------------ |
-// | Bookkeeping        | 0             | 85               |                                            |
-// | Global inputs      | 400           | 40               |                                            |
-// | Block header       | 800           | 44               |                                            |
-// | Partial blockchain | 1_200         | 132              |                                            |
-// | Kernel data        | 1_600         | 224              | 56 procedures in total, 4 elements each    |
-// | Accounts data      | 8_192         | 524_288          | 64 accounts max, 8192 elements each        |
-// | Account delta      | 532_480       | 264              | fungible + non-fungible ptr + 256 patches  |
-// | Account upgrade    | 532_744       | 8                | code + storage upgrade commitment          |
-// | Input notes        | 4_194_304     | 1_114_112        | nullifiers data segment (2^16 elements)    |
-// |                    |               |                  | + 1024 input notes max, 1024 elements each |
-// | Output notes       | 16_777_216    | 1_048_576        | 1024 output notes max, 1024 elements each  |
-// | Link Map Memory    | 33_554_432    | 33_554_432       | Enough for 2_097_151 key-value pairs       |
+// | Section            | Start address | Size in elements | Comment                                     |
+// | ------------------ | ------------- | ---------------- | ------------------------------------------- |
+// | Kernel procs       | 0             | 1_024            | 255 procedures, 4 elements each + num_procs |
+// | Num kernel procs   | 1024          | 1                |                                             |
+// | Bookkeeping        | 1_200         | 85               |                                             |
+// | Global inputs      | 1_600         | 40               |                                             |
+// | Block header       | 2_000         | 44               |                                             |
+// | Partial blockchain | 2_400         | 132              |                                             |
+// | Accounts data      | 8_192         | 524_288          | 64 accounts max, 8192 elements each         |
+// | Account delta      | 532_480       | 264              | fungible + non-fungible ptr + 256 patches   |
+// | Account upgrade    | 532_744       | 8                | code + storage upgrade commitment           |
+// | Input notes        | 4_194_304     | 1_114_112        | nullifiers data segment (2^16 elements)     |
+// |                    |               |                  | + 1024 input notes max, 1024 elements each  |
+// | Output notes       | 16_777_216    | 1_048_576        | 1024 output notes max, 1024 elements each   |
+// | Link Map Memory    | 33_554_432    | 33_554_432       | Enough for 2_097_151 key-value pairs        |
 
 // Relative layout of one account
 //
@@ -51,40 +56,55 @@ pub type StorageSlot = u8;
 //
 // For now each Storage Map pointer (a link map ptr) occupies a single element.
 //
-// | Section                      | Start address | Size in elements | Comment                             |
-// | ---------------------------- | ------------- | ---------------- | ----------------------------------- |
-// | Fungible Asset Delta Ptr     | 0             | 4                |                                     |
-// | Non-Fungible Asset Delta Ptr | 4             | 4                |                                     |
-// | Storage Map Patch Ptrs       | 8             | 256              | Max 255 storage map patches         |
+// | Section                      | Start address | Size in elements | Comment                      |
+// | ---------------------------- | ------------- | ---------------- | ---------------------------- |
+// | Fungible Asset Delta Ptr     | 0             | 4                |                              |
+// | Non-Fungible Asset Delta Ptr | 4             | 4                |                              |
+// | Storage Map Patch Ptrs       | 8             | 256              | Max 255 storage map patches  |
+
+// KERNEL DATA
+// ------------------------------------------------------------------------------------------------
+
+/// The procedure roots of the kernel procedures.
+///
+/// Placed at address 0 so that multiple kernels can share the same dispatcher procedure.
+pub const KERNEL_PROCEDURES_PTR: MemoryAddress = 0;
+
+/// The maximum number of procedures which the transaction kernel can have.
+pub const MAX_KERNEL_PROCEDURES: usize = KernelDescriptor::MAX_NUM_PROCEDURES;
+
+/// The memory address at which the number of the kernel procedures is stored.
+pub const NUM_KERNEL_PROCEDURES_PTR: MemoryAddress =
+    MAX_KERNEL_PROCEDURES as MemoryAddress * WORD_SIZE as MemoryAddress;
 
 // BOOKKEEPING
 // ------------------------------------------------------------------------------------------------
 
 /// The memory address at which a pointer to the currently active input note is stored.
-pub const ACTIVE_INPUT_NOTE_PTR: MemoryAddress = 0;
+pub const ACTIVE_INPUT_NOTE_PTR: MemoryAddress = 1200;
 
 /// The memory address at which the number of output notes is stored.
-pub const NUM_OUTPUT_NOTES_PTR: MemoryAddress = 1;
+pub const NUM_OUTPUT_NOTES_PTR: MemoryAddress = 1201;
 
 /// The memory address at which the transaction expiration block number is stored.
-pub const TX_EXPIRATION_BLOCK_NUM_PTR: MemoryAddress = 2;
+pub const TX_EXPIRATION_BLOCK_NUM_PTR: MemoryAddress = 1202;
 
 /// The memory address at which the dirty flag of the storage commitment of the native account is
 /// stored.
 ///
 /// This binary flag specifies whether the commitment is outdated: it holds 1 if some changes were
 /// made to the account storage since the last re-computation, and 0 otherwise.
-pub const NATIVE_ACCT_STORAGE_COMMITMENT_DIRTY_FLAG_PTR: MemoryAddress = 3;
+pub const NATIVE_ACCT_STORAGE_COMMITMENT_DIRTY_FLAG_PTR: MemoryAddress = 1203;
 
 /// The memory address at which the input vault root is stored.
-pub const INPUT_VAULT_ROOT_PTR: MemoryAddress = 4;
+pub const INPUT_VAULT_ROOT_PTR: MemoryAddress = 1204;
 
 /// The memory address at which the output vault root is stored.
-pub const OUTPUT_VAULT_ROOT_PTR: MemoryAddress = 8;
+pub const OUTPUT_VAULT_ROOT_PTR: MemoryAddress = 1208;
 
 // Pointer to the suffix and prefix of the ID of the foreign account which will be loaded during the
 // upcoming FPI call. This ID is updated during the `prepare_fpi_call` kernel procedure.
-pub const UPCOMING_FOREIGN_ACCOUNT_PREFIX_PTR: MemoryAddress = 12;
+pub const UPCOMING_FOREIGN_ACCOUNT_PREFIX_PTR: MemoryAddress = 1212;
 pub const UPCOMING_FOREIGN_ACCOUNT_SUFFIX_PTR: MemoryAddress =
     UPCOMING_FOREIGN_ACCOUNT_PREFIX_PTR + 1;
 
@@ -92,20 +112,20 @@ pub const UPCOMING_FOREIGN_ACCOUNT_SUFFIX_PTR: MemoryAddress =
 // FPI call. This "buffer" value helps to work around the 15 value limitation of the
 // `exec_kernel_proc` kernel procedure, so that any account procedure, even if it has 16 input
 // values, could be executed as foreign.
-pub const UPCOMING_FOREIGN_PROC_INPUT_VALUE_15_PTR: MemoryAddress = 14;
+pub const UPCOMING_FOREIGN_PROC_INPUT_VALUE_15_PTR: MemoryAddress = 1214;
 
 // The memory address at which the flag indicating that the epilogue is running the account's
 // authentication procedure is stored.
-pub const EPILOGUE_AUTH_IN_PROGRESS_FLAG_PTR: MemoryAddress = 15;
+pub const EPILOGUE_AUTH_IN_PROGRESS_FLAG_PTR: MemoryAddress = 1215;
 
 // Pointer to the root of the foreign procedure which will be executed during the upcoming FPI call.
 // This root is updated during the `prepare_fpi_call` kernel procedure.
-pub const UPCOMING_FOREIGN_PROCEDURE_PTR: MemoryAddress = 16;
+pub const UPCOMING_FOREIGN_PROCEDURE_PTR: MemoryAddress = 1216;
 
 /// The memory address at which the pointer to the stack element containing the pointer to the
 /// active account data is stored.
 ///
-/// The stack starts at the address `29`. Stack has a length of `64` elements meaning that the
+/// The stack starts at the address `1221`. Stack has a length of `64` elements meaning that the
 /// maximum depth of FPI calls is `63` — the first slot is always occupied by the native account
 /// data pointer.
 ///
@@ -113,79 +133,79 @@ pub const UPCOMING_FOREIGN_PROCEDURE_PTR: MemoryAddress = 16;
 /// ┌───────────────┬────────────────┬───────────────────┬─────┬────────────────────┐
 /// │ STACK TOP PTR │ NATIVE ACCOUNT │ FOREIGN ACCOUNT 1 │ ... │ FOREIGN ACCOUNT 63 │
 /// ├───────────────┼────────────────┼───────────────────┼─────┼────────────────────┤
-///        20               21                22                         84
+///       1220             1221              1222                      1284
 /// ```
-pub const ACCOUNT_STACK_TOP_PTR: MemoryAddress = 20;
+pub const ACCOUNT_STACK_TOP_PTR: MemoryAddress = 1220;
 
 // GLOBAL INPUTS
 // ------------------------------------------------------------------------------------------------
 
 /// The memory address at which the global inputs section begins.
-pub const GLOBAL_INPUTS_SECTION_OFFSET: MemoryOffset = 400;
+pub const GLOBAL_INPUTS_SECTION_OFFSET: MemoryOffset = 1600;
 
 /// The memory address at which the commitment of the transaction's reference block is stored.
-pub const BLOCK_COMMITMENT_PTR: MemoryAddress = 400;
+pub const BLOCK_COMMITMENT_PTR: MemoryAddress = 1600;
 
 /// The memory address at which the native account ID suffix provided as a global transaction input
 /// is stored.
-pub const GLOBAL_ACCOUNT_ID_SUFFIX_PTR: MemoryAddress = 404;
+pub const GLOBAL_ACCOUNT_ID_SUFFIX_PTR: MemoryAddress = 1604;
 /// The memory address at which the native account ID prefix provided as a global transaction input
 /// is stored.
 pub const GLOBAL_ACCOUNT_ID_PREFIX_PTR: MemoryAddress = GLOBAL_ACCOUNT_ID_SUFFIX_PTR + 1;
 
 /// The memory address at which the initial account commitment is stored.
-pub const INIT_ACCT_COMMITMENT_PTR: MemoryAddress = 408;
+pub const INIT_ACCT_COMMITMENT_PTR: MemoryAddress = 1608;
 
 /// The memory address at which the initial nonce is stored.
-pub const INIT_NONCE_PTR: MemoryAddress = 412;
+pub const INIT_NONCE_PTR: MemoryAddress = 1612;
 
 /// The memory address at which the initial vault root of the native account is stored.
-pub const INIT_NATIVE_ACCT_VAULT_ROOT_PTR: MemoryAddress = 416;
+pub const INIT_NATIVE_ACCT_VAULT_ROOT_PTR: MemoryAddress = 1616;
 
 /// The memory address at which the initial storage commitment of the native account is stored.
-pub const INIT_NATIVE_ACCT_STORAGE_COMMITMENT_PTR: MemoryAddress = 420;
+pub const INIT_NATIVE_ACCT_STORAGE_COMMITMENT_PTR: MemoryAddress = 1620;
 
 /// The memory address at which the input notes commitment is stored.
-pub const INPUT_NOTES_COMMITMENT_PTR: MemoryAddress = 424;
+pub const INPUT_NOTES_COMMITMENT_PTR: MemoryAddress = 1624;
 
 /// The memory address at which the transaction script mast root is store
-pub const TX_SCRIPT_ROOT_PTR: MemoryAddress = 428;
+pub const TX_SCRIPT_ROOT_PTR: MemoryAddress = 1628;
 
 /// The memory address at which the transaction script arguments are stored.
-pub const TX_SCRIPT_ARGS: MemoryAddress = 432;
+pub const TX_SCRIPT_ARGS: MemoryAddress = 1632;
 
 /// The memory address at which the key of the auth procedure arguments is stored.
-pub const AUTH_ARGS_PTR: MemoryAddress = 436;
+pub const AUTH_ARGS_PTR: MemoryAddress = 1636;
 
 // BLOCK DATA
 // ------------------------------------------------------------------------------------------------
 
 /// The memory address at which the block data section begins.
-pub const BLOCK_DATA_SECTION_OFFSET: MemoryOffset = 800;
+pub const BLOCK_DATA_SECTION_OFFSET: MemoryOffset = 2000;
 
 /// The memory address at which the previous block commitment is stored.
-pub const PREV_BLOCK_COMMITMENT_PTR: MemoryAddress = 800;
+pub const PREV_BLOCK_COMMITMENT_PTR: MemoryAddress = 2000;
 
 /// The memory address at which the chain commitment is stored.
-pub const CHAIN_COMMITMENT_PTR: MemoryAddress = 804;
+pub const CHAIN_COMMITMENT_PTR: MemoryAddress = 2004;
 
 /// The memory address at which the state root is stored.
-pub const ACCT_DB_ROOT_PTR: MemoryAddress = 808;
+pub const ACCT_DB_ROOT_PTR: MemoryAddress = 2008;
 
 /// The memory address at which the nullifier db root is store.
-pub const NULLIFIER_DB_ROOT_PTR: MemoryAddress = 812;
+pub const NULLIFIER_DB_ROOT_PTR: MemoryAddress = 2012;
 
 /// The memory address at which the TX commitment is stored.
-pub const TX_COMMITMENT_PTR: MemoryAddress = 816;
+pub const TX_COMMITMENT_PTR: MemoryAddress = 2016;
 
 /// The memory address at which the transaction kernel commitment is stored.
-pub const TX_KERNEL_COMMITMENT_PTR: MemoryAddress = 820;
+pub const TX_KERNEL_COMMITMENT_PTR: MemoryAddress = 2020;
 
 /// The memory address at which the public key is stored.
-pub const VALIDATOR_KEY_COMMITMENT_PTR: MemoryAddress = 824;
+pub const VALIDATOR_KEY_COMMITMENT_PTR: MemoryAddress = 2024;
 
 /// The memory address at which the block number is stored.
-pub const BLOCK_METADATA_PTR: MemoryAddress = 828;
+pub const BLOCK_METADATA_PTR: MemoryAddress = 2028;
 
 /// The index of the block number within the block metadata.
 pub const BLOCK_NUMBER_IDX: DataIndex = 0;
@@ -197,7 +217,7 @@ pub const PROTOCOL_VERSION_IDX: DataIndex = 1;
 pub const TIMESTAMP_IDX: DataIndex = 2;
 
 /// The memory address at which the fee parameters are stored. These occupy a double word.
-pub const FEE_PARAMETERS_PTR: MemoryAddress = 832;
+pub const FEE_PARAMETERS_PTR: MemoryAddress = 2032;
 
 /// The index of the verification base fee within the block fee parameters.
 pub const VERIFICATION_BASE_FEE_IDX: DataIndex = 1;
@@ -209,29 +229,19 @@ pub const FEE_FAUCET_ID_SUFFIX_IDX: DataIndex = 2;
 pub const FEE_FAUCET_ID_PREFIX_IDX: DataIndex = 3;
 
 /// The memory address at which the note root is stored.
-pub const NOTE_ROOT_PTR: MemoryAddress = 840;
+pub const NOTE_ROOT_PTR: MemoryAddress = 2040;
 
 // CHAIN DATA
 // ------------------------------------------------------------------------------------------------
 
 /// The memory address at which the chain data section begins.
-pub const PARTIAL_BLOCKCHAIN_PTR: MemoryAddress = 1200;
+pub const PARTIAL_BLOCKCHAIN_PTR: MemoryAddress = 2400;
 
 /// The memory address at which the total number of leaves in the partial blockchain is stored.
-pub const PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR: MemoryAddress = 1200;
+pub const PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR: MemoryAddress = 2400;
 
 /// The memory address at which the partial blockchain peaks are stored.
-pub const PARTIAL_BLOCKCHAIN_PEAKS_PTR: MemoryAddress = 1204;
-
-// KERNEL DATA
-// ------------------------------------------------------------------------------------------------
-
-/// The memory address at which the number of the kernel procedures is stored.
-pub const NUM_KERNEL_PROCEDURES_PTR: MemoryAddress = 1600;
-
-/// The memory address at which the section, where the hashes of the kernel procedures are stored,
-/// begins.
-pub const KERNEL_PROCEDURES_PTR: MemoryAddress = 1604;
+pub const PARTIAL_BLOCKCHAIN_PEAKS_PTR: MemoryAddress = 2404;
 
 // ACCOUNT DATA
 // ------------------------------------------------------------------------------------------------

--- a/crates/miden-protocol/src/transaction/kernel/memory.rs
+++ b/crates/miden-protocol/src/transaction/kernel/memory.rs
@@ -19,7 +19,6 @@ pub type StorageSlot = u8;
 // | Section            | Start address | Size in elements | Comment                                     |
 // | ------------------ | ------------- | ---------------- | ------------------------------------------- |
 // | Kernel procs       | 0             | 1_024            | 255 procedures, 4 elements each + num_procs |
-// | Num kernel procs   | 1024          | 1                |                                             |
 // | Bookkeeping        | 1_200         | 85               |                                             |
 // | Global inputs      | 1_600         | 40               |                                             |
 // | Block header       | 2_000         | 44               |                                             |

--- a/crates/miden-protocol/src/transaction/kernel/mod.rs
+++ b/crates/miden-protocol/src/transaction/kernel/mod.rs
@@ -587,6 +587,34 @@ pub(crate) mod source_manager_ext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::transaction::kernel::memory::KERNEL_PROCEDURES_PTR;
+    use crate::word;
+
+    /// The root of `exec_kernel_proc`.
+    ///
+    /// Every kernel caller commits to this root through its `syscall` instructions, so this root
+    /// must be stable.
+    const EXEC_KERNEL_PROC_ROOT: Word =
+        word!("0x5234d0969f1a3e08bcd099fd71220f5c354eac99ab6a750368560722c5b8b113");
+
+    #[test]
+    fn exec_kernel_proc_root_is_stable() {
+        let root = TransactionKernel::package()
+            .get_procedure_root_by_path("$kernel::exec_kernel_proc")
+            .unwrap();
+
+        assert_eq!(
+            root, EXEC_KERNEL_PROC_ROOT,
+            "exec_kernel_proc root {root} was not the expected {EXEC_KERNEL_PROC_ROOT}"
+        );
+    }
+
+    /// `exec_kernel_proc` derives the procedure pointer from the procedure offset alone, which is
+    /// only correct while the kernel procedures section begins at address 0.
+    #[test]
+    fn kernel_procedures_section_begins_at_zero() {
+        assert_eq!(KERNEL_PROCEDURES_PTR, 0);
+    }
 
     #[test]
     fn tx_kernel_exports_only_exec_kernel_proc() {

--- a/crates/miden-standards/src/note/costs/table.rs
+++ b/crates/miden-standards/src/note/costs/table.rs
@@ -2,54 +2,54 @@
 // Values are maxima across the benchmarked paths; see `miden_standards::note::costs` for the
 // caveats on what they do and do not cover.
 
-/// Cycles of consuming a P2ID note: 1 asset 18689, 16 assets 57002 (maximum).
-pub const P2ID_CONSUMPTION_CYCLES: u32 = 57002;
+/// Cycles of consuming a P2ID note: 1 asset 18648, 16 assets 56946 (maximum).
+pub const P2ID_CONSUMPTION_CYCLES: u32 = 56946;
 
-/// Cycles of consuming a P2IDE note: claim 18814, claim with 16 assets 57127 (maximum), reclaim
-/// 18969.
-pub const P2IDE_CONSUMPTION_CYCLES: u32 = 57127;
+/// Cycles of consuming a P2IDE note: claim 18772, claim with 16 assets 57070 (maximum), reclaim
+/// 18927.
+pub const P2IDE_CONSUMPTION_CYCLES: u32 = 57070;
 
-/// Cycles of consuming a SWAP note: public payback 22746 (maximum), private payback 22226.
-pub const SWAP_CONSUMPTION_CYCLES: u32 = 22746;
+/// Cycles of consuming a SWAP note: public payback 22697 (maximum), private payback 22178.
+pub const SWAP_CONSUMPTION_CYCLES: u32 = 22697;
 
-/// Cycles of consuming a PSWAP note: full fill 25344, partial fill 29372 (maximum).
-pub const PSWAP_CONSUMPTION_CYCLES: u32 = 29372;
+/// Cycles of consuming a PSWAP note: full fill 25293, partial fill 29310 (maximum).
+pub const PSWAP_CONSUMPTION_CYCLES: u32 = 29310;
 
-/// Cycles of consuming a MINT note: fungible faucet 34858, non-fungible faucet 38453 (maximum).
-pub const MINT_CONSUMPTION_CYCLES: u32 = 38453;
+/// Cycles of consuming a MINT note: fungible faucet 33475, non-fungible faucet 36815 (maximum).
+pub const MINT_CONSUMPTION_CYCLES: u32 = 36815;
 
 /// Cycles of consuming a BURN note (single benchmarked path).
-pub const BURN_CONSUMPTION_CYCLES: u32 = 29447;
+pub const BURN_CONSUMPTION_CYCLES: u32 = 29452;
 
 /// Cycles of consuming a CONSTANT_FEE_POLICY_CONFIG note (single benchmarked path).
-pub const CONSTANT_FEE_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 20104;
+pub const CONSTANT_FEE_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 20058;
 
 /// Cycles of consuming a FAUCET_POLICY_CONFIG note (single benchmarked path).
-pub const FAUCET_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 28327;
+pub const FAUCET_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 27618;
 
 /// Cycles of consuming a FAUCET_METADATA_CONFIG note (single benchmarked path).
-pub const FAUCET_METADATA_CONFIG_CONSUMPTION_CYCLES: u32 = 27650;
+pub const FAUCET_METADATA_CONFIG_CONSUMPTION_CYCLES: u32 = 27597;
 
 /// Cycles of consuming a MIN_BURN_AMOUNT_CONFIG note (single benchmarked path).
-pub const MIN_BURN_AMOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 25995;
+pub const MIN_BURN_AMOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 25951;
 
 /// Cycles of consuming an ALLOWLIST_CONFIG note (single benchmarked path).
-pub const ALLOWLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 26745;
+pub const ALLOWLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 26701;
 
 /// Cycles of consuming a BLOCKLIST_CONFIG note (single benchmarked path).
-pub const BLOCKLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 26745;
+pub const BLOCKLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 26701;
 
 /// Cycles of consuming a PAUSE_CONFIG note (single benchmarked path).
-pub const PAUSE_CONFIG_CONSUMPTION_CYCLES: u32 = 18695;
+pub const PAUSE_CONFIG_CONSUMPTION_CYCLES: u32 = 18651;
 
 /// Cycles of consuming an OWNER_CONFIG note (single benchmarked path).
-pub const OWNER_CONFIG_CONSUMPTION_CYCLES: u32 = 18289;
+pub const OWNER_CONFIG_CONSUMPTION_CYCLES: u32 = 18245;
 
 /// Cycles of consuming an RBAC_CONFIG note (single benchmarked path).
-pub const RBAC_CONFIG_CONSUMPTION_CYCLES: u32 = 22153;
+pub const RBAC_CONFIG_CONSUMPTION_CYCLES: u32 = 22106;
 
 /// Cycles of consuming a NETWORK_ACCOUNT_CONFIG note (single benchmarked path).
-pub const NETWORK_ACCOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 19189;
+pub const NETWORK_ACCOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 19145;
 
 /// Cycles of consuming a FEE_SPONSORSHIP note (single benchmarked path).
-pub const FEE_SPONSORSHIP_CONSUMPTION_CYCLES: u32 = 21521;
+pub const FEE_SPONSORSHIP_CONSUMPTION_CYCLES: u32 = 21472;

--- a/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_tx.rs
@@ -24,6 +24,7 @@ use miden_protocol::assembly::{DefaultSourceManager, ModuleKind, ModuleParser, P
 use miden_protocol::asset::{Asset, AssetVault, FungibleAsset, NonFungibleAsset};
 use miden_protocol::block::BlockNumber;
 use miden_protocol::errors::ProvenTransactionError;
+use miden_protocol::errors::tx_kernel::ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS;
 use miden_protocol::note::{
     Note,
     NoteAssets,
@@ -83,7 +84,7 @@ use rstest::rstest;
 
 use crate::kernel_tests::tx::ExecutionOutputExt;
 use crate::utils::{create_p2any_note, create_public_p2any_note, create_spawn_note};
-use crate::{Auth, MockChain, TestTransactionBuilder};
+use crate::{Auth, MockChain, TestTransactionBuilder, assert_transaction_executor_error};
 
 /// Tests that consuming a note created in a block that is newer than the reference block of the
 /// transaction fails.
@@ -1249,6 +1250,42 @@ async fn kernel_procedures_are_not_directly_syscallable() -> anyhow::Result<()> 
         anyhow::bail!("syscall to kernel procedure {procedure_root} should be rejected");
     };
     assert!(error.to_string().contains("is not an exported kernel procedure"));
+
+    Ok(())
+}
+
+/// Tests that `exec_kernel_proc` rejects the first procedure offset which is out of bounds.
+#[tokio::test]
+async fn exec_kernel_proc_rejects_out_of_bounds_offset() -> anyhow::Result<()> {
+    let mut builder = MockChain::builder();
+    let account = builder.add_existing_wallet(Auth::IncrNonce)?;
+    let chain = builder.build()?;
+
+    // Procedure offsets are zero-based, so the number of kernel procedures is the smallest offset
+    // which no longer refers to a kernel procedure.
+    let out_of_bounds_offset = TransactionKernel::PROCEDURES.len();
+    let tx_script_source = format!(
+        "
+        @transaction_script
+        pub proc main
+            # pad the stack the way the protocol library does before a syscall
+            padw padw padw push.0.0.0
+
+            push.{out_of_bounds_offset}
+            syscall.exec_kernel_proc
+        end
+        "
+    );
+    let tx_script = CodeBuilder::new().compile_tx_script(&tx_script_source)?;
+
+    let result = chain
+        .build_transaction(account.id())
+        .tx_script(tx_script)
+        .build()?
+        .execute()
+        .await;
+
+    assert_transaction_executor_error!(result, ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS);
 
     Ok(())
 }


### PR DESCRIPTION
Addresses https://github.com/0xMiden/protocol/pull/3646#discussion_r3824533691.

Moves the kernel proc memory section to start at offset 0. This means no base address needs to be added in `exec_kernel_proc` to calculate the proc ptr, and the procedure becomes reusable across kernels so long as those kernels also lay out their procedures starting from address 0. Reduces cycle cost by using `u32lt` over `lt`.
