### PR TITLE
fix: remove dead branch in asset removal logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 - [BREAKING] Foreign procedure invocation now requires the provided procedure root to be part of the foreign account's code, so a caller can no longer execute arbitrary code under a foreign account's identity ([#3575](https://github.com/0xMiden/protocol/pull/3575)).
 - Verified each input note's storage-item count and preimage against its authenticated storage commitment ([#3593](https://github.com/0xMiden/protocol/issues/3593)).
 - Fixed `PrivateOutputNote` construction and deserialization accepting attachment data that is not committed by the note header ([#3579](https://github.com/0xMiden/protocol/pull/3579)).
-- Fixed `input_note::remove_asset` leaving a dangling asset slot when a non-canonical fungible value produced an empty removal remainder ([#3606](https://github.com/0xMiden/protocol/pull/3606)).
+- Fixed `input_note::remove_asset` leaving a dangling asset slot when a non-canonical fungible value produced an empty removal remainder ([#3606](https://github.com/0xMiden/protocol/pull/3606), [#3755](https://github.com/0xMiden/protocol/pull/3755)).
 - Fixed `input_note::remove_asset` succeeding when asked to remove an empty or malformed asset ID instead of reporting the asset as not found ([#3607](https://github.com/0xMiden/protocol/pull/3607)).
 - Storage slot types are now validated against the supported set at account creation, and the delta commitment rejects an unrecognized slot type instead of treating it as a map ([#3608](https://github.com/0xMiden/protocol/pull/3608)).
 - MINT and BURN notes for a public faucet now carry the `NetworkAccountTarget` attachment that identifies them as network notes ([#3664](https://github.com/0xMiden/protocol/pull/3664)).

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/input_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/input_note.masm
@@ -231,22 +231,9 @@ pub proc remove_asset
         exec.asset::split
         # => [FINAL_ASSET_VALUE, found_asset_ptr]
 
-        # if nothing remains, clear the whole slot
-        exec.word::testz
-        # => [is_empty_remainder, FINAL_ASSET_VALUE, found_asset_ptr]
-
-        if.true
-            # clear the asset's slot; the removed asset becomes (EMPTY_WORD, EMPTY_WORD)
-            padw movup.8 exec.asset::store
-            # => []
-
-            padw
-            # => [FINAL_ASSET_VALUE]
-        else
-            # write the reduced value back to the note's asset slot
-            movup.4 add.ASSET_VALUE_MEMORY_OFFSET mem_storew_le
-            # => [FINAL_ASSET_VALUE]
-        end
+        # write the reduced value back to the note's asset slot
+        movup.4 add.ASSET_VALUE_MEMORY_OFFSET mem_storew_le
+        # => [FINAL_ASSET_VALUE]
     end
 end
 


### PR DESCRIPTION
follow-up fix to [L-03](https://github.com/0xMiden/protocol/issues/3591) (see the audit follow-ups [here](https://audits.openzeppelin.com/miden/miden-q3-06-tx-kernel-programable-assets-diff/issue/non-canonical-fungible-values-can-leave-a-non-empty-asset_id-slot-with-empty_word-value-31f8d703)) and the [Slack thread](https://midengroup.slack.com/archives/C09V2APRZ8B/p1787841936788239?thread_ts=1785921796.837129&cid=C09V2APRZ8B)