### PR TITLE
packaging: publish standard components as a tarball asset

### DIFF
--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -89,6 +89,10 @@ jobs:
           cp "$protocol/assets/kernels/miden-tx-kernel.masp" miden-tx-kernel.masp
           cp "$protocol/assets/miden-protocol.masp" miden-protocol.masp
           cp "$standards/assets/miden-standards.masp" miden-standards.masp
+          target_dir=$(pwd)
+          cd "$standards/assets/components"
+          tar -czf "$target_dir/miden-standards-components.tar.gz" *.masp
+          cd "$target_dir"
       - name: Attest packages
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
         with:
@@ -96,10 +100,12 @@ jobs:
             miden-tx-kernel.masp
             miden-protocol.masp
             miden-standards.masp
+            miden-standards-components.tar.gz
+
       - name: Upload packages
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          gh release upload ${RELEASE_TAG} miden-tx-kernel.masp miden-protocol.masp miden-standards.masp --clobber
+          gh release upload ${RELEASE_TAG} miden-tx-kernel.masp miden-protocol.masp miden-standards.masp miden-standards-components.tar.gz --clobber


### PR DESCRIPTION
This adds the `miden-standards` component packages as release assets (they are currently missing).

It publishes them as a single tarball (`midenup` knows how to extract these for installation) - this also makes it so that we don't need to update the build/release scripts every time we add a new component (unless it is something that is not part of the existing `miden-standards` workspace).

I based this on `next` assuming the next `-rc.N` release will be tagged off of that branch - but if `main` is the appropriate branch for that, just let me know and I'll rebase it onto `main` instead. We should ensure these go out in the next release.