### PR TITLE
feat(agglayer): add bridge pauser role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `active_note::get_storage_info` and `active_note::get_bounded_storage`, and switched the standard and agglayer note scripts with a bounded storage layout over to the latter ([#3563](https://github.com/0xMiden/protocol/pull/3563)).
 - [BREAKING] AggLayer bridge and faucet accounts now map note repricing to an initial `FEE_MNGR` role instead of the built-in `ADMIN` role ([#3571](https://github.com/0xMiden/protocol/issues/3571)).
+- [BREAKING] AggLayer bridge accounts now map emergency pause to an initial `PAUSER` role, while unpause remains restricted to `ADMIN` ([#3572](https://github.com/0xMiden/protocol/issues/3572)).
 
 ### Changes
 

--- a/bin/bench-transaction/src/context_setups/mod.rs
+++ b/bin/bench-transaction/src/context_setups/mod.rs
@@ -446,6 +446,7 @@ fn setup_bridge_fixture(
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
 

--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -22,12 +22,12 @@ implementation are called out inline with `TODO (Future)` markers.
 | **User** | End-user Miden account that holds assets and initiates bridge-out deposits, or receives assets from a bridge-in claim. | Any account with `basic_wallet` component |
 | **AggLayer Bridge** | Onchain bridge account that manages the Local Exit Tree (LET), faucet registry, and GER state. Consumes B2AGG, CONFIG, and UPDATE_GER notes. | Network-mode account with a single `bridge` component |
 | **AggLayer Faucet** | Fungible faucet that represents a single bridged token. Mints on bridge-in claims, burns on bridge-out. Each foreign token has its own faucet instance. | `FungibleFaucet`, network-mode, with `agglayer_faucet` component |
-| **Integration Service** (offchain) | Observes L1 events (deposits, GER updates) and creates UPDATE_GER and CLAIM notes on Miden. Trusted to provide correct proofs and data. | Not an onchain entity; creates notes targeting bridge/faucet |
-| **Bridge Operator** (offchain) | Deploys bridge and faucet accounts. Creates CONFIG_AGG_BRIDGE notes to register faucets. Must hold the `FAUCET_MNGR` role. | Not an onchain entity; creates config notes |
-| **Bridge Admin (`BRIDGE_ADMIN`)** (offchain) | Holds the bridge account's built-in `ADMIN` role. Manages bridge roles, restores a paused bridge, and controls allowlists and fee-policy selection. | Not an onchain entity; creates RBAC_CONFIG, PAUSE_CONFIG, and NETWORK_ACCOUNT_CONFIG notes |
-| **Faucet Admin (`FAUCET_ADMIN`)** (offchain) | Holds a faucet account's separate built-in `ADMIN` role. Manages that faucet's roles, allowlists, and fee-policy selection but cannot mint or change its owner. | Not an onchain entity; creates RBAC_CONFIG and NETWORK_ACCOUNT_CONFIG notes |
-| **Fee Manager (`FEE_MNGR`)** (offchain) | Holds a bridge or faucet account's `FEE_MNGR` role and updates that account's note fee schedule. | Not an onchain entity; creates CONSTANT_FEE_POLICY_CONFIG notes |
-| **Pauser (`PAUSER`)** (offchain) | Holds the bridge account's `PAUSER` role and can halt bridge operations, but cannot resume them. | Not an onchain entity; creates PAUSE_CONFIG notes |
+| **Integration Service** (offchain) | Observes L1 events (deposits, GER updates) and creates UPDATE_GER and CLAIM notes on Miden. Trusted to provide correct proofs and data. | Creates notes targeting bridge/faucet |
+| **Bridge Operator** (offchain) | Deploys bridge and faucet accounts. Creates CONFIG_AGG_BRIDGE notes to register faucets. Must hold the `FAUCET_MNGR` role. | Creates config notes |
+| **Bridge Admin (`BRIDGE_ADMIN`)** (offchain) | Holds the bridge account's built-in `ADMIN` role. Manages bridge roles, restores a paused bridge, and controls allowlists and fee-policy selection. | Creates RBAC_CONFIG, PAUSE_CONFIG, and NETWORK_ACCOUNT_CONFIG notes |
+| **Faucet Admin (`FAUCET_ADMIN`)** (offchain) | Holds a faucet account's separate built-in `ADMIN` role. Manages that faucet's roles, allowlists, and fee-policy selection but cannot mint or change its owner. | Creates RBAC_CONFIG and NETWORK_ACCOUNT_CONFIG notes |
+| **Fee Manager (`FEE_MNGR`)** (offchain) | Holds a bridge or faucet account's `FEE_MNGR` role and updates that account's note fee schedule. | Creates CONSTANT_FEE_POLICY_CONFIG notes |
+| **Pauser (`PAUSER`)** (offchain) | Holds the bridge account's `PAUSER` role and can halt bridge operations, but cannot resume them. | Creates PAUSE_CONFIG notes |
 
 ---
 

--- a/crates/miden-agglayer/SPEC.md
+++ b/crates/miden-agglayer/SPEC.md
@@ -24,9 +24,10 @@ implementation are called out inline with `TODO (Future)` markers.
 | **AggLayer Faucet** | Fungible faucet that represents a single bridged token. Mints on bridge-in claims, burns on bridge-out. Each foreign token has its own faucet instance. | `FungibleFaucet`, network-mode, with `agglayer_faucet` component |
 | **Integration Service** (offchain) | Observes L1 events (deposits, GER updates) and creates UPDATE_GER and CLAIM notes on Miden. Trusted to provide correct proofs and data. | Not an onchain entity; creates notes targeting bridge/faucet |
 | **Bridge Operator** (offchain) | Deploys bridge and faucet accounts. Creates CONFIG_AGG_BRIDGE notes to register faucets. Must hold the `FAUCET_MNGR` role. | Not an onchain entity; creates config notes |
-| **Bridge Admin (`BRIDGE_ADMIN`)** (offchain) | Holds the bridge account's built-in `ADMIN` role. Manages bridge roles, pause state, allowlists, and fee-policy selection. | Not an onchain entity; creates RBAC_CONFIG, PAUSE_CONFIG, and NETWORK_ACCOUNT_CONFIG notes |
+| **Bridge Admin (`BRIDGE_ADMIN`)** (offchain) | Holds the bridge account's built-in `ADMIN` role. Manages bridge roles, restores a paused bridge, and controls allowlists and fee-policy selection. | Not an onchain entity; creates RBAC_CONFIG, PAUSE_CONFIG, and NETWORK_ACCOUNT_CONFIG notes |
 | **Faucet Admin (`FAUCET_ADMIN`)** (offchain) | Holds a faucet account's separate built-in `ADMIN` role. Manages that faucet's roles, allowlists, and fee-policy selection but cannot mint or change its owner. | Not an onchain entity; creates RBAC_CONFIG and NETWORK_ACCOUNT_CONFIG notes |
 | **Fee Manager (`FEE_MNGR`)** (offchain) | Holds a bridge or faucet account's `FEE_MNGR` role and updates that account's note fee schedule. | Not an onchain entity; creates CONSTANT_FEE_POLICY_CONFIG notes |
+| **Pauser (`PAUSER`)** (offchain) | Holds the bridge account's `PAUSER` role and can halt bridge operations, but cannot resume them. | Not an onchain entity; creates PAUSE_CONFIG notes |
 
 ---
 
@@ -222,6 +223,8 @@ bridge instance `BRIDGE_ADMIN` and each faucet instance `FAUCET_ADMIN`.
 - **`FEE_MNGR` role**: authorizes note-fee updates via
   [`CONSTANT_FEE_POLICY_CONFIG`](#412-constant_fee_policy_config-standards) notes
   (`set_note_fee`). The bridge and each faucet have separate holders of this account-local role.
+- **`PAUSER` role**: authorizes emergency pause via [`PAUSE_CONFIG`](#411-pause_config-standards)
+  notes (`pause`). Unpause remains restricted to `BRIDGE_ADMIN`.
 
 Each role-gated procedure calls `authority::assert_authorized`, which resolves the calling
 procedure's required role from the account's `Authority` procedure-to-role map and asserts that the
@@ -241,7 +244,7 @@ miden-standards [`RoleBasedAccessControl`](../miden-standards/src/account/access
 component and the [`RBAC_CONFIG` note](../miden-standards/src/note/rbac_config.rs); the
 AggLayer-specific consequences are:
 
-- **`BRIDGE_ADMIN` is the bridge's root authority.** It is the effective admin of all four
+- **`BRIDGE_ADMIN` is the bridge's root authority.** It is the effective admin of all five
   operational roles, and the auto-allowlisted `NETWORK_ACCOUNT_CONFIG` note dispatches the
   admin-defaulted note-, tx-script-, and allowed-fee-policy-update procedures, so a compromised
   `BRIDGE_ADMIN` key controls the whole bridge configuration (see
@@ -271,8 +274,8 @@ re-injected until unpause. The management notes (`RBAC_CONFIG`, `NETWORK_ACCOUNT
 can still be administered.
 
 The pause is toggled via the standards [`PAUSE_CONFIG`](#411-pause_config-standards) note, which
-dispatches to `PausableManager`'s `pause` / `unpause`. These have no entry in the bridge's
-`Authority` procedure-to-role map, so authorization falls back to `BRIDGE_ADMIN`.
+dispatches to `PausableManager`'s `pause` / `unpause`. The bridge maps `pause` to `PAUSER`, while
+`unpause` has no explicit mapping and therefore falls back to `BRIDGE_ADMIN`.
 
 The pause complements the `Authority` freeze switch: freezing blocks every authority-gated
 procedure - including `remove_ger` - but not `claim` / `bridge_out`, while the pause is the
@@ -472,8 +475,8 @@ pause state lives in the `Pausable` component's own `is_paused` slot. See
 [Administration](#25-administration).
 
 Initial state: all map slots empty, all value slots `[0, 0, 0, 0]`. The initial `BRIDGE_ADMIN`
-member and the initial `FAUCET_MNGR` / `GER_INJECTOR` / `GER_REMOVER` / `FEE_MNGR` role holders are
-seeded into the access-control components at account creation time.
+member and the initial `FAUCET_MNGR` / `GER_INJECTOR` / `GER_REMOVER` / `FEE_MNGR` / `PAUSER` role
+holders are seeded into the access-control components at account creation time.
 
 ### 3.2 Faucet Account Component
 
@@ -891,10 +894,9 @@ while overwriting it with `[0, 0, 0, 0]`, and updates the removed-GER hash chain
 
 **Purpose:** Triggers a role-management action (`grant_role`, `revoke_role`, `set_role_admin`,
 `renounce_role`) on a bridge or faucet RBAC component, enabling on-chain rotation of
-`BRIDGE_ADMIN`, `FAUCET_ADMIN`, `FAUCET_MNGR`, `GER_INJECTOR`, `GER_REMOVER`, and `FEE_MNGR`
-roles (see
-[Section 2.5](#25-administration)). This is the `miden-standards` `RBAC_CONFIG` note
-(`RbacConfigNote` in Rust), not a bridge-specific script.
+`BRIDGE_ADMIN`, `FAUCET_ADMIN`, `FAUCET_MNGR`, `GER_INJECTOR`, `GER_REMOVER`, `FEE_MNGR`, and
+`PAUSER` roles (see [Section 2.5](#25-administration)). This is the `miden-standards` `RBAC_CONFIG`
+note (`RbacConfigNote` in Rust), not a bridge-specific script.
 
 **`NoteHeader`**
 
@@ -1111,7 +1113,8 @@ agglayer-specific note; the bridge merely includes its script root in
 
 **Consumption:** The script loads the selector and `call`s the matching `PausableManager`
 procedure, which runs `authority::assert_authorized` before flipping the pause state. On the
-bridge that procedure has no mapped role, so the note sender must hold `BRIDGE_ADMIN`.
+bridge, `pause` is mapped to `PAUSER`; `unpause` has no explicit mapping and falls back to
+`BRIDGE_ADMIN`.
 
 The builder binds the note to the bridge via a `NetworkAccountTarget` attachment, which the
 script asserts against the consuming account; [`AggLayerBridge::pause_note`] wraps the builder
@@ -1121,7 +1124,7 @@ with clearer error reporting for non-public targets.
 
 | Role | Enforcement |
 |------|------------|
-| **Issuer** | `BRIDGE_ADMIN` only -- **enforced** by `PausableManager::pause` / `unpause` via `authority::assert_authorized` (unmapped-procedure fallback) |
+| **Issuer** | `PAUSER` for pause; `BRIDGE_ADMIN` for unpause -- **enforced** by `PausableManager::pause` / `unpause` via `authority::assert_authorized` (explicit pause mapping and unmapped unpause fallback) |
 | **Consumer** | Bridge account -- **enforced**: the script asserts the consuming account matches the `NetworkAccountTarget` attachment |
 
 ---

--- a/crates/miden-agglayer/src/bridge.rs
+++ b/crates/miden-agglayer/src/bridge.rs
@@ -20,7 +20,7 @@ use miden_protocol::crypto::hash::poseidon2::Poseidon2;
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::NoteError;
 use miden_protocol::note::{Note, NoteScriptRoot};
-use miden_standards::account::access::{PausableStorage, RoleConfig};
+use miden_standards::account::access::{PausableManager, PausableStorage, RoleConfig};
 use miden_standards::account::auth::AuthNetworkAccount;
 use miden_standards::account::fees::ConstantFeeManager;
 use miden_standards::note::{
@@ -155,6 +155,8 @@ static GER_REMOVER_ROLE: LazyLock<RoleSymbol> = LazyLock::new(|| {
 });
 static FEE_MANAGER_ROLE: LazyLock<RoleSymbol> =
     LazyLock::new(|| RoleSymbol::new("FEE_MNGR").expect("FEE_MNGR role symbol should be valid"));
+static PAUSER_ROLE: LazyLock<RoleSymbol> =
+    LazyLock::new(|| RoleSymbol::new("PAUSER").expect("PAUSER role symbol should be valid"));
 
 /// The assembled bridge account component code, used to resolve the roots of the bridge's
 /// role-gated procedures.
@@ -203,6 +205,7 @@ procedure_root!(
 /// - `GER_INJECTOR` gates `update_ger`.
 /// - `GER_REMOVER` gates `remove_ger`.
 /// - `FEE_MNGR` gates `set_note_fee`.
+/// - `PAUSER` gates `pause`; `unpause` remains gated by `ADMIN`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BridgeRoles {
     roles: Vec<RoleConfig>,
@@ -215,13 +218,14 @@ impl BridgeRoles {
     ///
     /// # Errors
     ///
-    /// Returns [`AgglayerBridgeError::EmptyBridgeRole`] if any of the four roles is given an empty
+    /// Returns [`AgglayerBridgeError::EmptyBridgeRole`] if any of the five roles is given an empty
     /// set of holders.
     pub fn new(
         faucet_managers: BTreeSet<AccountId>,
         ger_injectors: BTreeSet<AccountId>,
         ger_removers: BTreeSet<AccountId>,
         fee_managers: BTreeSet<AccountId>,
+        pausers: BTreeSet<AccountId>,
     ) -> Result<Self, AgglayerBridgeError> {
         let mut roles = Vec::new();
         for (role, members) in [
@@ -229,6 +233,7 @@ impl BridgeRoles {
             (AggLayerBridge::ger_injector_role(), &ger_injectors),
             (AggLayerBridge::ger_remover_role(), &ger_removers),
             (AggLayerBridge::fee_manager_role(), &fee_managers),
+            (AggLayerBridge::pauser_role(), &pausers),
         ] {
             if members.is_empty() {
                 return Err(AgglayerBridgeError::EmptyBridgeRole(role));
@@ -358,6 +363,11 @@ impl AggLayerBridge {
         FEE_MANAGER_ROLE.clone()
     }
 
+    /// Returns the `PAUSER` role symbol. Holders may pause, but not unpause, the bridge.
+    pub fn pauser_role() -> RoleSymbol {
+        PAUSER_ROLE.clone()
+    }
+
     /// Returns the procedure root of the bridge's `register_faucet` procedure.
     pub fn register_faucet_root() -> AccountProcedureRoot {
         *REGISTER_FAUCET_ROOT
@@ -394,6 +404,7 @@ impl AggLayerBridge {
             (Self::update_ger_root(), Self::ger_injector_role()),
             (Self::remove_ger_root(), Self::ger_remover_role()),
             (ConstantFeeManager::set_note_fee_root(), Self::fee_manager_role()),
+            (PausableManager::pause_root(), Self::pauser_role()),
         ])
     }
 
@@ -509,7 +520,8 @@ impl AggLayerBridge {
     // --------------------------------------------------------------------------------------------
 
     /// Builds a [`PauseConfigNote`] that toggles the emergency pause of the bridge account
-    /// `bridge_id`. `sender` must hold the bridge's `ADMIN` role.
+    /// `bridge_id`. For [`PauseConfig::Pause`], `sender` must hold the bridge's `PAUSER` role; for
+    /// [`PauseConfig::Unpause`], `sender` must hold its `ADMIN` role.
     ///
     /// Use this instead of [`PauseConfigNote::builder`] directly: it reports a non-public
     /// `bridge_id` as [`AgglayerBridgeError::NonPublicPauseNoteTarget`] rather than as an opaque

--- a/crates/miden-agglayer/src/lib.rs
+++ b/crates/miden-agglayer/src/lib.rs
@@ -277,7 +277,7 @@ mod tests {
         let id = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE).unwrap();
 
         let bridge =
-            create_existing_bridge_account_with_roles(Word::default(), id, id, id, id, id, 77);
+            create_existing_bridge_account_with_roles(Word::default(), id, id, id, id, id, id, 77);
         let faucet = create_existing_agglayer_faucet(
             Word::default(),
             "AGG",

--- a/crates/miden-agglayer/src/testing/mod.rs
+++ b/crates/miden-agglayer/src/testing/mod.rs
@@ -61,6 +61,7 @@ pub fn bridge_admin_account_id() -> AccountId {
 }
 
 /// Creates an existing bridge account with one holder per operational role.
+#[allow(clippy::too_many_arguments)]
 pub fn create_existing_bridge_account_with_roles(
     seed: Word,
     bridge_admin: AccountId,
@@ -68,6 +69,7 @@ pub fn create_existing_bridge_account_with_roles(
     ger_injector: AccountId,
     ger_remover: AccountId,
     fee_manager: AccountId,
+    pauser: AccountId,
     network_id: u32,
 ) -> Account {
     let fee_policy = zero_fee_policy(AggLayerBridge::allowed_notes());
@@ -76,7 +78,7 @@ pub fn create_existing_bridge_account_with_roles(
         BTreeSet::from([ger_injector]),
         BTreeSet::from([ger_remover]),
         BTreeSet::from([fee_manager]),
-        BTreeSet::from([bridge_admin]),
+        BTreeSet::from([pauser]),
     )
     .expect("single-holder role sets are non-empty");
 

--- a/crates/miden-agglayer/src/testing/mod.rs
+++ b/crates/miden-agglayer/src/testing/mod.rs
@@ -76,6 +76,7 @@ pub fn create_existing_bridge_account_with_roles(
         BTreeSet::from([ger_injector]),
         BTreeSet::from([ger_remover]),
         BTreeSet::from([fee_manager]),
+        BTreeSet::from([bridge_admin]),
     )
     .expect("single-holder role sets are non-empty");
 

--- a/crates/miden-testing/tests/agglayer/bridge_in.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_in.rs
@@ -511,6 +511,7 @@ async fn test_mint_cannot_be_consumed_by_unrelated_faucet() -> anyhow::Result<()
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -718,6 +719,7 @@ async fn test_claim_rejects_wrong_destination_network() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -870,6 +872,7 @@ async fn test_duplicate_claim_note_rejected() -> anyhow::Result<()> {
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
@@ -1040,6 +1043,7 @@ async fn test_claim_rejects_removed_ger() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -1199,6 +1203,7 @@ async fn bridge_in_unlock_native_token() -> anyhow::Result<()> {
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
@@ -1490,6 +1495,7 @@ async fn bridge_in_unlock_native_duplicate_rejected() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -1742,6 +1748,7 @@ async fn test_claim_fails_when_origin_network_unregistered() -> anyhow::Result<(
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -1888,6 +1895,7 @@ async fn test_reregister_clears_prior_token_key() -> anyhow::Result<()> {
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );

--- a/crates/miden-testing/tests/agglayer/bridge_out.rs
+++ b/crates/miden-testing/tests/agglayer/bridge_out.rs
@@ -453,6 +453,7 @@ async fn bridge_out_at_high_num_leaves(#[case] initial_num_leaves: u32) -> anyho
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     populate_let_state(&mut bridge_account, initial_num_leaves, &initial_frontier);
@@ -591,6 +592,7 @@ async fn test_bridge_out_fails_with_unregistered_faucet() -> anyhow::Result<()> 
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -693,6 +695,7 @@ async fn test_bridge_out_rejects_invalid_b2agg_note(
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
@@ -870,6 +873,7 @@ async fn b2agg_note_reclaim_scenario() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -998,6 +1002,7 @@ async fn b2agg_note_non_target_account_cannot_consume() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -1014,6 +1019,7 @@ async fn b2agg_note_non_target_account_cannot_consume() -> anyhow::Result<()> {
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
@@ -1087,6 +1093,7 @@ async fn bridge_out_lock_native_token() -> anyhow::Result<()> {
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );

--- a/crates/miden-testing/tests/agglayer/config_bridge.rs
+++ b/crates/miden-testing/tests/agglayer/config_bridge.rs
@@ -123,6 +123,7 @@ async fn test_config_agg_bridge_registers_faucet() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -220,6 +221,7 @@ async fn test_config_agg_bridge_distinguishes_origin_network() -> anyhow::Result
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
@@ -342,6 +344,7 @@ async fn config_agg_bridge_non_admin_sender_reverts() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -461,6 +464,7 @@ async fn test_deregister_agg_faucet_clears_both_registries() -> anyhow::Result<(
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
@@ -608,6 +612,7 @@ async fn test_deregister_agg_faucet_clears_native_faucet() -> anyhow::Result<()>
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -741,6 +746,7 @@ async fn test_deregister_agg_faucet_rejects_invalid(
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );

--- a/crates/miden-testing/tests/agglayer/config_bridge.rs
+++ b/crates/miden-testing/tests/agglayer/config_bridge.rs
@@ -26,6 +26,7 @@ use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::MasmError;
 use miden_protocol::transaction::RawOutputNote;
 use miden_protocol::{Felt, Hasher, Word};
+use miden_standards::account::access::PausableManager;
 use miden_standards::account::fees::ConstantFeeManager;
 use miden_standards::errors::standards::ERR_SENDER_LACKS_ROLE;
 use miden_standards::interop::eth::EthAddress;
@@ -55,7 +56,7 @@ fn token_registry_key(origin_token_address: &EthAddress, origin_network: u32) ->
 fn test_bridge_procedure_roles_mapping() {
     let roles = AggLayerBridge::procedure_roles();
 
-    assert_eq!(roles.len(), 6, "exactly the six role-gated procedures must be mapped");
+    assert_eq!(roles.len(), 7, "exactly the seven role-gated procedures must be mapped");
     assert_eq!(
         roles.get(&AggLayerBridge::register_faucet_root()),
         Some(&AggLayerBridge::faucet_manager_role()),
@@ -79,6 +80,11 @@ fn test_bridge_procedure_roles_mapping() {
     assert_eq!(
         roles.get(&ConstantFeeManager::set_note_fee_root()),
         Some(&AggLayerBridge::fee_manager_role()),
+    );
+    assert_eq!(roles.get(&PausableManager::pause_root()), Some(&AggLayerBridge::pauser_role()),);
+    assert!(
+        !roles.contains_key(&PausableManager::unpause_root()),
+        "unpause must fall back to ADMIN",
     );
 }
 
@@ -386,7 +392,7 @@ fn bridge_roles_new_rejects_empty_role() {
             .account_type(AccountType::Public)
             .build_with_seed([seed; 32])
     };
-    let (a, b, c, d) = (account(1), account(2), account(3), account(4));
+    let (a, b, c, d, e) = (account(1), account(2), account(3), account(4), account(5));
 
     // A non-empty set for every role succeeds.
     assert!(
@@ -395,21 +401,23 @@ fn bridge_roles_new_rejects_empty_role() {
             BTreeSet::from([b]),
             BTreeSet::from([c]),
             BTreeSet::from([d]),
+            BTreeSet::from([e]),
         )
         .is_ok()
     );
 
     // An empty set for any single role is rejected.
-    for empty in 0..4 {
-        let sets: [BTreeSet<AccountId>; 4] = core::array::from_fn(|i| {
+    for empty in 0..5 {
+        let sets: [BTreeSet<AccountId>; 5] = core::array::from_fn(|i| {
             if i == empty {
                 BTreeSet::new()
             } else {
                 BTreeSet::from([a])
             }
         });
-        let [faucet_managers, ger_injectors, ger_removers, fee_managers] = sets;
-        let result = BridgeRoles::new(faucet_managers, ger_injectors, ger_removers, fee_managers);
+        let [faucet_managers, ger_injectors, ger_removers, fee_managers, pausers] = sets;
+        let result =
+            BridgeRoles::new(faucet_managers, ger_injectors, ger_removers, fee_managers, pausers);
         assert!(matches!(result, Err(AgglayerBridgeError::EmptyBridgeRole(_))));
     }
 }

--- a/crates/miden-testing/tests/agglayer/faucet_helpers.rs
+++ b/crates/miden-testing/tests/agglayer/faucet_helpers.rs
@@ -35,6 +35,7 @@ fn test_faucet_helper_methods() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;

--- a/crates/miden-testing/tests/agglayer/fee_policy.rs
+++ b/crates/miden-testing/tests/agglayer/fee_policy.rs
@@ -135,6 +135,7 @@ fn bridge_account_builder() -> anyhow::Result<AccountBuilder> {
         [bridge_admin].into(),
         [bridge_admin].into(),
         [fee_manager_id()].into(),
+        [bridge_admin].into(),
     )?;
     let pricer = network_note_pricer(VERIFICATION_BASE_FEE);
     let fee_policy = pricer.basic_constant_fee_policy(AggLayerBridge::allowed_notes())?;

--- a/crates/miden-testing/tests/agglayer/network_account_regression.rs
+++ b/crates/miden-testing/tests/agglayer/network_account_regression.rs
@@ -63,6 +63,7 @@ async fn bridge_rejects_tx_script() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -119,6 +120,7 @@ async fn bridge_rejects_non_allowlisted_input_note() -> anyhow::Result<()> {
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );

--- a/crates/miden-testing/tests/agglayer/pause.rs
+++ b/crates/miden-testing/tests/agglayer/pause.rs
@@ -60,14 +60,18 @@ fn pause_config_note(
     Ok(AggLayerBridge::pause_note(action, sender, bridge_id, &mut rng)?)
 }
 
-/// Builds an admin-sent [`PauseConfigNote`] for `action` and stages it on the chain so it can
-/// later be consumed as an authenticated note.
+/// Builds an authorized [`PauseConfigNote`] for `action` and stages it on the chain so it can later
+/// be consumed as an authenticated note. The pauser sends `Pause`; the admin sends `Unpause`.
 fn stage_pause_note(
     builder: &mut MockChainBuilder,
-    bridge_id: AccountId,
+    setup: &BridgeSetup,
     action: PauseConfig,
 ) -> anyhow::Result<Note> {
-    let note = pause_config_note(bridge_admin_account_id(), bridge_id, action)?;
+    let sender = match action {
+        PauseConfig::Pause => setup.pauser.id(),
+        PauseConfig::Unpause => bridge_admin_account_id(),
+    };
+    let note = pause_config_note(sender, setup.bridge.id(), action)?;
     builder.add_output_note(RawOutputNote::Full(note.clone()));
     Ok(note)
 }
@@ -83,7 +87,7 @@ async fn assert_note_rejected_while_paused(build_note: BuildNote<'_>) -> anyhow:
     let setup = setup_bridge(&mut builder)?;
     let note = build_note(&mut builder, &setup)?;
     builder.add_output_note(RawOutputNote::Full(note.clone()));
-    let pause_note = stage_pause_note(&mut builder, setup.bridge.id(), PauseConfig::Pause)?;
+    let pause_note = stage_pause_note(&mut builder, &setup, PauseConfig::Pause)?;
     let mut mock_chain = builder.build()?;
 
     consume_note(&mut mock_chain, setup.bridge.id(), &pause_note).await?;
@@ -108,14 +112,14 @@ fn dummy_faucet_id() -> AccountId {
 // TESTS
 // ================================================================================================
 
-/// An ADMIN-sent PAUSE_CONFIG note pauses the bridge and a second one unpauses it. This also
-/// proves the note passes the bridge's note allowlist and is routable as a network note.
+/// A PAUSER-sent PAUSE_CONFIG note pauses the bridge and an ADMIN-sent one unpauses it. This also
+/// proves the notes pass the bridge's note allowlist and are routable as network notes.
 #[tokio::test]
 async fn pause_config_note_pauses_and_unpauses_bridge() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let setup = setup_bridge(&mut builder)?;
-    let pause_note = stage_pause_note(&mut builder, setup.bridge.id(), PauseConfig::Pause)?;
-    let unpause_note = stage_pause_note(&mut builder, setup.bridge.id(), PauseConfig::Unpause)?;
+    let pause_note = stage_pause_note(&mut builder, &setup, PauseConfig::Pause)?;
+    let unpause_note = stage_pause_note(&mut builder, &setup, PauseConfig::Unpause)?;
     let mut mock_chain = builder.build()?;
 
     // The note must be discoverable by network-note routing, and routed to the bridge: the same
@@ -134,16 +138,14 @@ async fn pause_config_note_pauses_and_unpauses_bridge() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A PAUSE_CONFIG note from a sender without the ADMIN role is rejected: the pause procedures
-/// have no mapped role, so `authority::assert_authorized` falls back to the ADMIN check.
+/// The bridge admin cannot pause unless it separately holds the `PAUSER` role.
 #[tokio::test]
-async fn non_admin_pause_reverts() -> anyhow::Result<()> {
+async fn admin_without_pauser_role_cannot_pause() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let setup = setup_bridge(&mut builder)?;
     let mock_chain = builder.build()?;
 
-    // The GER injector holds an operational role but not ADMIN.
-    let note = pause_config_note(setup.ger_injector.id(), setup.bridge.id(), PauseConfig::Pause)?;
+    let note = pause_config_note(bridge_admin_account_id(), setup.bridge.id(), PauseConfig::Pause)?;
     let result = mock_chain
         .build_transaction(setup.bridge.id())
         .unauthenticated_input_note(note)
@@ -155,18 +157,18 @@ async fn non_admin_pause_reverts() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A non-ADMIN sender cannot unpause a bridge that is actually paused.
+/// Holding the `PAUSER` role does not authorize unpause, which remains admin-only.
 #[tokio::test]
-async fn non_admin_unpause_of_paused_bridge_reverts() -> anyhow::Result<()> {
+async fn pauser_cannot_unpause_a_paused_bridge() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
     let setup = setup_bridge(&mut builder)?;
-    let pause_note = stage_pause_note(&mut builder, setup.bridge.id(), PauseConfig::Pause)?;
+    let pause_note = stage_pause_note(&mut builder, &setup, PauseConfig::Pause)?;
     let mut mock_chain = builder.build()?;
 
     consume_note(&mut mock_chain, setup.bridge.id(), &pause_note).await?;
     assert!(is_bridge_paused(&mock_chain, setup.bridge.id())?);
 
-    let note = pause_config_note(setup.ger_injector.id(), setup.bridge.id(), PauseConfig::Unpause)?;
+    let note = pause_config_note(setup.pauser.id(), setup.bridge.id(), PauseConfig::Unpause)?;
     let result = mock_chain
         .build_transaction(setup.bridge.id())
         .unauthenticated_input_note(note)
@@ -179,7 +181,7 @@ async fn non_admin_unpause_of_paused_bridge_reverts() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The `PAUSE_CONFIG` script asserts its target, so an `ADMIN`-issued pause note built for a
+/// The `PAUSE_CONFIG` script asserts its target, so a `PAUSER`-issued pause note built for a
 /// *different* account is rejected by the bridge even though its sender is authorized.
 #[tokio::test]
 async fn pause_note_targeting_another_account_is_rejected() -> anyhow::Result<()> {
@@ -187,18 +189,14 @@ async fn pause_note_targeting_another_account_is_rejected() -> anyhow::Result<()
     let setup = setup_bridge(&mut builder)?;
     let mock_chain = builder.build()?;
 
-    // Admin-sent, but built for an unrelated account: the attachment names that account, not the
+    // Pauser-sent, but built for an unrelated account: the attachment names that account, not the
     // bridge, so the script's target check rejects it.
     let other_account = AccountIdBuilder::new()
         .account_type(AccountType::Public)
         .build_with_seed([9; 32]);
     let mut rng = RandomCoin::new([Felt::from(45u32); 4].into());
-    let note = AggLayerBridge::pause_note(
-        PauseConfig::Pause,
-        bridge_admin_account_id(),
-        other_account,
-        &mut rng,
-    )?;
+    let note =
+        AggLayerBridge::pause_note(PauseConfig::Pause, setup.pauser.id(), other_account, &mut rng)?;
 
     let result = mock_chain
         .build_transaction(setup.bridge.id())
@@ -287,10 +285,7 @@ async fn paused_bridge_rejects_bridge_out() -> anyhow::Result<()> {
 async fn paused_bridge_rejects_claim() -> anyhow::Result<()> {
     assert_note_rejected_while_paused(&|builder, setup| {
         let (proof_data, leaf_data, _ger, _cgi_chain_hash) = ClaimDataSource::L1ToMiden.get_data();
-        let miden_claim_amount = leaf_data
-            .amount
-            .scale_to_asset_amount(10)
-            .expect("test vector amount should scale");
+        let miden_claim_amount = leaf_data.amount.scale_to_asset_amount(10)?;
         let storage = ClaimNoteStorage {
             proof_data,
             leaf_data,
@@ -320,7 +315,7 @@ async fn paused_bridge_allows_remove_ger() -> anyhow::Result<()> {
     let remove_note =
         RemoveGerNote::create(ger, setup.ger_remover.id(), setup.bridge.id(), builder.rng_mut())?;
     builder.add_output_note(RawOutputNote::Full(remove_note.clone()));
-    let pause_note = stage_pause_note(&mut builder, setup.bridge.id(), PauseConfig::Pause)?;
+    let pause_note = stage_pause_note(&mut builder, &setup, PauseConfig::Pause)?;
 
     let mut mock_chain = builder.build()?;
 
@@ -352,8 +347,8 @@ async fn unpause_restores_operation() -> anyhow::Result<()> {
     let update_note =
         UpdateGerNote::create(ger, setup.ger_injector.id(), setup.bridge.id(), builder.rng_mut())?;
     builder.add_output_note(RawOutputNote::Full(update_note.clone()));
-    let pause_note = stage_pause_note(&mut builder, setup.bridge.id(), PauseConfig::Pause)?;
-    let unpause_note = stage_pause_note(&mut builder, setup.bridge.id(), PauseConfig::Unpause)?;
+    let pause_note = stage_pause_note(&mut builder, &setup, PauseConfig::Pause)?;
+    let unpause_note = stage_pause_note(&mut builder, &setup, PauseConfig::Unpause)?;
 
     let mut mock_chain = builder.build()?;
 

--- a/crates/miden-testing/tests/agglayer/rbac_rotation.rs
+++ b/crates/miden-testing/tests/agglayer/rbac_rotation.rs
@@ -229,7 +229,7 @@ async fn paused_bridge_allows_role_rotation() -> anyhow::Result<()> {
 
     let pause = AggLayerBridge::pause_note(
         PauseConfig::Pause,
-        bridge_admin_account_id(),
+        setup.pauser.id(),
         bridge_id,
         builder.rng_mut(),
     )?;

--- a/crates/miden-testing/tests/agglayer/rbac_rotation.rs
+++ b/crates/miden-testing/tests/agglayer/rbac_rotation.rs
@@ -288,6 +288,7 @@ fn bridge_allowed_notes_pin() {
         dummy,
         dummy,
         dummy,
+        dummy,
         MIDEN_NETWORK_ID,
     );
     let network_account =

--- a/crates/miden-testing/tests/agglayer/test_utils.rs
+++ b/crates/miden-testing/tests/agglayer/test_utils.rs
@@ -258,24 +258,16 @@ pub fn setup_bridge(builder: &mut MockChainBuilder) -> anyhow::Result<BridgeSetu
     })?;
 
     let bridge_admin = bridge_admin_account_id();
-    let roles = BridgeRoles::new(
-        [faucet_manager.id()].into(),
-        [ger_injector.id()].into(),
-        [ger_remover.id()].into(),
-        [bridge_admin].into(),
-        [pauser.id()].into(),
-    )?;
-    let pricer = network_note_pricer(0);
-    let fee_policy = pricer.basic_constant_fee_policy(AggLayerBridge::allowed_notes())?;
-    let bridge = AggLayerBridge::account_builder(
+    let bridge = create_existing_bridge_account_with_roles(
         builder.rng_mut().draw_word(),
         bridge_admin,
-        roles,
+        faucet_manager.id(),
+        ger_injector.id(),
+        ger_remover.id(),
+        bridge_admin,
+        pauser.id(),
         MIDEN_NETWORK_ID,
-        pricer.fee_parameters().fee_faucet_id(),
-        fee_policy,
-    )
-    .build_existing()?;
+    );
     builder.add_account(bridge.clone())?;
 
     Ok(BridgeSetup {

--- a/crates/miden-testing/tests/agglayer/test_utils.rs
+++ b/crates/miden-testing/tests/agglayer/test_utils.rs
@@ -155,6 +155,7 @@ pub fn create_existing_priced_bridge(
         [ger_injector].into(),
         [ger_remover].into(),
         [bridge_admin].into(),
+        [bridge_admin].into(),
     )?;
     let pricer = network_note_pricer(verification_base_fee);
     let fee_policy = pricer.basic_constant_fee_policy(AggLayerBridge::allowed_notes())?;
@@ -239,6 +240,7 @@ pub struct BridgeSetup {
     pub faucet_manager: Account,
     pub ger_injector: Account,
     pub ger_remover: Account,
+    pub pauser: Account,
 }
 
 pub fn setup_bridge(builder: &mut MockChainBuilder) -> anyhow::Result<BridgeSetup> {
@@ -251,16 +253,29 @@ pub fn setup_bridge(builder: &mut MockChainBuilder) -> anyhow::Result<BridgeSetu
     let ger_remover = builder.add_existing_wallet(Auth::BasicAuth {
         auth_scheme: AuthScheme::Falcon512Poseidon2,
     })?;
+    let pauser = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthScheme::Falcon512Poseidon2,
+    })?;
 
-    let bridge = create_existing_bridge_account_with_roles(
+    let bridge_admin = bridge_admin_account_id();
+    let roles = BridgeRoles::new(
+        [faucet_manager.id()].into(),
+        [ger_injector.id()].into(),
+        [ger_remover.id()].into(),
+        [bridge_admin].into(),
+        [pauser.id()].into(),
+    )?;
+    let pricer = network_note_pricer(0);
+    let fee_policy = pricer.basic_constant_fee_policy(AggLayerBridge::allowed_notes())?;
+    let bridge = AggLayerBridge::account_builder(
         builder.rng_mut().draw_word(),
-        bridge_admin_account_id(),
-        faucet_manager.id(),
-        ger_injector.id(),
-        ger_remover.id(),
-        bridge_admin_account_id(),
+        bridge_admin,
+        roles,
         MIDEN_NETWORK_ID,
-    );
+        pricer.fee_parameters().fee_faucet_id(),
+        fee_policy,
+    )
+    .build_existing()?;
     builder.add_account(bridge.clone())?;
 
     Ok(BridgeSetup {
@@ -268,5 +283,6 @@ pub fn setup_bridge(builder: &mut MockChainBuilder) -> anyhow::Result<BridgeSetu
         faucet_manager,
         ger_injector,
         ger_remover,
+        pauser,
     })
 }

--- a/crates/miden-testing/tests/agglayer/update_ger.rs
+++ b/crates/miden-testing/tests/agglayer/update_ger.rs
@@ -81,6 +81,7 @@ async fn update_ger_note_updates_storage() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -313,6 +314,7 @@ async fn update_ger_rejects_duplicate() -> anyhow::Result<()> {
         ger_injector.id(),
         ger_remover.id(),
         bridge_admin_account_id(),
+        bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );
     builder.add_account(bridge_account.clone())?;
@@ -380,6 +382,7 @@ async fn update_ger_non_injector_sender_reverts() -> anyhow::Result<()> {
         faucet_manager.id(),
         ger_injector.id(),
         ger_remover.id(),
+        bridge_admin_account_id(),
         bridge_admin_account_id(),
         MIDEN_NETWORK_ID,
     );


### PR DESCRIPTION
## Summary

- Add a `PAUSER` role to bridge accounts only.
- Require `PAUSER` to pause the bridge.
- Keep unpause restricted to the bridge `ADMIN`.

Replaces #3634, which GitHub closed unmerged while processing the stacked PR merge queue.

Closes #3572.