### PR TITLE
refactor(standards): drop redundant dupw/dropw around `loc_storew_le` in `mint_and_send`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 - [BREAKING] Refactored `AccountVaultDelta` to track generic assets. `FungibleAssetDelta`, `NonFungibleAssetDelta` and `NonFungibleDeltaAction` were removed ([3485](https://github.com/0xMiden/protocol/pull/3485)).
 - [BREAKING] The transaction kernel no longer requires assets with `AssetComposition::None` to have the non-fungible asset layout ([#3624](https://github.com/0xMiden/protocol/pull/3624)).
 - [BREAKING] Refactored `Asset` into a struct holding `AssetId` and `AssetValue` ([#3625](https://github.com/0xMiden/protocol/pull/3625)).
-- Removed a redundant `dupw`/`dropw` pair around the `loc_storew_le` in `non_fungible::mint_and_send` ([#3660](https://github.com/0xMiden/protocol/pull/3660)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [BREAKING] Refactored `AccountVaultDelta` to track generic assets. `FungibleAssetDelta`, `NonFungibleAssetDelta` and `NonFungibleDeltaAction` were removed ([3485](https://github.com/0xMiden/protocol/pull/3485)).
 - [BREAKING] The transaction kernel no longer requires assets with `AssetComposition::None` to have the non-fungible asset layout ([#3624](https://github.com/0xMiden/protocol/pull/3624)).
 - [BREAKING] Refactored `Asset` into a struct holding `AssetId` and `AssetValue` ([#3625](https://github.com/0xMiden/protocol/pull/3625)).
+- Removed a redundant `dupw`/`dropw` pair around the `loc_storew_le` in `non_fungible::mint_and_send` ([#3660](https://github.com/0xMiden/protocol/pull/3660)).
 
 ### Fixes
 

--- a/crates/miden-standards/asm/standards/faucets/non_fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/non_fungible.masm
@@ -208,8 +208,8 @@ pub proc mint_and_send
     loc_storew_le.MINT_ASSET_ID_LOCAL dropw
     # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(6)]
 
-    # stash the asset value for the status key and the asset creation
-    dupw loc_storew_le.ASSET_VALUE_LOCAL dropw
+    # save the asset value for the status key and the asset creation
+    loc_storew_le.ASSET_VALUE_LOCAL
     # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(6)]
 
     # run the active mint policy over the asset value


### PR DESCRIPTION
## Summary

- Drop the surrounding `dupw`/`dropw`, which are redundant because `loc_storew_le` leaves the stored word on the stack
