### PR TITLE
feat: expand note version to 6 bits, reduce block version to 8 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Changes
 
 - [BREAKING] Refactored `AccountVaultDelta` to track generic assets. `FungibleAssetDelta`, `NonFungibleAssetDelta` and `NonFungibleDeltaAction` were removed ([3485](https://github.com/0xMiden/protocol/pull/3485)).
+- [BREAKING] Widened the note metadata version field from 4 to 6 bits, moving the note type to bit 6 ([#3695](https://github.com/0xMiden/protocol/pull/3695)).
+- [BREAKING] Narrowed the block header version field from 32 to 8 bits and set it to the only supported version instead of taking it as a `BlockHeader::new` parameter ([#3695](https://github.com/0xMiden/protocol/pull/3695)).
 - [BREAKING] Moved the internal shared helpers of `miden::protocol::input_note`, `miden::protocol::active_note`, and the note memory-write helpers into private `input_note_internal` and `note_internal` modules ([#3501](https://github.com/0xMiden/protocol/pull/3501)).
 - [BREAKING] Added the `miden::standards::expiration` MASM module with `apply_default` and used it to apply a default 20-block transaction expiration limit to the standard allowlist and blocklist transfer policies and the fee manager's `estimate_note_fee` procedure ([#3512](https://github.com/0xMiden/protocol/pull/3512)).
 - The transaction kernel now validates that a new account's procedures are sorted and unique ([#3567](https://github.com/0xMiden/protocol/pull/3567)).

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/output_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/output_note.masm
@@ -487,9 +487,9 @@ pub proc build_metadata
     # => [sender_id_suffix, sender_id_prefix, attachment_num_words_and_tag, note_type]
 
     # The lower 8 bits of the account ID suffix are guaranteed to be zero by construction.
-    # Encode note_type at bit 4 and version at bits 0..=3.
-    # Shifting note_type left by 4 is equivalent to multiplying by 16.
-    movup.3 mul.16 add.NOTE_METADATA_VERSION_1 add
+    # Encode note_type at bit 6 and version at bits 0..=5.
+    # Shifting note_type left by 6 is equivalent to multiplying by 64.
+    movup.3 mul.64 add.NOTE_METADATA_VERSION_1 add
     # => [sender_id_suffix_type_version, sender_id_prefix, tag]
 
     # Build metadata.

--- a/crates/miden-protocol/asm/protocol/src/note.masm
+++ b/crates/miden-protocol/asm/protocol/src/note.masm
@@ -209,7 +209,7 @@ end
 
 #! Extracts the note type from the provided metadata.
 #!
-#! The note type is encoded as a single bit at the 4th position from the right side (LSB) of the
+#! The note type is encoded as a single bit at the 6th position from the right side (LSB) of the
 #! first felt of the metadata, where 0 = Private and 1 = Public.
 #!
 #! Inputs:  [METADATA]
@@ -219,7 +219,7 @@ end
 #! - METADATA is the metadata of a note, laid out on the stack as
 #!   [sender_id_suffix_type_version, sender_id_prefix, tag, attachment_schemes].
 #!   The first felt (sender_id_suffix_type_version) has the following bit layout:
-#!   [sender_id_suffix (56 bits) | reserved (3 bits) | note_type (1 bit) | version (4 bits)]
+#!   [sender_id_suffix (56 bits) | reserved (1 bit) | note_type (1 bit) | version (6 bits)]
 #! - note_type is the type of the note (0 for private, 1 for public).
 #!
 #! Invocation: exec
@@ -230,7 +230,7 @@ pub proc metadata_into_note_type(metadata: NoteMetadata) -> NoteType
     u32split swap drop
     # => [lo32]
 
-    u32shr.4
+    u32shr.6
     # => [shifted]
 
     u32and.1

--- a/crates/miden-protocol/src/block/header.rs
+++ b/crates/miden-protocol/src/block/header.rs
@@ -38,7 +38,7 @@ use crate::{Felt, Hasher, Word, ZERO};
 /// - `commitment` is a 2-to-1 hash of the sub_commitment and the note_root.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct BlockHeader {
-    version: u32,
+    version: u8,
     prev_block_commitment: Word,
     block_num: BlockNumber,
     chain_commitment: Word,
@@ -55,10 +55,20 @@ pub struct BlockHeader {
 }
 
 impl BlockHeader {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+
+    /// Version 1 of the block header.
+    ///
+    /// It is encoded using 8 bits.
+    const VERSION_1: u8 = 1;
+
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
     /// Creates a new block header.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        version: u32,
         prev_block_commitment: Word,
         block_num: BlockNumber,
         chain_commitment: Word,
@@ -71,6 +81,8 @@ impl BlockHeader {
         fee_parameters: FeeParameters,
         timestamp: u32,
     ) -> Self {
+        let version = Self::VERSION_1;
+
         // Compute block sub commitment.
         let sub_commitment = Self::compute_sub_commitment(
             version,
@@ -113,8 +125,8 @@ impl BlockHeader {
     // ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the protocol version.
-    pub fn version(&self) -> u32 {
+    /// Returns the block version.
+    pub fn version(&self) -> u8 {
         self.version
     }
 
@@ -281,7 +293,7 @@ impl BlockHeader {
     /// the `note_root`).
     #[allow(clippy::too_many_arguments)]
     fn compute_sub_commitment(
-        version: u32,
+        version: u8,
         prev_block_commitment: Word,
         chain_commitment: Word,
         account_root: Word,
@@ -343,7 +355,6 @@ impl BlockHeader {
         let fee_parameters =
             FeeParameters::new(ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET.try_into().unwrap(), 500);
         BlockHeader::new(
-            0,
             prev_block_commitment,
             BlockNumber::from(block_num),
             Word::empty(),
@@ -399,7 +410,16 @@ impl Serializable for BlockHeader {
 
 impl Deserializable for BlockHeader {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let version = source.read()?;
+        let version = u8::read_from(source)?;
+
+        if version != Self::VERSION_1 {
+            return Err(DeserializationError::InvalidValue(format!(
+                "block version is {} but only version {} is supported",
+                version,
+                Self::VERSION_1,
+            )));
+        }
+
         let prev_block_commitment = source.read()?;
         let block_num = source.read()?;
         let chain_commitment = source.read()?;
@@ -413,7 +433,6 @@ impl Deserializable for BlockHeader {
         let timestamp = source.read()?;
 
         Ok(Self::new(
-            version,
             prev_block_commitment,
             block_num,
             chain_commitment,
@@ -523,11 +542,21 @@ pub(crate) enum ParentValidationError {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use miden_core::Word;
     use miden_crypto::rand::test_utils::rand_value;
 
     use super::*;
     use crate::testing::validator_keys::{random_validator_set, sign_all};
+
+    #[test]
+    fn block_header_deserialization_rejects_unsupported_version() {
+        let error = BlockHeader::read_from_bytes(&[0]).unwrap_err();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) => {
+            assert!(message.contains("block version is 0"));
+        });
+    }
 
     #[test]
     fn test_serde() {

--- a/crates/miden-protocol/src/block/proposed_block.rs
+++ b/crates/miden-protocol/src/block/proposed_block.rs
@@ -541,12 +541,8 @@ impl ProposedBlock {
         // updated based on the demand in the currently proposed block.
         let fee_parameters = prev_block_header.fee_parameters().clone();
 
-        // Currently undefined and reserved for future use.
-        // See https://github.com/0xMiden/protocol/issues/1155.
-        let version = 0;
         let tx_kernel_commitment = TransactionKernel.to_commitment();
         let header = BlockHeader::new(
-            version,
             prev_block_commitment,
             block_num,
             new_chain_commitment,

--- a/crates/miden-protocol/src/note/metadata.rs
+++ b/crates/miden-protocol/src/note/metadata.rs
@@ -131,7 +131,7 @@ impl Deserializable for PartialNoteMetadata {
 /// The metadata word is encoded as a single [`Word`] (4 felts) with the following layout:
 ///
 /// ```text
-/// 0th felt: [sender_id_suffix (56 bits) | reserved (3 bits) | note_type (1 bit) | version (4 bits)]
+/// 0th felt: [sender_id_suffix (56 bits) | reserved (1 bit) | note_type (1 bit) | version (6 bits)]
 /// 1st felt: [sender_id_prefix (64 bits)]
 /// 2nd felt: [reserved (32 bits) | note_tag (32 bits)]
 /// 3rd felt: [attachment_3_scheme (16 bits) | attachment_2_scheme (16 bits) |
@@ -160,12 +160,11 @@ impl NoteMetadata {
     // --------------------------------------------------------------------------------------------
 
     /// The number of bits by which the note type is offset in the first felt of the metadata word.
-    const NOTE_TYPE_SHIFT: u64 = 4;
+    const NOTE_TYPE_SHIFT: u64 = 6;
 
     /// Version 1 of the note metadata encoding.
     ///
-    /// If we make this public, we may want to instead consider introducing a `NoteMetadataVersion`
-    /// struct, similar to `AccountIdVersion`.
+    /// It is encoded using 6 bits.
     const VERSION_1: u8 = 1;
 
     // CONSTRUCTORS
@@ -333,7 +332,7 @@ impl Deserializable for NoteMetadata {
 /// The layout is as follows:
 ///
 /// ```text
-/// [sender_id_suffix (56 bits) | reserved (3 bits) | note_type (1 bit) | version (4 bits)]
+/// [sender_id_suffix (56 bits) | reserved (1 bit) | note_type (1 bit) | version (6 bits)]
 /// ```
 ///
 /// The most significant bit of the suffix is guaranteed to be zero, so the felt retains its
@@ -345,7 +344,7 @@ fn merge_sender_suffix_and_note_type(sender_id_suffix: Felt, note_type: NoteType
 
     let note_type_byte = note_type as u8;
     debug_assert!(note_type_byte < 2, "note type must not contain values >= 2");
-    // note_type at bit 4, version at bits 0..=3 (hardcoded to NoteMetadata::VERSION_1)
+    // note_type at bit 6, version at bits 0..=5 (hardcoded to NoteMetadata::VERSION_1)
     merged |= (note_type_byte as u64) << NoteMetadata::NOTE_TYPE_SHIFT;
     merged |= NoteMetadata::VERSION_1 as u64;
 
@@ -452,16 +451,29 @@ mod tests {
         Ok(())
     }
 
+    /// Pins the note metadata layout.
+    #[rstest::rstest]
+    #[case::private(NoteType::Private, 0b0000_0001)]
+    #[case::public(NoteType::Public, 0b0100_0001)]
     #[test]
-    fn note_metadata_header_encodes_v1_as_one() {
-        let sender = AccountId::try_from(ACCOUNT_ID_MAX_ONES).unwrap();
-        let metadata = PartialNoteMetadata::new(sender, NoteType::Private);
-        let metadata = NoteMetadata::new(metadata, &NoteAttachments::default());
+    fn note_metadata_first_felt_layout(
+        #[case] note_type: NoteType,
+        #[case] expected_low_byte: u64,
+    ) -> anyhow::Result<()> {
+        const SUFFIX_MASK: u64 = !0xff;
 
-        let metadata = metadata.to_metadata_word();
-        let version = metadata[0].as_canonical_u64() & 0b1111;
+        // Use the Account ID with the maximum one bits to check that the suffix is untouched even
+        // when all of its non-constrained bits are set.
+        let sender = AccountId::try_from(ACCOUNT_ID_MAX_ONES)?;
+        let partial_metadata = PartialNoteMetadata::new(sender, note_type);
+        let metadata = NoteMetadata::new(partial_metadata, &NoteAttachments::default());
 
-        assert_eq!(version, NoteMetadata::VERSION_1 as u64);
-        assert_eq!(version, 1);
+        let first_felt = metadata.to_metadata_word()[0].as_canonical_u64();
+
+        assert_eq!(first_felt & !SUFFIX_MASK, expected_low_byte);
+        assert_eq!(first_felt & SUFFIX_MASK, sender.suffix().as_canonical_u64());
+        assert_eq!(u64::from(NoteMetadata::VERSION_1), 1);
+
+        Ok(())
     }
 }

--- a/crates/miden-protocol/src/testing/block.rs
+++ b/crates/miden-protocol/src/testing/block.rs
@@ -82,7 +82,6 @@ impl BlockHeader {
         };
 
         BlockHeader::new(
-            0,
             prev_block_commitment,
             block_num.into(),
             chain_commitment,

--- a/crates/miden-protocol/src/transaction/partial_blockchain.rs
+++ b/crates/miden-protocol/src/transaction/partial_blockchain.rs
@@ -483,7 +483,6 @@ mod tests {
             ValidatorKeys::new(alloc::vec![SigningKey::with_rng(&mut rng).public_key()]).unwrap();
 
         BlockHeader::new(
-            0,
             Word::empty(),
             block_num.into(),
             Word::empty(),

--- a/crates/miden-testing/src/mock_chain/chain_builder.rs
+++ b/crates/miden-testing/src/mock_chain/chain_builder.rs
@@ -249,7 +249,6 @@ impl MockChainBuilder {
         let note_tree = BlockNoteTree::from_note_batches(&output_note_batches)
             .context("failed to create block note tree")?;
 
-        let version = 0;
         let prev_block_commitment = Word::empty();
         let block_num = BlockNumber::from(0u32);
         let chain_commitment = Blockchain::new().commitment();
@@ -267,7 +266,6 @@ impl MockChainBuilder {
                 .expect("randomly generated genesis validator keys should be distinct");
 
         let header = BlockHeader::new(
-            version,
             prev_block_commitment,
             block_num,
             chain_commitment,


### PR DESCRIPTION
- Expands the note version to 6 bits, leaving 1 reserved bit. Note that this is zero by construction, so we never assert it is zero explicitly.
- Reduce the block header version to 8 bits and define it as 1 (previously 0 by convention). Remove the version parameter from `BlockHeader::new` as it can never be set to anything other than 1, and validating it would make `new` fallible, causing further API churn.
    - Reject any other version than 1 in block header deserialization.