### PR TITLE
feat: serialize version in account, note and assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Documented that standard note scripts claim only the assets remaining in a note at consumption time ([#3650](https://github.com/0xMiden/protocol/pull/3650)).
 - [BREAKING] Moved the kernel data section of the transaction kernel memory to address `0`, so that `exec_kernel_proc` becomes reusable across multiple kernels ([#3655](https://github.com/0xMiden/protocol/pull/3655)).
 - [BREAKING] Added a 4-bit version to the lowest bits of the asset ID's metadata byte, moving the asset composition to bits 4-5 ([#3670](https://github.com/0xMiden/protocol/pull/3670)).
+- [BREAKING] Serialize the version in `Account`, `AccountHeader`, `PartialNoteMetadata` and `AssetId` ([#3697](https://github.com/0xMiden/protocol/pull/3697)).
 
 ### Fixes
 

--- a/crates/miden-protocol/src/account/header.rs
+++ b/crates/miden-protocol/src/account/header.rs
@@ -42,10 +42,7 @@ impl AccountHeader {
     /// The version occupies the first element of the account metadata word, so a reader can get it
     /// before it interprets the rest of the header. Version 0 is unused, which means an all-zero
     /// word is never valid account metadata.
-    ///
-    /// If we make this public, we may want to instead consider introducing an `AccountVersion`
-    /// struct, similar to [`AccountIdVersion`](crate::account::AccountIdVersion).
-    const VERSION_1: u8 = 1;
+    pub(crate) const VERSION_1: u8 = 1;
 
     /// The number of elements in an account header.
     pub(crate) const NUM_ELEMENTS: u8 = 16;
@@ -221,6 +218,7 @@ impl SequentialCommit for AccountHeader {
 
 impl Serializable for AccountHeader {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        Self::VERSION_1.write_into(target);
         self.id.write_into(target);
         self.nonce.write_into(target);
         self.vault_root.write_into(target);
@@ -231,6 +229,16 @@ impl Serializable for AccountHeader {
 
 impl Deserializable for AccountHeader {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let version = u8::read_from(source)?;
+
+        if version != Self::VERSION_1 {
+            return Err(DeserializationError::InvalidValue(format!(
+                "account version is {} but only version {} is supported",
+                version,
+                Self::VERSION_1,
+            )));
+        }
+
         let id = AccountId::read_from(source)?;
         let nonce = Felt::read_from(source)?;
         let vault_root = Word::read_from(source)?;
@@ -272,7 +280,7 @@ mod tests {
     use crate::asset::FungibleAsset;
     use crate::errors::AccountError;
     use crate::testing::account_id::ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE;
-    use crate::utils::serde::{Deserializable, Serializable};
+    use crate::utils::serde::{Deserializable, DeserializationError, Serializable};
 
     /// Builds an account header whose fields are all distinguishable from one another so that a
     /// swapped element in the encoding is visible.
@@ -322,5 +330,14 @@ mod tests {
         let header_bytes = account_header.to_bytes();
         let deserialized_header = AccountHeader::read_from_bytes(&header_bytes).unwrap();
         assert_eq!(deserialized_header, account_header);
+    }
+
+    #[test]
+    fn account_header_deserialization_rejects_unsupported_version() {
+        let error = AccountHeader::read_from_bytes(&[0]).unwrap_err();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) => {
+            assert!(message.contains("account version is 0"));
+        });
     }
 }

--- a/crates/miden-protocol/src/account/mod.rs
+++ b/crates/miden-protocol/src/account/mod.rs
@@ -500,6 +500,7 @@ impl Serializable for Account {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let Account { id, vault, storage, code, nonce, seed } = self;
 
+        AccountHeader::VERSION_1.write_into(target);
         id.write_into(target);
         vault.write_into(target);
         storage.write_into(target);
@@ -509,7 +510,8 @@ impl Serializable for Account {
     }
 
     fn get_size_hint(&self) -> usize {
-        self.id.get_size_hint()
+        AccountHeader::VERSION_1.get_size_hint()
+            + self.id.get_size_hint()
             + self.vault.get_size_hint()
             + self.storage.get_size_hint()
             + self.code.get_size_hint()
@@ -520,6 +522,16 @@ impl Serializable for Account {
 
 impl Deserializable for Account {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let version = u8::read_from(source)?;
+
+        if version != AccountHeader::VERSION_1 {
+            return Err(DeserializationError::InvalidValue(format!(
+                "account version is {} but only version {} is supported",
+                version,
+                AccountHeader::VERSION_1,
+            )));
+        }
+
         let id = AccountId::read_from(source)?;
         let vault = AssetVault::read_from(source)?;
         let storage = AccountStorage::read_from(source)?;
@@ -574,7 +586,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use assert_matches::assert_matches;
-    use miden_crypto::utils::{Deserializable, Serializable};
+    use miden_crypto::utils::{Deserializable, DeserializationError, Serializable};
     use miden_crypto::{Felt, Word};
 
     use super::{AccountCode, AccountDelta, AccountId, AccountStorage, AccountStoragePatch};
@@ -923,5 +935,14 @@ mod tests {
         let _partial_account = PartialAccount::from(&account);
 
         Ok(())
+    }
+
+    #[test]
+    fn account_deserialization_rejects_unsupported_version() {
+        let error = Account::read_from_bytes(&[0]).unwrap_err();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) => {
+            assert!(message.contains("account version is 0"));
+        });
     }
 }

--- a/crates/miden-protocol/src/asset/fungible.rs
+++ b/crates/miden-protocol/src/asset/fungible.rs
@@ -206,32 +206,34 @@ impl fmt::Display for FungibleAsset {
 
 impl Serializable for FungibleAsset {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        // Lead with the asset composition byte to distinguish asset types on the wire.
-        target.write(AssetComposition::Fungible);
-        target.write(self.faucet_id);
+        // Serialize the asset ID to version the fungible asset.
+        self.id().write_into(target);
         target.write(self.amount.as_u64());
     }
 
     fn get_size_hint(&self) -> usize {
-        AssetComposition::SERIALIZED_SIZE
-            + self.faucet_id.get_size_hint()
-            + self.amount.as_u64().get_size_hint()
+        self.id().get_size_hint() + self.amount.as_u64().get_size_hint()
     }
 }
 
 impl Deserializable for FungibleAsset {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let composition: AssetComposition = source.read()?;
-        if !composition.is_fungible() {
+        let id = AssetId::read_from(source)?;
+
+        if !id.composition().is_fungible() {
             return Err(DeserializationError::InvalidValue(format!(
-                "expected fungible asset composition but found {composition:?}"
+                "expected fungible asset composition but found {:?}",
+                id.composition()
             )));
         }
+        debug_assert!(
+            id.asset_class().is_empty(),
+            "asset ID should validate asset class is empty for composition fungible"
+        );
 
-        let faucet_id: AccountId = source.read()?;
         let amount: u64 = source.read()?;
 
-        FungibleAsset::new(faucet_id, amount)
+        FungibleAsset::new(id.faucet_id(), amount)
             .map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }

--- a/crates/miden-protocol/src/asset/mod.rs
+++ b/crates/miden-protocol/src/asset/mod.rs
@@ -305,17 +305,6 @@ mod tests {
         Ok(())
     }
 
-    /// Asserts that every serialized asset leads with the [`AssetComposition`] byte of its
-    /// [`AssetId`]. Deserialization of the ID relies on this discriminator.
-    #[test]
-    fn test_composition_byte_is_serialized_first() {
-        let fungible_bytes = FungibleAsset::mock(300).to_bytes();
-        assert_eq!(fungible_bytes[0], AssetComposition::Fungible.as_u8());
-
-        let non_fungible_bytes = NonFungibleAsset::mock(&[0xaa, 0xbb]).to_bytes();
-        assert_eq!(non_fungible_bytes[0], AssetComposition::None.as_u8());
-    }
-
     /// `Asset::from_id_and_value` must reject a [`AssetComposition::Custom`] asset ID with
     /// `UnsupportedAssetComposition`.
     #[test]

--- a/crates/miden-protocol/src/asset/vault/asset_id.rs
+++ b/crates/miden-protocol/src/asset/vault/asset_id.rs
@@ -19,6 +19,8 @@ use crate::utils::serde::{
 };
 use crate::{Felt, Hasher, Word};
 
+type AssetIdVersion = u8;
+
 /// The unique identifier of an [`Asset`] in the [`AssetVault`](crate::asset::AssetVault).
 ///
 /// Its [`Word`] layout is:
@@ -54,8 +56,9 @@ impl AssetId {
     /// The serialized size of an [`AssetId`] with [`AssetComposition::Fungible`] in bytes.
     ///
     /// The asset class of a fungible asset is always empty and so it is not serialized.
-    const FUNGIBLE_SERIALIZED_SIZE: usize =
-        AssetComposition::SERIALIZED_SIZE + AccountId::SERIALIZED_SIZE;
+    const FUNGIBLE_SERIALIZED_SIZE: usize = core::mem::size_of::<AssetIdVersion>()
+        + AssetComposition::SERIALIZED_SIZE
+        + AccountId::SERIALIZED_SIZE;
 
     /// The serialized size of an [`AssetId`] with any other [`AssetComposition`] in bytes.
     const NON_FUNGIBLE_SERIALIZED_SIZE: usize =
@@ -306,7 +309,7 @@ impl Serializable for AssetId {
     /// asset class of a fungible asset is always empty, it is not written, saving
     /// [`AssetClass::SERIALIZED_SIZE`] bytes per fungible ID.
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        // Lead with the asset composition byte.
+        target.write(AssetId::VERSION_1);
         target.write(self.composition);
         target.write(self.faucet_id);
 
@@ -326,6 +329,16 @@ impl Serializable for AssetId {
 
 impl Deserializable for AssetId {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let version: u8 = source.read()?;
+
+        if version != Self::VERSION_1 {
+            return Err(DeserializationError::InvalidValue(format!(
+                "asset version is {} but only version {} is supported",
+                version,
+                Self::VERSION_1,
+            )));
+        }
+
         let composition: AssetComposition = source.read()?;
         let faucet_id: AccountId = source.read()?;
         let asset_class = if composition.is_fungible() {
@@ -344,6 +357,8 @@ impl Deserializable for AssetId {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
+
     use super::*;
     use crate::asset::AssetComposition;
     use crate::asset::tests::{asset_metadata, set_asset_metadata};
@@ -421,5 +436,14 @@ mod tests {
         assert_eq!(asset_metadata(non_fungible), 0b0000_0001);
 
         Ok(())
+    }
+
+    #[test]
+    fn asset_id_deserialization_rejects_unsupported_version() {
+        let error = AssetId::read_from_bytes(&[0]).unwrap_err();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) => {
+            assert!(message.contains("asset version is 0"));
+        });
     }
 }

--- a/crates/miden-protocol/src/note/header.rs
+++ b/crates/miden-protocol/src/note/header.rs
@@ -17,8 +17,8 @@ use super::{
 /// See [NoteDetailsCommitment] and [NoteMetadata] for additional details.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoteHeader {
-    details_commitment: NoteDetailsCommitment,
     metadata: NoteMetadata,
+    details_commitment: NoteDetailsCommitment,
 }
 
 impl NoteHeader {
@@ -56,20 +56,37 @@ impl NoteHeader {
 
 impl Serializable for NoteHeader {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.details_commitment.write_into(target);
         self.metadata.write_into(target);
+        self.details_commitment.write_into(target);
     }
 
     fn get_size_hint(&self) -> usize {
-        self.details_commitment.get_size_hint() + self.metadata.get_size_hint()
+        self.metadata.get_size_hint() + self.details_commitment.get_size_hint()
     }
 }
 
 impl Deserializable for NoteHeader {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let details_commitment = NoteDetailsCommitment::read_from(source)?;
         let metadata = NoteMetadata::read_from(source)?;
+        let details_commitment = NoteDetailsCommitment::read_from(source)?;
 
         Ok(Self::new(details_commitment, metadata))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use super::*;
+    use crate::utils::serde::{Deserializable, DeserializationError};
+
+    #[test]
+    fn note_header_deserialization_rejects_unsupported_version() {
+        let error = NoteHeader::read_from_bytes(&[0]).unwrap_err();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) => {
+            assert!(message.contains("note version is 0"));
+        });
     }
 }

--- a/crates/miden-protocol/src/note/metadata.rs
+++ b/crates/miden-protocol/src/note/metadata.rs
@@ -98,13 +98,15 @@ impl PartialNoteMetadata {
 
 impl Serializable for PartialNoteMetadata {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        NoteMetadata::VERSION_1.write_into(target);
         self.note_type().write_into(target);
         self.sender().write_into(target);
         self.tag().write_into(target);
     }
 
     fn get_size_hint(&self) -> usize {
-        self.note_type().get_size_hint()
+        NoteMetadata::VERSION_1.get_size_hint()
+            + self.note_type().get_size_hint()
             + self.sender().get_size_hint()
             + self.tag().get_size_hint()
     }
@@ -112,6 +114,16 @@ impl Serializable for PartialNoteMetadata {
 
 impl Deserializable for PartialNoteMetadata {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let version = u8::read_from(source)?;
+
+        if version != NoteMetadata::VERSION_1 {
+            return Err(DeserializationError::InvalidValue(format!(
+                "note version is {} but only version {} is supported",
+                version,
+                NoteMetadata::VERSION_1,
+            )));
+        }
+
         let note_type = NoteType::read_from(source)?;
         let sender = AccountId::read_from(source)?;
         let tag = NoteTag::read_from(source)?;
@@ -379,6 +391,8 @@ fn merge_schemes(headers: [NoteAttachmentHeader; NoteAttachments::MAX_COUNT]) ->
 #[cfg(test)]
 mod tests {
 
+    use assert_matches::assert_matches;
+
     use super::*;
     use crate::note::{NoteAttachment, NoteAttachmentScheme};
     use crate::testing::account_id::ACCOUNT_ID_MAX_ONES;
@@ -463,5 +477,14 @@ mod tests {
 
         assert_eq!(version, NoteMetadata::VERSION_1 as u64);
         assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn partial_note_metadata_deserialization_rejects_unsupported_version() {
+        let error = PartialNoteMetadata::read_from_bytes(&[0]).unwrap_err();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) => {
+            assert!(message.contains("note version is 0"));
+        });
     }
 }

--- a/crates/miden-protocol/src/note/mod.rs
+++ b/crates/miden-protocol/src/note/mod.rs
@@ -293,3 +293,20 @@ impl Deserializable for Note {
         Ok(Self::with_attachments(assets, partial_metadata, recipient, attachments))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use super::*;
+    use crate::utils::serde::{Deserializable, DeserializationError};
+
+    #[test]
+    fn note_deserialization_rejects_unsupported_version() {
+        let error = Note::read_from_bytes(&[0]).unwrap_err();
+
+        assert_matches!(error, DeserializationError::InvalidValue(message) => {
+            assert!(message.contains("note version is 0"));
+        });
+    }
+}


### PR DESCRIPTION
Serialize the version for account, note and assets.

- Version for notes is serialized in `PartialNoteMetadata`, because `Note` serializes only that, not the full `NoteMetadata`. This way, the `Note` object gets versioned.
- Swaps the `NoteHeader` field serialization order so the `NoteMetadata`, with it version, is serialized first.
- Any type that serializes `Note` (e.g. `OutputNote`) or `NoteHeader` (e.g. `PrivateOutputNote`) get the version naturally, which should be fine and have no particular up- or downsides.

For accounts, it's a bit different because the account header isn't serialized in an embedded way. Only the `Account` serializes the version explicitly as well as the header. Notably, `PartialAccount` does not serialize the version, and I'm not sure if we should add it here. 

The `AssetId` carries the version and serializes it.
- `NonFungibleAsset` serializes `AssetId` so it serializes the version.
- `FungibleAsset` did not serialize the version and the custom format was replaced by asset ID serialization because, due to recent changes, the custom format isn't technically necessary anymore and this way it also serializes the version.

Arguably, we could also always say that these two assets are always of version 1, and the version isn't necessary, but I think it doesn't hurt, and now they consistently both serialize the version.