### PR TITLE
fix(standards): bound role symbol validation to a 4-bit exponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Fixed the fungible and non-fungible MINT note scripts assuming their `exec` callers provide blank stack slot ([#3668](https://github.com/0xMiden/protocol/pull/3668)).
 - [BREAKING] Bounded the multisig approver set to 64 signers, enforced both by `ApproverSet::MAX_APPROVERS` at account creation and by `MAX_NUM_APPROVERS` in the `multisig` and `multisig_smart` `update_signers_and_threshold` procedures ([#3723](https://github.com/0xMiden/protocol/pull/3723)).
 - The PSWAP note script now rejects a `PswapAttachment` that does not consist of exactly one word, instead of letting the attachment write past the four locals of `get_current_depth` ([#3761](https://github.com/0xMiden/protocol/pull/3761)).
+- Role symbol validation now bounds its exponentiation to the four bits the announced length can occupy, so a prover can no longer forge the encoding's upper bound through the unconstrained 64-bit decomposition of a bare `exp` ([#3712](https://github.com/0xMiden/miden-vm/pull/3712)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 - Fixed the fungible and non-fungible MINT note scripts assuming their `exec` callers provide blank stack slot ([#3668](https://github.com/0xMiden/protocol/pull/3668)).
 - [BREAKING] Bounded the multisig approver set to 64 signers, enforced both by `ApproverSet::MAX_APPROVERS` at account creation and by `MAX_NUM_APPROVERS` in the `multisig` and `multisig_smart` `update_signers_and_threshold` procedures ([#3723](https://github.com/0xMiden/protocol/pull/3723)).
 - The PSWAP note script now rejects a `PswapAttachment` that does not consist of exactly one word, instead of letting the attachment write past the four locals of `get_current_depth` ([#3761](https://github.com/0xMiden/protocol/pull/3761)).
-- Role symbol validation now bounds its exponentiation to the four bits the announced length can occupy, so a prover can no longer forge the encoding's upper bound through the unconstrained 64-bit decomposition of a bare `exp` ([#3712](https://github.com/0xMiden/miden-vm/pull/3712)).
+- Role symbol validation now bounds its exponentiation to the four bits the announced length can occupy, so a prover can no longer forge the encoding's upper bound through the unconstrained 64-bit decomposition of a bare `exp` ([#3774](https://github.com/0xMiden/protocol/pull/3774)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 - Fixed the fungible and non-fungible MINT note scripts assuming their `exec` callers provide blank stack slot ([#3668](https://github.com/0xMiden/protocol/pull/3668)).
 - [BREAKING] Bounded the multisig approver set to 64 signers, enforced both by `ApproverSet::MAX_APPROVERS` at account creation and by `MAX_NUM_APPROVERS` in the `multisig` and `multisig_smart` `update_signers_and_threshold` procedures ([#3723](https://github.com/0xMiden/protocol/pull/3723)).
 - The PSWAP note script now rejects a `PswapAttachment` that does not consist of exactly one word, instead of letting the attachment write past the four locals of `get_current_depth` ([#3761](https://github.com/0xMiden/protocol/pull/3761)).
-- Role symbol validation now bounds its exponentiation to the four bits the announced length can occupy, so a prover can no longer forge the encoding's upper bound through the unconstrained 64-bit decomposition of a bare `exp` ([#3774](https://github.com/0xMiden/protocol/pull/3774)).
+- Role symbol validation now computes its upper bound with `exp.u4`, whose unique exponent decomposition stops a prover from widening the bound and slipping a non-canonical symbol through ([#3774](https://github.com/0xMiden/protocol/pull/3774)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/crates/miden-standards/asm/standards/access/role_symbol.masm
+++ b/crates/miden-standards/asm/standards/access/role_symbol.masm
@@ -60,7 +60,13 @@ pub proc validate_encoding
 
     # The encoding stacks `num_chars` character digits on top of the length digit, so it spans
     # `num_chars + 1` base-`ALPHABET_LEN` digits: hence the `add.1` in the exponent.
-    push.ALPHABET_LEN swap add.1 exp
+    #
+    # The assertion above caps that exponent at `MAX_LENGTH + 1 = 13`, so four bits carry it, and
+    # spelling the width out is what makes the bound trustworthy: a bare `exp` decomposes the
+    # exponent into 64 bits, which do not pin down a field element, so a prover may reconstruct
+    # `e + Q` in place of `e` and land on `ALPHABET_LEN^(e + 1)` as the bound, admitting one digit
+    # past the announced length. Keep `MAX_LENGTH` below 15 so the exponent still fits four bits.
+    push.ALPHABET_LEN swap add.1 exp.u4
     # => [upper_bound, role_symbol]
 
     # The value must fit in the characters its length announces.

--- a/crates/miden-standards/asm/standards/access/role_symbol.masm
+++ b/crates/miden-standards/asm/standards/access/role_symbol.masm
@@ -60,12 +60,6 @@ pub proc validate_encoding
 
     # The encoding stacks `num_chars` character digits on top of the length digit, so it spans
     # `num_chars + 1` base-`ALPHABET_LEN` digits: hence the `add.1` in the exponent.
-    #
-    # The assertion above caps that exponent at `MAX_LENGTH + 1 = 13`, so four bits carry it, and
-    # spelling the width out is what makes the bound trustworthy: a bare `exp` decomposes the
-    # exponent into 64 bits, which do not pin down a field element, so a prover may reconstruct
-    # `e + Q` in place of `e` and land on `ALPHABET_LEN^(e + 1)` as the bound, admitting one digit
-    # past the announced length. Keep `MAX_LENGTH` below 15 so the exponent still fits four bits.
     push.ALPHABET_LEN swap add.1 exp.u4
     # => [upper_bound, role_symbol]
 

--- a/crates/miden-testing/tests/scripts/rbac/mod.rs
+++ b/crates/miden-testing/tests/scripts/rbac/mod.rs
@@ -721,11 +721,8 @@ async fn test_rbac_non_admin_cannot_set_role_admin() -> anyhow::Result<()> {
 /// that no reader can decode back into a symbol.
 ///
 /// `27` announces a length of zero (it is the first multiple of the alphabet size), and
-/// `MAX_ENCODED_VALUE + 1` runs past the longest encodable symbol; neither names a role.
-///
-/// `ALPHABET_LEN^13 + 12` announces the longest encodable length while carrying a digit past it,
-/// so only the `ALPHABET_LEN^(num_chars + 1)` bound rejects it. It pins that bound at the widest
-/// exponent the validation computes.
+/// `MAX_ENCODED_VALUE + 1` runs past the longest encodable symbol, and `ALPHABET_LEN^13 + 12`
+/// announces the longest encodable length while carrying a digit past it; none names a role.
 #[rstest]
 #[case::announces_no_characters(Felt::new(27).unwrap())]
 #[case::past_the_longest_symbol(Felt::new(4052555153018976253).unwrap())]

--- a/crates/miden-testing/tests/scripts/rbac/mod.rs
+++ b/crates/miden-testing/tests/scripts/rbac/mod.rs
@@ -722,9 +722,14 @@ async fn test_rbac_non_admin_cannot_set_role_admin() -> anyhow::Result<()> {
 ///
 /// `27` announces a length of zero (it is the first multiple of the alphabet size), and
 /// `MAX_ENCODED_VALUE + 1` runs past the longest encodable symbol; neither names a role.
+///
+/// `ALPHABET_LEN^13 + 12` announces the longest encodable length while carrying a digit past it,
+/// so only the `ALPHABET_LEN^(num_chars + 1)` bound rejects it. It pins that bound at the widest
+/// exponent the validation computes.
 #[rstest]
 #[case::announces_no_characters(Felt::new(27).unwrap())]
 #[case::past_the_longest_symbol(Felt::new(4052555153018976253).unwrap())]
+#[case::a_digit_past_the_announced_length(Felt::new(4052555153018976279).unwrap())]
 #[tokio::test]
 async fn test_rbac_grant_role_rejects_non_canonical_role_symbol(
     #[case] role_symbol: Felt,


### PR DESCRIPTION
Applies @Al-Kindi-0 's [suggestion](https://github.com/0xMiden/miden-vm/pull/3712#issuecomment-5477008043): a bare `exp` lowers to 64 `EXPACC` rows, and 64 bits do not pin down a field element, so a prover can decompose `e + Q` instead of `e`.

Instead, `exp.u4` makes the decomposition unique