### PR TITLE
feat: add versions to the account delta and patch commitments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Documented that standard note scripts claim only the assets remaining in a note at consumption time ([#3650](https://github.com/0xMiden/protocol/pull/3650)).
 - [BREAKING] Moved the kernel data section of the transaction kernel memory to address `0`, so that `exec_kernel_proc` becomes reusable across multiple kernels ([#3655](https://github.com/0xMiden/protocol/pull/3655)).
 - [BREAKING] Added a 4-bit version to the lowest bits of the asset ID's metadata byte, moving the asset composition to bits 4-5 ([#3670](https://github.com/0xMiden/protocol/pull/3670)).
+- [BREAKING] Moved the account delta and patch domain separators into the hasher capacity word. Added a version to their commitments ([#3698](https://github.com/0xMiden/protocol/pull/3698)).
 
 ### Fixes
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
@@ -42,16 +42,22 @@ const ACCOUNT_ON_ASSET_DELTA_COMPUTATION_EVENT =
 # CONSTANTS
 # =================================================================================================
 
-# The domain of the delta commitment header.
-const DOMAIN_DELTA = 1
-# The domain of the patch commitment header.
-const DOMAIN_PATCH = 2
-# The domain of an asset in the delta commitment.
-const DOMAIN_ASSET = 3
-# The domain of a value storage slot in the delta commitment.
-const DOMAIN_VALUE = 5
-# The domain of a map storage slot in the delta commitment.
-const DOMAIN_MAP = 6
+# The domains of the delta and patch commitments. They are absorbed via the hasher capacity word.
+const DOMAIN_DELTA = 0x020001
+const DOMAIN_PATCH = 0x020000
+
+#! The domain of an asset in a delta or patch commitment.
+const DOMAIN_ASSET = 1
+#! The domain of a value storage slot in a delta or patch commitment.
+const DOMAIN_VALUE = 2
+#! The domain of a map storage slot in a delta or patch commitment.
+const DOMAIN_MAP = 3
+
+#! The version of the delta commitment layout.
+const DELTA_VERSION_1 = 1
+
+#! The version of the patch commitment layout.
+const PATCH_VERSION_1 = 1
 
 #! The default delta operation indicating no change.
 const DELTA_OP_NONE = 0
@@ -120,8 +126,15 @@ const MAX_ASSETS_PER_DELTA_OP = 1024
 #! Panics if:
 #! - the vault patch or storage patch is not empty but the nonce increment is zero.
 pub proc compute_patch_commitment
-    # pad capacity and RATE1 of the hasher with empty words
-    padw padw
+    # domain-separate the patch commitment through the hasher capacity
+    push.0.0.DOMAIN_PATCH.0
+    # => [CAPACITY]
+
+    exec.poseidon2::init_with_capacity
+    # => [RATE0 = EMPTY_WORD, RATE1 = EMPTY_WORD, CAPACITY]
+
+    # drop the zeroed RATE0 to make room for the commitment header
+    dropw
     # => [EMPTY_WORD, CAPACITY]
 
     exec.memory::get_native_account_id
@@ -130,33 +143,32 @@ pub proc compute_patch_commitment
     # get the nonce of the account and assume it is the final nonce
     # we later assert that the nonce was incremented (unless the patch is empty)
     exec.memory::get_native_account_nonce
-    push.DOMAIN_PATCH
-    # => [domain_patch, final_nonce, native_account_id_suffix, native_account_id_prefix, EMPTY_WORD, CAPACITY]
-    # => [ID_AND_NONCE, EMPTY_WORD, CAPACITY]
+    push.PATCH_VERSION_1
+    # => [patch_version, final_nonce, native_account_id_suffix, native_account_id_prefix, EMPTY_WORD, CAPACITY]
+    # => [METADATA, EMPTY_WORD, CAPACITY]
 
     exec.poseidon2::permute
     # => [RATE0, RATE1, CAPACITY]
 
-    # save the ID and nonce digest (RATE0 word) for a later check
+    # save the metadata digest (RATE0 word) for a later check
     exec.poseidon2::copy_digest movdnw.3
-    # => [RATE0, RATE1, CAPACITY, ID_AND_NONCE_DIGEST]
+    # => [RATE0, RATE1, CAPACITY, METADATA_DIGEST]
 
     exec.commit_asset_patch
-    # => [RATE0, RATE1, CAPACITY, ID_AND_NONCE_DIGEST]
+    # => [RATE0, RATE1, CAPACITY, METADATA_DIGEST]
 
     exec.commit_storage_patch
-    # => [RATE0, RATE1, CAPACITY, ID_AND_NONCE_DIGEST]
+    # => [RATE0, RATE1, CAPACITY, METADATA_DIGEST]
 
     exec.poseidon2::squeeze_digest
-    # => [PATCH_COMMITMENT, ID_AND_NONCE_DIGEST]
+    # => [PATCH_COMMITMENT, METADATA_DIGEST]
 
     exec.was_nonce_incremented not
-    # => [!was_nonce_incremented, PATCH_COMMITMENT, ID_AND_NONCE_DIGEST]
+    # => [!was_nonce_incremented, PATCH_COMMITMENT, METADATA_DIGEST]
 
     if.true
         # if the nonce wasn't incremented, then the vault and storage patch is required to be empty
-        # storage and vault patch were empty if the patch commitment is equal to
-        # ID_AND_NONCE_DIGEST
+        # storage and vault patch were empty if the patch commitment is equal to METADATA_DIGEST
         assert_eqw.err=ERR_ACCOUNT_PATCH_NONCE_MUST_BE_INCREMENTED_IF_VAULT_OR_STORAGE_CHANGED
         # => []
 
@@ -164,7 +176,7 @@ pub proc compute_patch_commitment
         padw
         # => [EMPTY_WORD]
     else
-        # drop the ID and nonce digest
+        # drop the metadata digest
         swapw dropw
         # => [PATCH_COMMITMENT]
     end
@@ -183,41 +195,47 @@ end
 #! Panics if:
 #! - the vault delta or storage patch is not empty but the nonce increment is zero.
 pub proc compute_delta_commitment
-    # pad capacity and RATE1 of the hasher with empty words
-    padw padw
+    # domain-separate the delta commitment through the hasher capacity
+    push.0.0.DOMAIN_DELTA.0
+    # => [CAPACITY]
+
+    exec.poseidon2::init_with_capacity
+    # => [RATE0 = EMPTY_WORD, RATE1= EMPTY_WORD, CAPACITY]
+
+    # drop the zeroed RATE0 to make room for the commitment header
+    dropw
     # => [EMPTY_WORD, CAPACITY]
 
     exec.memory::get_native_account_id
     # => [native_acct_id_suffix, native_acct_id_prefix, EMPTY_WORD, CAPACITY]
 
     # the delta of the nonce is equal to was_nonce_incremented
-    exec.was_nonce_incremented push.DOMAIN_DELTA
-    # => [domain_delta, nonce_delta, native_acct_id_suffix, native_acct_id_prefix, EMPTY_WORD, CAPACITY]
-    # => [ID_AND_NONCE, EMPTY_WORD, CAPACITY]
+    exec.was_nonce_incremented push.DELTA_VERSION_1
+    # => [delta_version, nonce_delta, native_acct_id_suffix, native_acct_id_prefix, EMPTY_WORD, CAPACITY]
+    # => [METADATA, EMPTY_WORD, CAPACITY]
 
     exec.poseidon2::permute
     # => [RATE0, RATE1, CAPACITY]
 
-    # save the ID and nonce digest (RATE0 word) for a later check
+    # save the metadata digest (RATE0 word) for a later check
     exec.poseidon2::copy_digest movdnw.3
-    # => [RATE0, RATE1, CAPACITY, ID_AND_NONCE_DIGEST]
+    # => [RATE0, RATE1, CAPACITY, METADATA_DIGEST]
 
     exec.commit_asset_delta
-    # => [RATE0, RATE1, CAPACITY, ID_AND_NONCE_DIGEST]
+    # => [RATE0, RATE1, CAPACITY, METADATA_DIGEST]
 
     exec.commit_storage_patch
-    # => [RATE0, RATE1, CAPACITY, ID_AND_NONCE_DIGEST]
+    # => [RATE0, RATE1, CAPACITY, METADATA_DIGEST]
 
     exec.poseidon2::squeeze_digest
-    # => [DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]
+    # => [DELTA_COMMITMENT, METADATA_DIGEST]
 
     exec.was_nonce_incremented not
-    # => [!was_nonce_incremented, DELTA_COMMITMENT, ID_AND_NONCE_DIGEST]
+    # => [!was_nonce_incremented, DELTA_COMMITMENT, METADATA_DIGEST]
 
     if.true
         # if the nonce wasn't incremented, then the vault and storage delta is required to be empty
-        # storage and vault delta were empty if the delta commitment is equal to
-        # ID_AND_NONCE_DIGEST
+        # storage and vault delta were empty if the delta commitment is equal to METADATA_DIGEST
         assert_eqw.err=ERR_ACCOUNT_DELTA_NONCE_MUST_BE_INCREMENTED_IF_VAULT_OR_STORAGE_CHANGED
         # => []
 
@@ -225,7 +243,7 @@ pub proc compute_delta_commitment
         padw
         # => [EMPTY_WORD]
     else
-        # drop the ID and nonce digest
+        # drop the metadata digest
         swapw dropw
         # => [DELTA_COMMITMENT]
     end

--- a/crates/miden-protocol/src/account/delta/mod.rs
+++ b/crates/miden-protocol/src/account/delta/mod.rs
@@ -12,7 +12,7 @@ use crate::utils::serde::{
     DeserializationError,
     Serializable,
 };
-use crate::{Felt, Word, ZERO};
+use crate::{Felt, Hasher, Word, ZERO};
 
 mod delta_op;
 pub use delta_op::AssetDeltaOperation;
@@ -62,8 +62,21 @@ impl AccountDelta {
     // CONSTANTS
     // --------------------------------------------------------------------------------------------
 
-    /// Domain separator for the account delta commitment header.
-    const DOMAIN: Felt = Felt::new_unchecked(1);
+    /// Domain separator for the account delta commitment.
+    ///
+    /// It is placed in the capacity word of the hasher rather than in the hashed elements, so that
+    /// it stays fixed even as the layout of those elements evolves across versions. The value is
+    /// allocated from the range that the [Poseidon2 domain registry][registry] delegates to this
+    /// repository.
+    ///
+    /// [registry]: https://github.com/0xMiden/crypto/blob/main/docs/registry/poseidon2-domains.toml
+    const DOMAIN: Felt = Felt::new_unchecked(0x02_0001);
+
+    /// Version 1 of the account delta commitment layout.
+    ///
+    /// The version occupies the first element of the commitment header, so a reader can get it
+    /// before it interprets the rest of the commitment.
+    const VERSION_1: u8 = 1;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -170,22 +183,24 @@ impl AccountDelta {
     /// ## Computation
     ///
     /// The delta commitment is a sequential hash over a vector of field elements which starts out
-    /// empty and is appended to in the following way. Whenever sorting is expected, it is that
-    /// of a [`Word`].
+    /// empty and is appended to in the following way. If no asset or storage elements were
+    /// appended, the commitment is defined as the empty word. Whenever sorting is expected, it
+    /// is that of a [`Word`]. The hash is domain-separated by the delta's `DOMAIN`, which is
+    /// placed in the capacity word of the hasher.
     ///
-    /// - Append `[[domain = 1, nonce_delta, account_id_suffix, account_id_prefix], EMPTY_WORD]`,
+    /// - Append `[[version = 1, nonce_delta, account_id_suffix, account_id_prefix], EMPTY_WORD]`,
     ///   where `account_id_{prefix,suffix}` are the prefix and suffix felts of the native account
-    ///   id, `nonce_delta` is the value by which the nonce was incremented, and `domain = 1`
-    ///   identifies the header as the start of an account delta commitment.
+    ///   id, `nonce_delta` is the value by which the nonce was incremented, and `version` is the
+    ///   version of this layout.
     /// - Asset Delta
     ///   - For each **added** asset, sorted by its asset ID:
     ///     - Append `[ASSET_ID, ASSET_VALUE]`.
-    ///   - Append `[domain = 3, delta_op = 1, num_added_assets, 0]` if `num_added_assets != 0`
+    ///   - Append `[domain = 1, delta_op = 1, num_added_assets, 0]` if `num_added_assets != 0`
     ///     where `num_added_assets` is the number of added assets and `delta_op` is set to `1`
     ///     indicating asset addition.
     ///   - For each **removed** asset, sorted by its asset ID:
     ///     - Append `[ASSET_ID, ASSET_VALUE]`.
-    ///   - Append `[domain = 3, delta_op = 2, num_removed_assets, 0]` if `num_removed_assets != 0`
+    ///   - Append `[domain = 1, delta_op = 2, num_removed_assets, 0]` if `num_removed_assets != 0`
     ///     where `num_removed_assets` is the number of removed assets and `delta_op` is set to `2`
     ///     indicating asset removal.
     ///   - Note that the domain is the same independent of asset addition or removal, since the
@@ -195,13 +210,13 @@ impl AccountDelta {
     ///   `slot_id_{suffix, prefix}` is the identifier of the slot. For each slot, depending on its
     ///   slot type:
     ///   - Value Slot
-    ///     - Append `[[domain = 5, patch_op, slot_id_suffix, slot_id_prefix], NEW_VALUE]` where
+    ///     - Append `[[domain = 2, patch_op, slot_id_suffix, slot_id_prefix], NEW_VALUE]` where
     ///       `NEW_VALUE` is the new value of the slot.
     ///   - Map Slot
     ///     - For each key-value pair, sorted by key, whose new value is different from the previous
     ///       value in the map:
     ///       - Append `[KEY, NEW_VALUE]`.
-    ///     - The map trailer is constructed as `[[domain = 6, patch_op, slot_id_suffix,
+    ///     - The map trailer is constructed as `[[domain = 3, patch_op, slot_id_suffix,
     ///       slot_id_prefix], [num_changed_entries, 0, 0, 0]]`, where `num_changed_entries` is the
     ///       number of key-value pairs appended above. Whether the trailer is included depends on
     ///       `patch_op`:
@@ -246,7 +261,8 @@ impl AccountDelta {
     ///   hasher, domain separators are used to disambiguate. For each changed asset and each
     ///   changed slot in the delta, a domain separator is hashed into the delta. The domain
     ///   separator is always at the same index in each layout so it cannot be maliciously crafted
-    ///   (see below for an example).
+    ///   (see below for an example). These separators only need to be unique _within_ a delta or
+    ///   patch, since the `DOMAIN` of a delta and of a patch already separate the two objects.
     /// - Storage value slots:
     ///   - since value slots are only included in the patch if their value has changed when the
     ///     operation is `Update`, there is no ambiguity between a value slot being set to
@@ -263,9 +279,9 @@ impl AccountDelta {
     ///
     /// ```text
     /// [
-    ///   ID_AND_NONCE, EMPTY_WORD,
+    ///   METADATA, EMPTY_WORD,
     ///   [ASSET_ID, ASSET_VALUE],
-    ///   [[domain = 3, delta_op = 1, num_added_assets = 1, 0], EMPTY_WORD],
+    ///   [[domain = 1, delta_op = 1, num_added_assets = 1, 0], EMPTY_WORD],
     ///   [/* no removed assets delta */],
     ///   [/* no storage patch */]
     /// ]
@@ -273,10 +289,10 @@ impl AccountDelta {
     ///
     /// ```text
     /// [
-    ///   ID_AND_NONCE, EMPTY_WORD,
+    ///   METADATA, EMPTY_WORD,
     ///   [/* no asset delta */],
-    ///   [[domain = 5, patch_op, slot_id_suffix0, slot_id_prefix0], NEW_VALUE]
-    ///   [[domain = 5, patch_op, slot_id_suffix1, slot_id_prefix1], NEW_VALUE]
+    ///   [[domain = 2, patch_op, slot_id_suffix0, slot_id_prefix0], NEW_VALUE]
+    ///   [[domain = 2, patch_op, slot_id_suffix1, slot_id_prefix1], NEW_VALUE]
     /// ]
     /// ```
     ///
@@ -285,8 +301,9 @@ impl AccountDelta {
     ///   in the asset ID or `num_added_assets` and the fixed 0.
     /// - This leaves only the domain separator and the patch_op to differentiate these two deltas.
     ///
-    /// The delta and patch headers further use distinct domain separators (1 and 2 respectively),
-    /// so a delta and a patch with otherwise identical bodies can never collide.
+    /// A delta and a patch have identically shaped headers, so their element sequences can be made
+    /// to match. They cannot collide because the delta and the patch commitment use distinct hasher
+    /// capacity domains.
     ///
     /// ### Number of Changed Entries
     ///
@@ -294,19 +311,19 @@ impl AccountDelta {
     ///
     /// ```text
     /// [
-    ///   ID_AND_NONCE, EMPTY_WORD,
+    ///   METADATA, EMPTY_WORD,
     ///   [/* no asset delta */],
-    ///   [domain = 6, patch_op, slot_id_suffix = 20, slot_id_prefix = 21, num_changed_entries = 0, 0, 0, 0]
-    ///   [domain = 6, patch_op, slot_id_suffix = 42, slot_id_prefix = 43, num_changed_entries = 0, 0, 0, 0]
+    ///   [domain = 3, patch_op, slot_id_suffix = 20, slot_id_prefix = 21, num_changed_entries = 0, 0, 0, 0]
+    ///   [domain = 3, patch_op, slot_id_suffix = 42, slot_id_prefix = 43, num_changed_entries = 0, 0, 0, 0]
     /// ]
     /// ```
     ///
     /// ```text
     /// [
-    ///   ID_AND_NONCE, EMPTY_WORD,
+    ///   METADATA, EMPTY_WORD,
     ///   [/* no asset delta */],
     ///   [KEY0, VALUE0],
-    ///   [domain = 6, patch_op, slot_id_suffix = 42, slot_id_prefix = 43, num_changed_entries = 1, 0, 0, 0]
+    ///   [domain = 3, patch_op, slot_id_suffix = 42, slot_id_prefix = 43, num_changed_entries = 1, 0, 0, 0]
     /// ]
     /// ```
     ///
@@ -378,6 +395,20 @@ impl TryFrom<&AccountDelta> for Account {
 impl SequentialCommit for AccountDelta {
     type Commitment = Word;
 
+    /// Computes the commitment to the delta, domain-separated by its `DOMAIN`.
+    ///
+    /// See [AccountDelta::to_commitment()] for more details.
+    fn to_commitment(&self) -> Word {
+        let elements = self.to_elements();
+
+        // An empty delta produces no elements and its commitment is defined as the empty word.
+        if elements.is_empty() {
+            return Word::empty();
+        }
+
+        Hasher::hash_elements_in_domain(&elements, Self::DOMAIN)
+    }
+
     /// Reduces the delta to a sequence of field elements.
     ///
     /// See [AccountDelta::to_commitment()] for more details.
@@ -390,9 +421,9 @@ impl SequentialCommit for AccountDelta {
         // Minor optimization: At least 24 elements are always added.
         let mut elements = Vec::with_capacity(24);
 
-        // ID and Nonce
+        // Metadata
         elements.extend_from_slice(&[
-            Self::DOMAIN,
+            Felt::from(Self::VERSION_1),
             self.nonce_delta,
             self.account_id.suffix(),
             self.account_id.prefix().as_felt(),
@@ -492,8 +523,10 @@ mod tests {
         Account,
         AccountCode,
         AccountId,
+        AccountPatch,
         AccountStorage,
         AccountType,
+        AccountVaultPatch,
         StorageMapKey,
         StorageMapPatch,
         StorageSlotName,
@@ -505,6 +538,7 @@ mod tests {
         NonFungibleAsset,
         NonFungibleAssetDetails,
     };
+    use crate::crypto::SequentialCommit;
     use crate::errors::AccountDeltaError;
     use crate::testing::account_id::{
         ACCOUNT_ID_PRIVATE_SENDER,
@@ -512,7 +546,50 @@ mod tests {
         AccountIdBuilder,
     };
     use crate::utils::serde::Serializable;
-    use crate::{ONE, Word, ZERO};
+    use crate::{Felt, ONE, Word, ZERO};
+
+    #[test]
+    fn empty_account_delta_commitment_is_empty_word() -> anyhow::Result<()> {
+        let empty_delta = AccountDelta::new(
+            AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER)?,
+            AccountStoragePatch::new(),
+            AccountVaultDelta::default(),
+            None,
+            ZERO,
+        )?;
+        assert_eq!(empty_delta.to_commitment(), Word::empty());
+
+        Ok(())
+    }
+
+    /// A delta and a patch that reduce to identical element sequences still commit to different
+    /// words, because they use distinct hasher domains.
+    #[test]
+    fn account_delta_commitment_domain_separation() -> anyhow::Result<()> {
+        let account_id = AccountId::try_from(ACCOUNT_ID_PRIVATE_SENDER)?;
+        let nonce = Felt::from(2u8);
+
+        let delta = AccountDelta::new(
+            account_id,
+            AccountStoragePatch::new(),
+            AccountVaultDelta::default(),
+            None,
+            nonce,
+        )?;
+        let patch = AccountPatch::new(
+            account_id,
+            AccountStoragePatch::new(),
+            AccountVaultPatch::default(),
+            None,
+            Some(nonce),
+        )?;
+
+        assert_eq!(delta.to_elements(), patch.to_elements());
+        assert_ne!(delta.to_commitment(), Word::empty());
+        assert_ne!(delta.to_commitment(), patch.to_commitment());
+
+        Ok(())
+    }
 
     #[test]
     fn account_delta_nonce_validation() {

--- a/crates/miden-protocol/src/account/delta/vault.rs
+++ b/crates/miden-protocol/src/account/delta/vault.rs
@@ -76,8 +76,8 @@ pub struct AccountVaultDelta {
 }
 
 impl AccountVaultDelta {
-    /// Domain separator for assets in the account delta commitment.
-    pub(in crate::account) const DOMAIN: Felt = Felt::new_unchecked(3);
+    /// Domain separator for assets in delta and patch commitments.
+    pub(in crate::account) const DOMAIN: Felt = Felt::new_unchecked(1);
 
     /// Maximum number of added or removed assets in a vault delta.
     pub const MAX_ASSETS_PER_DELTA_OP: u16 = 1024;

--- a/crates/miden-protocol/src/account/patch/mod.rs
+++ b/crates/miden-protocol/src/account/patch/mod.rs
@@ -27,7 +27,7 @@ use crate::utils::serde::{
     DeserializationError,
     Serializable,
 };
-use crate::{Felt, Word};
+use crate::{Felt, Hasher, Word};
 
 /// An [`AccountPatch`] describes the new absolute state of an account after one or more
 /// transactions, in contrast to an [`AccountDelta`](crate::account::AccountDelta), which describes
@@ -78,8 +78,18 @@ impl AccountPatch {
     // CONSTANTS
     // --------------------------------------------------------------------------------------------
 
-    /// Domain separator for the account patch commitment header.
-    const DOMAIN: Felt = Felt::new_unchecked(2);
+    /// Domain separator for the account patch commitment.
+    ///
+    /// See [`AccountDelta::DOMAIN`](crate::account::AccountDelta) for why it lives in the capacity
+    /// word and where the value is allocated from.
+    const DOMAIN: Felt = Felt::new_unchecked(0x02_0000);
+
+    /// Version 1 of the account patch commitment layout.
+    ///
+    /// The version occupies the first element of the commitment header, so a reader can get it
+    /// before it interprets the rest of the commitment. Version 0 is unused, which means an
+    /// all-zero word is never a valid header.
+    const VERSION_1: u8 = 1;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -313,35 +323,37 @@ impl AccountPatch {
     /// ## Computation
     ///
     /// The patch commitment is a sequential hash over a vector of field elements which starts out
-    /// empty and is appended to in the following way. Whenever sorting is expected, it is that
-    /// of a [`Word`].
+    /// empty and is appended to in the following way. If no asset or storage elements were
+    /// appended, the commitment is defined as the empty word. Whenever sorting is expected, it is
+    /// that of a [`Word`]. The hash is domain-separated by the patch's `DOMAIN`, which is
+    /// placed in the capacity word of the hasher. This is what distinguishes a patch commitment
+    /// from a delta commitment, whose headers are otherwise identically shaped.
     ///
-    /// - Append `[[domain = 2, final_nonce, account_id_suffix, account_id_prefix], EMPTY_WORD]`,
+    /// - Append `[[version = 1, final_nonce, account_id_suffix, account_id_prefix], EMPTY_WORD]`,
     ///   where `account_id_{prefix,suffix}` are the prefix and suffix felts of the native account
-    ///   id, `final_nonce` is the new nonce of the account, and `domain = 2` identifies the header
-    ///   as the start of an account patch commitment (distinguishing it from a delta commitment,
-    ///   which uses `domain = 1`).
+    ///   id, `final_nonce` is the new nonce of the account, and `version` is the version of this
+    ///   layout.
     /// - Asset Patch
     ///   - For each asset whose value has changed compared to the initial state of the transaction,
     ///     including if it was removed, sorted by its asset ID:
     ///     - Append `[ASSET_ID, ASSET_VALUE_OR_EMPTY_WORD]` which are the key and either the value
     ///       of the asset (for updates) or the empty word (for removals).
-    ///     - Append `[[domain = 4, num_changed_assets, 0, 0], 0, 0, 0, 0]`, where
-    ///       `num_changed_assets` is the number of assets that were appended. Note that this is a
-    ///       distinct domain from the delta asset domain (`3`), so an asset delta and an asset
-    ///       patch can never produce the same commitment.
+    ///     - Append `[[domain = 1, num_changed_assets, 0, 0], 0, 0, 0, 0]`, where
+    ///       `num_changed_assets` is the number of assets that were appended. This is the same
+    ///       domain as the delta asset section uses, since the capacity domain already prevents an
+    ///       asset delta and an asset patch from producing the same commitment.
     /// - Storage Slots are sorted by slot ID and are iterated in this order. `patch_op` is the
     ///   [`StoragePatchOperation`](crate::account::StoragePatchOperation) of the slot patch and
     ///   `slot_id_{suffix, prefix}` is the identifier of the slot. For each slot, depending on its
     ///   slot type:
     ///   - Value Slot
-    ///     - Append `[[domain = 5, patch_op, slot_id_suffix, slot_id_prefix], NEW_VALUE]` where
+    ///     - Append `[[domain = 2, patch_op, slot_id_suffix, slot_id_prefix], NEW_VALUE]` where
     ///       `NEW_VALUE` is the new value of the slot.
     ///   - Map Slot
     ///     - For each key-value pair, sorted by key, whose new value is different from the previous
     ///       value in the map:
     ///       - Append `[KEY, NEW_VALUE]`.
-    ///     - The map trailer is constructed as `[[domain = 6, patch_op, slot_id_suffix,
+    ///     - The map trailer is constructed as `[[domain = 3, patch_op, slot_id_suffix,
     ///       slot_id_prefix], [num_changed_entries, 0, 0, 0]]`, where `num_changed_entries` is the
     ///       number of key-value pairs appended above. Whether the trailer is included depends on
     ///       `patch_op`:
@@ -404,6 +416,20 @@ impl TryFrom<&AccountPatch> for Account {
 impl SequentialCommit for AccountPatch {
     type Commitment = Word;
 
+    /// Computes the commitment to the patch, domain-separated by its `DOMAIN`.
+    ///
+    /// See [AccountPatch::to_commitment()] for more details.
+    fn to_commitment(&self) -> Word {
+        let elements = self.to_elements();
+
+        // An empty patch produces no elements and its commitment is defined as the empty word.
+        if elements.is_empty() {
+            return Word::empty();
+        }
+
+        Hasher::hash_elements_in_domain(&elements, Self::DOMAIN)
+    }
+
     /// Reduces the patch to a sequence of field elements.
     ///
     /// See [AccountPatch::to_commitment()] for more details.
@@ -416,10 +442,10 @@ impl SequentialCommit for AccountPatch {
         // Minor optimization: At least 8 elements are always added.
         let mut elements = Vec::with_capacity(8);
 
-        // ID and Nonce
+        // Metadata
         let final_nonce = self.final_nonce.expect("non-empty patches should have a new nonce set");
         elements.extend_from_slice(&[
-            Self::DOMAIN,
+            Felt::from(Self::VERSION_1),
             final_nonce,
             self.account_id.suffix(),
             self.account_id.prefix().as_felt(),

--- a/crates/miden-protocol/src/account/patch/storage/storage_patch.rs
+++ b/crates/miden-protocol/src/account/patch/storage/storage_patch.rs
@@ -36,10 +36,10 @@ pub struct AccountStoragePatch {
 
 impl AccountStoragePatch {
     /// Domain separator for value storage slots in delta and patch commitments.
-    const DOMAIN_VALUE: Felt = Felt::new_unchecked(5);
+    const DOMAIN_VALUE: Felt = Felt::new_unchecked(2);
 
     /// Domain separator for map storage slots in delta and patch commitments.
-    const DOMAIN_MAP: Felt = Felt::new_unchecked(6);
+    const DOMAIN_MAP: Felt = Felt::new_unchecked(3);
 
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------

--- a/crates/miden-protocol/src/account/patch/vault.rs
+++ b/crates/miden-protocol/src/account/patch/vault.rs
@@ -2,6 +2,7 @@ use alloc::collections::BTreeMap;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
+use crate::account::AccountVaultDelta;
 use crate::asset::{Asset, AssetId};
 use crate::errors::AssetError;
 use crate::utils::serde::{
@@ -23,8 +24,9 @@ pub struct AccountVaultPatch {
 }
 
 impl AccountVaultPatch {
-    /// Domain separator for assets in the account patch commitment.
-    const DOMAIN: Felt = Felt::new_unchecked(3);
+    /// The asset sections of a delta and a patch share one domain. They cannot collide,
+    /// because the delta and patch commitments already use distinct hasher domains.
+    const DOMAIN: Felt = AccountVaultDelta::DOMAIN;
 
     /// Creates a new vault patch directly from its raw key/value entries.
     ///


### PR DESCRIPTION
## Changes

- Replaces the domain in the delta/patch header with a version.
- Delta and patch produce identically shaped headers and can reduce to the same elements, but their commitments stay distinct because the capacity domains differ.
- Header becomes `[[version = 1, nonce, account_id_suffix, account_id_prefix], EMPTY_WORD]` and the capacity becomes `[0, domain, 0, 0]`
- Patch domain is `0x020000`, delta is `0x020001`.
  - Those values come from the range the [[Poseidon2 domain registry](https://github.com/0xMiden/crypto/blob/main/docs/registry/poseidon2-domains.toml)](https://github.com/0xMiden/crypto/blob/main/docs/registry/poseidon2-domains.toml) delegates to this repository.
- `AccountDelta` and `AccountPatch` override `SequentialCommit::to_commitment` to hash in their domain. The "empty delta/patch commits to the empty word" rule moves into that override, because `hash_elements_in_domain` marks empty input and permutes under a nonzero domain instead of returning the zero digest.
- Delta/patch domains are made contiguous, asset `1`, value slot `2`, map slot `3`.