### PR TITLE
fix(standards): stop the MINT note scripts assuming caller-provided stack padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Faucet asset-callback procedure roots are now verified against the faucet's account code before dispatch, so a misconfigured callback root can no longer make an asset nontransferable ([#3612](https://github.com/0xMiden/protocol/pull/3612)).
 - [BREAKING] Enforced the limit of 1024 per asset delta op for added and removed account vault deltas inside and outside the tx kernel ([#3623](https://github.com/0xMiden/protocol/pull/3623)).
 - Fixed `AccountSchemaCommitment`'s `get_schema_commitment` returning above the 16-element stack depth ([#3645](https://github.com/0xMiden/protocol/pull/3645)).
-- Fixed the fungible and non-fungible MINT note scripts assuming their `exec` callers provide blank trailing stack slots, which let them overwrite caller data; the `mint_and_send` input window is now padded explicitly ([#3661](https://github.com/0xMiden/protocol/pull/3661)).
+- Fixed the fungible and non-fungible MINT note scripts assuming their `exec` callers provide blank stack slot ([#3668](https://github.com/0xMiden/protocol/pull/3668)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Faucet asset-callback procedure roots are now verified against the faucet's account code before dispatch, so a misconfigured callback root can no longer make an asset nontransferable ([#3612](https://github.com/0xMiden/protocol/pull/3612)).
 - [BREAKING] Enforced the limit of 1024 per asset delta op for added and removed account vault deltas inside and outside the tx kernel ([#3623](https://github.com/0xMiden/protocol/pull/3623)).
 - Fixed `AccountSchemaCommitment`'s `get_schema_commitment` returning above the 16-element stack depth ([#3645](https://github.com/0xMiden/protocol/pull/3645)).
+- Fixed the fungible and non-fungible MINT note scripts assuming their `exec` callers provide blank trailing stack slots, which let them overwrite caller data; the `mint_and_send` input window is now padded explicitly ([#3661](https://github.com/0xMiden/protocol/pull/3661)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/crates/miden-standards/asm/standards/notes/mint_fungible.masm
+++ b/crates/miden-standards/asm/standards/notes/mint_fungible.masm
@@ -36,48 +36,49 @@ const ERR_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS = "fungible MINT scri
 
 #! Builds the fungible mint arguments for a PUBLIC output note from the note storage.
 #!
-#! Inputs:  [num_storage_items, pad(16)]
-#! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+#! Inputs:  [num_storage_items]
+#! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 #!
 #! Invocation: exec
 proc mint_public
-    movdn.8
-    # => [EMPTY_WORD, EMPTY_WORD, num_storage_items, pad(8)]
+    # pad the tail of the `mint_and_send` input window, keeping num_storage_items on top
+    push.0.0 movup.2
+    # => [num_storage_items, pad(2)]
 
-    mem_loadw_le.FUNGIBLE_PUBLIC_SCRIPT_ROOT_PTR
-    # => [SCRIPT_ROOT, EMPTY_WORD, num_storage_items, pad(8)]
+    padw mem_loadw_le.FUNGIBLE_PUBLIC_SCRIPT_ROOT_PTR
+    # => [SCRIPT_ROOT, num_storage_items, pad(2)]
 
-    swapw mem_loadw_le.FUNGIBLE_PUBLIC_SERIAL_NUM_PTR
-    # => [SERIAL_NUM, SCRIPT_ROOT, num_storage_items, pad(8)]
+    padw mem_loadw_le.FUNGIBLE_PUBLIC_SERIAL_NUM_PTR
+    # => [SERIAL_NUM, SCRIPT_ROOT, num_storage_items, pad(2)]
 
     # compute variable length note storage for the output note
     movup.8 sub.FUNGIBLE_MIN_NUM_STORAGE_ITEMS_PUBLIC
-    # => [num_output_note_storage, SERIAL_NUM, SCRIPT_ROOT, pad(8)]
+    # => [num_output_note_storage, SERIAL_NUM, SCRIPT_ROOT, pad(2)]
 
     push.FUNGIBLE_PUBLIC_OUTPUT_NOTE_STORAGE_PTR
-    # => [storage_ptr, num_output_note_storage, SERIAL_NUM, SCRIPT_ROOT, pad(8)]
+    # => [storage_ptr, num_output_note_storage, SERIAL_NUM, SCRIPT_ROOT, pad(2)]
 
     exec.note::compute_and_store_recipient
-    # => [RECIPIENT, pad(12)]
+    # => [RECIPIENT, pad(2)]
 
     # push note_type and tag, then ASSET_VALUE and ASSET_ID on top
     push.NOTE_TYPE_PUBLIC
-    # => [note_type, RECIPIENT, pad(12)]
+    # => [note_type, RECIPIENT, pad(2)]
 
     mem_load.FUNGIBLE_PUBLIC_TAG_PTR
-    # => [tag, note_type, RECIPIENT, pad(12)]
+    # => [tag, note_type, RECIPIENT, pad(2)]
 
     padw mem_loadw_le.FUNGIBLE_PUBLIC_ASSET_VALUE_PTR
-    # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 
     padw mem_loadw_le.FUNGIBLE_PUBLIC_ASSET_ID_PTR
-    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 end
 
 #! Builds the fungible mint arguments for a PRIVATE output note from the note storage.
 #!
-#! Inputs:  [num_storage_items, pad(16)]
-#! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+#! Inputs:  [num_storage_items]
+#! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 #!
 #! Panics if:
 #! - the number of storage items is not exactly 13.
@@ -85,31 +86,35 @@ end
 #! Invocation: exec
 proc mint_private
     eq.FUNGIBLE_NUM_STORAGE_ITEMS_PRIVATE assert.err=ERR_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
-    # => [pad(16)]
+    # => []
 
-    mem_loadw_le.FUNGIBLE_PRIVATE_RECIPIENT_PTR
-    # => [RECIPIENT, pad(12)]
+    # pad the tail of the `mint_and_send` input window
+    push.0.0
+    # => [pad(2)]
+
+    padw mem_loadw_le.FUNGIBLE_PRIVATE_RECIPIENT_PTR
+    # => [RECIPIENT, pad(2)]
 
     # push note_type and tag, then ASSET_VALUE and ASSET_ID on top
     push.NOTE_TYPE_PRIVATE
-    # => [note_type, RECIPIENT, pad(12)]
+    # => [note_type, RECIPIENT, pad(2)]
 
     mem_load.FUNGIBLE_PRIVATE_TAG_PTR
-    # => [tag, note_type, RECIPIENT, pad(12)]
+    # => [tag, note_type, RECIPIENT, pad(2)]
 
     padw mem_loadw_le.FUNGIBLE_PRIVATE_ASSET_VALUE_PTR
-    # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 
     padw mem_loadw_le.FUNGIBLE_PRIVATE_ASSET_ID_PTR
-    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 end
 
 #! Mints the fungible asset stored in the active note by calling the consuming faucet's
 #! `mint_and_send` procedure. Selects the public or private output-note layout based on the number
 #! of note storage items (see `mint_public` / `mint_private`).
 #!
-#! Inputs:  [pad(16)]
-#! Outputs: [pad(16)]
+#! Inputs:  []
+#! Outputs: []
 #!
 #! Panics if:
 #! - the number of storage items is not exactly 13 for private or less than 20 for public output
@@ -119,25 +124,26 @@ end
 #! Invocation: exec
 pub proc mint
     push.STORAGE_PTR exec.active_note::get_storage
-    # => [num_storage_items, pad(16)]
+    # => [num_storage_items]
 
     dup
-    # => [num_storage_items, num_storage_items, pad(16)]
+    # => [num_storage_items, num_storage_items]
 
     u32assert2.err=ERR_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     u32gte.FUNGIBLE_MIN_NUM_STORAGE_ITEMS_PUBLIC
-    # => [is_public_output_note, num_storage_items, pad(16)]
+    # => [is_public_output_note, num_storage_items]
 
     if.true
         exec.mint_public
     else
         exec.mint_private
     end
-    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 
     call.fungible::mint_and_send
-    # => [note_idx, pad(25)]
+    # => [note_idx, pad(15)]
 
-    dropw dropw drop drop
-    # => [pad(16)]
+    # truncate the called procedure's output window, restoring the base stack
+    dropw dropw dropw dropw
+    # => []
 end

--- a/crates/miden-standards/asm/standards/notes/mint_non_fungible.masm
+++ b/crates/miden-standards/asm/standards/notes/mint_non_fungible.masm
@@ -37,45 +37,46 @@ const ERR_NON_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS = "non-fungible M
 
 #! Builds the non-fungible mint arguments for a PUBLIC output note from the note storage.
 #!
-#! Inputs:  [num_storage_items, pad(16)]
-#! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+#! Inputs:  [num_storage_items]
+#! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 #!
 #! Invocation: exec
 proc mint_public
-    movdn.8
-    # => [EMPTY_WORD, EMPTY_WORD, num_storage_items, pad(8)]
+    # pad the tail of the `mint_and_send` input window, keeping num_storage_items on top
+    push.0.0 movup.2
+    # => [num_storage_items, pad(2)]
 
-    mem_loadw_le.NFT_PUBLIC_SCRIPT_ROOT_PTR
-    # => [SCRIPT_ROOT, EMPTY_WORD, num_storage_items, pad(8)]
+    padw mem_loadw_le.NFT_PUBLIC_SCRIPT_ROOT_PTR
+    # => [SCRIPT_ROOT, num_storage_items, pad(2)]
 
-    swapw mem_loadw_le.NFT_PUBLIC_SERIAL_NUM_PTR
-    # => [SERIAL_NUM, SCRIPT_ROOT, num_storage_items, pad(8)]
+    padw mem_loadw_le.NFT_PUBLIC_SERIAL_NUM_PTR
+    # => [SERIAL_NUM, SCRIPT_ROOT, num_storage_items, pad(2)]
 
     # compute variable length note storage for the output note
     movup.8 sub.NFT_MIN_NUM_STORAGE_ITEMS_PUBLIC
-    # => [num_output_note_storage, SERIAL_NUM, SCRIPT_ROOT, pad(8)]
+    # => [num_output_note_storage, SERIAL_NUM, SCRIPT_ROOT, pad(2)]
 
     push.NFT_PUBLIC_OUTPUT_NOTE_STORAGE_PTR
-    # => [storage_ptr, num_output_note_storage, SERIAL_NUM, SCRIPT_ROOT, pad(8)]
+    # => [storage_ptr, num_output_note_storage, SERIAL_NUM, SCRIPT_ROOT, pad(2)]
 
     exec.note::compute_and_store_recipient
-    # => [RECIPIENT, pad(12)]
+    # => [RECIPIENT, pad(2)]
 
     # push note_type and tag, then the asset on top
     push.NOTE_TYPE_PUBLIC
-    # => [note_type, RECIPIENT, pad(12)]
+    # => [note_type, RECIPIENT, pad(2)]
 
     mem_load.NFT_PUBLIC_TAG_PTR
-    # => [tag, note_type, RECIPIENT, pad(12)]
+    # => [tag, note_type, RECIPIENT, pad(2)]
 
     push.NFT_PUBLIC_ASSET_PTR exec.asset::load
-    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 end
 
 #! Builds the non-fungible mint arguments for a PRIVATE output note from the note storage.
 #!
-#! Inputs:  [num_storage_items, pad(16)]
-#! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+#! Inputs:  [num_storage_items]
+#! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 #!
 #! Panics if:
 #! - the number of storage items is not exactly 13.
@@ -83,28 +84,32 @@ end
 #! Invocation: exec
 proc mint_private
     eq.NFT_NUM_STORAGE_ITEMS_PRIVATE assert.err=ERR_NON_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
-    # => [pad(16)]
+    # => []
 
-    mem_loadw_le.NFT_PRIVATE_RECIPIENT_PTR
-    # => [RECIPIENT, pad(12)]
+    # pad the tail of the `mint_and_send` input window
+    push.0.0
+    # => [pad(2)]
+
+    padw mem_loadw_le.NFT_PRIVATE_RECIPIENT_PTR
+    # => [RECIPIENT, pad(2)]
 
     # push note_type and tag, then the asset on top
     push.NOTE_TYPE_PRIVATE
-    # => [note_type, RECIPIENT, pad(12)]
+    # => [note_type, RECIPIENT, pad(2)]
 
     mem_load.NFT_PRIVATE_TAG_PTR
-    # => [tag, note_type, RECIPIENT, pad(12)]
+    # => [tag, note_type, RECIPIENT, pad(2)]
 
     push.NFT_PRIVATE_ASSET_PTR exec.asset::load
-    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 end
 
 #! Mints the non-fungible asset stored in the active note by calling the consuming faucet's
 #! `mint_and_send` procedure. Selects the public or private output-note layout based on the number
 #! of note storage items (see `mint_public` / `mint_private`).
 #!
-#! Inputs:  [pad(16)]
-#! Outputs: [pad(16)]
+#! Inputs:  []
+#! Outputs: []
 #!
 #! Panics if:
 #! - the number of storage items is not exactly 13 for private or less than 20 for public output
@@ -114,25 +119,26 @@ end
 #! Invocation: exec
 pub proc mint
     push.STORAGE_PTR exec.active_note::get_storage
-    # => [num_storage_items, pad(16)]
+    # => [num_storage_items]
 
     dup
-    # => [num_storage_items, num_storage_items, pad(16)]
+    # => [num_storage_items, num_storage_items]
 
     u32assert2.err=ERR_NON_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     u32gte.NFT_MIN_NUM_STORAGE_ITEMS_PUBLIC
-    # => [is_public_output_note, num_storage_items, pad(16)]
+    # => [is_public_output_note, num_storage_items]
 
     if.true
         exec.mint_public
     else
         exec.mint_private
     end
-    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(12)]
+    # => [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 
     call.non_fungible::mint_and_send
-    # => [note_idx, pad(25)]
+    # => [note_idx, pad(15)]
 
-    dropw dropw drop drop
-    # => [pad(16)]
+    # truncate the called procedure's output window, restoring the base stack
+    dropw dropw dropw dropw
+    # => []
 end


### PR DESCRIPTION
Closes: https://github.com/0xMiden/protocol/issues/3667