### PR TITLE
Record Poseidon2 AIR rows for transactions

### DIFF
--- a/bin/bench-transaction/README.md
+++ b/bin/bench-transaction/README.md
@@ -57,7 +57,7 @@ Each of the above transactions is measured in two groups:
     - Authentication procedure
     - After tx cycles were obtained (The number of cycles the epilogue took to execute after the number of transaction cycles were obtained)
 
-  In the same pass we also rebuild the `ExecutionTrace` for each scenario and emit per-component trace row counts (`core_rows`, `chiplets_rows`, `range_rows`) plus the per-chiplet shape breakdown (`hasher_rows`, `bitwise_rows`, `memory_rows`, `kernel_rom_rows`, `ace_rows`).
+  In the same pass we also rebuild the `ExecutionTrace` for each scenario and emit per-component trace row counts (`core_rows`, `chiplets_rows`, `poseidon2_permutation_rows`, `range_rows`) plus the per-chiplet shape breakdown (`hasher_rows`, `bitwise_rows`, `memory_rows`, `kernel_rom_rows`, `ace_rows`).
 
   Results of this benchmark will be stored in the [`bin/bench-tx/bench-tx.json`](bench-tx.json) file.
 - Benchmarking the transaction execution and proving.
@@ -166,14 +166,19 @@ cargo bench --bin bench-transaction --bench time_counting_benchmarks --features 
 
 ## Trace shape and miden-vm's synthetic benchmark
 
-The `trace` section in `bench-tx.json` is the input contract for miden-vm's `miden-vm-synthetic-bench`. Its hard targets are the AIR-side row totals (`trace.core_rows`, `trace.chiplets_rows`, `trace.range_rows`); the `trace.chiplets_shape.*` per-chiplet breakdown is advisory profiling metadata and is required to satisfy the chiplet-bus invariant `chiplets_rows == hasher + bitwise + memory + kernel_rom + ace + 1`.
+The `trace` section in `bench-tx.json` is the input contract for miden-vm's `miden-vm-synthetic-bench`. Its hard targets are the AIR-side row totals (`trace.core_rows`, `trace.chiplets_rows`, `trace.poseidon2_permutation_rows`, `trace.range_rows`); the `trace.chiplets_shape.*` per-chiplet breakdown is advisory profiling metadata and is required to satisfy the chiplet-bus invariant `chiplets_rows == hasher + bitwise + memory + kernel_rom + ace + 1`.
 
 The consumer's hard match is on padded power-of-two brackets, not raw row equality:
 
 - `padded_core_side = max(64, next_pow2(max(core_rows, range_rows)))`
 - `padded_chiplets  = max(64, next_pow2(chiplets_rows))`
+- `padded_poseidon2 = max(64, next_pow2(poseidon2_permutation_rows))`
 
-These two can land in different brackets on the same workload (e.g. `consume two P2ID notes with Falcon signing` has `padded_core_side = 131072` but `padded_chiplets = 262144`).
+These three can land in different brackets on the same workload (e.g. `consume two P2ID notes with Falcon signing` currently has `padded_core_side = 131072` but `padded_chiplets = 16384`).
+
+Raw `range_rows` can vary slightly with witness values between producer runs. The checked contract
+is the generated scenario, its authoritative Poseidon2 count, and the independently pinned padded
+brackets rather than byte stability across separate executions.
 
 To feed the snapshot into `miden-vm`, regenerate `bench-tx.json` here and copy it across:
 
@@ -184,7 +189,10 @@ cp bin/bench-transaction/bench-tx.json \
 cargo bench -p miden-vm-synthetic-bench
 ```
 
-The schema is maintained manually; bench-tx.json's `trace` section is what the consumer's loader keys off. When changing the shape of the trace section, bump both repos together.
+The VM keeps a byte-for-byte copy of this generated file but selects only its canonical six
+Falcon/ECDSA P2ID scenarios for the default synthetic suite. The schema is maintained manually;
+`bench-tx.json`'s `trace` section is what the consumer's loader keys off. When changing the shape
+of the trace section, update both repositories together.
 
 ## License
 

--- a/bin/bench-transaction/bench-tx.json
+++ b/bin/bench-transaction/bench-tx.json
@@ -1,1030 +1,1073 @@
 {
   "consume single P2ID note with Falcon signing": {
-    "prologue": 4282,
-    "notes_processing": 2194,
+    "prologue": 4492,
+    "notes_processing": 2151,
     "note_execution": {
-      "0x5166fb09b1ba37e20ca5cbdeb2ce8b3d0c7a0b045007f792bebb3d1b2b041aea": 2152
+      "0xc4e2427e43c7965071b694bff219dd2b4f668978639085cf4df6e54972aa2426": 2109
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 73741,
-      "auth_procedure": 72631
+      "total": 73556,
+      "auth_procedure": 72437
     },
     "trace": {
-      "core_rows": 80302,
-      "chiplets_rows": 11270,
-      "range_rows": 20695,
+      "core_rows": 80284,
+      "chiplets_rows": 11351,
+      "poseidon2_permutation_rows": 54160,
+      "range_rows": 20521,
       "chiplets_shape": {
-        "hasher_rows": 8272,
-        "bitwise_rows": 584,
-        "memory_rows": 2412,
+        "hasher_rows": 8360,
+        "bitwise_rows": 592,
+        "memory_rows": 2397,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume single P2ID note with ECDSA signing": {
-    "prologue": 4282,
-    "notes_processing": 2194,
+    "prologue": 4492,
+    "notes_processing": 2151,
     "note_execution": {
-      "0x58a1dea9f42bafeedf8714b36a4aaa3a3578bb6b16ee62809aaa161c75e531f5": 2152
+      "0x7f66e8f045f7dd99060ad8623e15bb2f18e333af0ef1c51156ebe43e1a08bd77": 2109
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 6103,
-      "auth_procedure": 4993
+      "total": 5918,
+      "auth_procedure": 4799
     },
     "trace": {
-      "core_rows": 12664,
-      "chiplets_rows": 5527,
-      "range_rows": 1895,
+      "core_rows": 12646,
+      "chiplets_rows": 5608,
+      "poseidon2_permutation_rows": 19056,
+      "range_rows": 1859,
       "chiplets_shape": {
-        "hasher_rows": 3920,
-        "bitwise_rows": 840,
-        "memory_rows": 765,
+        "hasher_rows": 4008,
+        "bitwise_rows": 848,
+        "memory_rows": 750,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume two P2ID notes with Falcon signing": {
-    "prologue": 5025,
-    "notes_processing": 4570,
+    "prologue": 5328,
+    "notes_processing": 4484,
     "note_execution": {
-      "0xa0e74e49449bb191ff2634814ee96b269f29ccde0dd9f15fb08c1d44d47fd2f3": 2367,
-      "0xf1a2a585b29a07684a88d02bcc763c7981d409c9784c7f0fa25bab85677d7d67": 2152
+      "0x3dda3c3c3a56ee37e27a6cb453913fec8663269d75aa7f4cf66fc31771401939": 2109,
+      "0x811b72abe68d792c3bd5c57464a8dc3c803703e741cb8630ca25bb8a2cea31a7": 2324
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 73669,
-      "auth_procedure": 72595
+      "total": 73484,
+      "auth_procedure": 72401
     },
     "trace": {
-      "core_rows": 83349,
-      "chiplets_rows": 13238,
-      "range_rows": 20353,
+      "core_rows": 83381,
+      "chiplets_rows": 13360,
+      "poseidon2_permutation_rows": 54784,
+      "range_rows": 20457,
       "chiplets_shape": {
-        "hasher_rows": 9776,
-        "bitwise_rows": 928,
-        "memory_rows": 2532,
+        "hasher_rows": 9880,
+        "bitwise_rows": 944,
+        "memory_rows": 2534,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume two P2ID notes with ECDSA signing": {
-    "prologue": 5025,
-    "notes_processing": 4570,
+    "prologue": 5328,
+    "notes_processing": 4484,
     "note_execution": {
-      "0xa0e74e49449bb191ff2634814ee96b269f29ccde0dd9f15fb08c1d44d47fd2f3": 2367,
-      "0xf1a2a585b29a07684a88d02bcc763c7981d409c9784c7f0fa25bab85677d7d67": 2152
+      "0x3dda3c3c3a56ee37e27a6cb453913fec8663269d75aa7f4cf66fc31771401939": 2109,
+      "0x811b72abe68d792c3bd5c57464a8dc3c803703e741cb8630ca25bb8a2cea31a7": 2324
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 6031,
-      "auth_procedure": 4957
+      "total": 5846,
+      "auth_procedure": 4763
     },
     "trace": {
-      "core_rows": 15711,
-      "chiplets_rows": 7495,
-      "range_rows": 1483,
+      "core_rows": 15743,
+      "chiplets_rows": 7617,
+      "poseidon2_permutation_rows": 19696,
+      "range_rows": 1441,
       "chiplets_shape": {
-        "hasher_rows": 5424,
-        "bitwise_rows": 1184,
-        "memory_rows": 885,
+        "hasher_rows": 5528,
+        "bitwise_rows": 1200,
+        "memory_rows": 887,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "create single P2ID note with Falcon signing": {
-    "prologue": 1881,
+    "prologue": 1876,
     "notes_processing": 35,
     "note_execution": {},
-    "tx_script_processing": 1904,
+    "tx_script_processing": 1854,
     "epilogue": {
-      "total": 75268,
-      "auth_procedure": 73231
+      "total": 75067,
+      "auth_procedure": 73021
     },
     "trace": {
-      "core_rows": 79132,
-      "chiplets_rows": 10841,
-      "range_rows": 20345,
+      "core_rows": 78876,
+      "chiplets_rows": 10845,
+      "poseidon2_permutation_rows": 52464,
+      "range_rows": 20463,
       "chiplets_shape": {
-        "hasher_rows": 7992,
+        "hasher_rows": 8008,
         "bitwise_rows": 544,
-        "memory_rows": 2303,
+        "memory_rows": 2291,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "create single P2ID note with ECDSA signing": {
-    "prologue": 1881,
+    "prologue": 1876,
     "notes_processing": 35,
     "note_execution": {},
-    "tx_script_processing": 1904,
+    "tx_script_processing": 1854,
     "epilogue": {
-      "total": 7630,
-      "auth_procedure": 5593
+      "total": 7429,
+      "auth_procedure": 5383
     },
     "trace": {
-      "core_rows": 11494,
-      "chiplets_rows": 5106,
-      "range_rows": 1317,
+      "core_rows": 11238,
+      "chiplets_rows": 5102,
+      "poseidon2_permutation_rows": 17360,
+      "range_rows": 1271,
       "chiplets_shape": {
-        "hasher_rows": 3648,
+        "hasher_rows": 3656,
         "bitwise_rows": 800,
-        "memory_rows": 656,
+        "memory_rows": 644,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L1 to Miden)": {
-    "prologue": 4033,
-    "notes_processing": 28611,
+    "prologue": 4821,
+    "notes_processing": 28305,
     "note_execution": {
-      "0x7bea021213b295ee78576f67b78275a36ee5383a2fefa3ad65b5aa76d54ae854": 28569
+      "0xb3af39ecb1ce4d350adbc2c16f9fd10f3ccd7e30f1fa482d53114a213829fa4b": 28263
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 16862,
-      "auth_procedure": 11808
+      "total": 16564,
+      "auth_procedure": 11312
     },
     "trace": {
-      "core_rows": 49591,
-      "chiplets_rows": 19555,
-      "range_rows": 3471,
+      "core_rows": 49775,
+      "chiplets_rows": 20164,
+      "poseidon2_permutation_rows": 41072,
+      "range_rows": 3501,
       "chiplets_shape": {
-        "hasher_rows": 12720,
-        "bitwise_rows": 2752,
-        "memory_rows": 4081,
+        "hasher_rows": 13184,
+        "bitwise_rows": 2760,
+        "memory_rows": 4218,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L2 to Miden)": {
-    "prologue": 4033,
-    "notes_processing": 38773,
+    "prologue": 4821,
+    "notes_processing": 38467,
     "note_execution": {
-      "0x0b5ac42d7096eab566b98f2a4347b6723be173d3142833418efb059e7708a3bd": 38731
+      "0x10fe6fd6fef122257048c92009b43e6df141e09cf1c75f99cc8d2f92017bde43": 38425
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 16862,
-      "auth_procedure": 11808
+      "total": 16564,
+      "auth_procedure": 11312
     },
     "trace": {
-      "core_rows": 59753,
-      "chiplets_rows": 22305,
-      "range_rows": 3633,
+      "core_rows": 59937,
+      "chiplets_rows": 22914,
+      "poseidon2_permutation_rows": 43216,
+      "range_rows": 3699,
       "chiplets_shape": {
-        "hasher_rows": 14272,
-        "bitwise_rows": 3008,
-        "memory_rows": 5023,
+        "hasher_rows": 14736,
+        "bitwise_rows": 3016,
+        "memory_rows": 5160,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out)": {
-    "prologue": 4957,
-    "notes_processing": 117975,
+    "prologue": 5106,
+    "notes_processing": 119258,
     "note_execution": {
-      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 117933
+      "0xe81d88c72f6fbfe4453b450f29d2c107eb04907da068a61beb1bc90da0a56ec2": 119216
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 26629,
-      "auth_procedure": 11893
+      "total": 25085,
+      "auth_procedure": 10151
     },
     "trace": {
-      "core_rows": 149646,
-      "chiplets_rows": 70620,
-      "range_rows": 4681,
+      "core_rows": 149534,
+      "chiplets_rows": 71108,
+      "poseidon2_permutation_rows": 113680,
+      "range_rows": 4887,
       "chiplets_shape": {
-        "hasher_rows": 56552,
-        "bitwise_rows": 3528,
-        "memory_rows": 10538,
+        "hasher_rows": 57160,
+        "bitwise_rows": 3552,
+        "memory_rows": 10394,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31 leaves)": {
-    "prologue": 4957,
-    "notes_processing": 116268,
+    "prologue": 5106,
+    "notes_processing": 117567,
     "note_execution": {
-      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 116226
+      "0xe81d88c72f6fbfe4453b450f29d2c107eb04907da068a61beb1bc90da0a56ec2": 117525
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 26341,
-      "auth_procedure": 11893
+      "total": 24797,
+      "auth_procedure": 10151
     },
     "trace": {
-      "core_rows": 147651,
-      "chiplets_rows": 69633,
-      "range_rows": 4691,
+      "core_rows": 147555,
+      "chiplets_rows": 70129,
+      "poseidon2_permutation_rows": 115072,
+      "range_rows": 4941,
       "chiplets_shape": {
-        "hasher_rows": 55696,
-        "bitwise_rows": 3528,
-        "memory_rows": 10407,
+        "hasher_rows": 56304,
+        "bitwise_rows": 3552,
+        "memory_rows": 10271,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31-1 leaves)": {
-    "prologue": 4957,
-    "notes_processing": 61619,
+    "prologue": 5106,
+    "notes_processing": 63398,
     "note_execution": {
-      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 61577
+      "0xe81d88c72f6fbfe4453b450f29d2c107eb04907da068a61beb1bc90da0a56ec2": 63356
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 17701,
-      "auth_procedure": 11893
+      "total": 16157,
+      "auth_procedure": 10151
     },
     "trace": {
-      "core_rows": 84362,
-      "chiplets_rows": 39535,
-      "range_rows": 3653,
+      "core_rows": 84746,
+      "chiplets_rows": 40271,
+      "poseidon2_permutation_rows": 51504,
+      "range_rows": 3781,
       "chiplets_shape": {
-        "hasher_rows": 29528,
-        "bitwise_rows": 3528,
-        "memory_rows": 6477,
+        "hasher_rows": 30136,
+        "bitwise_rows": 3552,
+        "memory_rows": 6581,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2ID note (network account)": {
-    "prologue": 3719,
-    "notes_processing": 2194,
+    "prologue": 3868,
+    "notes_processing": 2151,
     "note_execution": {
-      "0x6495b4e27e12699e75ff36925212c87fec735ed3fd368ea3d149f57c2cbf7b70": 2152
+      "0x78438b9aa97434c7c975348963bd663562965e1f1db79254ecaaa9d41fc8c96e": 2109
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 12694,
-      "auth_procedure": 9522
+      "total": 12227,
+      "auth_procedure": 9004
     },
     "trace": {
-      "core_rows": 18692,
-      "chiplets_rows": 8263,
-      "range_rows": 1449,
+      "core_rows": 18331,
+      "chiplets_rows": 8329,
+      "poseidon2_permutation_rows": 25680,
+      "range_rows": 1475,
       "chiplets_shape": {
-        "hasher_rows": 6336,
-        "bitwise_rows": 824,
-        "memory_rows": 1101,
+        "hasher_rows": 6400,
+        "bitwise_rows": 832,
+        "memory_rows": 1095,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2ID note (16 assets, network account)": {
-    "prologue": 11894,
-    "notes_processing": 29838,
+    "prologue": 12043,
+    "notes_processing": 29525,
     "note_execution": {
-      "0x26b9d5425af9d8aab3e4a5e3ab4d358ad779f0aead666bdb4ce0a2f8a7c31232": 29796
+      "0x3dc96c9a47952e4eb15af508916f3fef731cf2cd58e25f717975463d20aef230": 29483
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 15173,
-      "auth_procedure": 9841
+      "total": 14706,
+      "auth_procedure": 9323
     },
     "trace": {
-      "core_rows": 56990,
-      "chiplets_rows": 32445,
-      "range_rows": 3593,
+      "core_rows": 56359,
+      "chiplets_rows": 32489,
+      "poseidon2_permutation_rows": 42240,
+      "range_rows": 3635,
       "chiplets_shape": {
-        "hasher_rows": 24728,
-        "bitwise_rows": 4784,
-        "memory_rows": 2931,
+        "hasher_rows": 24800,
+        "bitwise_rows": 4792,
+        "memory_rows": 2895,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (claim, network account)": {
-    "prologue": 3719,
-    "notes_processing": 2318,
+    "prologue": 3868,
+    "notes_processing": 2259,
     "note_execution": {
-      "0xcba9e1f5fcd0ef144f503fa91f0cf56a2b8e187a993af184265e624e96bf3eca": 2276
+      "0x63eabc40d31379b86e0ded89177dbabf362e0fcfd67e02182e5db0f9df5c5f7d": 2217
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 12694,
-      "auth_procedure": 9522
+      "total": 12227,
+      "auth_procedure": 9004
     },
     "trace": {
-      "core_rows": 18816,
-      "chiplets_rows": 8291,
-      "range_rows": 1473,
+      "core_rows": 18439,
+      "chiplets_rows": 8365,
+      "poseidon2_permutation_rows": 25776,
+      "range_rows": 1467,
       "chiplets_shape": {
-        "hasher_rows": 6360,
-        "bitwise_rows": 824,
-        "memory_rows": 1105,
+        "hasher_rows": 6432,
+        "bitwise_rows": 832,
+        "memory_rows": 1099,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (claim, 16 assets, network account)": {
-    "prologue": 11894,
-    "notes_processing": 29962,
+    "prologue": 12043,
+    "notes_processing": 29633,
     "note_execution": {
-      "0x892585dcabda6b524b99bfea1a67784809df641574326d175447082d821c329a": 29920
+      "0x7629580d7445907dd8d5674f42d8a03706bb1d5e925fc8bc9f5814eaf1817f02": 29591
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 15173,
-      "auth_procedure": 9841
+      "total": 14706,
+      "auth_procedure": 9323
     },
     "trace": {
-      "core_rows": 57114,
-      "chiplets_rows": 32481,
-      "range_rows": 3621,
+      "core_rows": 56467,
+      "chiplets_rows": 32525,
+      "poseidon2_permutation_rows": 42336,
+      "range_rows": 3647,
       "chiplets_shape": {
-        "hasher_rows": 24760,
-        "bitwise_rows": 4784,
-        "memory_rows": 2935,
+        "hasher_rows": 24832,
+        "bitwise_rows": 4792,
+        "memory_rows": 2899,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume P2IDE note (reclaim, network account)": {
-    "prologue": 3822,
-    "notes_processing": 2370,
+    "prologue": 3971,
+    "notes_processing": 2311,
     "note_execution": {
-      "0xc19feee7c5779c4cd9618e0938246740f54a1880bdbc5a81ef4f346d93bac041": 2328
+      "0x0cb8c3d38910a1dacb14737ce17290bb10bd2102cc312aab73aeefa6c707430f": 2269
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 12694,
-      "auth_procedure": 9522
+      "total": 12227,
+      "auth_procedure": 9004
     },
     "trace": {
-      "core_rows": 18971,
-      "chiplets_rows": 8322,
-      "range_rows": 1461,
+      "core_rows": 18594,
+      "chiplets_rows": 8396,
+      "poseidon2_permutation_rows": 25968,
+      "range_rows": 1511,
       "chiplets_shape": {
-        "hasher_rows": 6384,
-        "bitwise_rows": 824,
-        "memory_rows": 1112,
+        "hasher_rows": 6456,
+        "bitwise_rows": 832,
+        "memory_rows": 1106,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume SWAP note (public payback, network account)": {
-    "prologue": 3719,
-    "notes_processing": 4583,
+    "prologue": 3877,
+    "notes_processing": 4490,
     "note_execution": {
-      "0x831f0b151ca2841de114e5fbf49ce0cc0f2757fb0d61bc922ecc03a7dc46c926": 4541
+      "0x82d7f7ae0d13f63dae7e20e1cd20c33291c91edb9cdac8b26c249356d50326f1": 4448
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 14354,
-      "auth_procedure": 10059
+      "total": 13871,
+      "auth_procedure": 9525
     },
     "trace": {
-      "core_rows": 22741,
-      "chiplets_rows": 10305,
-      "range_rows": 1759,
+      "core_rows": 22323,
+      "chiplets_rows": 10379,
+      "poseidon2_permutation_rows": 27872,
+      "range_rows": 1779,
       "chiplets_shape": {
-        "hasher_rows": 7904,
-        "bitwise_rows": 1144,
-        "memory_rows": 1255,
+        "hasher_rows": 7976,
+        "bitwise_rows": 1152,
+        "memory_rows": 1249,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume SWAP note (private payback, network account)": {
-    "prologue": 3719,
-    "notes_processing": 4064,
+    "prologue": 3877,
+    "notes_processing": 3987,
     "note_execution": {
-      "0xbf0594a8a71ed5b2cb9967bfccdb15e435f5ffedd781db5f5ef86320ec3a7bf3": 4022
+      "0x380f3b2672cde5e59ac03e7d616b374526eeb55b36c26058c579b1adb291e447": 3945
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 14354,
-      "auth_procedure": 10059
+      "total": 13871,
+      "auth_procedure": 9525
     },
     "trace": {
-      "core_rows": 22222,
-      "chiplets_rows": 10184,
+      "core_rows": 21820,
+      "chiplets_rows": 10258,
+      "poseidon2_permutation_rows": 27552,
       "range_rows": 1757,
       "chiplets_shape": {
-        "hasher_rows": 7800,
-        "bitwise_rows": 1144,
-        "memory_rows": 1238,
+        "hasher_rows": 7872,
+        "bitwise_rows": 1152,
+        "memory_rows": 1232,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume PSWAP note (full fill, network account)": {
-    "prologue": 3719,
-    "notes_processing": 7143,
+    "prologue": 3868,
+    "notes_processing": 7286,
     "note_execution": {
-      "0x5b49ce1dd31c9fc1e6660d5ce57602d43bd3d0727cbc74b290567fe510cee9d1": 7101
+      "0x72d4eff497e5ed31de0b876e71a833c0d417d697f884f6adc770989aa0297182": 7244
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 14390,
-      "auth_procedure": 10059
+      "total": 13907,
+      "auth_procedure": 9525
     },
     "trace": {
-      "core_rows": 25337,
-      "chiplets_rows": 11049,
-      "range_rows": 1759,
+      "core_rows": 25146,
+      "chiplets_rows": 11216,
+      "poseidon2_permutation_rows": 30496,
+      "range_rows": 1833,
       "chiplets_shape": {
-        "hasher_rows": 8352,
-        "bitwise_rows": 1264,
-        "memory_rows": 1431,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume PSWAP note (partial fill, network account)": {
-    "prologue": 3719,
-    "notes_processing": 9749,
-    "note_execution": {
-      "0x5b49ce1dd31c9fc1e6660d5ce57602d43bd3d0727cbc74b290567fe510cee9d1": 9707
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 15801,
-      "auth_procedure": 10279
-    },
-    "trace": {
-      "core_rows": 29354,
-      "chiplets_rows": 12797,
-      "range_rows": 1979,
-      "chiplets_shape": {
-        "hasher_rows": 9560,
-        "bitwise_rows": 1640,
-        "memory_rows": 1595,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume MINT note (fungible faucet, network account)": {
-    "prologue": 5447,
-    "notes_processing": 8806,
-    "note_execution": {
-      "0xa0d1aa4c9e5a3c18eebc8023934763769e278133a9afdceb00a6eba5557e98e9": 8764
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 19181,
-      "auth_procedure": 9814
-    },
-    "trace": {
-      "core_rows": 33519,
-      "chiplets_rows": 12925,
-      "range_rows": 2807,
-      "chiplets_shape": {
-        "hasher_rows": 9680,
-        "bitwise_rows": 1144,
-        "memory_rows": 2099,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume MINT note (non-fungible faucet, network account)": {
-    "prologue": 5496,
-    "notes_processing": 11832,
-    "note_execution": {
-      "0xdd8a2ea724860b76cdb00db7c255fb112b25d37412bcfa63b1221fd668636d6d": 11790
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 19446,
-      "auth_procedure": 9823
-    },
-    "trace": {
-      "core_rows": 36859,
-      "chiplets_rows": 14060,
-      "range_rows": 2965,
-      "chiplets_shape": {
-        "hasher_rows": 10776,
-        "bitwise_rows": 1048,
-        "memory_rows": 2234,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume BURN note (network account)": {
-    "prologue": 6046,
-    "notes_processing": 5439,
-    "note_execution": {
-      "0x2ee00ed0d857480af3d474d6eb4ddb4ee721b734a609b343f3992b3fb73292e3": 5397
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 17926,
-      "auth_procedure": 9596
-    },
-    "trace": {
-      "core_rows": 29496,
-      "chiplets_rows": 11560,
-      "range_rows": 2571,
-      "chiplets_shape": {
-        "hasher_rows": 8776,
-        "bitwise_rows": 880,
-        "memory_rows": 1902,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume FAUCET_POLICY_CONFIG note (network account)": {
-    "prologue": 5400,
-    "notes_processing": 4398,
-    "note_execution": {
-      "0x5ee6b7875961eb6cf45f6b867ef596485916493175744d96c2becc73a009279d": 4356
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 17779,
-      "auth_procedure": 9587
-    },
-    "trace": {
-      "core_rows": 27662,
-      "chiplets_rows": 10143,
-      "range_rows": 2517,
-      "chiplets_shape": {
-        "hasher_rows": 7808,
-        "bitwise_rows": 560,
-        "memory_rows": 1773,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume FAUCET_METADATA_CONFIG note (network account)": {
-    "prologue": 4824,
-    "notes_processing": 6298,
-    "note_execution": {
-      "0x70cebe3a3c700b76e269c95d9a4d221e1ea47dc3b5cd94872b376202ad0a6cba": 6256
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 16434,
-      "auth_procedure": 9506
-    },
-    "trace": {
-      "core_rows": 27641,
-      "chiplets_rows": 10125,
-      "range_rows": 2395,
-      "chiplets_shape": {
-        "hasher_rows": 7720,
-        "bitwise_rows": 568,
-        "memory_rows": 1835,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume MIN_BURN_AMOUNT_CONFIG note (network account)": {
-    "prologue": 5457,
-    "notes_processing": 2527,
-    "note_execution": {
-      "0x4f24c4fecad6adcd971a9a73443f8785dc88d59860a29d46ec8611e4f042afae": 2485
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 17926,
-      "auth_procedure": 9596
-    },
-    "trace": {
-      "core_rows": 25995,
-      "chiplets_rows": 9612,
-      "range_rows": 2421,
-      "chiplets_shape": {
-        "hasher_rows": 7336,
-        "bitwise_rows": 560,
-        "memory_rows": 1714,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume ALLOWLIST_CONFIG note (network account)": {
-    "prologue": 5457,
-    "notes_processing": 3101,
-    "note_execution": {
-      "0xa12cccb957dc237ce3a5daf2844fafee3d43229b5c09b9e3cc744729e64378b5": 3059
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 18102,
-      "auth_procedure": 9596
-    },
-    "trace": {
-      "core_rows": 26745,
-      "chiplets_rows": 10240,
-      "range_rows": 2447,
-      "chiplets_shape": {
-        "hasher_rows": 7888,
-        "bitwise_rows": 560,
-        "memory_rows": 1790,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume BLOCKLIST_CONFIG note (network account)": {
-    "prologue": 5457,
-    "notes_processing": 3101,
-    "note_execution": {
-      "0x310c085efd662ab82f78d98744827ea2056f9105b93d8a4a803cfce478555bc2": 3059
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 18102,
-      "auth_procedure": 9596
-    },
-    "trace": {
-      "core_rows": 26745,
-      "chiplets_rows": 10240,
-      "range_rows": 2451,
-      "chiplets_shape": {
-        "hasher_rows": 7888,
-        "bitwise_rows": 560,
-        "memory_rows": 1790,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume PAUSE_CONFIG note (network account)": {
-    "prologue": 3327,
-    "notes_processing": 2542,
-    "note_execution": {
-      "0x8ced3f952199688034cb25cc6e74d04f3c2bd80b7d0f1fbcfed3f0b21f59a64c": 2500
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 12741,
-      "auth_procedure": 9281
-    },
-    "trace": {
-      "core_rows": 18695,
-      "chiplets_rows": 7424,
-      "range_rows": 1547,
-      "chiplets_shape": {
-        "hasher_rows": 5712,
-        "bitwise_rows": 560,
-        "memory_rows": 1150,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume OWNER_CONFIG note (network account)": {
-    "prologue": 3186,
-    "notes_processing": 2571,
-    "note_execution": {
-      "0x866357dfcef38b790d5e4f36bcdfde152219052cf36cd936fff970ec2d8f22f3": 2529
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 12447,
-      "auth_procedure": 9263
-    },
-    "trace": {
-      "core_rows": 18289,
-      "chiplets_rows": 7312,
-      "range_rows": 1509,
-      "chiplets_shape": {
-        "hasher_rows": 5616,
-        "bitwise_rows": 576,
-        "memory_rows": 1118,
-        "kernel_rom_rows": 1,
-        "ace_rows": 0
-      }
-    }
-  },
-  "consume RBAC_CONFIG note (network account)": {
-    "prologue": 3365,
-    "notes_processing": 5432,
-    "note_execution": {
-      "0x035211253a92572f63e9dff299426456a88dbd7ff57a77b6c628f9acb6ee81ef": 5390
-    },
-    "tx_script_processing": 41,
-    "epilogue": {
-      "total": 13268,
-      "auth_procedure": 9290
-    },
-    "trace": {
-      "core_rows": 22150,
-      "chiplets_rows": 9768,
-      "range_rows": 1685,
-      "chiplets_shape": {
-        "hasher_rows": 7752,
-        "bitwise_rows": 576,
+        "hasher_rows": 8496,
+        "bitwise_rows": 1280,
         "memory_rows": 1438,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
-  "consume NETWORK_ACCOUNT_CONFIG note (network account)": {
-    "prologue": 3270,
-    "notes_processing": 3074,
+  "consume PSWAP note (partial fill, network account)": {
+    "prologue": 3868,
+    "notes_processing": 9764,
     "note_execution": {
-      "0x74c16ef12e615b835dd41dcc8b3760cf093c530773d3567c8e87179b0bc41a37": 3032
+      "0x72d4eff497e5ed31de0b876e71a833c0d417d697f884f6adc770989aa0297182": 9722
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 12760,
-      "auth_procedure": 9272
+      "total": 15302,
+      "auth_procedure": 9729
     },
     "trace": {
-      "core_rows": 19189,
-      "chiplets_rows": 7970,
-      "range_rows": 1575,
+      "core_rows": 29019,
+      "chiplets_rows": 12964,
+      "poseidon2_permutation_rows": 32288,
+      "range_rows": 1937,
       "chiplets_shape": {
-        "hasher_rows": 6208,
-        "bitwise_rows": 560,
-        "memory_rows": 1200,
+        "hasher_rows": 9704,
+        "bitwise_rows": 1656,
+        "memory_rows": 1602,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume MINT note (fungible faucet, network account)": {
+    "prologue": 5614,
+    "notes_processing": 7929,
+    "note_execution": {
+      "0x4a83ca97c7bf0131e229dafb19dc5098f001bcde3ade01f64fa6ad366211623f": 7887
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 18938,
+      "auth_procedure": 9280
+    },
+    "trace": {
+      "core_rows": 32566,
+      "chiplets_rows": 13031,
+      "poseidon2_permutation_rows": 28368,
+      "range_rows": 2853,
+      "chiplets_shape": {
+        "hasher_rows": 9792,
+        "bitwise_rows": 1152,
+        "memory_rows": 2085,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume MINT note (non-fungible faucet, network account)": {
+    "prologue": 5663,
+    "notes_processing": 10838,
+    "note_execution": {
+      "0xc95ff03a78dc62970c83d47146a48dc73162836fbaedf444f64f7adbc1c29181": 10796
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 19212,
+      "auth_procedure": 9289
+    },
+    "trace": {
+      "core_rows": 35798,
+      "chiplets_rows": 14146,
+      "poseidon2_permutation_rows": 30240,
+      "range_rows": 3049,
+      "chiplets_shape": {
+        "hasher_rows": 10872,
+        "bitwise_rows": 1056,
+        "memory_rows": 2216,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume BURN note (network account)": {
+    "prologue": 6195,
+    "notes_processing": 4495,
+    "note_execution": {
+      "0x3fc3626c806a146f13e1ac9e59c0eac978fb59766d51c45911444bcad9b1f20f": 4453
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 17699,
+      "auth_procedure": 9078
+    },
+    "trace": {
+      "core_rows": 28474,
+      "chiplets_rows": 11610,
+      "poseidon2_permutation_rows": 27552,
+      "range_rows": 2619,
+      "chiplets_shape": {
+        "hasher_rows": 8840,
+        "bitwise_rows": 888,
+        "memory_rows": 1880,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume FAUCET_POLICY_CONFIG note (network account)": {
+    "prologue": 5549,
+    "notes_processing": 3592,
+    "note_execution": {
+      "0x1f2ce020e34fbcc888d18a7dd727829d1f1795fbb5c90927db0c51cf26bcab0b": 3550
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 17546,
+      "auth_procedure": 9069
+    },
+    "trace": {
+      "core_rows": 26772,
+      "chiplets_rows": 10220,
+      "poseidon2_permutation_rows": 26144,
+      "range_rows": 2439,
+      "chiplets_shape": {
+        "hasher_rows": 7896,
+        "bitwise_rows": 568,
+        "memory_rows": 1754,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume FAUCET_METADATA_CONFIG note (network account)": {
+    "prologue": 5000,
+    "notes_processing": 6023,
+    "note_execution": {
+      "0xc5d07af771df01abcd0fb395b32d26f7ba9205f09d4360ecca7876101017ecf4": 5981
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 16135,
+      "auth_procedure": 8988
+    },
+    "trace": {
+      "core_rows": 27243,
+      "chiplets_rows": 10321,
+      "poseidon2_permutation_rows": 25440,
+      "range_rows": 2403,
+      "chiplets_shape": {
+        "hasher_rows": 7920,
+        "bitwise_rows": 576,
+        "memory_rows": 1823,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume MIN_BURN_AMOUNT_CONFIG note (network account)": {
+    "prologue": 5606,
+    "notes_processing": 2418,
+    "note_execution": {
+      "0x7aeb862ad5ae354ca222f42cb76f60de52b8cfc78a8c540bce55b8b6a2dc6e81": 2376
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 17699,
+      "auth_procedure": 9078
+    },
+    "trace": {
+      "core_rows": 25808,
+      "chiplets_rows": 9830,
+      "poseidon2_permutation_rows": 24736,
+      "range_rows": 2463,
+      "chiplets_shape": {
+        "hasher_rows": 7552,
+        "bitwise_rows": 568,
+        "memory_rows": 1708,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume ALLOWLIST_CONFIG note (network account)": {
+    "prologue": 5606,
+    "notes_processing": 2985,
+    "note_execution": {
+      "0xc27f85d59a55783f8405b4aaa258e2bbc0789f9b5d600a9fc6b0b648fbb08854": 2943
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 17878,
+      "auth_procedure": 9078
+    },
+    "trace": {
+      "core_rows": 26554,
+      "chiplets_rows": 10464,
+      "poseidon2_permutation_rows": 27280,
+      "range_rows": 2497,
+      "chiplets_shape": {
+        "hasher_rows": 8112,
+        "bitwise_rows": 568,
+        "memory_rows": 1782,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume BLOCKLIST_CONFIG note (network account)": {
+    "prologue": 5606,
+    "notes_processing": 2985,
+    "note_execution": {
+      "0x57e359b416c6054eaaee8ec6d101dfa7ccd1e8897014e6004cd8b87e1b82ba77": 2943
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 17878,
+      "auth_procedure": 9078
+    },
+    "trace": {
+      "core_rows": 26554,
+      "chiplets_rows": 10464,
+      "poseidon2_permutation_rows": 27104,
+      "range_rows": 2513,
+      "chiplets_shape": {
+        "hasher_rows": 8112,
+        "bitwise_rows": 568,
+        "memory_rows": 1782,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume PAUSE_CONFIG note (network account)": {
+    "prologue": 3476,
+    "notes_processing": 2433,
+    "note_execution": {
+      "0xebe32aa38938bfc16f277b8542e58ed4b6b7a4ea9be764972291b965299f59a6": 2391
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 12292,
+      "auth_procedure": 8763
+    },
+    "trace": {
+      "core_rows": 18286,
+      "chiplets_rows": 7506,
+      "poseidon2_permutation_rows": 23536,
+      "range_rows": 1569,
+      "chiplets_shape": {
+        "hasher_rows": 5792,
+        "bitwise_rows": 568,
+        "memory_rows": 1144,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume OWNER_CONFIG note (network account)": {
+    "prologue": 3335,
+    "notes_processing": 2461,
+    "note_execution": {
+      "0x413694d4ebf2f4f4ad41eb749201f02c2d3e4c08da7f36eb957ccab987124fb7": 2419
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 11986,
+      "auth_procedure": 8745
+    },
+    "trace": {
+      "core_rows": 17867,
+      "chiplets_rows": 7386,
+      "poseidon2_permutation_rows": 23392,
+      "range_rows": 1503,
+      "chiplets_shape": {
+        "hasher_rows": 5688,
+        "bitwise_rows": 584,
+        "memory_rows": 1112,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume RBAC_CONFIG note (network account)": {
+    "prologue": 3514,
+    "notes_processing": 5257,
+    "note_execution": {
+      "0xe8b49ff8fb19d28da5c7e5266fe1a243b31cbb6e350636449d856e180797e81d": 5215
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 12834,
+      "auth_procedure": 8772
+    },
+    "trace": {
+      "core_rows": 21690,
+      "chiplets_rows": 9844,
+      "poseidon2_permutation_rows": 29824,
+      "range_rows": 1665,
+      "chiplets_shape": {
+        "hasher_rows": 7832,
+        "bitwise_rows": 584,
+        "memory_rows": 1426,
+        "kernel_rom_rows": 1,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume NETWORK_ACCOUNT_CONFIG note (network account)": {
+    "prologue": 3419,
+    "notes_processing": 2958,
+    "note_execution": {
+      "0x89ace2ea72ffd23f3252bf317ed8155bf1e79fc769d166f538487c5b74d646c6": 2916
+    },
+    "tx_script_processing": 41,
+    "epilogue": {
+      "total": 12305,
+      "auth_procedure": 8754
+    },
+    "trace": {
+      "core_rows": 18767,
+      "chiplets_rows": 8042,
+      "poseidon2_permutation_rows": 26080,
+      "range_rows": 1557,
+      "chiplets_shape": {
+        "hasher_rows": 6280,
+        "bitwise_rows": 568,
+        "memory_rows": 1192,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CONSTANT_FEE_POLICY_CONFIG note (network account)": {
-    "prologue": 3317,
-    "notes_processing": 3793,
+    "prologue": 3475,
+    "notes_processing": 3643,
     "note_execution": {
-      "0x0d576089fb4f0ac6ecbd22ad77330b06c3481f9e603ca1e222c95242d264876f": 3751
+      "0xa7d88a5ea6ffa94733184dccae85c121eaa85ec4b00e6231fe0305de18a2782d": 3601
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 12907,
-      "auth_procedure": 9281
+      "total": 12458,
+      "auth_procedure": 8763
     },
     "trace": {
-      "core_rows": 20102,
-      "chiplets_rows": 8246,
-      "range_rows": 1543,
+      "core_rows": 19661,
+      "chiplets_rows": 8336,
+      "poseidon2_permutation_rows": 26192,
+      "range_rows": 1601,
       "chiplets_shape": {
-        "hasher_rows": 6408,
-        "bitwise_rows": 560,
-        "memory_rows": 1276,
+        "hasher_rows": 6496,
+        "bitwise_rows": 568,
+        "memory_rows": 1270,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume FEE_SPONSORSHIP note with feature note (network account)": {
-    "prologue": 4775,
-    "notes_processing": 1196,
+    "prologue": 5071,
+    "notes_processing": 1155,
     "note_execution": {
-      "0x38b367dcdad68d422859f08b8cc2994f6b8168f5d7f9a95c7e6aa4bae442060e": 472,
-      "0xc66d02bd1583a26b36b48d0648dde8b721325db0113054b61a894a3fdc53ffea": 673
+      "0x6199ee3ed355b92a02eb0d8f15891778431c64c1de383fb8d12a79c8cd7820b6": 648,
+      "0xaa511953232bfdd8bde965cf9b0cca4b57e4a9d9a83ba375ea8002caec40eff1": 456
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 15460,
-      "auth_procedure": 12432
+      "total": 14872,
+      "auth_procedure": 11793
     },
     "trace": {
-      "core_rows": 21516,
-      "chiplets_rows": 9318,
-      "range_rows": 1577,
+      "core_rows": 21183,
+      "chiplets_rows": 9444,
+      "poseidon2_permutation_rows": 25984,
+      "range_rows": 1565,
       "chiplets_shape": {
-        "hasher_rows": 7208,
-        "bitwise_rows": 888,
-        "memory_rows": 1220,
+        "hasher_rows": 7320,
+        "bitwise_rows": 904,
+        "memory_rows": 1218,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume FEE_SPONSORSHIP note (reclaim)": {
-    "prologue": 3605,
-    "notes_processing": 2950,
+    "prologue": 3754,
+    "notes_processing": 2843,
     "note_execution": {
-      "0xc9a85e5d49decb62e8e7273c1481deae65578c7144e274a66bf8def2a612e1c0": 2908
+      "0x69c307c81334697abfed0ba239cb2a5f3357658acb54bb3d3792c16a774d081b": 2801
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 10451,
-      "auth_procedure": 8238
+      "total": 10168,
+      "auth_procedure": 7946
     },
     "trace": {
-      "core_rows": 17091,
-      "chiplets_rows": 7672,
-      "range_rows": 1587,
+      "core_rows": 16850,
+      "chiplets_rows": 7730,
+      "poseidon2_permutation_rows": 23392,
+      "range_rows": 1553,
       "chiplets_shape": {
-        "hasher_rows": 5656,
-        "bitwise_rows": 1144,
-        "memory_rows": 870,
+        "hasher_rows": 5712,
+        "bitwise_rows": 1152,
+        "memory_rows": 864,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L1 to Miden, with fee payment)": {
-    "prologue": 4033,
-    "notes_processing": 28611,
+    "prologue": 4821,
+    "notes_processing": 28305,
     "note_execution": {
-      "0x7bea021213b295ee78576f67b78275a36ee5383a2fefa3ad65b5aa76d54ae854": 28569
+      "0xb3af39ecb1ce4d350adbc2c16f9fd10f3ccd7e30f1fa482d53114a213829fa4b": 28263
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 21004,
-      "auth_procedure": 14568
+      "total": 20608,
+      "auth_procedure": 13974
     },
     "trace": {
-      "core_rows": 53733,
-      "chiplets_rows": 21675,
-      "range_rows": 3595,
+      "core_rows": 53819,
+      "chiplets_rows": 22282,
+      "poseidon2_permutation_rows": 46336,
+      "range_rows": 3633,
       "chiplets_shape": {
-        "hasher_rows": 14352,
-        "bitwise_rows": 3088,
-        "memory_rows": 4233,
+        "hasher_rows": 14816,
+        "bitwise_rows": 3096,
+        "memory_rows": 4368,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L2 to Miden, with fee payment)": {
-    "prologue": 4033,
-    "notes_processing": 38773,
+    "prologue": 4821,
+    "notes_processing": 38467,
     "note_execution": {
-      "0x0b5ac42d7096eab566b98f2a4347b6723be173d3142833418efb059e7708a3bd": 38731
+      "0x10fe6fd6fef122257048c92009b43e6df141e09cf1c75f99cc8d2f92017bde43": 38425
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 21004,
-      "auth_procedure": 14568
+      "total": 20608,
+      "auth_procedure": 13974
     },
     "trace": {
-      "core_rows": 63895,
-      "chiplets_rows": 24425,
-      "range_rows": 3789,
+      "core_rows": 63981,
+      "chiplets_rows": 25032,
+      "poseidon2_permutation_rows": 48480,
+      "range_rows": 3871,
       "chiplets_shape": {
-        "hasher_rows": 15904,
-        "bitwise_rows": 3344,
-        "memory_rows": 5175,
+        "hasher_rows": 16368,
+        "bitwise_rows": 3352,
+        "memory_rows": 5310,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, with fee payment)": {
-    "prologue": 4957,
-    "notes_processing": 117975,
+    "prologue": 5106,
+    "notes_processing": 119258,
     "note_execution": {
-      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 117933
+      "0xe81d88c72f6fbfe4453b450f29d2c107eb04907da068a61beb1bc90da0a56ec2": 119216
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 30771,
-      "auth_procedure": 14653
+      "total": 29129,
+      "auth_procedure": 12813
     },
     "trace": {
-      "core_rows": 153788,
-      "chiplets_rows": 72732,
-      "range_rows": 4883,
+      "core_rows": 153578,
+      "chiplets_rows": 73218,
+      "poseidon2_permutation_rows": 117808,
+      "range_rows": 5063,
       "chiplets_shape": {
-        "hasher_rows": 58176,
-        "bitwise_rows": 3864,
-        "memory_rows": 10690,
+        "hasher_rows": 58784,
+        "bitwise_rows": 3888,
+        "memory_rows": 10544,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31-1 leaves, with fee payment)": {
-    "prologue": 4957,
-    "notes_processing": 61619,
+    "prologue": 5106,
+    "notes_processing": 63398,
     "note_execution": {
-      "0xe4f72d0ab29683bffdb29f1081081d5d9be4115c4401a57da35895311bd04454": 61577
+      "0xe81d88c72f6fbfe4453b450f29d2c107eb04907da068a61beb1bc90da0a56ec2": 63356
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 21843,
-      "auth_procedure": 14653
+      "total": 20201,
+      "auth_procedure": 12813
     },
     "trace": {
-      "core_rows": 88504,
-      "chiplets_rows": 41655,
-      "range_rows": 3799,
+      "core_rows": 88790,
+      "chiplets_rows": 42389,
+      "poseidon2_permutation_rows": 55600,
+      "range_rows": 3957,
       "chiplets_shape": {
-        "hasher_rows": 31160,
-        "bitwise_rows": 3864,
-        "memory_rows": 6629,
+        "hasher_rows": 31768,
+        "bitwise_rows": 3888,
+        "memory_rows": 6731,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume CONFIG_AGG_BRIDGE note (with fee payment)": {
-    "prologue": 4341,
-    "notes_processing": 13728,
+    "prologue": 4508,
+    "notes_processing": 13318,
     "note_execution": {
-      "0x2b6789ea1f4051b038115581fc45fe5ef5640ddca84a5b4376bd64747646cbd8": 13686
+      "0x4a95146177b6458432d5a1f60f8ade60686c30743fcc89271463bc1bf577ff97": 13276
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 16296,
-      "auth_procedure": 9434
+      "total": 15976,
+      "auth_procedure": 8916
     },
     "trace": {
-      "core_rows": 34450,
-      "chiplets_rows": 15012,
-      "range_rows": 2443,
+      "core_rows": 33887,
+      "chiplets_rows": 15156,
+      "poseidon2_permutation_rows": 37200,
+      "range_rows": 2449,
       "chiplets_shape": {
-        "hasher_rows": 12008,
-        "bitwise_rows": 616,
-        "memory_rows": 2386,
+        "hasher_rows": 12168,
+        "bitwise_rows": 624,
+        "memory_rows": 2362,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume DEREGISTER_AGG_FAUCET note (with fee payment)": {
-    "prologue": 4400,
-    "notes_processing": 12971,
+    "prologue": 4549,
+    "notes_processing": 12628,
     "note_execution": {
-      "0x6d5162b070084e53389394472579ec1fdfee66744b0186f48b4e6adc189bd4c3": 12929
+      "0xe4cef1d192ed7353b3cdb747f5b6beec5419c36c49d96a6d954e3c694ecc9653": 12586
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 16296,
-      "auth_procedure": 9434
+      "total": 15976,
+      "auth_procedure": 8916
     },
     "trace": {
-      "core_rows": 33752,
-      "chiplets_rows": 14654,
-      "range_rows": 2325,
+      "core_rows": 33238,
+      "chiplets_rows": 14786,
+      "poseidon2_permutation_rows": 35984,
+      "range_rows": 2361,
       "chiplets_shape": {
-        "hasher_rows": 11784,
-        "bitwise_rows": 608,
-        "memory_rows": 2260,
+        "hasher_rows": 11936,
+        "bitwise_rows": 616,
+        "memory_rows": 2232,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume UPDATE_GER note (with fee payment)": {
-    "prologue": 4341,
-    "notes_processing": 4514,
+    "prologue": 4490,
+    "notes_processing": 4347,
     "note_execution": {
-      "0x647f3a0b261d5527584bc401839b229a52f25b9251df7823c8809fe48a60a3aa": 4472
+      "0x0f17499940516b9743f89ef52d6cb1d3bb002d1c196e033af53a792302987c9a": 4305
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 15496,
-      "auth_procedure": 9434
+      "total": 15176,
+      "auth_procedure": 8916
     },
     "trace": {
-      "core_rows": 24436,
-      "chiplets_rows": 9867,
-      "range_rows": 2055,
+      "core_rows": 24098,
+      "chiplets_rows": 10019,
+      "poseidon2_permutation_rows": 29424,
+      "range_rows": 2099,
       "chiplets_shape": {
-        "hasher_rows": 7656,
-        "bitwise_rows": 560,
-        "memory_rows": 1649,
+        "hasher_rows": 7808,
+        "bitwise_rows": 568,
+        "memory_rows": 1641,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }
     }
   },
   "consume REMOVE_GER note (with fee payment)": {
-    "prologue": 4400,
-    "notes_processing": 5576,
+    "prologue": 4549,
+    "notes_processing": 5371,
     "note_execution": {
-      "0x50fe02a4740223ab69567829530c755b42b5e096de41fbeb3029b95595eeb663": 5534
+      "0x7305f2b4fc451fa2cdb9c1799357f8b43637ea09330da85535339a02fc427395": 5329
     },
     "tx_script_processing": 41,
     "epilogue": {
-      "total": 15532,
-      "auth_procedure": 9434
+      "total": 15212,
+      "auth_procedure": 8916
     },
     "trace": {
-      "core_rows": 25593,
-      "chiplets_rows": 10187,
-      "range_rows": 2089,
+      "core_rows": 25217,
+      "chiplets_rows": 10335,
+      "poseidon2_permutation_rows": 29920,
+      "range_rows": 2135,
       "chiplets_shape": {
-        "hasher_rows": 7888,
-        "bitwise_rows": 560,
-        "memory_rows": 1737,
+        "hasher_rows": 8040,
+        "bitwise_rows": 568,
+        "memory_rows": 1725,
         "kernel_rom_rows": 1,
         "ace_rows": 0
       }

--- a/bin/bench-transaction/src/cycle_counting_benchmarks/utils.rs
+++ b/bin/bench-transaction/src/cycle_counting_benchmarks/utils.rs
@@ -66,12 +66,14 @@ impl EpilogueMeasurements {
 }
 
 /// Per-component trace row counts from a real `ExecutionTrace`. `core_rows`, `chiplets_rows`,
-/// and `range_rows` are the AIR-side totals; `chiplets_shape` is an advisory per-chiplet breakdown
-/// that satisfies `chiplets_rows == hasher + bitwise + memory + kernel_rom + ace + 1`.
+/// `poseidon2_permutation_rows`, and `range_rows` are the AIR-side totals; `chiplets_shape` is an
+/// advisory per-chiplet breakdown that satisfies
+/// `chiplets_rows == hasher + bitwise + memory + kernel_rom + ace + 1`.
 #[derive(Debug, Clone, Serialize)]
 struct TraceMeasurements {
     core_rows: usize,
     chiplets_rows: usize,
+    poseidon2_permutation_rows: usize,
     range_rows: usize,
     chiplets_shape: ChipletsTraceShape,
 }
@@ -88,33 +90,17 @@ struct ChipletsTraceShape {
 impl From<TraceLenSummary> for TraceMeasurements {
     fn from(summary: TraceLenSummary) -> Self {
         let chiplets = summary.chiplets_trace_len();
-        // The pinned `miden-processor` doesn't expose an ACE accessor yet, so derive it from the
-        // total. The chiplet-bus invariant
-        // (`chiplets_rows == hasher + bitwise + memory + kernel_rom + ace + 1`) keeps holding
-        // when the upstream accessor lands.
-        let known = chiplets.hash_chiplet_len()
-            + chiplets.bitwise_chiplet_len()
-            + chiplets.memory_chiplet_len()
-            + chiplets.kernel_rom_len();
-        // Guard against the per-chiplet accessors and `trace_len()` going out of sync upstream;
-        // without this, `saturating_sub` below would silently produce `ace_rows = 0`.
-        debug_assert!(
-            known < chiplets.trace_len(),
-            "chiplet accessors disagree with trace_len(): known = {} >= trace_len = {}",
-            known,
-            chiplets.trace_len(),
-        );
-        let ace_rows = chiplets.trace_len().saturating_sub(known + 1);
         Self {
             core_rows: summary.core_trace_len(),
             chiplets_rows: chiplets.trace_len(),
+            poseidon2_permutation_rows: summary.poseidon2_permutation_trace_len(),
             range_rows: summary.range_trace_len(),
             chiplets_shape: ChipletsTraceShape {
                 hasher_rows: chiplets.hash_chiplet_len(),
                 bitwise_rows: chiplets.bitwise_chiplet_len(),
                 memory_rows: chiplets.memory_chiplet_len(),
                 kernel_rom_rows: chiplets.kernel_rom_len(),
-                ace_rows,
+                ace_rows: chiplets.ace_chiplet_len(),
             },
         }
     }
@@ -152,7 +138,7 @@ mod tests {
     use miden_processor::trace::{ChipletsLengths, TraceLenSummary};
     use serde::Deserialize;
 
-    use super::TraceMeasurements;
+    use super::{ExecutionBenchmark, TraceMeasurements};
 
     /// Minimal mirror of the bench-tx.json `trace` section used to validate the committed file
     /// against the producer's contract.
@@ -165,6 +151,7 @@ mod tests {
     struct TraceForTest {
         core_rows: u64,
         chiplets_rows: u64,
+        poseidon2_permutation_rows: u64,
         range_rows: u64,
         chiplets_shape: ChipletsShapeForTest,
     }
@@ -179,6 +166,7 @@ mod tests {
     }
 
     const MIN_TRACE_LEN: u64 = 64;
+    const POSEIDON2_CYCLE_LEN: u64 = 16;
     const COMMITTED_BENCH_TX_JSON: &str = include_str!("../../bench-tx.json");
 
     /// Expected padded brackets per committed scenario. Mirrors `COMMITTED_SCENARIO_EXPECTATIONS`
@@ -187,6 +175,7 @@ mod tests {
         name: &'static str,
         padded_core_side: u64,
         padded_chiplets: u64,
+        padded_poseidon2: u64,
     }
 
     const COMMITTED_SCENARIO_EXPECTATIONS: &[ScenarioExpectation] = &[
@@ -194,46 +183,55 @@ mod tests {
             name: "consume single P2ID note with Falcon signing",
             padded_core_side: 131_072,
             padded_chiplets: 16_384,
+            padded_poseidon2: 65_536,
         },
         ScenarioExpectation {
             name: "consume single P2ID note with ECDSA signing",
             padded_core_side: 16_384,
             padded_chiplets: 8_192,
+            padded_poseidon2: 32_768,
         },
         ScenarioExpectation {
             name: "consume two P2ID notes with Falcon signing",
             padded_core_side: 131_072,
             padded_chiplets: 16_384,
+            padded_poseidon2: 65_536,
         },
         ScenarioExpectation {
             name: "consume two P2ID notes with ECDSA signing",
             padded_core_side: 16_384,
             padded_chiplets: 8_192,
+            padded_poseidon2: 32_768,
         },
         ScenarioExpectation {
             name: "create single P2ID note with Falcon signing",
             padded_core_side: 131_072,
             padded_chiplets: 16_384,
+            padded_poseidon2: 65_536,
         },
         ScenarioExpectation {
             name: "create single P2ID note with ECDSA signing",
             padded_core_side: 16_384,
             padded_chiplets: 8_192,
+            padded_poseidon2: 32_768,
         },
         ScenarioExpectation {
             name: "consume CLAIM note (L1 to Miden)",
             padded_core_side: 65_536,
             padded_chiplets: 32_768,
+            padded_poseidon2: 65_536,
         },
         ScenarioExpectation {
             name: "consume CLAIM note (L2 to Miden)",
             padded_core_side: 65_536,
             padded_chiplets: 32_768,
+            padded_poseidon2: 65_536,
         },
         ScenarioExpectation {
             name: "consume B2AGG note (bridge-out)",
             padded_core_side: 262_144,
             padded_chiplets: 131_072,
+            padded_poseidon2: 131_072,
         },
     ];
 
@@ -245,11 +243,11 @@ mod tests {
         t.chiplets_rows.next_power_of_two().max(MIN_TRACE_LEN)
     }
 
-    fn assert_scenario(scenarios: &serde_json::Value, expected: &ScenarioExpectation) {
-        let name = expected.name;
-        let raw = scenarios
-            .get(name)
-            .unwrap_or_else(|| panic!("scenario `{name}` is missing from bench-tx.json"));
+    fn padded_poseidon2(t: &TraceForTest) -> u64 {
+        t.poseidon2_permutation_rows.next_power_of_two().max(MIN_TRACE_LEN)
+    }
+
+    fn parse_and_assert_trace_contract(name: &str, raw: &serde_json::Value) -> TraceForTest {
         let scenario: ScenarioForTest = serde_json::from_value(raw.clone())
             .unwrap_or_else(|err| panic!("scenario `{name}` does not match the schema: {err}"));
         let trace = &scenario.trace;
@@ -257,6 +255,14 @@ mod tests {
 
         assert!(trace.core_rows > 0, "{name}: core_rows should be > 0");
         assert!(trace.chiplets_rows > 0, "{name}: chiplets_rows should be > 0");
+        assert!(
+            trace.poseidon2_permutation_rows > 0,
+            "{name}: poseidon2_permutation_rows should be > 0",
+        );
+        assert!(
+            trace.poseidon2_permutation_rows.is_multiple_of(POSEIDON2_CYCLE_LEN),
+            "{name}: poseidon2_permutation_rows should be a multiple of {POSEIDON2_CYCLE_LEN}",
+        );
         assert!(trace.range_rows > 0, "{name}: range_rows should be > 0");
 
         let chiplets_sum = chiplets_shape.hasher_rows
@@ -270,8 +276,18 @@ mod tests {
             "{name}: chiplets_rows must equal sum(chiplets_shape) + 1",
         );
 
-        let core_side = padded_core_side(trace);
-        let chiplets = padded_chiplets(trace);
+        scenario.trace
+    }
+
+    fn assert_scenario(scenarios: &serde_json::Value, expected: &ScenarioExpectation) {
+        let name = expected.name;
+        let raw = scenarios
+            .get(name)
+            .unwrap_or_else(|| panic!("scenario `{name}` is missing from bench-tx.json"));
+        let trace = parse_and_assert_trace_contract(name, raw);
+
+        let core_side = padded_core_side(&trace);
+        let chiplets = padded_chiplets(&trace);
         assert!(core_side.is_power_of_two(), "{name}: padded_core_side not a power of two");
         assert!(chiplets.is_power_of_two(), "{name}: padded_chiplets not a power of two");
         assert_eq!(
@@ -282,12 +298,26 @@ mod tests {
             chiplets, expected.padded_chiplets,
             "{name}: padded_chiplets regressed to a different bracket",
         );
+        assert_eq!(
+            padded_poseidon2(&trace),
+            expected.padded_poseidon2,
+            "{name}: padded_poseidon2 regressed to a different bracket",
+        );
     }
 
     #[test]
     fn committed_bench_tx_matches_trace_contract() {
         let parsed: serde_json::Value = serde_json::from_str(COMMITTED_BENCH_TX_JSON)
             .expect("bench-tx.json should be valid JSON");
+        let scenarios = parsed.as_object().expect("bench-tx.json should contain an object");
+        assert_eq!(
+            scenarios.len(),
+            ExecutionBenchmark::all().len(),
+            "bench-tx.json should contain every ExecutionBenchmark scenario",
+        );
+        for (name, raw) in scenarios {
+            parse_and_assert_trace_contract(name, raw);
+        }
         for expected in COMMITTED_SCENARIO_EXPECTATIONS {
             assert_scenario(&parsed, expected);
         }
@@ -306,6 +336,25 @@ mod tests {
 
         assert_eq!(measurements.core_rows, summary.core_trace_len());
         assert_eq!(measurements.chiplets_rows, summary.chiplets_trace_len().trace_len());
+        assert_eq!(
+            measurements.poseidon2_permutation_rows,
+            summary.poseidon2_permutation_trace_len(),
+        );
         assert_eq!(measurements.range_rows, summary.range_trace_len());
+    }
+
+    #[test]
+    fn trace_measurements_preserve_poseidon2_permutation_rows() {
+        let summary = TraceLenSummary::new_with_padded(
+            10,
+            20,
+            ChipletsLengths::from_parts(30, 40, 50, 60, 70),
+            80,
+            128,
+        );
+
+        let measurements = TraceMeasurements::from(summary);
+
+        assert_eq!(measurements.poseidon2_permutation_rows, 80);
     }
 }


### PR DESCRIPTION
Export standalone Poseidon2 permutation rows alongside the existing transaction trace measurements and validate the complete generated scenario set.