### PR TITLE
perf(protocol): stop re-hashing input-note storage on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [BREAKING] Refactored `AccountVaultDelta` to track generic assets. `FungibleAssetDelta`, `NonFungibleAssetDelta` and `NonFungibleDeltaAction` were removed ([3485](https://github.com/0xMiden/protocol/pull/3485)).
 - [BREAKING] The transaction kernel no longer requires assets with `AssetComposition::None` to have the non-fungible asset layout ([#3624](https://github.com/0xMiden/protocol/pull/3624)).
 - [BREAKING] Refactored `Asset` into a struct holding `AssetId` and `AssetValue` ([#3625](https://github.com/0xMiden/protocol/pull/3625)).
+- [BREAKING] Replaced `miden::protocol::active_note::write_storage_to_memory` and `miden::standards::note::input_note_get_storage` with `miden::protocol::input_note::get_storage`, which reads the note's storage without recomputing its commitment now that the prologue verifies it ([#3593](https://github.com/0xMiden/protocol/issues/3593)).
 
 ### Fixes
 

--- a/crates/miden-protocol/asm/protocol/src/active_note.masm
+++ b/crates/miden-protocol/asm/protocol/src/active_note.masm
@@ -1,4 +1,3 @@
-use miden::protocol_utils::mem
 use miden::protocol::note
 use miden::protocol::input_note_internal
 use miden::protocol::note_internal
@@ -8,11 +7,6 @@ use {AccountId, Bool, MemoryAddress, NoteId, NoteMetadata, NoteRecipient, NoteSc
 
 # ERRORS
 # =================================================================================================
-
-const ERR_NOTE_DATA_DOES_NOT_MATCH_COMMITMENT = "note data does not match the commitment"
-
-const ERR_NOTE_INVALID_NUMBER_OF_STORAGE_ITEMS =
-    "the specified number of note storage items does not match the actual number"
 
 const ERR_NOTE_TOO_MANY_STORAGE_ITEMS =
     "the number of note storage items exceeds the maximum accepted by the note script"
@@ -279,9 +273,12 @@ end
 #! - dest_ptr is the memory address to write the note storage.
 #! - NOTE_STORAGE_COMMITMENT is the commitment to the note's storage.
 #! - STORAGE is the data corresponding to the note's storage.
+#! - num_storage_items is the number of storage items of the active note.
 #!
 #! Panics if:
 #! - no note is currently active.
+#! - the advice map does not contain the storage items for NOTE_STORAGE_COMMITMENT.
+#! - the number of storage items from the advice map does not match the note's item count.
 #!
 #! Invocation: exec
 pub proc get_storage(dest_ptr: MemoryAddress) -> u16
@@ -289,15 +286,7 @@ pub proc get_storage(dest_ptr: MemoryAddress) -> u16
     push.0.1
     # => [is_active_note = 1, note_index = 0, dest_ptr]
 
-    exec.input_note_internal::get_storage_info_raw
-    # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
-
-    # save num_storage_items for the return value
-    dup.4 movdn.6
-    # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, num_storage_items]
-
-    # write the inputs to the provided destination pointer
-    exec.write_storage_to_memory
+    exec.input_note_internal::get_storage_raw
     # => [num_storage_items]
 end
 
@@ -320,13 +309,15 @@ end
 #! Panics if:
 #! - no note is currently active.
 #! - num_storage_items is greater than max_num_storage_items.
+#! - the advice map does not contain the storage items for NOTE_STORAGE_COMMITMENT.
+#! - the number of storage items from the advice map does not match the note's item count.
 #!
 #! Invocation: exec
 pub proc get_bounded_storage(dest_ptr: MemoryAddress, max_num_storage_items: u16) -> u16
     exec.get_storage_info
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, max_num_storage_items]
 
-    # reject an oversized note before its storage preimage is loaded and hashed
+    # reject an oversized note before its storage preimage is loaded
     dup.4 movup.7 lte assert.err=ERR_NOTE_TOO_MANY_STORAGE_ITEMS
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
 
@@ -335,7 +326,7 @@ pub proc get_bounded_storage(dest_ptr: MemoryAddress, max_num_storage_items: u16
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, num_storage_items]
 
     # write the inputs to the provided destination pointer
-    exec.write_storage_to_memory
+    exec.input_note_internal::write_storage_to_memory
     # => [num_storage_items]
 end
 
@@ -467,54 +458,6 @@ pub proc get_script_root() -> NoteScriptRoot
 
     exec.input_note_internal::get_script_root_raw
     # => [SCRIPT_ROOT]
-end
-
-# HELPER PROCEDURES
-# =================================================================================================
-
-#! Writes the note storage stored in the advice map to the memory specified by the provided
-#! destination pointer.
-#!
-#! Inputs:
-#!   Operand stack: [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
-#!   Advice map: {
-#!     NOTE_STORAGE_COMMITMENT: [[INPUT_VALUES]]
-#!   }
-#! Outputs:
-#!   Operand stack: []
-#!
-#! Panics if:
-#! - the advice map does not contain the storage items for NOTE_STORAGE_COMMITMENT.
-#! - the items written to memory do not match NOTE_STORAGE_COMMITMENT.
-#!
-#! Invocation: exec
-pub proc write_storage_to_memory
-    # load the inputs from the advice map to the advice stack, padded to the next multiple of 8 so
-    # they can be written with `pipe_elements_preimage_to_memory`
-    adv.push_mapvaln.8
-    # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
-    # AS => [advice_num_storage_items, [INPUT_VALUES]]
-
-    # move the number of inputs obtained from advice map to the operand stack
-    adv_push dup.5
-    # OS => [num_storage_items, advice_num_storage_items, NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
-    # AS => [[INPUT_VALUES]]
-
-    assert_eq.err=ERR_NOTE_INVALID_NUMBER_OF_STORAGE_ITEMS
-    # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
-    # AS => [[INPUT_VALUES]]
-
-    # write the inputs to memory and compute their commitment
-    movup.5 movup.5
-    # OS => [num_storage_items, dest_ptr, NOTE_STORAGE_COMMITMENT]
-    # AS => [[INPUT_VALUES]]
-
-    exec.mem::pipe_elements_preimage_to_memory
-    # OS => [COMPUTED_COMMITMENT, NOTE_STORAGE_COMMITMENT]
-
-    # validate that the inputs written to memory match the inputs commitment
-    assert_eqw.err=ERR_NOTE_DATA_DOES_NOT_MATCH_COMMITMENT
-    # => []
 end
 
 # ATTACHMENTS

--- a/crates/miden-protocol/asm/protocol/src/input_note.masm
+++ b/crates/miden-protocol/asm/protocol/src/input_note.masm
@@ -390,6 +390,38 @@ pub proc get_storage_info(note_index: u16) -> (word, u16)
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items]
 end
 
+#! Writes the storage of the input note with the specified index into memory starting at the
+#! specified address.
+#!
+#! Inputs:
+#!   Operand stack: [dest_ptr, note_index]
+#!   Advice map: {
+#!     NOTE_STORAGE_COMMITMENT: [[STORAGE_ITEMS]]
+#!   }
+#! Outputs:
+#!   Operand stack: [num_storage_items]
+#!
+#! Where:
+#! - dest_ptr is the memory address the storage items are written to.
+#! - note_index is the index of the input note whose storage should be written.
+#! - NOTE_STORAGE_COMMITMENT is the storage commitment of the specified input note.
+#! - STORAGE_ITEMS are the storage items of the specified input note.
+#! - num_storage_items is the number of storage items of the specified input note.
+#!
+#! Panics if:
+#! - the note index is greater or equal to the total number of input notes.
+#! - the advice map does not contain the storage items for NOTE_STORAGE_COMMITMENT.
+#! - the number of storage items from the advice map does not match the note's item count.
+#!
+#! Invocation: exec
+pub proc get_storage(dest_ptr: MemoryAddress, note_index: u16) -> u16
+    swap push.0
+    # => [is_active_note = 0, note_index, dest_ptr]
+
+    exec.input_note_internal::get_storage_raw
+    # => [num_storage_items]
+end
+
 #! Returns the script root of the input note with the specified index.
 #!
 #! Inputs:  [note_index]

--- a/crates/miden-protocol/asm/protocol/src/input_note_internal.masm
+++ b/crates/miden-protocol/asm/protocol/src/input_note_internal.masm
@@ -1,8 +1,15 @@
 use {INPUT_NOTE_GET_ASSET_OFFSET, INPUT_NOTE_GET_ATTACHMENTS_COMMITMENT_OFFSET, INPUT_NOTE_GET_INITIAL_ASSETS_INFO_OFFSET, INPUT_NOTE_GET_METADATA_OFFSET, INPUT_NOTE_GET_NOTE_ID_OFFSET, INPUT_NOTE_GET_RECIPIENT_OFFSET, INPUT_NOTE_GET_SCRIPT_ROOT_OFFSET, INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET, INPUT_NOTE_GET_STORAGE_INFO_OFFSET, INPUT_NOTE_REMOVE_ALL_ASSETS_OFFSET, INPUT_NOTE_REMOVE_ASSET_OFFSET}
     from miden::protocol::kernel_proc_offsets
 use miden::protocol::note_internal
+use miden::protocol_utils::mem
 use {Asset, AssetId, AssetValue, Bool, MemoryAddress, NoteId, NoteMetadata, NoteRecipient, NoteScriptRoot}
     from miden::protocol::types
+
+# ERRORS
+# =================================================================================================
+
+const ERR_NOTE_INVALID_NUMBER_OF_STORAGE_ITEMS =
+    "the specified number of note storage items does not match the actual number"
 
 # PROCEDURES
 # =================================================================================================
@@ -345,6 +352,100 @@ pub proc get_storage_info_raw(is_active_note: Bool, note_index: u16) -> (word, u
         movup.5 drop
     end
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items]
+end
+
+#! Writes the storage of the input note with the specified index or the active note, depending on
+#! the provided flag, into memory starting at the specified address.
+#!
+#! This is the shared implementation used by both `input_note::get_storage` and
+#! `active_note::get_storage`.
+#!
+#! The storage items are read from the advice map under the note's storage commitment. They are not
+#! re-hashed here: the transaction prologue already verified every input note's storage against its
+#! authenticated commitment, and the advice map rejects rebinding a key to different values, so the
+#! preimage returned for that key is the one the prologue verified.
+#!
+#! Inputs:
+#!   Operand stack: [is_active_note, note_index, dest_ptr]
+#!   Advice map: {
+#!     NOTE_STORAGE_COMMITMENT: [[STORAGE_ITEMS]]
+#!   }
+#! Outputs:
+#!   Operand stack: [num_storage_items]
+#!
+#! Where:
+#! - is_active_note is 0 for indexed access, 1 for the currently active note.
+#! - note_index is the index of the input note.
+#! - dest_ptr is the memory address the storage items are written to.
+#! - NOTE_STORAGE_COMMITMENT is the storage commitment of the specified input note.
+#! - STORAGE_ITEMS are the storage items of the specified input note.
+#! - num_storage_items is the number of storage items of the specified input note.
+#!
+#! Panics if:
+#! - the note index is greater or equal to the total number of input notes.
+#! - the advice map does not contain the storage items for NOTE_STORAGE_COMMITMENT.
+#! - the number of storage items from the advice map does not match the note's item count.
+#!
+#! Invocation: exec
+pub proc get_storage_raw(is_active_note: Bool, note_index: u16, dest_ptr: MemoryAddress) -> u16
+    exec.get_storage_info_raw
+    # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
+
+    # save num_storage_items for the return value
+    dup.4 movdn.6
+    # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, num_storage_items]
+
+    exec.write_storage_to_memory
+    # => [num_storage_items]
+end
+
+#! Writes the storage items committed to by the provided note storage commitment into memory
+#! starting at the specified address.
+#!
+#! The storage items are read from the advice map under the note's storage commitment. They are not
+#! re-hashed here: the transaction prologue already verified every input note's storage against its
+#! authenticated commitment, and the advice map rejects rebinding a key to different values, so the
+#! preimage returned for that key is the one the prologue verified. That argument only holds for a
+#! commitment read from kernel memory, so callers must source NOTE_STORAGE_COMMITMENT from
+#! `get_storage_info_raw` rather than from an untrusted input.
+#!
+#! Inputs:
+#!   Operand stack: [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
+#!   Advice map: {
+#!     NOTE_STORAGE_COMMITMENT: [[STORAGE_ITEMS]]
+#!   }
+#! Outputs:
+#!   Operand stack: []
+#!
+#! Where:
+#! - NOTE_STORAGE_COMMITMENT is the storage commitment of the note.
+#! - num_storage_items is the number of storage items the note was created with.
+#! - dest_ptr is the memory address the storage items are written to.
+#! - STORAGE_ITEMS are the storage items of the note.
+#!
+#! Panics if:
+#! - the advice map does not contain the storage items for NOTE_STORAGE_COMMITMENT.
+#! - the number of storage items from the advice map does not match the note's item count.
+#!
+#! Invocation: exec
+pub proc write_storage_to_memory
+    # load the storage preimage from the advice map onto the advice stack, prefixed with its
+    # element count and padded to the next multiple of 8
+    adv.push_mapvaln.8
+    # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
+    # AS => [advice_num_storage_items, [STORAGE_ITEMS]]
+
+    # assert the item count from the advice map matches the note's item count
+    adv_push dup.5 assert_eq.err=ERR_NOTE_INVALID_NUMBER_OF_STORAGE_ITEMS
+    # OS => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
+    # AS => [[STORAGE_ITEMS]]
+
+    # drop the commitment, which was only needed as the advice map key
+    dropw
+    # => [num_storage_items, dest_ptr]
+
+    exec.mem::write_elements_to_memory
+    # => []
 end
 
 #! Returns the script root of the input note with the specified index or the active note,

--- a/crates/miden-protocol/asm/protocol_utils/src/mem.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/mem.masm
@@ -62,3 +62,61 @@ pub proc pipe_elements_preimage_to_memory
     movup.4 drop
     # => [COMPUTED_COMMITMENT]
 end
+
+#! Writes `num_elements` elements from the advice stack to memory starting at `dest_ptr`, without
+#! computing a commitment over them.
+#!
+#! This is the non-hashing counterpart of `pipe_elements_preimage_to_memory` and must only be used
+#! when the elements are already known to be authentic. It copies with the same `adv_pipe`
+#! instruction but omits the Poseidon2 permutations, so it requires the same input shape: the
+#! elements must already be on the advice stack, padded to the next multiple of 8 (e.g. via
+#! `adv.push_mapvaln.8`). The padding zeros are consumed and written to memory alongside the
+#! elements, so `dest_ptr` must have room for the padded length.
+#!
+#! Inputs:
+#!   Operand stack: [num_elements, dest_ptr]
+#!   Advice stack:  [[ELEMENTS]]
+#! Outputs:
+#!   Operand stack: []
+#!   Advice stack:  []
+#!
+#! Where:
+#! - num_elements is the number of elements to write.
+#! - dest_ptr is the memory pointer at which the elements are written.
+#! - ELEMENTS are the elements written to memory.
+#!
+#! Invocation: exec
+pub proc write_elements_to_memory
+    # compute the number of words required to store the elements: ceil(num_elements / 4)
+    u32divmod.WORD_NUM_ELEMENTS neq.0 add
+    # => [num_words, dest_ptr]
+
+    # round the number of words up to the next multiple of 2, since `adv_pipe` copies two at a time
+    dup is_odd add
+    # => [even_num_words, dest_ptr]
+
+    # compute end_ptr = dest_ptr + even_num_words * WORD_NUM_ELEMENTS
+    mul.WORD_NUM_ELEMENTS dup.1 add swap
+    # => [dest_ptr, end_ptr]
+
+    # `adv_pipe` reads the write pointer from position 12, so pad the rate and capacity words it
+    # overwrites. Their contents are irrelevant because no commitment is computed.
+    padw padw padw
+    # => [RATE0, RATE1, CAPACITY, dest_ptr, end_ptr]
+
+    dup.13 dup.13 neq
+    # => [has_more_words, RATE0, RATE1, CAPACITY, write_ptr, end_ptr]
+
+    # copy two words per iteration until write_ptr reaches end_ptr
+    while.true
+        adv_pipe
+        # => [RATE0', RATE1', CAPACITY, write_ptr', end_ptr]
+
+        dup.13 dup.13 neq
+        # => [has_more_words, RATE0', RATE1', CAPACITY, write_ptr', end_ptr]
+    end
+    # => [RATE0, RATE1, CAPACITY, end_ptr, end_ptr]
+
+    dropw dropw dropw drop drop
+    # => []
+end

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -22,7 +22,6 @@ use {NOTE_TYPE_PUBLIC} from miden::protocol::note
 
 use miden::standards::assets::fungible_asset
 use miden::standards::attachments::network_account_target
-use miden::standards::note
 use miden::standards::note::note_tag
 use miden::standards::notes::fee_sponsorship
 use {NUM_ASSETS as SPONSORSHIP_NUM_ASSETS, FEATURE_NOTE_ID_ITEM_OFFSET} from miden::standards::notes::fee_sponsorship
@@ -424,7 +423,7 @@ end
 @locals(8)
 proc get_sponsored_feature_note_id
     # write the sponsorship note's storage items to memory
-    locaddr.SPONSORSHIP_STORAGE_LOC swap exec.note::input_note_get_storage
+    locaddr.SPONSORSHIP_STORAGE_LOC exec.input_note::get_storage drop
     # => []
 
     # load the sponsored feature note ID

--- a/crates/miden-standards/asm/standards/note/mod.masm
+++ b/crates/miden-standards/asm/standards/note/mod.masm
@@ -5,8 +5,6 @@
 
 use miden::core::crypto::hashes::poseidon2
 
-use miden::protocol::active_note
-use miden::protocol::input_note
 use miden::protocol::output_note
 
 use {NoteRecipient, NoteScriptRoot} from miden::protocol::types
@@ -22,34 +20,6 @@ const ERR_NOTE_RECIPIENT_PREIMAGE_MISMATCH = "recipient preimage from the advice
 
 # PROCEDURES
 # =================================================================================================
-
-#! TODO: Move this to miden::protocol::input_note.
-#!
-#! Loads the storage items of the input note at `note_index` into memory at `dest_ptr`.
-#!
-#! The items are read from the advice map keyed by the note's storage commitment and validated
-#! against it, so a host that supplies wrong storage aborts the transaction.
-#!
-#! Inputs:  [note_index, dest_ptr]
-#! Outputs: []
-#!
-#! Where:
-#! - note_index is the index of the input note whose storage is loaded.
-#! - dest_ptr is the memory address the storage items are written to.
-#!
-#! Panics if:
-#! - the note index is greater or equal to the total number of input notes.
-#! - the advice-provided storage does not match the note's storage commitment.
-#!
-#! Invocation: exec
-pub proc input_note_get_storage
-    exec.input_note::get_storage_info
-    # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
-
-    # note that this call does NOT depend on the active note, it is merely a helper
-    exec.active_note::write_storage_to_memory
-    # => []
-end
 
 #! TODO: Move this to miden::protocol::output_note.
 #!

--- a/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_active_note.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use alloc::vec::Vec;
 
 use anyhow::Context;
 use miden_protocol::account::auth::AuthScheme;
@@ -608,6 +609,84 @@ async fn test_active_note_get_storage() -> anyhow::Result<()> {
     );
 
     mock_tx.execute_code(&code).await?;
+    Ok(())
+}
+
+/// Verifies that `active_note::get_storage` writes every storage item to memory for item counts
+/// that straddle the word and double-word boundaries of the underlying advice-stack copy.
+#[rstest]
+#[case::one_item(1)]
+#[case::one_word(4)]
+#[case::partial_second_word(5)]
+#[case::two_words(8)]
+#[case::partial_third_word(9)]
+#[case::three_words(12)]
+#[tokio::test]
+async fn test_active_note_get_storage_writes_all_items(
+    #[case] num_items: u32,
+) -> anyhow::Result<()> {
+    const DEST_PTR: u32 = 100_000_000;
+
+    let sender_id = ACCOUNT_ID_SENDER.try_into().context("failed to convert sender account ID")?;
+    let target_id = ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE
+        .try_into()
+        .context("failed to convert target account ID")?;
+
+    let serial_num = RandomCoin::new(Word::from([4u32; 4])).draw_word();
+    let metadata = PartialNoteMetadata::new(sender_id, NoteType::Public)
+        .with_tag(NoteTag::with_account_target(target_id));
+    let vault = NoteAssets::new(vec![]).context("failed to create input note assets")?;
+    let note_script = CodeBuilder::default()
+        .compile_note_script(DEFAULT_NOTE_SCRIPT)
+        .context("failed to parse note script")?;
+
+    let items: Vec<Felt> = (1..=num_items).map(Felt::from).collect();
+    let recipient = NoteRecipient::new(
+        serial_num,
+        note_script,
+        NoteStorage::new(items.clone()).context("failed to create note storage")?,
+    );
+
+    let mock_tx = TestTransactionBuilder::with_existing_mock_account()
+        .input_note(Note::new(vault, metadata, recipient))
+        .build()?;
+
+    // assert every written word, including the zero padding of the final partial word
+    let mut storage_assertions = String::new();
+    for (word_idx, chunk) in items.chunks(WORD_SIZE).enumerate() {
+        let mut storage_word = EMPTY_WORD;
+        storage_word.as_mut_slice()[..chunk.len()].copy_from_slice(chunk);
+        let word_ptr = DEST_PTR as usize + word_idx * WORD_SIZE;
+
+        storage_assertions += &format!(
+            r#"
+            padw push.{word_ptr} mem_loadw_le
+            push.{storage_word} assert_eqw.err="storage items are incorrect"
+            "#
+        );
+    }
+
+    let tx_code = format!(
+        r#"
+        use miden::tx_kernel_core::prologue
+        use miden::protocol::active_note
+
+        begin
+            exec.prologue::prepare_transaction
+
+            push.{DEST_PTR} exec.active_note::get_storage
+            # => [num_storage_items]
+
+            eq.{num_items} assert.err="unexpected num_storage_items"
+            # => []
+
+            {storage_assertions}
+        end
+        "#
+    );
+
+    mock_tx.execute_code(&tx_code).await.context("transaction execution failed")?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Stacked on #3641.

Addresses [bobbinth's question](https://github.com/0xMiden/protocol/pull/3641#pullrequestreview-3826442886) on #3641 about recovering the hashing cost elsewhere.

#3641 makes the prologue verify every input note's storage against its authenticated commitment at load time. That makes the re-verification on every read redundant, so reads now copy the storage from the advice map without recomputing its commitment. Two facts make that safe:

- the prologue verifies `NOTE_STORAGE_COMMITMENT` -> preimage for every input note, and
- the advice map refuses to rebind a key to different values (`AdviceProvider::insert_into_map` raises `MapKeyAlreadyPresent` in `miden-processor`), so the preimage returned for a verified commitment cannot change mid-transaction.

`protocol_utils::mem::write_elements_to_memory` is the non-hashing counterpart of `pipe_elements_preimage_to_memory`: the same `adv_pipe` copy, without the Poseidon2 permutations.

`active_note::write_storage_to_memory` is removed rather than left unverified. It took a caller-supplied commitment, so dropping the hash in place would have turned a self-verifying public procedure into one that trusts any word handed to it. Both of its callers source the commitment from prologue-verified kernel memory, so they move to a new `input_note::get_storage`, which also resolves the `TODO: Move this to miden::protocol::input_note` on the standards wrapper.

The other candidate — having the prologue write the preimage into note memory so readers just copy it — is not viable: `MAX_NOTE_STORAGE_ITEMS` (1024) x `MAX_INPUT_NOTES_PER_TX` (1024) is up to ~1M elements of kernel memory, which is why the prologue writes to procedure locals and discards them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bLUPBgD8T6Edt2141yrvQ
