### PR TITLE
refactor(protocol): share the note storage preimage load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [BREAKING] The transaction kernel no longer requires assets with `AssetComposition::None` to have the non-fungible asset layout ([#3624](https://github.com/0xMiden/protocol/pull/3624)).
 - [BREAKING] Refactored `Asset` into a struct holding `AssetId` and `AssetValue` ([#3625](https://github.com/0xMiden/protocol/pull/3625)).
 - [BREAKING] Replaced `miden::protocol::active_note::write_storage_to_memory` and `miden::standards::note::input_note_get_storage` with `miden::protocol::input_note::get_storage`, which reads the note's storage without recomputing its commitment now that the prologue verifies it ([#3593](https://github.com/0xMiden/protocol/issues/3593)).
+- [BREAKING] Renamed `ERR_PROLOGUE_NOTE_STORAGE_ITEMS_COUNT_MISMATCH` to `ERR_NOTE_STORAGE_ITEMS_COUNT_MISMATCH`, now raised by the shared `miden::protocol_utils::note::load_storage_preimage` procedure ([#3656](https://github.com/0xMiden/protocol/pull/3656)).
 
 ### Fixes
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
@@ -6,6 +6,7 @@ use miden::core::word
 use miden::tx_kernel_core::account
 use miden::protocol_utils::account_id
 use miden::protocol_utils::mem as mem_utils
+use miden::protocol_utils::note as note_utils
 use miden::tx_kernel_core::asset_vault
 use miden::tx_kernel_core::asset
 use {ASSET_SIZE} from miden::tx_kernel_core::asset
@@ -65,9 +66,6 @@ const ERR_PROLOGUE_NEW_ACCOUNT_NONCE_MUST_BE_ZERO = "new account must have a zer
 
 const ERR_PROLOGUE_NUMBER_OF_NOTE_STORAGE_ITEMS_EXCEEDED_LIMIT =
     "number of note storage items exceeded the maximum limit of 1024"
-
-const ERR_PROLOGUE_NOTE_STORAGE_ITEMS_COUNT_MISMATCH =
-    "the specified number of note storage items does not match its commitment"
 
 const ERR_PROLOGUE_NOTE_STORAGE_DOES_NOT_MATCH_COMMITMENT =
     "note storage does not match the commitment"
@@ -689,15 +687,9 @@ proc process_note_num_storage_items
     locaddr.PROCESS_NOTE_STORAGE_PREIMAGE_LOC movdn.5
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, note_ptr]
 
-    # load the storage preimage from the advice map onto the advice stack, prefixed with its
-    # element count and padded to the next multiple of 8
-    adv.push_mapvaln.8
+    exec.note_utils::load_storage_preimage
     # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, note_ptr]
-    # AS => [advice_num_storage_items, [STORAGE_ITEMS]]
-
-    # assert the item count from the advice map matches the note's declared count
-    adv_push dup.5 assert_eq.err=ERR_PROLOGUE_NOTE_STORAGE_ITEMS_COUNT_MISMATCH
-    # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, note_ptr]
+    # AS => [[STORAGE_ITEMS]]
 
     # write the preimage to the memory locals and compute its commitment
     movup.5 movup.5

--- a/crates/miden-protocol/asm/protocol/src/input_note_internal.masm
+++ b/crates/miden-protocol/asm/protocol/src/input_note_internal.masm
@@ -2,14 +2,9 @@ use {INPUT_NOTE_GET_ASSET_OFFSET, INPUT_NOTE_GET_ATTACHMENTS_COMMITMENT_OFFSET, 
     from miden::protocol::kernel_proc_offsets
 use miden::protocol::note_internal
 use miden::protocol_utils::mem
+use miden::protocol_utils::note as note_utils
 use {Asset, AssetId, AssetValue, Bool, MemoryAddress, NoteId, NoteMetadata, NoteRecipient, NoteScriptRoot}
     from miden::protocol::types
-
-# ERRORS
-# =================================================================================================
-
-const ERR_NOTE_INVALID_NUMBER_OF_STORAGE_ITEMS =
-    "the specified number of note storage items does not match the actual number"
 
 # PROCEDURES
 # =================================================================================================
@@ -395,14 +390,7 @@ pub proc get_storage_raw(is_active_note: Bool, note_index: u16, dest_ptr: Memory
     dup.4 movdn.6
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, num_storage_items]
 
-    # load the storage preimage from the advice map onto the advice stack, prefixed with its
-    # element count and padded to the next multiple of 8
-    adv.push_mapvaln.8
-    # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, num_storage_items]
-    # AS => [advice_num_storage_items, [STORAGE_ITEMS]]
-
-    # assert the item count from the advice map matches the note's item count
-    adv_push dup.5 assert_eq.err=ERR_NOTE_INVALID_NUMBER_OF_STORAGE_ITEMS
+    exec.note_utils::load_storage_preimage
     # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, num_storage_items]
     # AS => [[STORAGE_ITEMS]]
 

--- a/crates/miden-protocol/asm/protocol_utils/src/note.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/note.masm
@@ -40,9 +40,6 @@ const ERR_NOTE_STORAGE_ITEMS_COUNT_MISMATCH =
 #! Loads the storage preimage committed to by `NOTE_STORAGE_COMMITMENT` from the advice map onto
 #! the advice stack and asserts that it holds the expected number of items.
 #!
-#! The preimage is padded to the next multiple of 8 so that it can be consumed by
-#! `mem::pipe_elements_preimage_to_memory` or `mem::write_elements_to_memory`.
-#!
 #! Inputs:
 #!   Operand stack: [NOTE_STORAGE_COMMITMENT, num_storage_items]
 #!   Advice stack:  []
@@ -64,8 +61,7 @@ const ERR_NOTE_STORAGE_ITEMS_COUNT_MISMATCH =
 #!
 #! Invocation: exec
 pub proc load_storage_preimage
-    # load the storage preimage from the advice map onto the advice stack, prefixed with its
-    # element count and padded to the next multiple of 8
+    # load the preimage + element count from the advice map onto the advice stack
     adv.push_mapvaln.8
     # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items]
     # AS => [advice_num_storage_items, [STORAGE_ITEMS]]

--- a/crates/miden-protocol/asm/protocol_utils/src/note.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/note.masm
@@ -27,3 +27,51 @@ pub const MAX_ATTACHMENT_TOTAL_WORDS = 512
 
 #! The reserved value to signal a `None` note attachment scheme.
 pub const ATTACHMENT_SCHEME_NONE = 1
+
+# ERRORS
+# =================================================================================================
+
+const ERR_NOTE_STORAGE_ITEMS_COUNT_MISMATCH =
+    "the number of note storage items from the advice map does not match the expected number"
+
+# PUBLIC INTERFACE
+# =================================================================================================
+
+#! Loads the storage preimage committed to by `NOTE_STORAGE_COMMITMENT` from the advice map onto
+#! the advice stack and asserts that it holds the expected number of items.
+#!
+#! The preimage is padded to the next multiple of 8 so that it can be consumed by
+#! `mem::pipe_elements_preimage_to_memory` or `mem::write_elements_to_memory`.
+#!
+#! Inputs:
+#!   Operand stack: [NOTE_STORAGE_COMMITMENT, num_storage_items]
+#!   Advice stack:  []
+#!   Advice map: {
+#!     NOTE_STORAGE_COMMITMENT: [[STORAGE_ITEMS]]
+#!   }
+#! Outputs:
+#!   Operand stack: [NOTE_STORAGE_COMMITMENT, num_storage_items]
+#!   Advice stack:  [[STORAGE_ITEMS]]
+#!
+#! Where:
+#! - NOTE_STORAGE_COMMITMENT is the commitment to the note's storage.
+#! - num_storage_items is the expected number of storage items.
+#! - STORAGE_ITEMS are the note's storage items, padded to the next multiple of 8.
+#!
+#! Panics if:
+#! - the advice map does not contain the storage items for NOTE_STORAGE_COMMITMENT.
+#! - the number of storage items from the advice map does not match num_storage_items.
+#!
+#! Invocation: exec
+pub proc load_storage_preimage
+    # load the storage preimage from the advice map onto the advice stack, prefixed with its
+    # element count and padded to the next multiple of 8
+    adv.push_mapvaln.8
+    # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items]
+    # AS => [advice_num_storage_items, [STORAGE_ITEMS]]
+
+    # assert the item count from the advice map matches the expected count
+    adv_push dup.5 assert_eq.err=ERR_NOTE_STORAGE_ITEMS_COUNT_MISMATCH
+    # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items]
+    # AS => [[STORAGE_ITEMS]]
+end

--- a/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_prologue.rs
@@ -17,7 +17,7 @@ use miden_protocol::asset::{FungibleAsset, NonFungibleAsset};
 use miden_protocol::block::account_tree::AccountIdKey;
 use miden_protocol::errors::tx_kernel::{
     ERR_ACCOUNT_SEED_AND_COMMITMENT_DIGEST_MISMATCH,
-    ERR_PROLOGUE_NOTE_STORAGE_ITEMS_COUNT_MISMATCH,
+    ERR_NOTE_STORAGE_ITEMS_COUNT_MISMATCH,
     ERR_PROLOGUE_NUMBER_OF_NOTE_ASSETS_EXCEEDS_LIMIT,
 };
 use miden_protocol::note::NoteId;
@@ -251,7 +251,7 @@ async fn test_transaction_prologue_verifies_note_storage_against_commitment() ->
     ));
 
     let result = mock_tx.execute_code(code).await;
-    assert_execution_error!(result, ERR_PROLOGUE_NOTE_STORAGE_ITEMS_COUNT_MISMATCH);
+    assert_execution_error!(result, ERR_NOTE_STORAGE_ITEMS_COUNT_MISMATCH);
 
     Ok(())
 }


### PR DESCRIPTION
Addresses [bobbinth's review comment](https://github.com/0xMiden/protocol/pull/3641#discussion_r3826455541) that the prologue's storage handling duplicates the input-note reader.

The prologue and `input_note_internal::get_storage_raw` both load a note's storage preimage from the advice map and assert its item count - this logic now became a new helper `protocol_utils::note::load_storage_preimage`.