### PR TITLE
fix(standards): reject PSWAP fills from the wrong faucet

### DIFF
--- a/crates/miden-standards/src/note/pswap.rs
+++ b/crates/miden-standards/src/note/pswap.rs
@@ -483,6 +483,10 @@ impl PswapNote {
         let requested_faucet_id = self.storage.requested_faucet_id();
         let min_requested_amount = self.storage.min_requested_amount();
 
+        if payback_asset.faucet_id() != requested_faucet_id {
+            return Err(NoteError::other("fill asset faucet must match the requested faucet"));
+        }
+
         // Validate fill amount
         if fill_amount == 0 {
             return Err(NoteError::other("Fill amount must be greater than 0"));
@@ -1280,5 +1284,20 @@ mod tests {
 
         // Full fill → no remainder note.
         assert!(remainder.is_none(), "full fill must not produce a remainder");
+    }
+
+    #[test]
+    fn pswap_execute_rejects_fill_from_another_faucet() {
+        let creator_id = dummy_creator_id();
+        let consumer_id = dummy_consumer_id();
+        let offered_asset = FungibleAsset::new(dummy_faucet_id(0xaa), 100).unwrap();
+        let requested_faucet = dummy_faucet_id(0xbb);
+        let requested_asset = FungibleAsset::new(requested_faucet, 50).unwrap();
+        let (pswap, _) = build_pswap_note(offered_asset, requested_asset, creator_id);
+
+        let wrong_fill = FungibleAsset::new(dummy_faucet_id(0xcc), 50).unwrap();
+
+        let error = pswap.execute(consumer_id, Some(wrong_fill), None).unwrap_err();
+        assert!(error.to_string().contains("requested faucet"));
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #3689 by rejecting PSWAP fills whose faucet does not match the requested faucet stored in the note.

## Root Cause

`PswapNote::execute` accepted a single caller-supplied fill asset verbatim. The two-fill path checked that both assets shared a faucet through `FungibleAsset::add`, but neither path checked the note's requested faucet. The on-chain script derives the payback faucet from note storage, so an invalid off-chain fill produced a predicted payback note with commitments that diverged from the on-chain output.

## Changes Made

- Validate the combined fill asset against `requested_faucet_id` before calculating outputs.
- Add a regression test covering a single fill from another faucet.

## How to Test

- `cargo test --locked -p miden-standards pswap_execute_rejects_fill_from_another_faucet --lib`
  - Could not reach the test binary on this Windows host because the registry `miden-core-lib v0.29.1` build script fails while canonicalizing its generated `mod.masm` path: `invalid root module path 'mod.masm': The system cannot find the file specified.`
- `git diff --check` passes.
- `rustfmt +1.96.1 --edition 2024 --check ...` reports pre-existing import-format differences in this file; the new validation is formatted according to the repository's current rustfmt output.

## Risk

Low. This only rejects inputs that cannot produce the same payback asset as the on-chain PSWAP script. Valid fills using the requested faucet are unchanged.
