### PR TITLE
test(bench): drive the cost drift guard from `PricedNote::all`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,6 @@ dependencies = [
  "miden-testing",
  "miden-tx",
  "rand 0.10.2",
- "rstest",
  "serde",
  "serde_json",
  "tokio",

--- a/bin/bench-transaction/Cargo.toml
+++ b/bin/bench-transaction/Cargo.toml
@@ -64,4 +64,3 @@ tokio      = { optional = true, workspace = true }
 
 [dev-dependencies]
 criterion = { features = ["async_tokio", "html_reports"], workspace = true }
-rstest    = { workspace = true }

--- a/bin/bench-transaction/README.md
+++ b/bin/bench-transaction/README.md
@@ -40,7 +40,7 @@ Regenerate the tables (and `bench-tx.json`) with:
 make update-note-costs
 ```
 
-Freshness is enforced in CI: the `checked_in_cost_matches_benched_cycles` snapshot test in `src/note_costs.rs` re-executes every priced scenario during the regular test run and fails when a measured cost drifts more than 5% from its checked-in constant. It walks `PricedNote::all` - the same list the generator renders the tables from - so a newly priced note is covered without touching the test. Drift within the tolerance (from unrelated changes landing on the base branch) is absorbed without regeneration - fee-wise this is safe, since the fee is logarithmic in cycles and the pricing safety margin dwarfs it. A PR that meaningfully changes cycle counts must run `make update-note-costs` and commit the updated tables - which doubles as review signal, since cost regressions show up as table diffs.
+Freshness is enforced in CI: the `checked_in_cost_matches_benched_cycles` snapshot test in `src/note_costs.rs` re-executes every priced scenario during the regular test run and fails when a measured cost drifts more than 5% from its checked-in constant. It walks `PricedNote::all` - so all priced notes are covered. Drift within the tolerance (from unrelated changes landing on the base branch) is absorbed without regeneration - fee-wise this is safe, since the fee is logarithmic in cycles and the pricing safety margin dwarfs it. A PR that meaningfully changes cycle counts must run `make update-note-costs` and commit the updated tables - which doubles as review signal, since cost regressions show up as table diffs.
 
 ### Benchmark Groups
 

--- a/bin/bench-transaction/README.md
+++ b/bin/bench-transaction/README.md
@@ -40,7 +40,7 @@ Regenerate the tables (and `bench-tx.json`) with:
 make update-note-costs
 ```
 
-Freshness is enforced in CI: the `checked_in_cost_matches_benched_cycles` snapshot tests in `src/note_costs.rs` re-execute every priced scenario during the regular test run and fail when a measured cost drifts more than 5% from its checked-in constant. Drift within the tolerance (from unrelated changes landing on the base branch) is absorbed without regeneration - fee-wise this is safe, since the fee is logarithmic in cycles and the pricing safety margin dwarfs it. A PR that meaningfully changes cycle counts must run `make update-note-costs` and commit the updated tables - which doubles as review signal, since cost regressions show up as table diffs.
+Freshness is enforced in CI: the `checked_in_cost_matches_benched_cycles` snapshot test in `src/note_costs.rs` re-executes every priced scenario during the regular test run and fails when a measured cost drifts more than 5% from its checked-in constant. It walks `PricedNote::all` - the same list the generator renders the tables from - so a newly priced note is covered without touching the test. Drift within the tolerance (from unrelated changes landing on the base branch) is absorbed without regeneration - fee-wise this is safe, since the fee is logarithmic in cycles and the pricing safety margin dwarfs it. A PR that meaningfully changes cycle counts must run `make update-note-costs` and commit the updated tables - which doubles as review signal, since cost regressions show up as table diffs.
 
 ### Benchmark Groups
 

--- a/bin/bench-transaction/src/note_costs.rs
+++ b/bin/bench-transaction/src/note_costs.rs
@@ -445,11 +445,6 @@ mod tests {
     /// [`DRIFT_TOLERANCE_PERCENT`]. Catches kernel, standards, or agglayer changes that
     /// meaningfully shift a note's consumption cost without the tables having been
     /// regenerated.
-    ///
-    /// Driven by [`PricedNote::all`] rather than a per-note case list, so a note cannot be
-    /// added to the tables without its constant gaining a drift guard. Drift is collected
-    /// across all the notes before it is asserted on, so one run reports every stale constant
-    /// (a scenario that fails to execute still aborts the run immediately).
     #[tokio::test]
     async fn checked_in_cost_matches_benched_cycles() -> Result<()> {
         let mut stale = Vec::new();

--- a/bin/bench-transaction/src/note_costs.rs
+++ b/bin/bench-transaction/src/note_costs.rs
@@ -357,7 +357,6 @@ mod tests {
     use miden_protocol::transaction::RawOutputNote;
     use miden_standards::note::TxFeeNote;
     use miden_tx::NetworkNotePricer;
-    use rstest::rstest;
 
     use super::*;
 
@@ -440,47 +439,42 @@ mod tests {
         Ok(())
     }
 
-    /// Snapshot check enforcing freshness of the checked-in cost tables: re-executes each priced
-    /// note's benchmark scenarios and compares the measured maximum against the compiled-in
-    /// constant, failing when they diverge by more than [`DRIFT_TOLERANCE_PERCENT`]. Catches
-    /// kernel, standards, or agglayer changes that meaningfully shift a note's consumption cost
-    /// without the tables having been regenerated.
-    #[rstest]
-    #[case::p2id(PricedNote::Standard(StandardNote::P2ID))]
-    #[case::p2ide(PricedNote::Standard(StandardNote::P2IDE))]
-    #[case::swap(PricedNote::Standard(StandardNote::SWAP))]
-    #[case::pswap(PricedNote::Standard(StandardNote::PSWAP))]
-    #[case::mint(PricedNote::Standard(StandardNote::MINT))]
-    #[case::burn(PricedNote::Standard(StandardNote::BURN))]
-    #[case::faucet_policy_config(PricedNote::Standard(StandardNote::FAUCET_POLICY_CONFIG))]
-    #[case::faucet_metadata_config(PricedNote::Standard(StandardNote::FAUCET_METADATA_CONFIG))]
-    #[case::min_burn_amount_config(PricedNote::Standard(StandardNote::MIN_BURN_AMOUNT_CONFIG))]
-    #[case::allowlist_config(PricedNote::Standard(StandardNote::ALLOWLIST_CONFIG))]
-    #[case::blocklist_config(PricedNote::Standard(StandardNote::BLOCKLIST_CONFIG))]
-    #[case::pause_config(PricedNote::Standard(StandardNote::PAUSE_CONFIG))]
-    #[case::owner_config(PricedNote::Standard(StandardNote::OWNER_CONFIG))]
-    #[case::rbac_config(PricedNote::Standard(StandardNote::RBAC_CONFIG))]
-    #[case::network_account_config(PricedNote::Standard(StandardNote::NETWORK_ACCOUNT_CONFIG))]
-    #[case::fee_sponsorship(PricedNote::Standard(StandardNote::FEE_SPONSORSHIP))]
-    #[case::claim(PricedNote::Agglayer(AgglayerNote::CLAIM))]
-    #[case::b2agg(PricedNote::Agglayer(AgglayerNote::B2AGG))]
-    #[case::config_agg_bridge(PricedNote::Agglayer(AgglayerNote::CONFIG_AGG_BRIDGE))]
-    #[case::deregister_agg_faucet(PricedNote::Agglayer(AgglayerNote::DEREGISTER_AGG_FAUCET))]
-    #[case::update_ger(PricedNote::Agglayer(AgglayerNote::UPDATE_GER))]
-    #[case::remove_ger(PricedNote::Agglayer(AgglayerNote::REMOVE_GER))]
+    /// Snapshot check enforcing freshness of the checked-in cost tables: re-executes the
+    /// benchmark scenarios of every note in [`PricedNote::all`] and compares each measured
+    /// maximum against the compiled-in constant, failing when they diverge by more than
+    /// [`DRIFT_TOLERANCE_PERCENT`]. Catches kernel, standards, or agglayer changes that
+    /// meaningfully shift a note's consumption cost without the tables having been
+    /// regenerated.
+    ///
+    /// Driven by [`PricedNote::all`] rather than a per-note case list, so a note cannot be
+    /// added to the tables without its constant gaining a drift guard. Drift is collected
+    /// across all the notes before it is asserted on, so one run reports every stale constant
+    /// (a scenario that fails to execute still aborts the run immediately).
     #[tokio::test]
-    async fn checked_in_cost_matches_benched_cycles(#[case] note: PricedNote) -> Result<()> {
-        let measured = benched_cycles(note).await?;
-        let committed = note.committed_cycles();
+    async fn checked_in_cost_matches_benched_cycles() -> Result<()> {
+        let mut stale = Vec::new();
+        for &note in PricedNote::all() {
+            let measured = benched_cycles(note).await?;
+            let committed = note.committed_cycles();
 
-        let (measured_scaled, committed) = (u64::from(measured) * 100, u64::from(committed));
-        let within_tolerance = measured_scaled <= committed * (100 + DRIFT_TOLERANCE_PERCENT)
-            && measured_scaled >= committed * (100 - DRIFT_TOLERANCE_PERCENT);
+            let (measured_scaled, committed) = (u64::from(measured) * 100, u64::from(committed));
+            let within_tolerance = measured_scaled <= committed * (100 + DRIFT_TOLERANCE_PERCENT)
+                && measured_scaled >= committed * (100 - DRIFT_TOLERANCE_PERCENT);
+            if !within_tolerance {
+                stale.push(format!(
+                    "{}: measured {measured} cycles vs checked-in {committed}",
+                    note.name(),
+                ));
+            }
+        }
+
         assert!(
-            within_tolerance,
-            "cost table stale for {note:?}: measured {measured} cycles vs checked-in \
-             {committed} (more than {DRIFT_TOLERANCE_PERCENT}% apart): run `make \
-             update-note-costs` and commit the updated tables",
+            stale.is_empty(),
+            "cost table stale for {} note(s), each more than {DRIFT_TOLERANCE_PERCENT}% from \
+             its checked-in constant: {}. Run `make update-note-costs` and commit the updated \
+             tables",
+            stale.len(),
+            stale.join("; "),
         );
         Ok(())
     }


### PR DESCRIPTION
`checked_in_cost_matches_benched_cycles` listed its notes as 22 hand-written rstest cases, mirroring the 23 entries of `PricedNote::all`. The CONSTANT_FEE_POLICY_CONFIG case was missing.

Rather than adding the missing case, the test now loops over `PricedNote::all` directly.