### PR TITLE
refactor(standards): split fee estimation out of pay_fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Changes
 
+- [BREAKING] Split the fee computation out of `fee::pay_fee` into the new `fee::estimate_fee`, which sponsors the transaction's network output notes and computes the fee without creating the fee note; `pay_fee` now calls it and its inputs, outputs and computed fee are unchanged, but its MAST root and therefore the code commitment of every fee-paying component change ([#3332](https://github.com/0xMiden/protocol/issues/3332)).
 - [BREAKING] The user fungible faucet factories now install `BasicWallet` so a faucet can hold the native fee asset ([#3766](https://github.com/0xMiden/protocol/pull/3766)).
 - [BREAKING] Bind the standard config notes to their target account: `OwnerConfigNote`, `PauseConfigNote`, `RbacConfigNote`, `FaucetPolicyConfigNote`, `AllowlistConfigNote`, `BlocklistConfigNote` and `FaucetMetadataConfigNote` now carry a `NetworkAccountTarget` attachment for that account ([#3433](https://github.com/0xMiden/protocol/issues/3433), [#3455](https://github.com/0xMiden/protocol/pull/3455)).
 - [BREAKING] BURN notes now store and validate the asset passed to `receive_and_burn`, and target its faucet with a `NetworkAccountTarget` attachment ([#2343](https://github.com/0xMiden/protocol/issues/2343)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Changes
 
-- [BREAKING] Split the fee computation out of `fee::pay_fee` into the new `fee::estimate_fee`, which sponsors the transaction's network output notes and computes the fee without creating the fee note; `pay_fee` now calls it and its inputs, outputs and computed fee are unchanged, but its MAST root and therefore the code commitment of every fee-paying component change ([#3332](https://github.com/0xMiden/protocol/issues/3332)).
+- [BREAKING] Split fee estimation out of fee payment: the new `fee::estimate_fee` only computes the fee, pricing the FEE_SPONSORSHIP notes the payment will need through the new `fees::estimate_network_note_sponsorships`, and the new `fee::pay_network_note_sponsorships` creates them; `fee::pay_fee` composes the two, with unchanged inputs, outputs and computed fee, but its MAST root and therefore the code commitment of every fee-paying component change ([#3332](https://github.com/0xMiden/protocol/issues/3332)).
 - [BREAKING] The user fungible faucet factories now install `BasicWallet` so a faucet can hold the native fee asset ([#3766](https://github.com/0xMiden/protocol/pull/3766)).
 - [BREAKING] Bind the standard config notes to their target account: `OwnerConfigNote`, `PauseConfigNote`, `RbacConfigNote`, `FaucetPolicyConfigNote`, `AllowlistConfigNote`, `BlocklistConfigNote` and `FaucetMetadataConfigNote` now carry a `NetworkAccountTarget` attachment for that account ([#3433](https://github.com/0xMiden/protocol/issues/3433), [#3455](https://github.com/0xMiden/protocol/pull/3455)).
 - [BREAKING] BURN notes now store and validate the asset passed to `receive_and_burn`, and target its faucet with a `NetworkAccountTarget` attachment ([#2343](https://github.com/0xMiden/protocol/issues/2343)).

--- a/bin/bench-transaction/bench-tx.json
+++ b/bin/bench-transaction/bench-tx.json
@@ -1,23 +1,23 @@
 {
   "consume single P2ID note with Falcon signing": {
     "prologue": 3754,
-    "notes_processing": 2161,
+    "notes_processing": 2184,
     "note_execution": {
-      "0x5cbede6b9f04c8219271e3221e97adaa749f01afe9888a9924d52307ccb22b1c": 2119
+      "0x4fc5493ff422c6d84b9f398f668fc702ce1a27427e07423000582dc3f81c28af": 2142
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 73710,
-      "auth_procedure": 72598
+      "total": 74025,
+      "auth_procedure": 72910
     },
     "trace": {
-      "core_rows": 79711,
-      "chiplets_rows": 11195,
-      "range_rows": 20245,
+      "core_rows": 80049,
+      "chiplets_rows": 11327,
+      "range_rows": 20373,
       "chiplets_shape": {
-        "hasher_rows": 8168,
+        "hasher_rows": 8288,
         "bitwise_rows": 584,
-        "memory_rows": 2380,
+        "memory_rows": 2392,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -25,23 +25,23 @@
   },
   "consume single P2ID note with ECDSA signing": {
     "prologue": 3754,
-    "notes_processing": 2161,
+    "notes_processing": 2184,
     "note_execution": {
-      "0x747a592f85aaf459c7a36387a89ef937b2d88941e2b535fe49b20ae9fb1e71a4": 2119
+      "0x4e9150c22e7560a766a3e42263212fe7ffa718f69a82ecf60648a2f62df3658e": 2142
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 6072,
-      "auth_procedure": 4960
+      "total": 6387,
+      "auth_procedure": 5272
     },
     "trace": {
-      "core_rows": 12073,
-      "chiplets_rows": 5452,
-      "range_rows": 1543,
+      "core_rows": 12411,
+      "chiplets_rows": 5584,
+      "range_rows": 1529,
       "chiplets_shape": {
-        "hasher_rows": 3816,
+        "hasher_rows": 3936,
         "bitwise_rows": 840,
-        "memory_rows": 733,
+        "memory_rows": 745,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -49,24 +49,24 @@
   },
   "consume two P2ID notes with Falcon signing": {
     "prologue": 5025,
-    "notes_processing": 4504,
+    "notes_processing": 4550,
     "note_execution": {
-      "0x0ff983e6b5e8a0a04e7375b87d8e811ad51de36406f871e1d9d4e219f0f8abfb": 2334,
-      "0x60bba08165a03bfcf1febebf16679a0661b4d2672d9341545034f86c5c03a295": 2119
+      "0x0ff983e6b5e8a0a04e7375b87d8e811ad51de36406f871e1d9d4e219f0f8abfb": 2357,
+      "0x60bba08165a03bfcf1febebf16679a0661b4d2672d9341545034f86c5c03a295": 2142
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 73638,
-      "auth_procedure": 72562
+      "total": 73953,
+      "auth_procedure": 72874
     },
     "trace": {
-      "core_rows": 83253,
-      "chiplets_rows": 13219,
-      "range_rows": 20293,
+      "core_rows": 83614,
+      "chiplets_rows": 13370,
+      "range_rows": 20537,
       "chiplets_shape": {
-        "hasher_rows": 9704,
+        "hasher_rows": 9840,
         "bitwise_rows": 928,
-        "memory_rows": 2524,
+        "memory_rows": 2539,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -74,24 +74,24 @@
   },
   "consume two P2ID notes with ECDSA signing": {
     "prologue": 5025,
-    "notes_processing": 4504,
+    "notes_processing": 4550,
     "note_execution": {
-      "0x0ff983e6b5e8a0a04e7375b87d8e811ad51de36406f871e1d9d4e219f0f8abfb": 2334,
-      "0x60bba08165a03bfcf1febebf16679a0661b4d2672d9341545034f86c5c03a295": 2119
+      "0x0ff983e6b5e8a0a04e7375b87d8e811ad51de36406f871e1d9d4e219f0f8abfb": 2357,
+      "0x60bba08165a03bfcf1febebf16679a0661b4d2672d9341545034f86c5c03a295": 2142
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 6000,
-      "auth_procedure": 4924
+      "total": 6315,
+      "auth_procedure": 5236
     },
     "trace": {
-      "core_rows": 15615,
-      "chiplets_rows": 7476,
-      "range_rows": 1487,
+      "core_rows": 15976,
+      "chiplets_rows": 7627,
+      "range_rows": 1505,
       "chiplets_shape": {
-        "hasher_rows": 5352,
+        "hasher_rows": 5488,
         "bitwise_rows": 1184,
-        "memory_rows": 877,
+        "memory_rows": 892,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -101,19 +101,19 @@
     "prologue": 1881,
     "notes_processing": 35,
     "note_execution": {},
-    "tx_script_processing": 1844,
+    "tx_script_processing": 1888,
     "epilogue": {
-      "total": 75244,
-      "auth_procedure": 73205
+      "total": 75780,
+      "auth_procedure": 73738
     },
     "trace": {
-      "core_rows": 79048,
-      "chiplets_rows": 10846,
-      "range_rows": 20363,
+      "core_rows": 79628,
+      "chiplets_rows": 11073,
+      "range_rows": 20355,
       "chiplets_shape": {
-        "hasher_rows": 7944,
-        "bitwise_rows": 544,
-        "memory_rows": 2295,
+        "hasher_rows": 8120,
+        "bitwise_rows": 576,
+        "memory_rows": 2314,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -123,139 +123,139 @@
     "prologue": 1881,
     "notes_processing": 35,
     "note_execution": {},
-    "tx_script_processing": 1844,
+    "tx_script_processing": 1888,
     "epilogue": {
-      "total": 7606,
-      "auth_procedure": 5567
+      "total": 8142,
+      "auth_procedure": 6100
     },
     "trace": {
-      "core_rows": 11410,
-      "chiplets_rows": 5103,
-      "range_rows": 1341,
+      "core_rows": 11990,
+      "chiplets_rows": 5330,
+      "range_rows": 1359,
       "chiplets_shape": {
-        "hasher_rows": 3592,
-        "bitwise_rows": 800,
-        "memory_rows": 648,
+        "hasher_rows": 3768,
+        "bitwise_rows": 832,
+        "memory_rows": 667,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L1 to Miden)": {
-    "prologue": 3957,
-    "notes_processing": 28344,
+    "prologue": 4033,
+    "notes_processing": 28614,
     "note_execution": {
-      "0xbdfc5507d93648b80a38dc73a200a09635e05ad56f11c8faf6d5403cb0d393ee": 28302
+      "0x7ba705db8a8a71392d468e19b6d1abf206ca3358bba4dc2bf3dd92b5187856dc": 28572
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 16518,
-      "auth_procedure": 11600
+      "total": 21038,
+      "auth_procedure": 15979
     },
     "trace": {
-      "core_rows": 48905,
-      "chiplets_rows": 19128,
-      "range_rows": 3425,
+      "core_rows": 53771,
+      "chiplets_rows": 21031,
+      "range_rows": 3471,
       "chiplets_shape": {
-        "hasher_rows": 12312,
-        "bitwise_rows": 2752,
-        "memory_rows": 4001,
+        "hasher_rows": 13824,
+        "bitwise_rows": 2840,
+        "memory_rows": 4304,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L2 to Miden)": {
-    "prologue": 3957,
-    "notes_processing": 38506,
+    "prologue": 4033,
+    "notes_processing": 38776,
     "note_execution": {
-      "0xee8c28c427c5a7b02c43ee3512550d029ad914f8ccd4770e62abbf7ad18dc631": 38464
+      "0x927c8823d42f4ca75bfe60aedf56d3c2dc30ed4ee9db3657a63ade6bdaecc1e0": 38734
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 16518,
-      "auth_procedure": 11600
+      "total": 21038,
+      "auth_procedure": 15979
     },
     "trace": {
-      "core_rows": 59067,
-      "chiplets_rows": 21878,
-      "range_rows": 3585,
+      "core_rows": 63933,
+      "chiplets_rows": 23781,
+      "range_rows": 3641,
       "chiplets_shape": {
-        "hasher_rows": 13864,
-        "bitwise_rows": 3008,
-        "memory_rows": 4943,
+        "hasher_rows": 15376,
+        "bitwise_rows": 3096,
+        "memory_rows": 5246,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out)": {
-    "prologue": 4881,
-    "notes_processing": 116251,
+    "prologue": 4957,
+    "notes_processing": 118011,
     "note_execution": {
-      "0x747971468f66129ecef049ba8c86fa71f87ce9730dcb5c49939446186373d21e": 116209
+      "0x2ca2d2a9fbfd77c6817c923b1d797f92e3f31c3aa9b828b2ad869e5de4e3dd9f": 117969
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 26285,
-      "auth_procedure": 11685
+      "total": 30805,
+      "auth_procedure": 16064
     },
     "trace": {
-      "core_rows": 147503,
-      "chiplets_rows": 69206,
-      "range_rows": 4685,
+      "core_rows": 153859,
+      "chiplets_rows": 72080,
+      "range_rows": 4755,
       "chiplets_shape": {
-        "hasher_rows": 55352,
-        "bitwise_rows": 3528,
-        "memory_rows": 10263,
+        "hasher_rows": 57640,
+        "bitwise_rows": 3616,
+        "memory_rows": 10761,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31 leaves)": {
-    "prologue": 4881,
-    "notes_processing": 114554,
+    "prologue": 4957,
+    "notes_processing": 116304,
     "note_execution": {
-      "0x747971468f66129ecef049ba8c86fa71f87ce9730dcb5c49939446186373d21e": 114512
+      "0x2ca2d2a9fbfd77c6817c923b1d797f92e3f31c3aa9b828b2ad869e5de4e3dd9f": 116262
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 25997,
-      "auth_procedure": 11685
+      "total": 30517,
+      "auth_procedure": 16064
     },
     "trace": {
-      "core_rows": 145518,
-      "chiplets_rows": 68227,
-      "range_rows": 4657,
+      "core_rows": 151864,
+      "chiplets_rows": 71093,
+      "range_rows": 4717,
       "chiplets_shape": {
-        "hasher_rows": 54504,
-        "bitwise_rows": 3528,
-        "memory_rows": 10132,
+        "hasher_rows": 56784,
+        "bitwise_rows": 3616,
+        "memory_rows": 10630,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31-1 leaves)": {
-    "prologue": 4881,
-    "notes_processing": 60205,
+    "prologue": 4957,
+    "notes_processing": 61655,
     "note_execution": {
-      "0x747971468f66129ecef049ba8c86fa71f87ce9730dcb5c49939446186373d21e": 60163
+      "0x2ca2d2a9fbfd77c6817c923b1d797f92e3f31c3aa9b828b2ad869e5de4e3dd9f": 61613
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 17357,
-      "auth_procedure": 11685
+      "total": 21877,
+      "auth_procedure": 16064
     },
     "trace": {
-      "core_rows": 82529,
-      "chiplets_rows": 38249,
-      "range_rows": 3559,
+      "core_rows": 88575,
+      "chiplets_rows": 40995,
+      "range_rows": 3717,
       "chiplets_shape": {
-        "hasher_rows": 28456,
-        "bitwise_rows": 3528,
-        "memory_rows": 6202,
+        "hasher_rows": 30616,
+        "bitwise_rows": 3616,
+        "memory_rows": 6700,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -263,23 +263,23 @@
   },
   "consume P2ID note (network account)": {
     "prologue": 3719,
-    "notes_processing": 2161,
+    "notes_processing": 2184,
     "note_execution": {
-      "0x9ffdc9ed78028f7eda93f7c44287cb1f719d69069d2d8669025fc760c7da567a": 2119
+      "0x9ffdc9ed78028f7eda93f7c44287cb1f719d69069d2d8669025fc760c7da567a": 2142
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 12541,
-      "auth_procedure": 9367
+      "total": 12962,
+      "auth_procedure": 9785
     },
     "trace": {
-      "core_rows": 18507,
-      "chiplets_rows": 8127,
-      "range_rows": 1467,
+      "core_rows": 18951,
+      "chiplets_rows": 8379,
+      "range_rows": 1479,
       "chiplets_shape": {
-        "hasher_rows": 6144,
+        "hasher_rows": 6384,
         "bitwise_rows": 824,
-        "memory_rows": 1096,
+        "memory_rows": 1108,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -287,23 +287,23 @@
   },
   "consume P2ID note (16 assets, network account)": {
     "prologue": 12314,
-    "notes_processing": 29805,
+    "notes_processing": 30173,
     "note_execution": {
-      "0x27098731a1d1d6d12551117a4e3c77fa946491a977105e8d33f70a367fbceda7": 29763
+      "0x27098731a1d1d6d12551117a4e3c77fa946491a977105e8d33f70a367fbceda7": 30131
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15020,
-      "auth_procedure": 9686
+      "total": 15441,
+      "auth_procedure": 10104
     },
     "trace": {
-      "core_rows": 57225,
-      "chiplets_rows": 32864,
-      "range_rows": 3635,
+      "core_rows": 58014,
+      "chiplets_rows": 33345,
+      "range_rows": 3609,
       "chiplets_shape": {
-        "hasher_rows": 24416,
+        "hasher_rows": 24840,
         "bitwise_rows": 5504,
-        "memory_rows": 2881,
+        "memory_rows": 2938,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -311,23 +311,23 @@
   },
   "consume P2IDE note (claim, network account)": {
     "prologue": 3719,
-    "notes_processing": 2286,
+    "notes_processing": 2309,
     "note_execution": {
-      "0x05847ac68b2b527d6932ebc07325c6e4346cacba2c8eca17334cabaed180fe50": 2244
+      "0x05847ac68b2b527d6932ebc07325c6e4346cacba2c8eca17334cabaed180fe50": 2267
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 12541,
-      "auth_procedure": 9367
+      "total": 12962,
+      "auth_procedure": 9785
     },
     "trace": {
-      "core_rows": 18632,
-      "chiplets_rows": 8155,
-      "range_rows": 1497,
+      "core_rows": 19076,
+      "chiplets_rows": 8415,
+      "range_rows": 1471,
       "chiplets_shape": {
-        "hasher_rows": 6168,
+        "hasher_rows": 6416,
         "bitwise_rows": 824,
-        "memory_rows": 1100,
+        "memory_rows": 1112,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -335,23 +335,23 @@
   },
   "consume P2IDE note (claim, 16 assets, network account)": {
     "prologue": 12314,
-    "notes_processing": 29930,
+    "notes_processing": 30298,
     "note_execution": {
-      "0x3cb8d89cd690317eadc9777eb377d0bc75e44c5f3b76b4484a3928c9fc0bb16f": 29888
+      "0x3cb8d89cd690317eadc9777eb377d0bc75e44c5f3b76b4484a3928c9fc0bb16f": 30256
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15020,
-      "auth_procedure": 9686
+      "total": 15441,
+      "auth_procedure": 10104
     },
     "trace": {
-      "core_rows": 57350,
-      "chiplets_rows": 32900,
-      "range_rows": 3645,
+      "core_rows": 58139,
+      "chiplets_rows": 33381,
+      "range_rows": 3621,
       "chiplets_shape": {
-        "hasher_rows": 24448,
+        "hasher_rows": 24872,
         "bitwise_rows": 5504,
-        "memory_rows": 2885,
+        "memory_rows": 2942,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -359,23 +359,23 @@
   },
   "consume P2IDE note (reclaim, network account)": {
     "prologue": 3822,
-    "notes_processing": 2338,
+    "notes_processing": 2361,
     "note_execution": {
-      "0xbb2f39f6cb6f735050be9911032bebb082c4477c01920a05bdf81449a2a2531f": 2296
+      "0xbb2f39f6cb6f735050be9911032bebb082c4477c01920a05bdf81449a2a2531f": 2319
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 12541,
-      "auth_procedure": 9367
+      "total": 12962,
+      "auth_procedure": 9785
     },
     "trace": {
-      "core_rows": 18787,
-      "chiplets_rows": 8186,
-      "range_rows": 1483,
+      "core_rows": 19231,
+      "chiplets_rows": 8446,
+      "range_rows": 1517,
       "chiplets_shape": {
-        "hasher_rows": 6192,
+        "hasher_rows": 6440,
         "bitwise_rows": 824,
-        "memory_rows": 1107,
+        "memory_rows": 1119,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -383,23 +383,23 @@
   },
   "consume SWAP note (public payback, network account)": {
     "prologue": 3719,
-    "notes_processing": 4511,
+    "notes_processing": 4578,
     "note_execution": {
-      "0xd642acc2180f1ea6f6fbd1bce45b076d517ed595c4f3c3bd9bce22ec66e9e5c7": 4469
+      "0xd642acc2180f1ea6f6fbd1bce45b076d517ed595c4f3c3bd9bce22ec66e9e5c7": 4536
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14232,
-      "auth_procedure": 9907
+      "total": 14874,
+      "auth_procedure": 10546
     },
     "trace": {
-      "core_rows": 22548,
-      "chiplets_rows": 10187,
-      "range_rows": 1753,
+      "core_rows": 23257,
+      "chiplets_rows": 10553,
+      "range_rows": 1761,
       "chiplets_shape": {
-        "hasher_rows": 7688,
-        "bitwise_rows": 1192,
-        "memory_rows": 1244,
+        "hasher_rows": 8000,
+        "bitwise_rows": 1224,
+        "memory_rows": 1266,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -407,23 +407,23 @@
   },
   "consume SWAP note (private payback, network account)": {
     "prologue": 3719,
-    "notes_processing": 3997,
+    "notes_processing": 4064,
     "note_execution": {
-      "0x6d44d87b75165cdc5794a3dbc5cdba77277e5241ccd2e332e9d78b47f58a29af": 3955
+      "0x6d44d87b75165cdc5794a3dbc5cdba77277e5241ccd2e332e9d78b47f58a29af": 4022
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14232,
-      "auth_procedure": 9907
+      "total": 14874,
+      "auth_procedure": 10546
     },
     "trace": {
-      "core_rows": 22034,
-      "chiplets_rows": 10066,
-      "range_rows": 1761,
+      "core_rows": 22743,
+      "chiplets_rows": 10432,
+      "range_rows": 1777,
       "chiplets_shape": {
-        "hasher_rows": 7584,
-        "bitwise_rows": 1192,
-        "memory_rows": 1227,
+        "hasher_rows": 7896,
+        "bitwise_rows": 1224,
+        "memory_rows": 1249,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -431,23 +431,23 @@
   },
   "consume PSWAP note (full fill, network account)": {
     "prologue": 3719,
-    "notes_processing": 7033,
+    "notes_processing": 7100,
     "note_execution": {
-      "0x8258ed08b1106ffafca1fa325d7588834fea990bd9e6c4600b871ef6e2708192": 6991
+      "0x8258ed08b1106ffafca1fa325d7588834fea990bd9e6c4600b871ef6e2708192": 7058
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 14240,
-      "auth_procedure": 9907
+      "total": 14882,
+      "auth_procedure": 10546
     },
     "trace": {
-      "core_rows": 25078,
-      "chiplets_rows": 10875,
-      "range_rows": 1795,
+      "core_rows": 25787,
+      "chiplets_rows": 11241,
+      "range_rows": 1809,
       "chiplets_shape": {
-        "hasher_rows": 8128,
-        "bitwise_rows": 1264,
-        "memory_rows": 1420,
+        "hasher_rows": 8440,
+        "bitwise_rows": 1296,
+        "memory_rows": 1442,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -455,23 +455,23 @@
   },
   "consume PSWAP note (partial fill, network account)": {
     "prologue": 3719,
-    "notes_processing": 9574,
+    "notes_processing": 9662,
     "note_execution": {
-      "0x8258ed08b1106ffafca1fa325d7588834fea990bd9e6c4600b871ef6e2708192": 9532
+      "0x8258ed08b1106ffafca1fa325d7588834fea990bd9e6c4600b871ef6e2708192": 9620
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15654,
-      "auth_procedure": 10130
+      "total": 16519,
+      "auth_procedure": 10992
     },
     "trace": {
-      "core_rows": 29033,
-      "chiplets_rows": 12580,
-      "range_rows": 1991,
+      "core_rows": 29986,
+      "chiplets_rows": 13049,
+      "range_rows": 1965,
       "chiplets_shape": {
-        "hasher_rows": 9296,
-        "bitwise_rows": 1640,
-        "memory_rows": 1581,
+        "hasher_rows": 9672,
+        "bitwise_rows": 1704,
+        "memory_rows": 1610,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -479,23 +479,23 @@
   },
   "consume MINT note (fungible faucet, network account)": {
     "prologue": 5447,
-    "notes_processing": 7263,
+    "notes_processing": 7585,
     "note_execution": {
-      "0x61eb35dd4fa928f4b4ef9be8a1c8ef62b6f904483a96904854cbd23a95a58456": 7221
+      "0x7cb085b49226958234c26ea8f79155940e3a985b932c3ce66b76e9fd1420e456": 7543
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 19031,
-      "auth_procedure": 9662
+      "total": 19673,
+      "auth_procedure": 10301
     },
     "trace": {
-      "core_rows": 31827,
-      "chiplets_rows": 12355,
-      "range_rows": 2815,
+      "core_rows": 32791,
+      "chiplets_rows": 12852,
+      "range_rows": 2825,
       "chiplets_shape": {
-        "hasher_rows": 9120,
-        "bitwise_rows": 1144,
-        "memory_rows": 2028,
+        "hasher_rows": 9528,
+        "bitwise_rows": 1176,
+        "memory_rows": 2085,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -503,23 +503,23 @@
   },
   "consume MINT note (non-fungible faucet, network account)": {
     "prologue": 5496,
-    "notes_processing": 9800,
+    "notes_processing": 10133,
     "note_execution": {
-      "0xf17cb88ebe534db086dc129df0773363e7ecc8c492acb4a92b000ecb1605bfcd": 9758
+      "0xa488b4dd26ce659555153165a2b5dd830383a226748abc325f19cc39e914ad8c": 10091
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 19324,
-      "auth_procedure": 9671
+      "total": 19966,
+      "auth_procedure": 10310
     },
     "trace": {
-      "core_rows": 34706,
-      "chiplets_rows": 13480,
-      "range_rows": 2945,
+      "core_rows": 35681,
+      "chiplets_rows": 13980,
+      "range_rows": 2971,
       "chiplets_shape": {
-        "hasher_rows": 10128,
-        "bitwise_rows": 1144,
-        "memory_rows": 2145,
+        "hasher_rows": 10536,
+        "bitwise_rows": 1176,
+        "memory_rows": 2205,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -527,23 +527,23 @@
   },
   "consume BURN note (network account)": {
     "prologue": 6046,
-    "notes_processing": 4584,
+    "notes_processing": 4758,
     "note_execution": {
-      "0x90c1f0a2c27744efd107c653e6dba134c6713257427980e503580fa4931dc935": 4542
+      "0x652872e4aa6a0681c4fa88e107ca15726c52b521e30ab84049a8eaf3e4422026": 4716
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 17773,
-      "auth_procedure": 9441
+      "total": 18194,
+      "auth_procedure": 9859
     },
     "trace": {
-      "core_rows": 28489,
-      "chiplets_rows": 11174,
-      "range_rows": 2559,
+      "core_rows": 29084,
+      "chiplets_rows": 11520,
+      "range_rows": 2613,
       "chiplets_shape": {
-        "hasher_rows": 8392,
+        "hasher_rows": 8704,
         "bitwise_rows": 856,
-        "memory_rows": 1863,
+        "memory_rows": 1897,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -551,23 +551,23 @@
   },
   "consume FAUCET_POLICY_CONFIG note (network account)": {
     "prologue": 5400,
-    "notes_processing": 5301,
+    "notes_processing": 5407,
     "note_execution": {
-      "0xc7d1d6d6dc6a738a3115fb8aec12c2fb9767356f2c67fd08a7163d7aadc1e7e0": 5259
+      "0xc7d1d6d6dc6a738a3115fb8aec12c2fb9767356f2c67fd08a7163d7aadc1e7e0": 5365
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 17626,
-      "auth_procedure": 9432
+      "total": 18047,
+      "auth_procedure": 9850
     },
     "trace": {
-      "core_rows": 28413,
-      "chiplets_rows": 10164,
-      "range_rows": 2589,
+      "core_rows": 28940,
+      "chiplets_rows": 10479,
+      "range_rows": 2587,
       "chiplets_shape": {
-        "hasher_rows": 7768,
+        "hasher_rows": 8056,
         "bitwise_rows": 560,
-        "memory_rows": 1773,
+        "memory_rows": 1800,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -575,23 +575,47 @@
   },
   "consume FAUCET_METADATA_CONFIG note (network account)": {
     "prologue": 4824,
-    "notes_processing": 6043,
+    "notes_processing": 6294,
     "note_execution": {
-      "0x8ea187c948675fe48a1ef5dcf25edeb636f501de68daffcad465c87fc418d30b": 6001
+      "0x8ea187c948675fe48a1ef5dcf25edeb636f501de68daffcad465c87fc418d30b": 6252
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 16281,
-      "auth_procedure": 9351
+      "total": 16702,
+      "auth_procedure": 9769
     },
     "trace": {
-      "core_rows": 27234,
-      "chiplets_rows": 9828,
-      "range_rows": 2407,
+      "core_rows": 27906,
+      "chiplets_rows": 10241,
+      "range_rows": 2391,
       "chiplets_shape": {
-        "hasher_rows": 7400,
+        "hasher_rows": 7768,
         "bitwise_rows": 568,
-        "memory_rows": 1797,
+        "memory_rows": 1842,
+        "kernel_rom_rows": 62,
+        "ace_rows": 0
+      }
+    }
+  },
+  "consume MIN_BURN_AMOUNT_CONFIG note (network account)": {
+    "prologue": 5457,
+    "notes_processing": 2514,
+    "note_execution": {
+      "0xd1e581d8109fee2c5b6e8c4d5600506cdf6128e7d40bb27236f6b383e8208898": 2472
+    },
+    "tx_script_processing": 42,
+    "epilogue": {
+      "total": 18194,
+      "auth_procedure": 9859
+    },
+    "trace": {
+      "core_rows": 26251,
+      "chiplets_rows": 9720,
+      "range_rows": 2483,
+      "chiplets_shape": {
+        "hasher_rows": 7376,
+        "bitwise_rows": 560,
+        "memory_rows": 1721,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -599,23 +623,23 @@
   },
   "consume ALLOWLIST_CONFIG note (network account)": {
     "prologue": 5457,
-    "notes_processing": 3029,
+    "notes_processing": 3088,
     "note_execution": {
-      "0x96371aba3cc701dee73e96fbbc51f87d716641a06ccc6e455168e7a4ae443e94": 2987
+      "0x96371aba3cc701dee73e96fbbc51f87d716641a06ccc6e455168e7a4ae443e94": 3046
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 17949,
-      "auth_procedure": 9441
+      "total": 18370,
+      "auth_procedure": 9859
     },
     "trace": {
-      "core_rows": 26521,
-      "chiplets_rows": 10074,
-      "range_rows": 2489,
+      "core_rows": 27001,
+      "chiplets_rows": 10356,
+      "range_rows": 2473,
       "chiplets_shape": {
-        "hasher_rows": 7672,
+        "hasher_rows": 7936,
         "bitwise_rows": 560,
-        "memory_rows": 1779,
+        "memory_rows": 1797,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -623,23 +647,23 @@
   },
   "consume BLOCKLIST_CONFIG note (network account)": {
     "prologue": 5457,
-    "notes_processing": 3029,
+    "notes_processing": 3088,
     "note_execution": {
-      "0xe13a4c39807ed4265ac1abb9de8509a3f9a23bfca58de66624560c04c164ccc4": 2987
+      "0xe13a4c39807ed4265ac1abb9de8509a3f9a23bfca58de66624560c04c164ccc4": 3046
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 17949,
-      "auth_procedure": 9441
+      "total": 18370,
+      "auth_procedure": 9859
     },
     "trace": {
-      "core_rows": 26521,
-      "chiplets_rows": 10074,
-      "range_rows": 2479,
+      "core_rows": 27001,
+      "chiplets_rows": 10356,
+      "range_rows": 2457,
       "chiplets_shape": {
-        "hasher_rows": 7672,
+        "hasher_rows": 7936,
         "bitwise_rows": 560,
-        "memory_rows": 1779,
+        "memory_rows": 1797,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -647,23 +671,23 @@
   },
   "consume PAUSE_CONFIG note (network account)": {
     "prologue": 3327,
-    "notes_processing": 2470,
+    "notes_processing": 2529,
     "note_execution": {
-      "0x76891cc44cdb15d05251ecfe69b337f1281360a49b8b302640565382d9307143": 2428
+      "0x76891cc44cdb15d05251ecfe69b337f1281360a49b8b302640565382d9307143": 2487
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 12588,
-      "auth_procedure": 9126
+      "total": 13009,
+      "auth_procedure": 9544
     },
     "trace": {
-      "core_rows": 18471,
-      "chiplets_rows": 7250,
-      "range_rows": 1519,
+      "core_rows": 18951,
+      "chiplets_rows": 7532,
+      "range_rows": 1547,
       "chiplets_shape": {
-        "hasher_rows": 5488,
+        "hasher_rows": 5752,
         "bitwise_rows": 560,
-        "memory_rows": 1139,
+        "memory_rows": 1157,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -671,23 +695,23 @@
   },
   "consume OWNER_CONFIG note (network account)": {
     "prologue": 3186,
-    "notes_processing": 2499,
+    "notes_processing": 2558,
     "note_execution": {
-      "0xff8dc68047d1df36aa4b3b1130779084c9216aac8f9c8dfcdfbd1f82cbe8ec40": 2457
+      "0xff8dc68047d1df36aa4b3b1130779084c9216aac8f9c8dfcdfbd1f82cbe8ec40": 2516
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 12294,
-      "auth_procedure": 9108
+      "total": 12715,
+      "auth_procedure": 9526
     },
     "trace": {
-      "core_rows": 18065,
-      "chiplets_rows": 7146,
-      "range_rows": 1531,
+      "core_rows": 18545,
+      "chiplets_rows": 7428,
+      "range_rows": 1541,
       "chiplets_shape": {
-        "hasher_rows": 5400,
+        "hasher_rows": 5664,
         "bitwise_rows": 576,
-        "memory_rows": 1107,
+        "memory_rows": 1125,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -695,23 +719,23 @@
   },
   "consume RBAC_CONFIG note (network account)": {
     "prologue": 3365,
-    "notes_processing": 4761,
+    "notes_processing": 4861,
     "note_execution": {
-      "0xe12e2ed4219660c99f775b11d3ec2aabf69352a7d43fe25b94c63f9afe55199b": 4719
+      "0xe12e2ed4219660c99f775b11d3ec2aabf69352a7d43fe25b94c63f9afe55199b": 4819
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 13115,
-      "auth_procedure": 9135
+      "total": 13536,
+      "auth_procedure": 9553
     },
     "trace": {
-      "core_rows": 21327,
-      "chiplets_rows": 9286,
-      "range_rows": 1697,
+      "core_rows": 21848,
+      "chiplets_rows": 9598,
+      "range_rows": 1681,
       "chiplets_shape": {
-        "hasher_rows": 7256,
+        "hasher_rows": 7544,
         "bitwise_rows": 576,
-        "memory_rows": 1391,
+        "memory_rows": 1415,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -719,23 +743,23 @@
   },
   "consume NETWORK_ACCOUNT_CONFIG note (network account)": {
     "prologue": 3270,
-    "notes_processing": 3002,
+    "notes_processing": 3061,
     "note_execution": {
-      "0x963ba76870db04bbab4fd2fa4ed3939aa38dd709634296b681beac6723728d1e": 2960
+      "0x963ba76870db04bbab4fd2fa4ed3939aa38dd709634296b681beac6723728d1e": 3019
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 12607,
-      "auth_procedure": 9117
+      "total": 13028,
+      "auth_procedure": 9535
     },
     "trace": {
-      "core_rows": 18965,
-      "chiplets_rows": 7796,
-      "range_rows": 1583,
+      "core_rows": 19445,
+      "chiplets_rows": 8078,
+      "range_rows": 1573,
       "chiplets_shape": {
-        "hasher_rows": 5984,
+        "hasher_rows": 6248,
         "bitwise_rows": 560,
-        "memory_rows": 1189,
+        "memory_rows": 1207,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -743,23 +767,23 @@
   },
   "consume CONSTANT_FEE_POLICY_CONFIG note (network account)": {
     "prologue": 3317,
-    "notes_processing": 3687,
+    "notes_processing": 3782,
     "note_execution": {
-      "0xba847903cc257dbbe09852d5269201716661c41ad25494c8252ff15b423cc687": 3645
+      "0xba847903cc257dbbe09852d5269201716661c41ad25494c8252ff15b423cc687": 3740
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 12754,
-      "auth_procedure": 9126
+      "total": 13175,
+      "auth_procedure": 9544
     },
     "trace": {
-      "core_rows": 19844,
-      "chiplets_rows": 8050,
-      "range_rows": 1615,
+      "core_rows": 20360,
+      "chiplets_rows": 8362,
+      "range_rows": 1591,
       "chiplets_shape": {
-        "hasher_rows": 6168,
+        "hasher_rows": 6456,
         "bitwise_rows": 560,
-        "memory_rows": 1259,
+        "memory_rows": 1283,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -774,17 +798,17 @@
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15249,
-      "auth_procedure": 12219
+      "total": 15719,
+      "auth_procedure": 12686
     },
     "trace": {
-      "core_rows": 21301,
-      "chiplets_rows": 9142,
-      "range_rows": 1543,
+      "core_rows": 21771,
+      "chiplets_rows": 9426,
+      "range_rows": 1587,
       "chiplets_shape": {
-        "hasher_rows": 6976,
+        "hasher_rows": 7248,
         "bitwise_rows": 888,
-        "memory_rows": 1215,
+        "memory_rows": 1227,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
@@ -792,215 +816,215 @@
   },
   "consume FEE_SPONSORSHIP note (reclaim)": {
     "prologue": 3605,
-    "notes_processing": 2920,
+    "notes_processing": 2943,
     "note_execution": {
-      "0x10ecf93babe366a86b031e4bc407ec2e05f08b8be402539782e54f239aca3222": 2878
+      "0x10ecf93babe366a86b031e4bc407ec2e05f08b8be402539782e54f239aca3222": 2901
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 10374,
-      "auth_procedure": 8159
+      "total": 10725,
+      "auth_procedure": 8507
     },
     "trace": {
-      "core_rows": 16985,
-      "chiplets_rows": 7640,
-      "range_rows": 1609,
+      "core_rows": 17359,
+      "chiplets_rows": 7812,
+      "range_rows": 1565,
       "chiplets_shape": {
-        "hasher_rows": 5568,
+        "hasher_rows": 5728,
         "bitwise_rows": 1144,
-        "memory_rows": 865,
+        "memory_rows": 877,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L1 to Miden, with fee payment)": {
-    "prologue": 3957,
-    "notes_processing": 28344,
+    "prologue": 4033,
+    "notes_processing": 28614,
     "note_execution": {
-      "0xbdfc5507d93648b80a38dc73a200a09635e05ad56f11c8faf6d5403cb0d393ee": 28302
+      "0x7ba705db8a8a71392d468e19b6d1abf206ca3358bba4dc2bf3dd92b5187856dc": 28572
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 20610,
-      "auth_procedure": 14310
+      "total": 25166,
+      "auth_procedure": 18725
     },
     "trace": {
-      "core_rows": 52997,
-      "chiplets_rows": 21208,
-      "range_rows": 3529,
+      "core_rows": 57899,
+      "chiplets_rows": 23151,
+      "range_rows": 3617,
       "chiplets_shape": {
-        "hasher_rows": 13904,
-        "bitwise_rows": 3088,
-        "memory_rows": 4153,
+        "hasher_rows": 15456,
+        "bitwise_rows": 3176,
+        "memory_rows": 4456,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CLAIM note (L2 to Miden, with fee payment)": {
-    "prologue": 3957,
-    "notes_processing": 38506,
+    "prologue": 4033,
+    "notes_processing": 38776,
     "note_execution": {
-      "0xee8c28c427c5a7b02c43ee3512550d029ad914f8ccd4770e62abbf7ad18dc631": 38464
+      "0x927c8823d42f4ca75bfe60aedf56d3c2dc30ed4ee9db3657a63ade6bdaecc1e0": 38734
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 20610,
-      "auth_procedure": 14310
+      "total": 25166,
+      "auth_procedure": 18725
     },
     "trace": {
-      "core_rows": 63159,
-      "chiplets_rows": 23958,
-      "range_rows": 3737,
+      "core_rows": 68061,
+      "chiplets_rows": 25901,
+      "range_rows": 3827,
       "chiplets_shape": {
-        "hasher_rows": 15456,
-        "bitwise_rows": 3344,
-        "memory_rows": 5095,
+        "hasher_rows": 17008,
+        "bitwise_rows": 3432,
+        "memory_rows": 5398,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, with fee payment)": {
-    "prologue": 4881,
-    "notes_processing": 116251,
+    "prologue": 4957,
+    "notes_processing": 118011,
     "note_execution": {
-      "0x747971468f66129ecef049ba8c86fa71f87ce9730dcb5c49939446186373d21e": 116209
+      "0x2ca2d2a9fbfd77c6817c923b1d797f92e3f31c3aa9b828b2ad869e5de4e3dd9f": 117969
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 30377,
-      "auth_procedure": 14395
+      "total": 34933,
+      "auth_procedure": 18810
     },
     "trace": {
-      "core_rows": 151595,
-      "chiplets_rows": 71286,
-      "range_rows": 4753,
+      "core_rows": 157987,
+      "chiplets_rows": 74200,
+      "range_rows": 4937,
       "chiplets_shape": {
-        "hasher_rows": 56944,
-        "bitwise_rows": 3864,
-        "memory_rows": 10415,
+        "hasher_rows": 59272,
+        "bitwise_rows": 3952,
+        "memory_rows": 10913,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume B2AGG note (bridge-out, 2^31-1 leaves, with fee payment)": {
-    "prologue": 4881,
-    "notes_processing": 60205,
+    "prologue": 4957,
+    "notes_processing": 61655,
     "note_execution": {
-      "0x747971468f66129ecef049ba8c86fa71f87ce9730dcb5c49939446186373d21e": 60163
+      "0x2ca2d2a9fbfd77c6817c923b1d797f92e3f31c3aa9b828b2ad869e5de4e3dd9f": 61613
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 21449,
-      "auth_procedure": 14395
+      "total": 26005,
+      "auth_procedure": 18810
     },
     "trace": {
-      "core_rows": 86621,
-      "chiplets_rows": 40329,
-      "range_rows": 3737,
+      "core_rows": 92703,
+      "chiplets_rows": 43115,
+      "range_rows": 3837,
       "chiplets_shape": {
-        "hasher_rows": 30048,
-        "bitwise_rows": 3864,
-        "memory_rows": 6354,
+        "hasher_rows": 32248,
+        "bitwise_rows": 3952,
+        "memory_rows": 6852,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume CONFIG_AGG_BRIDGE note (with fee payment)": {
-    "prologue": 4265,
-    "notes_processing": 13388,
+    "prologue": 4341,
+    "notes_processing": 13724,
     "note_execution": {
-      "0x51eb958cc6ce003f866bed3f618c3a530dcb515bf791949db7707b662797a8a7": 13346
+      "0x51eb958cc6ce003f866bed3f618c3a530dcb515bf791949db7707b662797a8a7": 13682
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15996,
-      "auth_procedure": 9270
+      "total": 16564,
+      "auth_procedure": 9697
     },
     "trace": {
-      "core_rows": 33735,
-      "chiplets_rows": 14581,
-      "range_rows": 2465,
+      "core_rows": 34715,
+      "chiplets_rows": 15120,
+      "range_rows": 2475,
       "chiplets_shape": {
-        "hasher_rows": 11584,
+        "hasher_rows": 12048,
         "bitwise_rows": 616,
-        "memory_rows": 2318,
+        "memory_rows": 2393,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume DEREGISTER_AGG_FAUCET note (with fee payment)": {
-    "prologue": 4324,
-    "notes_processing": 12687,
+    "prologue": 4400,
+    "notes_processing": 12969,
     "note_execution": {
-      "0xdc8ae96d95b6c8bba383e0829a1de57827736349bf2a65d29b98a0b8ce8de44f": 12645
+      "0xdc8ae96d95b6c8bba383e0829a1de57827736349bf2a65d29b98a0b8ce8de44f": 12927
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15996,
-      "auth_procedure": 9270
+      "total": 16564,
+      "auth_procedure": 9697
     },
     "trace": {
-      "core_rows": 33093,
-      "chiplets_rows": 14272,
-      "range_rows": 2357,
+      "core_rows": 34019,
+      "chiplets_rows": 14770,
+      "range_rows": 2373,
       "chiplets_shape": {
-        "hasher_rows": 11400,
+        "hasher_rows": 11832,
         "bitwise_rows": 608,
-        "memory_rows": 2201,
+        "memory_rows": 2267,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume UPDATE_GER note (with fee payment)": {
-    "prologue": 4265,
-    "notes_processing": 4391,
+    "prologue": 4341,
+    "notes_processing": 4504,
     "note_execution": {
-      "0x83a2de49840c9bf985e0b919a89e3ce2e632036932a345ad4faf40bccf37b61f": 4349
+      "0x83a2de49840c9bf985e0b919a89e3ce2e632036932a345ad4faf40bccf37b61f": 4462
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15196,
-      "auth_procedure": 9270
+      "total": 15764,
+      "auth_procedure": 9697
     },
     "trace": {
-      "core_rows": 23938,
-      "chiplets_rows": 9597,
-      "range_rows": 2057,
+      "core_rows": 24695,
+      "chiplets_rows": 9983,
+      "range_rows": 2087,
       "chiplets_shape": {
-        "hasher_rows": 7360,
+        "hasher_rows": 7704,
         "bitwise_rows": 560,
-        "memory_rows": 1614,
+        "memory_rows": 1656,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }
     }
   },
   "consume REMOVE_GER note (with fee payment)": {
-    "prologue": 4324,
-    "notes_processing": 5409,
+    "prologue": 4400,
+    "notes_processing": 5568,
     "note_execution": {
-      "0xffa3eac6e83fdd664e9dca686e96d17b331a77437f1a5cbb3521b261fab833b9": 5367
+      "0xffa3eac6e83fdd664e9dca686e96d17b331a77437f1a5cbb3521b261fab833b9": 5526
     },
     "tx_script_processing": 42,
     "epilogue": {
-      "total": 15232,
-      "auth_procedure": 9270
+      "total": 15800,
+      "auth_procedure": 9697
     },
     "trace": {
-      "core_rows": 25051,
-      "chiplets_rows": 9887,
-      "range_rows": 2061,
+      "core_rows": 25854,
+      "chiplets_rows": 10303,
+      "range_rows": 2143,
       "chiplets_shape": {
-        "hasher_rows": 7568,
+        "hasher_rows": 7936,
         "bitwise_rows": 560,
-        "memory_rows": 1696,
+        "memory_rows": 1744,
         "kernel_rom_rows": 62,
         "ace_rows": 0
       }

--- a/crates/miden-agglayer/src/costs/table.rs
+++ b/crates/miden-agglayer/src/costs/table.rs
@@ -2,20 +2,20 @@
 // Values are maxima across the benchmarked paths; see `miden_standards::note::costs` for the
 // caveats on what they do and do not cover.
 
-/// Cycles of consuming a CLAIM note: L1 origin 52953, L2 origin 63115 (maximum).
-pub const CLAIM_CONSUMPTION_CYCLES: u32 = 63115;
+/// Cycles of consuming a CLAIM note: L1 origin 57855, L2 origin 68017 (maximum).
+pub const CLAIM_CONSUMPTION_CYCLES: u32 = 68017;
 
-/// Cycles of consuming a B2AGG note: empty frontier 151551 (maximum), 2^31-1 leaves 86577.
-pub const B2AGG_CONSUMPTION_CYCLES: u32 = 151551;
+/// Cycles of consuming a B2AGG note: empty frontier 157943 (maximum), 2^31-1 leaves 92659.
+pub const B2AGG_CONSUMPTION_CYCLES: u32 = 157943;
 
 /// Cycles of consuming a CONFIG_AGG_BRIDGE note (single benchmarked path).
-pub const CONFIG_AGG_BRIDGE_CONSUMPTION_CYCLES: u32 = 33691;
+pub const CONFIG_AGG_BRIDGE_CONSUMPTION_CYCLES: u32 = 34671;
 
 /// Cycles of consuming a DEREGISTER_AGG_FAUCET note (single benchmarked path).
-pub const DEREGISTER_AGG_FAUCET_CONSUMPTION_CYCLES: u32 = 33049;
+pub const DEREGISTER_AGG_FAUCET_CONSUMPTION_CYCLES: u32 = 33975;
 
 /// Cycles of consuming an UPDATE_GER note (single benchmarked path).
-pub const UPDATE_GER_CONSUMPTION_CYCLES: u32 = 23894;
+pub const UPDATE_GER_CONSUMPTION_CYCLES: u32 = 24651;
 
 /// Cycles of consuming a REMOVE_GER note (single benchmarked path).
-pub const REMOVE_GER_CONSUMPTION_CYCLES: u32 = 25007;
+pub const REMOVE_GER_CONSUMPTION_CYCLES: u32 = 25810;

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -338,7 +338,7 @@ pub proc create_and_fund_fee_note(asset: Asset)
     # => []
 end
 
-#! Computes the fee of the current transaction without paying anything.
+#! Estimates the fee of the current transaction.
 #!
 #! The fee covers the notes the payment goes on to create: the TX_FEE note, and one
 #! FEE_SPONSORSHIP note per network output note (see pay_network_note_sponsorships). Counting the

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -32,11 +32,13 @@ pub type ConversionInfo = word
 const PAY_FEE_CYCLES = 8192
 
 # Estimated upper bounds on the number of cycles the sponsorship payment spends after the
-# compute_fee call returns. It walks every output note looking for network notes (measured ~225
-# cycles per note), then prices and funds a FEE_SPONSORSHIP note for each one it finds; the
-# per-sponsorship figure covers the foreign procedure call into the target's fee policy (measured
-# ~4k cycles), the note creation and the vault withdrawal. Guarded by the fee-payment regression
-# tests.
+# compute_fee call returns: a walk over every output note looking for network notes, then pricing
+# and funding a FEE_SPONSORSHIP note for each one found, which covers the foreign procedure call
+# into the target's fee policy, the note creation and the vault withdrawal.
+#
+# NOT covered by a regression test: zeroing both leaves the suite green, because the sponsoring
+# case lands exactly on an ilog2 boundary either way. They are margins over a measurement, so a
+# test would have to assert cycle counts rather than behaviour. Re-measure if the payment changes.
 const SPONSORSHIP_WALK_PER_OUTPUT_NOTE_CYCLES = 512
 const SPONSORSHIP_NOTE_CYCLES = 16384
 

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -312,6 +312,59 @@ pub proc create_and_fund_fee_note(asset: Asset)
     # => []
 end
 
+#! Computes the fee of the current transaction without paying it.
+#!
+#! Before computing the fee, this creates a FEE_SPONSORSHIP note for every network output note
+#! of the transaction (see fees::create_network_note_sponsorships), so those notes are included
+#! in the cycle estimate and the fee. This prices each network note through its target account's
+#! fee policy via an FPI call, which requires that target to be provisioned as a foreign account.
+#!
+#! num_extra_cycles only needs to cover the number of cycles the caller spends after the fee flow
+#! returns (e.g. transaction summary creation, hashing and signature verification, see
+#! signature::estimate_authentication_cycles); this procedure adds the payment tail cycles and the
+#! post-authentication kernel epilogue cycles internally.
+#!
+#! Inputs:  [num_extra_cycles]
+#! Outputs: [fee_amount, total_sponsored_fee_amount]
+#!
+#! Where:
+#! - num_extra_cycles is the estimated number of cycles the caller spends after this call until
+#!   the end of the authentication procedure.
+#! - fee_amount is the computed fee of the transaction, denominated in the native fee asset.
+#! - total_sponsored_fee_amount is the total amount the sponsorship step moved into sponsorship
+#!   notes.
+#!
+#! Panics if:
+#! - the sponsorship step fails (propagates the panics of
+#!   fees::create_network_note_sponsorships, e.g. a target's fee policy is unset/unreachable or
+#!   the vault underfunds a sponsored amount).
+#! - num_extra_cycles (plus internal margins) is not a u32 or the total cycle count exceeds the
+#!   maximum cycle count.
+#!
+#! Invocation: exec
+pub proc estimate_fee(num_extra_cycles: felt) -> (felt, felt)
+    # sponsor any network output notes before the fee is computed, so the sponsorship notes
+    # this creates are counted by both the cycle estimate and compute_fee.
+    exec.tx::get_fee_faucet_id exec.fungible_asset::create_id
+    # => [FEE_ASSET_ID, num_extra_cycles]
+
+    exec.fees::create_network_note_sponsorships
+    # => [total_sponsored_fee_amount, num_extra_cycles]
+
+    swap
+    # => [num_extra_cycles, total_sponsored_fee_amount]
+
+    exec.apply_cycle_margins
+    # => [num_estimated_extra_cycles, total_sponsored_fee_amount]
+
+    # no output notes are excluded from the fee computation
+    padw movup.4
+    # => [num_estimated_extra_cycles, EXCLUDE_NOTES_COMMITMENT, total_sponsored_fee_amount]
+
+    exec.tx::compute_fee
+    # => [fee_amount, total_sponsored_fee_amount]
+end
+
 #! Computes the transaction fee and pays it by creating and funding a public TX_FEE note.
 #!
 #! This is the fee payment flow for all account types: the caller supplies the decoded
@@ -323,23 +376,13 @@ end
 #! and obtain the conversion info via native_conversion_info, which needs no commitment since
 #! it is read from the reference block.
 #!
-#! The fee amount is computed via the compute_fee kernel procedure. num_extra_cycles only needs
-#! to cover the number of cycles the authentication procedure spends after this procedure
-#! returns (e.g. transaction summary creation, hashing and signature verification, see
-#! signature::estimate_authentication_cycles); this procedure adds its own tail cycles and the
-#! post-authentication kernel epilogue cycles internally.
-#!
-#! The paid amount is ceil(fee_amount * rate_num / rate_den) of the asset issued by the faucet
-#! in the conversion info.
+#! The fee is computed by estimate_fee, which also sponsors the transaction's network output
+#! notes. The paid amount is ceil(fee_amount * rate_num / rate_den) of the asset issued by the
+#! faucet in the conversion info.
 #!
 #! If the computed fee is zero (e.g. the reference block's verification base fee is zero), no
 #! fee note is created and no conversion info is required (the empty word is accepted). Note that
 #! the sponsorship step above may still have created notes and withdrawn from the vault.
-#!
-#! Before computing the fee, this creates a FEE_SPONSORSHIP note for every network output note
-#! of the transaction (see fees::create_network_note_sponsorships), so those notes are included
-#! in the cycle estimate and the fee. This prices each network note through its target account's
-#! fee policy via an FPI call, which requires that target to be provisioned as a foreign account.
 #!
 #! Inputs:  [num_extra_cycles, CONVERSION_INFO]
 #! Outputs: [total_sponsored_fee_amount]
@@ -353,11 +396,7 @@ end
 #!   notes.
 #!
 #! Panics if:
-#! - the sponsorship step fails (propagates the panics of
-#!   fees::create_network_note_sponsorships, e.g. a target's fee policy is unset/unreachable or
-#!   the vault underfunds a sponsored amount).
-#! - num_extra_cycles (plus internal margins) is not a u32 or the total cycle count exceeds the
-#!   maximum cycle count.
+#! - estimate_fee panics.
 #! - the computed fee is non-zero and CONVERSION_INFO is the empty word.
 #! - the conversion rate is malformed or the converted amount overflows.
 #! - the account vault holds less of the payment asset than the amount to be paid.
@@ -365,26 +404,10 @@ end
 #!
 #! Invocation: exec
 pub proc pay_fee(num_extra_cycles: felt, conversion_info: ConversionInfo) -> felt
-    # sponsor any network output notes before the fee is computed, so the sponsorship notes
-    # this creates are counted by both the cycle estimate and compute_fee.
-    exec.tx::get_fee_faucet_id exec.fungible_asset::create_id
-    # => [FEE_ASSET_ID, num_extra_cycles, CONVERSION_INFO]
+    exec.estimate_fee
+    # => [fee_amount, total_sponsored_fee_amount, CONVERSION_INFO]
 
-    exec.fees::create_network_note_sponsorships
-    # => [total_sponsored_fee_amount, num_extra_cycles, CONVERSION_INFO]
-
-    movdn.5
-    # => [num_extra_cycles, CONVERSION_INFO, total_sponsored_fee_amount]
-
-    exec.apply_cycle_margins
-    # => [num_estimated_extra_cycles, CONVERSION_INFO, total_sponsored_fee_amount]
-
-    # no output notes are excluded from the fee computation
-    padw movup.4
-    # => [num_estimated_extra_cycles, EXCLUDE_NOTES_COMMITMENT, CONVERSION_INFO,
-    #     total_sponsored_fee_amount]
-
-    exec.tx::compute_fee
+    swap movdn.5
     # => [fee_amount, CONVERSION_INFO, total_sponsored_fee_amount]
 
     dup eq.0

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -341,9 +341,7 @@ end
 #! Estimates the fee of the current transaction.
 #!
 #! The fee covers the notes the payment goes on to create: the TX_FEE note, and one
-#! FEE_SPONSORSHIP note per network output note (see pay_network_note_sponsorships). Counting the
-#! latter prices each network note through its target account's fee policy via an FPI call, which
-#! requires that target to be provisioned as a foreign account.
+#! FEE_SPONSORSHIP note per network output note (see pay_network_note_sponsorships).
 #!
 #! num_extra_cycles only needs to cover the number of cycles the caller spends after the fee flow
 #! returns (e.g. transaction summary creation, hashing and signature verification, see

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -26,19 +26,29 @@ pub type ConversionInfo = word
 # CONSTANTS
 # =================================================================================================
 
-# Estimated upper bound on the number of cycles a pay_fee flow spends after the kernel's
+# Estimated upper bound on the number of cycles the fee note payment spends after the kernel's
 # compute_fee call returns: rate conversion, fee-asset construction, serial-number derivation,
 # recipient computation, note creation and funding. Guarded by the fee-payment regression tests.
 const PAY_FEE_CYCLES = 8192
+
+# Estimated upper bounds on the number of cycles the sponsorship payment spends after the
+# compute_fee call returns. It walks every output note looking for network notes (measured ~225
+# cycles per note), then prices and funds a FEE_SPONSORSHIP note for each one it finds; the
+# per-sponsorship figure covers the foreign procedure call into the target's fee policy (measured
+# ~4k cycles), the note creation and the vault withdrawal. Guarded by the fee-payment regression
+# tests.
+const SPONSORSHIP_WALK_PER_OUTPUT_NOTE_CYCLES = 512
+const SPONSORSHIP_NOTE_CYCLES = 16384
 
 # Estimated upper bounds on the number of kernel epilogue cycles spent after the auth procedure
 # returns: output vault build, output notes commitment, account patch and final account
 # commitments. The cost scales with the number of output notes (measured ~330 cycles per
 # asset-less note; ~1k-2k base for note-less transactions), so the estimate is computed as
-# BASE + PER_NOTE * (num_output_notes + 1), counting the fee note itself. Note that the per-note
-# figure is measured on asset-less notes; notes carrying many assets cost more, so asset-heavy
-# transactions may slightly under-estimate the fee (which fails closed: the batch builder may
-# reject the underpaying note). Guarded by the fee-payment regression tests.
+# BASE + PER_NOTE * (num_output_notes + 1 + num_sponsorship_notes), counting the fee note and the
+# sponsorship notes the payment has yet to create. Note that the per-note figure is measured on
+# asset-less notes; notes carrying many assets cost more, so asset-heavy transactions may slightly
+# under-estimate the fee (which fails closed: the batch builder may reject the underpaying note).
+# Guarded by the fee-payment regression tests.
 const POST_AUTH_EPILOGUE_BASE_CYCLES = 4096
 const POST_AUTH_EPILOGUE_PER_NOTE_CYCLES = 512
 
@@ -229,28 +239,42 @@ pub proc convert_amount(amount: felt, rate: ConversionRate) -> felt
     # => [converted_amount]
 end
 
-#! Adds the internal cycle margins of a pay_fee flow to the caller's estimate of remaining
+#! Adds the internal cycle margins of a fee flow to the caller's estimate of remaining
 #! authentication cycles.
 #!
-#! The margins cover the pay_fee tail (everything after the compute_fee call) and the post-auth
-#! kernel epilogue, whose cost scales with the number of output notes. All output notes except
-#! the fee note itself exist by the time a pay_fee flow runs, so the estimate is scaled by their
-#! count plus one.
+#! The margins cover the payment — everything the fee flow does after the compute_fee call,
+#! sponsorship notes included — and the post-auth kernel epilogue, whose cost scales with the
+#! number of output notes. The fee note and the sponsorship notes are created after the fee is
+#! computed, so the epilogue estimate is scaled by the count of the notes that already exist plus
+#! those.
 #!
-#! Inputs:  [num_extra_cycles]
+#! Inputs:  [num_extra_cycles, num_sponsorship_notes]
 #! Outputs: [num_estimated_extra_cycles]
 #!
 #! Where:
 #! - num_extra_cycles is the estimated number of cycles the authentication procedure spends after
-#!   the pay_fee flow returns.
+#!   the fee flow returns.
+#! - num_sponsorship_notes is the number of FEE_SPONSORSHIP notes the payment will create.
 #! - num_estimated_extra_cycles is the total estimate to pass to compute_fee.
 #!
 #! Invocation: exec
-pub proc apply_cycle_margins(num_extra_cycles: felt) -> felt
+pub proc apply_cycle_margins(num_extra_cycles: felt, num_sponsorship_notes: felt) -> felt
     add.PAY_FEE_CYCLES add.POST_AUTH_EPILOGUE_BASE_CYCLES
-    # => [num_partial_extra_cycles]
+    # => [num_estimated_extra_cycles, num_sponsorship_notes]
 
-    exec.tx::get_num_output_notes add.1 mul.POST_AUTH_EPILOGUE_PER_NOTE_CYCLES add
+    # the sponsorship payment walks every output note that exists
+    exec.tx::get_num_output_notes dup movdn.3
+    # => [num_output_notes, num_estimated_extra_cycles, num_sponsorship_notes, num_output_notes]
+
+    mul.SPONSORSHIP_WALK_PER_OUTPUT_NOTE_CYCLES add
+    # => [num_estimated_extra_cycles, num_sponsorship_notes, num_output_notes]
+
+    # and creates one sponsorship note per network note it finds
+    dup.1 mul.SPONSORSHIP_NOTE_CYCLES add
+    # => [num_estimated_extra_cycles, num_sponsorship_notes, num_output_notes]
+
+    # the epilogue processes the notes that exist, the sponsorship notes and the fee note
+    movup.2 movup.2 add add.1 mul.POST_AUTH_EPILOGUE_PER_NOTE_CYCLES add
     # => [num_estimated_extra_cycles]
 end
 
@@ -312,57 +336,80 @@ pub proc create_and_fund_fee_note(asset: Asset)
     # => []
 end
 
-#! Computes the fee of the current transaction without paying it.
+#! Computes the fee of the current transaction without paying anything.
 #!
-#! Before computing the fee, this creates a FEE_SPONSORSHIP note for every network output note
-#! of the transaction (see fees::create_network_note_sponsorships), so those notes are included
-#! in the cycle estimate and the fee. This prices each network note through its target account's
-#! fee policy via an FPI call, which requires that target to be provisioned as a foreign account.
+#! The fee covers the notes the payment goes on to create: the TX_FEE note, and one
+#! FEE_SPONSORSHIP note per network output note (see pay_network_note_sponsorships). Counting the
+#! latter prices each network note through its target account's fee policy via an FPI call, which
+#! requires that target to be provisioned as a foreign account.
 #!
 #! num_extra_cycles only needs to cover the number of cycles the caller spends after the fee flow
 #! returns (e.g. transaction summary creation, hashing and signature verification, see
-#! signature::estimate_authentication_cycles); this procedure adds the payment tail cycles and the
+#! signature::estimate_authentication_cycles); this procedure adds the payment cycles and the
 #! post-authentication kernel epilogue cycles internally.
 #!
 #! Inputs:  [num_extra_cycles]
-#! Outputs: [fee_amount, total_sponsored_fee_amount]
+#! Outputs: [fee_amount]
 #!
 #! Where:
 #! - num_extra_cycles is the estimated number of cycles the caller spends after this call until
 #!   the end of the authentication procedure.
 #! - fee_amount is the computed fee of the transaction, denominated in the native fee asset.
-#! - total_sponsored_fee_amount is the total amount the sponsorship step moved into sponsorship
-#!   notes.
 #!
 #! Panics if:
-#! - the sponsorship step fails (propagates the panics of
-#!   fees::create_network_note_sponsorships, e.g. a target's fee policy is unset/unreachable or
-#!   the vault underfunds a sponsored amount).
+#! - the sponsorship estimate fails (propagates the panics of
+#!   fees::estimate_network_note_sponsorships, e.g. a target's fee policy is unset or unreachable).
 #! - num_extra_cycles (plus internal margins) is not a u32 or the total cycle count exceeds the
 #!   maximum cycle count.
 #!
 #! Invocation: exec
-pub proc estimate_fee(num_extra_cycles: felt) -> (felt, felt)
-    # sponsor any network output notes before the fee is computed, so the sponsorship notes
-    # this creates are counted by both the cycle estimate and compute_fee.
+pub proc estimate_fee(num_extra_cycles: felt) -> felt
     exec.tx::get_fee_faucet_id exec.fungible_asset::create_id
     # => [FEE_ASSET_ID, num_extra_cycles]
 
-    exec.fees::create_network_note_sponsorships
-    # => [total_sponsored_fee_amount, num_extra_cycles]
+    # only the note count is needed: the fee prices the notes, not the amounts they carry
+    exec.fees::estimate_network_note_sponsorships drop
+    # => [num_sponsorship_notes, num_extra_cycles]
 
     swap
-    # => [num_extra_cycles, total_sponsored_fee_amount]
+    # => [num_extra_cycles, num_sponsorship_notes]
 
     exec.apply_cycle_margins
-    # => [num_estimated_extra_cycles, total_sponsored_fee_amount]
+    # => [num_estimated_extra_cycles]
 
     # no output notes are excluded from the fee computation
     padw movup.4
-    # => [num_estimated_extra_cycles, EXCLUDE_NOTES_COMMITMENT, total_sponsored_fee_amount]
+    # => [num_estimated_extra_cycles, EXCLUDE_NOTES_COMMITMENT]
 
     exec.tx::compute_fee
-    # => [fee_amount, total_sponsored_fee_amount]
+    # => [fee_amount]
+end
+
+#! Sponsors the transaction's network output notes, funding each sponsorship note from the
+#! account's vault.
+#!
+#! Creates a FEE_SPONSORSHIP note for every network output note, carrying the fee that note's
+#! target account charges for it (see fees::create_network_note_sponsorships). The notes are funded
+#! in the native fee asset read from the transaction's reference block.
+#!
+#! Inputs:  []
+#! Outputs: [total_sponsored_fee_amount]
+#!
+#! Where:
+#! - total_sponsored_fee_amount is the total amount moved into the sponsorship notes.
+#!
+#! Panics if:
+#! - a target account's fee policy is unset or unreachable, or charges in another asset.
+#! - the account vault holds less of the fee asset than a sponsored amount.
+#! - the maximum number of output notes is exceeded.
+#!
+#! Invocation: exec
+pub proc pay_network_note_sponsorships() -> felt
+    exec.tx::get_fee_faucet_id exec.fungible_asset::create_id
+    # => [FEE_ASSET_ID]
+
+    exec.fees::create_network_note_sponsorships
+    # => [total_sponsored_fee_amount]
 end
 
 #! Computes the transaction fee and pays it by creating and funding a public TX_FEE note.
@@ -376,13 +423,14 @@ end
 #! and obtain the conversion info via native_conversion_info, which needs no commitment since
 #! it is read from the reference block.
 #!
-#! The fee is computed by estimate_fee, which also sponsors the transaction's network output
-#! notes. The paid amount is ceil(fee_amount * rate_num / rate_den) of the asset issued by the
-#! faucet in the conversion info.
+#! The fee is computed by estimate_fee. The payment then settles both of the transaction's fee
+#! obligations, in order: the sponsorship notes of its network output notes, then the TX_FEE note
+#! carrying ceil(fee_amount * rate_num / rate_den) of the asset issued by the faucet in the
+#! conversion info.
 #!
 #! If the computed fee is zero (e.g. the reference block's verification base fee is zero), no
-#! fee note is created and no conversion info is required (the empty word is accepted). Note that
-#! the sponsorship step above may still have created notes and withdrawn from the vault.
+#! fee note is created and no conversion info is required (the empty word is accepted). The
+#! sponsorship notes are created regardless.
 #!
 #! Inputs:  [num_extra_cycles, CONVERSION_INFO]
 #! Outputs: [total_sponsored_fee_amount]
@@ -392,11 +440,10 @@ end
 #!   the end of the authentication procedure.
 #! - CONVERSION_INFO is [faucet_id_suffix, faucet_id_prefix, rate_num, rate_den], or the empty
 #!   word if no conversion info was committed (only accepted when the computed fee is zero).
-#! - total_sponsored_fee_amount is the total amount the sponsorship step moved into sponsorship
-#!   notes.
+#! - total_sponsored_fee_amount is the total amount moved into the sponsorship notes.
 #!
 #! Panics if:
-#! - estimate_fee panics.
+#! - estimate_fee or pay_network_note_sponsorships panics.
 #! - the computed fee is non-zero and CONVERSION_INFO is the empty word.
 #! - the conversion rate is malformed or the converted amount overflows.
 #! - the account vault holds less of the payment asset than the amount to be paid.
@@ -405,9 +452,12 @@ end
 #! Invocation: exec
 pub proc pay_fee(num_extra_cycles: felt, conversion_info: ConversionInfo) -> felt
     exec.estimate_fee
-    # => [fee_amount, total_sponsored_fee_amount, CONVERSION_INFO]
+    # => [fee_amount, CONVERSION_INFO]
 
-    swap movdn.5
+    exec.pay_network_note_sponsorships
+    # => [total_sponsored_fee_amount, fee_amount, CONVERSION_INFO]
+
+    movdn.5
     # => [fee_amount, CONVERSION_INFO, total_sponsored_fee_amount]
 
     dup eq.0

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -65,7 +65,7 @@ const WORD_ALIGNMENT_MASK = 0xFFFFFFFC
 const SPONSORSHIP_STORAGE_LOC = 0
 const SPONSORSHIP_FEATURE_NOTE_ID_LOC = SPONSORSHIP_STORAGE_LOC + FEATURE_NOTE_ID_ITEM_OFFSET
 
-# Local memory offset at which `create_network_note_sponsorship` caches the expected fee asset ID.
+# Local memory offset at which `handle_network_note_sponsorship` caches the expected fee asset ID.
 const EXPECTED_FEE_ASSET_ID_LOC = 0
 
 # Local memory offsets used by `compute_sponsorship_fee` (in its own local frame).
@@ -312,12 +312,13 @@ pub proc create_network_note_sponsorships(fee_asset_id: AssetId) -> felt
             # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
             #     total_sponsored_fee_amount]
 
-            # pass a copy of the expected fee asset ID along with the note parameters
-            dupw.1 movup.5 movup.5
-            # => [note_idx, attachment_idx, FEE_ASSET_ID, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount]
+            # pass a copy of the expected fee asset ID along with the note parameters, and ask for
+            # the sponsorship note to be created
+            dupw.1 movup.5 movup.5 push.1 movdn.6
+            # => [note_idx, attachment_idx, FEE_ASSET_ID, is_create = 1, note_idx, num_output_notes,
+            #     FEE_ASSET_ID, total_sponsored_fee_amount]
 
-            exec.create_network_note_sponsorship
+            exec.handle_network_note_sponsorship
             # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
             #     total_sponsored_fee_amount]
 
@@ -394,12 +395,13 @@ pub proc estimate_network_note_sponsorships(fee_asset_id: AssetId) -> (felt, fel
             # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
             #     total_sponsored_fee_amount, num_sponsorship_notes]
 
-            # pass a copy of the expected fee asset ID along with the note parameters
-            dupw.1 movup.5 movup.5
-            # => [note_idx, attachment_idx, FEE_ASSET_ID, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount, num_sponsorship_notes]
+            # pass a copy of the expected fee asset ID along with the note parameters, and ask for
+            # the note to only be priced
+            dupw.1 movup.5 movup.5 push.0 movdn.6
+            # => [note_idx, attachment_idx, FEE_ASSET_ID, is_create = 0, note_idx, num_output_notes,
+            #     FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes]
 
-            exec.estimate_network_note_sponsorship
+            exec.handle_network_note_sponsorship
             # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
             #     total_sponsored_fee_amount, num_sponsorship_notes]
 
@@ -697,20 +699,24 @@ proc is_network_note(note_idx: u16) -> (Bool, u8)
     # => [is_found, attachment_idx]
 end
 
-#! Creates a FEE_SPONSORSHIP note for the network output note at the given index.
+#! Prices the network output note at the given index and, when asked to, creates its
+#! FEE_SPONSORSHIP note.
 #!
-#! See [`create_network_note_sponsorships`] for the full behaviour; this procedure handles a single network
-#! note. A network note the target account prices to zero produces no sponsorship note.
+#! See [`create_network_note_sponsorships`] for the full behaviour; this procedure handles a single
+#! network note. A network note the target account prices to zero needs no sponsorship note, so
+#! none is created for it. When is_create is 0 the note is only priced: the vault and the output
+#! notes are left untouched.
 #!
-#! Inputs:  [note_idx, attachment_idx, EXPECTED_FEE_ASSET_ID]
+#! Inputs:  [note_idx, attachment_idx, EXPECTED_FEE_ASSET_ID, is_create]
 #! Outputs: [sponsored_fee_amount]
 #!
 #! Where:
 #! - note_idx is the index of the network output note to sponsor.
 #! - attachment_idx is the index of the note's network account target attachment.
 #! - EXPECTED_FEE_ASSET_ID is the ID of the asset the sponsorship note must be funded with.
-#! - sponsored_fee_amount is the amount moved into the sponsorship note, or zero if none was
-#!   created.
+#! - is_create is 1 to create the sponsorship note, 0 to only price it.
+#! - sponsored_fee_amount is the amount the sponsorship note carries, or zero if the target prices
+#!   the note to zero and so it needs none.
 #!
 #! Panics if:
 #! - the note's target ID attachment does not consist of exactly one word.
@@ -718,98 +724,55 @@ end
 #!   or does not hash to the recipient.
 #! - the target account's active fee policy is not set.
 #! - the target account charges a non-zero fee in an asset other than the expected fee asset.
-#! - the native account's vault does not hold enough of the fee asset.
+#! - is_create is 1 and the native account's vault does not hold enough of the fee asset.
 #!
 #! Invocation: exec
 @locals(4)
-proc create_network_note_sponsorship(
+proc handle_network_note_sponsorship(
     note_idx: u16,
     attachment_idx: u8,
-    expected_fee_asset_id: AssetId
+    expected_fee_asset_id: AssetId,
+    is_create: Bool
 ) -> felt
     # cache the expected fee asset ID for the target fee asset check
     movdn.5 movdn.5 loc_storew_le.EXPECTED_FEE_ASSET_ID_LOC dropw
-    # => [note_idx, attachment_idx]
+    # => [note_idx, attachment_idx, is_create]
 
-    dup movdn.2
-    # => [note_idx, attachment_idx, note_idx]
+    dup movdn.3
+    # => [note_idx, attachment_idx, is_create, note_idx]
 
     exec.compute_sponsorship_fee
-    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx]
+    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, is_create, note_idx]
 
     exec.fungible_asset::to_amount
-    # => [fee_amount, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx]
+    # => [fee_amount, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, is_create, note_idx]
 
-    movdn.10 dup.10 eq.0
-    # => [is_zero_fee, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx, fee_amount]
+    movdn.11 dup.11 eq.0
+    # => [is_zero_fee, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, is_create, note_idx,
+    #     fee_amount]
 
     if.true
-        # if the price of the note is zero, do not create a sponsorship note
-        dropw dropw drop drop
+        # if the price of the note is zero, it needs no sponsorship note
+        dropw dropw drop drop drop
         # => [fee_amount]
     else
         # reject a target whose fee asset differs from the expected fee asset
         dupw padw loc_loadw_le.EXPECTED_FEE_ASSET_ID_LOC exec.word::eq
         assert.err=ERR_FEE_MANAGER_TARGET_FEE_ASSET_MISMATCH
-        # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx, fee_amount]
+        # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, is_create, note_idx, fee_amount]
 
-        exec.create_sponsorship_note
-        # => [fee_amount]
+        movup.9
+        # => [is_create, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx, fee_amount]
+
+        if.true
+            exec.create_sponsorship_note
+            # => [fee_amount]
+        else
+            # only pricing the note: discard the inputs of the note creation
+            dropw dropw drop drop
+            # => [fee_amount]
+        end
     end
-end
-
-#! Prices the network output note at the given index without creating its FEE_SPONSORSHIP note.
-#!
-#! The estimation twin of `create_network_note_sponsorship`: it prices the note through the same
-#! fee policy call and applies the same fee asset check, but leaves the vault and the output notes
-#! untouched.
-#!
-#! Inputs:  [note_idx, attachment_idx, EXPECTED_FEE_ASSET_ID]
-#! Outputs: [sponsored_fee_amount]
-#!
-#! Where:
-#! - note_idx is the index of the network output note to price.
-#! - attachment_idx is the index of the note's network account target attachment.
-#! - EXPECTED_FEE_ASSET_ID is the ID of the asset the sponsorship note must be funded with.
-#! - sponsored_fee_amount is the amount the note's sponsorship note will carry, or zero if the
-#!   target prices it to zero and so needs none.
-#!
-#! Panics if:
-#! - the note's target ID attachment does not consist of exactly one word.
-#! - the target account's fee policy requires the note's recipient preimage and it is unavailable
-#!   or does not hash to the recipient.
-#! - the target account's active fee policy is not set.
-#! - the target account charges a non-zero fee in an asset other than the expected fee asset.
-#!
-#! Invocation: exec
-@locals(4)
-proc estimate_network_note_sponsorship(
-    note_idx: u16,
-    attachment_idx: u8,
-    expected_fee_asset_id: AssetId
-) -> felt
-    # cache the expected fee asset ID for the target fee asset check
-    movdn.5 movdn.5 loc_storew_le.EXPECTED_FEE_ASSET_ID_LOC dropw
-    # => [note_idx, attachment_idx]
-
-    exec.compute_sponsorship_fee
-    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix]
-
-    exec.fungible_asset::to_amount
-    # => [fee_amount, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix]
-
-    movdn.9 dup.9 neq.0
-    # => [is_sponsored, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, fee_amount]
-
-    if.true
-        # reject a target whose fee asset differs from the expected fee asset
-        dupw padw loc_loadw_le.EXPECTED_FEE_ASSET_ID_LOC exec.word::eq
-        assert.err=ERR_FEE_MANAGER_TARGET_FEE_ASSET_MISMATCH
-        # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, fee_amount]
-    end
-
-    dropw dropw drop
-    # => [fee_amount]
 end
 
 #! Computes the fee the target network account charges for the output note at the given index.

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -287,67 +287,16 @@ end
 #!
 #! Invocation: exec
 pub proc create_network_note_sponsorships(fee_asset_id: AssetId) -> felt
-    push.0 movdn.4
-    # => [FEE_ASSET_ID, total_sponsored_fee_amount = 0]
-
-    # get the output note count before any sponsorship notes were created, since creating them
-    # increments the count
-    exec.tx::get_num_output_notes
-    # => [num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
-
-    push.0
-    # => [note_idx = 0, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
-
-    dup.1 dup.1 neq
-    # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
-
-    while.true
-        # only network output notes are sponsored
-        dup exec.is_network_note
-        # => [is_network_note, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
-        #     total_sponsored_fee_amount]
-
-        if.true
-            dup.1
-            # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount]
-
-            # pass a copy of the expected fee asset ID along with the note parameters, and ask for
-            # the sponsorship note to be created
-            dupw.1 movup.5 movup.5 push.1 movdn.6
-            # => [note_idx, attachment_idx, FEE_ASSET_ID, is_create = 1, note_idx, num_output_notes,
-            #     FEE_ASSET_ID, total_sponsored_fee_amount]
-
-            exec.handle_network_note_sponsorship
-            # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount]
-
-            movup.7 add movdn.6
-            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
-        else
-            # do not sponsor non-network output notes
-            drop
-            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
-        end
-
-        add.1
-        # => [note_idx+1, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
-
-        dup.1 dup.1 neq
-        # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
-    end
-    # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount]
-
-    drop drop dropw
+    push.1 movdn.4 exec.handle_network_note_sponsorships swap drop
     # => [total_sponsored_fee_amount]
 end
 
 #! Estimates the FEE_SPONSORSHIP notes that this transaction's network output notes require.
 #!
-#! Walks the transaction's output notes exactly as `create_network_note_sponsorships` does and
-#! prices each network note through its target account's fee policy, but creates no note and moves
-#! nothing out of the vault. A note the target prices to zero needs no sponsorship note and so is
-#! counted in neither return value.
+#! Prices the network output notes exactly as `create_network_note_sponsorships` does, but creates
+#! no note and moves nothing out of the vault, so a caller can charge for those notes before it
+#! pays for them. A note the target prices to zero needs no sponsorship note and so is counted in
+#! neither return value.
 #!
 #! Inputs:  [FEE_ASSET_ID]
 #! Outputs: [total_sponsored_fee_amount, num_sponsorship_notes]
@@ -367,71 +316,7 @@ end
 #!
 #! Invocation: exec
 pub proc estimate_network_note_sponsorships(fee_asset_id: AssetId) -> (felt, felt)
-    push.0 movdn.4
-    # => [FEE_ASSET_ID, num_sponsorship_notes = 0]
-
-    push.0 movdn.4
-    # => [FEE_ASSET_ID, total_sponsored_fee_amount = 0, num_sponsorship_notes]
-
-    exec.tx::get_num_output_notes
-    # => [num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes]
-
-    push.0
-    # => [note_idx = 0, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-    #     num_sponsorship_notes]
-
-    dup.1 dup.1 neq
-    # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-    #     num_sponsorship_notes]
-
-    while.true
-        # only network output notes are sponsored
-        dup exec.is_network_note
-        # => [is_network_note, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
-        #     total_sponsored_fee_amount, num_sponsorship_notes]
-
-        if.true
-            dup.1
-            # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount, num_sponsorship_notes]
-
-            # pass a copy of the expected fee asset ID along with the note parameters, and ask for
-            # the note to only be priced
-            dupw.1 movup.5 movup.5 push.0 movdn.6
-            # => [note_idx, attachment_idx, FEE_ASSET_ID, is_create = 0, note_idx, num_output_notes,
-            #     FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes]
-
-            exec.handle_network_note_sponsorship
-            # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount, num_sponsorship_notes]
-
-            # a note priced to zero is sponsored by no note
-            dup neq.0 movup.9 add movdn.8
-            # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount, num_sponsorship_notes]
-
-            movup.7 add movdn.6
-            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-            #     num_sponsorship_notes]
-        else
-            # do not sponsor non-network output notes
-            drop
-            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-            #     num_sponsorship_notes]
-        end
-
-        add.1
-        # => [note_idx+1, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-        #     num_sponsorship_notes]
-
-        dup.1 dup.1 neq
-        # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-        #     num_sponsorship_notes]
-    end
-    # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-    #     num_sponsorship_notes]
-
-    drop drop dropw
+    push.0 movdn.4 exec.handle_network_note_sponsorships
     # => [total_sponsored_fee_amount, num_sponsorship_notes]
 end
 
@@ -699,13 +584,105 @@ proc is_network_note(note_idx: u16) -> (Bool, u8)
     # => [is_found, attachment_idx]
 end
 
+#! Walks the transaction's output notes and prices every network note through its target account's
+#! fee policy, creating its FEE_SPONSORSHIP note along the way when asked to.
+#!
+#! Backs `create_network_note_sponsorships` (is_create = 1) and
+#! `estimate_network_note_sponsorships` (is_create = 0); see those for the full behaviour.
+#!
+#! Inputs:  [FEE_ASSET_ID, is_create]
+#! Outputs: [total_sponsored_fee_amount, num_sponsorship_notes]
+#!
+#! Where:
+#! - FEE_ASSET_ID is the ID of the asset the sponsorship notes are funded with.
+#! - is_create is 1 to create the sponsorship notes, 0 to only price them.
+#! - total_sponsored_fee_amount is the total amount the sponsorship notes carry.
+#! - num_sponsorship_notes is the number of network notes priced above zero, i.e. of sponsorship
+#!   notes created or to be created.
+#!
+#! Panics if:
+#! - handle_network_note_sponsorship panics for a network output note.
+#!
+#! Invocation: exec
+proc handle_network_note_sponsorships(fee_asset_id: AssetId, is_create: Bool) -> (felt, felt)
+    push.0 movdn.4
+    # => [FEE_ASSET_ID, num_sponsorship_notes = 0, is_create]
+
+    push.0 movdn.4
+    # => [FEE_ASSET_ID, total_sponsored_fee_amount = 0, num_sponsorship_notes, is_create]
+
+    # get the output note count before any sponsorship notes are created, since creating them
+    # increments the count
+    exec.tx::get_num_output_notes
+    # => [num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes,
+    #     is_create]
+
+    push.0
+    # => [note_idx = 0, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+    #     num_sponsorship_notes, is_create]
+
+    dup.1 dup.1 neq
+    # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+    #     num_sponsorship_notes, is_create]
+
+    while.true
+        # only network output notes are sponsored
+        dup exec.is_network_note
+        # => [is_network_note, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
+        #     total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+
+        if.true
+            dup.1
+            # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+
+            # pass a copy of the expected fee asset ID and of the create flag along with the note
+            # parameters
+            dupw.1 movup.5 movup.5 dup.14 movdn.6
+            # => [note_idx, attachment_idx, FEE_ASSET_ID, is_create, note_idx, num_output_notes,
+            #     FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+
+            exec.handle_network_note_sponsorship
+            # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+
+            # a note priced to zero is sponsored by no note
+            dup neq.0 movup.9 add movdn.8
+            # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+
+            movup.7 add movdn.6
+            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+            #     num_sponsorship_notes, is_create]
+        else
+            # do not sponsor non-network output notes
+            drop
+            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+            #     num_sponsorship_notes, is_create]
+        end
+
+        add.1
+        # => [note_idx+1, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+        #     num_sponsorship_notes, is_create]
+
+        dup.1 dup.1 neq
+        # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+        #     num_sponsorship_notes, is_create]
+    end
+    # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+    #     num_sponsorship_notes, is_create]
+
+    drop drop dropw movup.2 drop
+    # => [total_sponsored_fee_amount, num_sponsorship_notes]
+end
+
 #! Prices the network output note at the given index and, when asked to, creates its
 #! FEE_SPONSORSHIP note.
 #!
-#! See [`create_network_note_sponsorships`] for the full behaviour; this procedure handles a single
-#! network note. A network note the target account prices to zero needs no sponsorship note, so
-#! none is created for it. When is_create is 0 the note is only priced: the vault and the output
-#! notes are left untouched.
+#! Handles a single network note for `create_network_note_sponsorships` (is_create = 1) and
+#! `estimate_network_note_sponsorships` (is_create = 0); see those for the full behaviour. A network
+#! note the target account prices to zero needs no sponsorship note, so none is created for it.
+#! When is_create is 0 the note is only priced: the vault and the output notes are left untouched.
 #!
 #! Inputs:  [note_idx, attachment_idx, EXPECTED_FEE_ASSET_ID, is_create]
 #! Outputs: [sponsored_fee_amount]

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -65,7 +65,7 @@ const WORD_ALIGNMENT_MASK = 0xFFFFFFFC
 const SPONSORSHIP_STORAGE_LOC = 0
 const SPONSORSHIP_FEATURE_NOTE_ID_LOC = SPONSORSHIP_STORAGE_LOC + FEATURE_NOTE_ID_ITEM_OFFSET
 
-# Local memory offset at which `handle_network_note_sponsorship` caches the expected fee asset ID.
+# Local memory offset at which `process_network_note_sponsorship` caches the expected fee asset ID.
 const EXPECTED_FEE_ASSET_ID_LOC = 0
 
 # Local memory offsets used by `compute_sponsorship_fee` (in its own local frame).
@@ -287,7 +287,7 @@ end
 #!
 #! Invocation: exec
 pub proc create_network_note_sponsorships(fee_asset_id: AssetId) -> felt
-    push.1 movdn.4 exec.handle_network_note_sponsorships swap drop
+    push.1 movdn.4 exec.process_network_note_sponsorships swap drop
     # => [total_sponsored_fee_amount]
 end
 
@@ -316,7 +316,7 @@ end
 #!
 #! Invocation: exec
 pub proc estimate_network_note_sponsorships(fee_asset_id: AssetId) -> (felt, felt)
-    push.0 movdn.4 exec.handle_network_note_sponsorships
+    push.0 movdn.4 exec.process_network_note_sponsorships
     # => [total_sponsored_fee_amount, num_sponsorship_notes]
 end
 
@@ -587,90 +587,90 @@ end
 #! Walks the transaction's output notes and prices every network note through its target account's
 #! fee policy, creating its FEE_SPONSORSHIP note along the way when asked to.
 #!
-#! Backs `create_network_note_sponsorships` (is_create = 1) and
-#! `estimate_network_note_sponsorships` (is_create = 0); see those for the full behaviour.
+#! Backs `create_network_note_sponsorships` (create_notes = 1) and
+#! `estimate_network_note_sponsorships` (create_notes = 0); see those for the full behaviour.
 #!
-#! Inputs:  [FEE_ASSET_ID, is_create]
+#! Inputs:  [FEE_ASSET_ID, create_notes]
 #! Outputs: [total_sponsored_fee_amount, num_sponsorship_notes]
 #!
 #! Where:
 #! - FEE_ASSET_ID is the ID of the asset the sponsorship notes are funded with.
-#! - is_create is 1 to create the sponsorship notes, 0 to only price them.
+#! - create_notes is 1 to create the sponsorship notes, 0 to only price them.
 #! - total_sponsored_fee_amount is the total amount the sponsorship notes carry.
 #! - num_sponsorship_notes is the number of network notes priced above zero, i.e. of sponsorship
 #!   notes created or to be created.
 #!
 #! Panics if:
-#! - handle_network_note_sponsorship panics for a network output note.
+#! - process_network_note_sponsorship panics for a network output note.
 #!
 #! Invocation: exec
-proc handle_network_note_sponsorships(fee_asset_id: AssetId, is_create: Bool) -> (felt, felt)
+proc process_network_note_sponsorships(fee_asset_id: AssetId, create_notes: Bool) -> (felt, felt)
     push.0 movdn.4
-    # => [FEE_ASSET_ID, num_sponsorship_notes = 0, is_create]
+    # => [FEE_ASSET_ID, num_sponsorship_notes = 0, create_notes]
 
     push.0 movdn.4
-    # => [FEE_ASSET_ID, total_sponsored_fee_amount = 0, num_sponsorship_notes, is_create]
+    # => [FEE_ASSET_ID, total_sponsored_fee_amount = 0, num_sponsorship_notes, create_notes]
 
     # get the output note count before any sponsorship notes are created, since creating them
     # increments the count
     exec.tx::get_num_output_notes
     # => [num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes,
-    #     is_create]
+    #     create_notes]
 
     push.0
     # => [note_idx = 0, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-    #     num_sponsorship_notes, is_create]
+    #     num_sponsorship_notes, create_notes]
 
     dup.1 dup.1 neq
     # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-    #     num_sponsorship_notes, is_create]
+    #     num_sponsorship_notes, create_notes]
 
     while.true
         # only network output notes are sponsored
         dup exec.is_network_note
         # => [is_network_note, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
-        #     total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+        #     total_sponsored_fee_amount, num_sponsorship_notes, create_notes]
 
         if.true
             dup.1
             # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+            #     total_sponsored_fee_amount, num_sponsorship_notes, create_notes]
 
             # pass a copy of the expected fee asset ID and of the create flag along with the note
             # parameters
             dupw.1 movup.5 movup.5 dup.14 movdn.6
-            # => [note_idx, attachment_idx, FEE_ASSET_ID, is_create, note_idx, num_output_notes,
-            #     FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+            # => [note_idx, attachment_idx, FEE_ASSET_ID, create_notes, note_idx, num_output_notes,
+            #     FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes, create_notes]
 
-            exec.handle_network_note_sponsorship
+            exec.process_network_note_sponsorship
             # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+            #     total_sponsored_fee_amount, num_sponsorship_notes, create_notes]
 
             # a note priced to zero is sponsored by no note
             dup neq.0 movup.9 add movdn.8
             # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
-            #     total_sponsored_fee_amount, num_sponsorship_notes, is_create]
+            #     total_sponsored_fee_amount, num_sponsorship_notes, create_notes]
 
             movup.7 add movdn.6
             # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-            #     num_sponsorship_notes, is_create]
+            #     num_sponsorship_notes, create_notes]
         else
             # do not sponsor non-network output notes
             drop
             # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-            #     num_sponsorship_notes, is_create]
+            #     num_sponsorship_notes, create_notes]
         end
 
         add.1
         # => [note_idx+1, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-        #     num_sponsorship_notes, is_create]
+        #     num_sponsorship_notes, create_notes]
 
         dup.1 dup.1 neq
         # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-        #     num_sponsorship_notes, is_create]
+        #     num_sponsorship_notes, create_notes]
     end
     # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
-    #     num_sponsorship_notes, is_create]
+    #     num_sponsorship_notes, create_notes]
 
     drop drop dropw movup.2 drop
     # => [total_sponsored_fee_amount, num_sponsorship_notes]
@@ -679,19 +679,20 @@ end
 #! Prices the network output note at the given index and, when asked to, creates its
 #! FEE_SPONSORSHIP note.
 #!
-#! Handles a single network note for `create_network_note_sponsorships` (is_create = 1) and
-#! `estimate_network_note_sponsorships` (is_create = 0); see those for the full behaviour. A network
-#! note the target account prices to zero needs no sponsorship note, so none is created for it.
-#! When is_create is 0 the note is only priced: the vault and the output notes are left untouched.
+#! Handles a single network note for `create_network_note_sponsorships` (create_notes = 1) and
+#! `estimate_network_note_sponsorships` (create_notes = 0); see those for the full behaviour. A
+#! network note the target account prices to zero needs no sponsorship note, so none is created for
+#! it. When create_notes is 0 the note is only priced: the vault and the output notes are left
+#! untouched.
 #!
-#! Inputs:  [note_idx, attachment_idx, EXPECTED_FEE_ASSET_ID, is_create]
+#! Inputs:  [note_idx, attachment_idx, EXPECTED_FEE_ASSET_ID, create_notes]
 #! Outputs: [sponsored_fee_amount]
 #!
 #! Where:
 #! - note_idx is the index of the network output note to sponsor.
 #! - attachment_idx is the index of the note's network account target attachment.
 #! - EXPECTED_FEE_ASSET_ID is the ID of the asset the sponsorship note must be funded with.
-#! - is_create is 1 to create the sponsorship note, 0 to only price it.
+#! - create_notes is 1 to create the sponsorship note, 0 to only price it.
 #! - sponsored_fee_amount is the amount the sponsorship note carries, or zero if the target prices
 #!   the note to zero and so it needs none.
 #!
@@ -701,31 +702,31 @@ end
 #!   or does not hash to the recipient.
 #! - the target account's active fee policy is not set.
 #! - the target account charges a non-zero fee in an asset other than the expected fee asset.
-#! - is_create is 1 and the native account's vault does not hold enough of the fee asset.
+#! - create_notes is 1 and the native account's vault does not hold enough of the fee asset.
 #!
 #! Invocation: exec
 @locals(4)
-proc handle_network_note_sponsorship(
+proc process_network_note_sponsorship(
     note_idx: u16,
     attachment_idx: u8,
     expected_fee_asset_id: AssetId,
-    is_create: Bool
+    create_notes: Bool
 ) -> felt
     # cache the expected fee asset ID for the target fee asset check
     movdn.5 movdn.5 loc_storew_le.EXPECTED_FEE_ASSET_ID_LOC dropw
-    # => [note_idx, attachment_idx, is_create]
+    # => [note_idx, attachment_idx, create_notes]
 
     dup movdn.3
-    # => [note_idx, attachment_idx, is_create, note_idx]
+    # => [note_idx, attachment_idx, create_notes, note_idx]
 
     exec.compute_sponsorship_fee
-    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, is_create, note_idx]
+    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, create_notes, note_idx]
 
     exec.fungible_asset::to_amount
-    # => [fee_amount, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, is_create, note_idx]
+    # => [fee_amount, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, create_notes, note_idx]
 
     movdn.11 dup.11 eq.0
-    # => [is_zero_fee, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, is_create, note_idx,
+    # => [is_zero_fee, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, create_notes, note_idx,
     #     fee_amount]
 
     if.true
@@ -736,10 +737,10 @@ proc handle_network_note_sponsorship(
         # reject a target whose fee asset differs from the expected fee asset
         dupw padw loc_loadw_le.EXPECTED_FEE_ASSET_ID_LOC exec.word::eq
         assert.err=ERR_FEE_MANAGER_TARGET_FEE_ASSET_MISMATCH
-        # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, is_create, note_idx, fee_amount]
+        # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, create_notes, note_idx, fee_amount]
 
         movup.9
-        # => [is_create, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx, fee_amount]
+        # => [create_notes, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, note_idx, fee_amount]
 
         if.true
             exec.create_sponsorship_note

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -8,6 +8,9 @@
 #
 # `create_network_note_sponsorships` walks the transaction's output notes and, for every note targeted at a
 # network account, creates a paired FEE_SPONSORSHIP note funded with the fee that account charges.
+#
+# `estimate_network_note_sponsorships` walks the same notes and prices them the same way, but creates
+# nothing, so a caller can charge for those notes before it pays for them.
 
 use miden::core::word
 use miden::core::crypto::hashes::poseidon2
@@ -338,6 +341,98 @@ pub proc create_network_note_sponsorships(fee_asset_id: AssetId) -> felt
     # => [total_sponsored_fee_amount]
 end
 
+#! Estimates the FEE_SPONSORSHIP notes that this transaction's network output notes require.
+#!
+#! Walks the transaction's output notes exactly as `create_network_note_sponsorships` does and
+#! prices each network note through its target account's fee policy, but creates no note and moves
+#! nothing out of the vault. A note the target prices to zero needs no sponsorship note and so is
+#! counted in neither return value.
+#!
+#! Inputs:  [FEE_ASSET_ID]
+#! Outputs: [total_sponsored_fee_amount, num_sponsorship_notes]
+#!
+#! Where:
+#! - FEE_ASSET_ID is the ID of the asset the sponsorship notes are funded with, typically read
+#!   from the fee manager's fee asset ID slot.
+#! - total_sponsored_fee_amount is the total amount those notes will carry.
+#! - num_sponsorship_notes is the number of notes `create_network_note_sponsorships` will create.
+#!
+#! Panics if:
+#! - a network output note's target ID attachment does not consist of exactly one word.
+#! - the target account's fee policy requires a network output note's recipient preimage and it
+#!   is unavailable or does not hash to the recipient.
+#! - the target account's active fee policy is not set.
+#! - a target account charges a non-zero fee in an asset other than the expected fee asset.
+#!
+#! Invocation: exec
+pub proc estimate_network_note_sponsorships(fee_asset_id: AssetId) -> (felt, felt)
+    push.0 movdn.4
+    # => [FEE_ASSET_ID, num_sponsorship_notes = 0]
+
+    push.0 movdn.4
+    # => [FEE_ASSET_ID, total_sponsored_fee_amount = 0, num_sponsorship_notes]
+
+    exec.tx::get_num_output_notes
+    # => [num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount, num_sponsorship_notes]
+
+    push.0
+    # => [note_idx = 0, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+    #     num_sponsorship_notes]
+
+    dup.1 dup.1 neq
+    # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+    #     num_sponsorship_notes]
+
+    while.true
+        # only network output notes are sponsored
+        dup exec.is_network_note
+        # => [is_network_note, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
+        #     total_sponsored_fee_amount, num_sponsorship_notes]
+
+        if.true
+            dup.1
+            # => [note_idx, attachment_idx, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount, num_sponsorship_notes]
+
+            # pass a copy of the expected fee asset ID along with the note parameters
+            dupw.1 movup.5 movup.5
+            # => [note_idx, attachment_idx, FEE_ASSET_ID, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount, num_sponsorship_notes]
+
+            exec.estimate_network_note_sponsorship
+            # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount, num_sponsorship_notes]
+
+            # a note priced to zero is sponsored by no note
+            dup neq.0 movup.9 add movdn.8
+            # => [sponsored_fee_amount, note_idx, num_output_notes, FEE_ASSET_ID,
+            #     total_sponsored_fee_amount, num_sponsorship_notes]
+
+            movup.7 add movdn.6
+            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+            #     num_sponsorship_notes]
+        else
+            # do not sponsor non-network output notes
+            drop
+            # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+            #     num_sponsorship_notes]
+        end
+
+        add.1
+        # => [note_idx+1, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+        #     num_sponsorship_notes]
+
+        dup.1 dup.1 neq
+        # => [should_loop, note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+        #     num_sponsorship_notes]
+    end
+    # => [note_idx, num_output_notes, FEE_ASSET_ID, total_sponsored_fee_amount,
+    #     num_sponsorship_notes]
+
+    drop drop dropw
+    # => [total_sponsored_fee_amount, num_sponsorship_notes]
+end
+
 # HELPER PROCEDURES
 # =================================================================================================
 
@@ -661,6 +756,60 @@ proc create_network_note_sponsorship(
         exec.create_sponsorship_note
         # => [fee_amount]
     end
+end
+
+#! Prices the network output note at the given index without creating its FEE_SPONSORSHIP note.
+#!
+#! The estimation twin of `create_network_note_sponsorship`: it prices the note through the same
+#! fee policy call and applies the same fee asset check, but leaves the vault and the output notes
+#! untouched.
+#!
+#! Inputs:  [note_idx, attachment_idx, EXPECTED_FEE_ASSET_ID]
+#! Outputs: [sponsored_fee_amount]
+#!
+#! Where:
+#! - note_idx is the index of the network output note to price.
+#! - attachment_idx is the index of the note's network account target attachment.
+#! - EXPECTED_FEE_ASSET_ID is the ID of the asset the sponsorship note must be funded with.
+#! - sponsored_fee_amount is the amount the note's sponsorship note will carry, or zero if the
+#!   target prices it to zero and so needs none.
+#!
+#! Panics if:
+#! - the note's target ID attachment does not consist of exactly one word.
+#! - the target account's fee policy requires the note's recipient preimage and it is unavailable
+#!   or does not hash to the recipient.
+#! - the target account's active fee policy is not set.
+#! - the target account charges a non-zero fee in an asset other than the expected fee asset.
+#!
+#! Invocation: exec
+@locals(4)
+proc estimate_network_note_sponsorship(
+    note_idx: u16,
+    attachment_idx: u8,
+    expected_fee_asset_id: AssetId
+) -> felt
+    # cache the expected fee asset ID for the target fee asset check
+    movdn.5 movdn.5 loc_storew_le.EXPECTED_FEE_ASSET_ID_LOC dropw
+    # => [note_idx, attachment_idx]
+
+    exec.compute_sponsorship_fee
+    # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix]
+
+    exec.fungible_asset::to_amount
+    # => [fee_amount, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix]
+
+    movdn.9 dup.9 neq.0
+    # => [is_sponsored, FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, fee_amount]
+
+    if.true
+        # reject a target whose fee asset differs from the expected fee asset
+        dupw padw loc_loadw_le.EXPECTED_FEE_ASSET_ID_LOC exec.word::eq
+        assert.err=ERR_FEE_MANAGER_TARGET_FEE_ASSET_MISMATCH
+        # => [FEE_ASSET_ID, FEE_ASSET_VALUE, target_id_prefix, fee_amount]
+    end
+
+    dropw dropw drop
+    # => [fee_amount]
 end
 
 #! Computes the fee the target network account charges for the output note at the given index.

--- a/crates/miden-standards/src/note/costs/table.rs
+++ b/crates/miden-standards/src/note/costs/table.rs
@@ -2,54 +2,54 @@
 // Values are maxima across the benchmarked paths; see `miden_standards::note::costs` for the
 // caveats on what they do and do not cover.
 
-/// Cycles of consuming a P2ID note: 1 asset 18463, 16 assets 57181 (maximum).
-pub const P2ID_CONSUMPTION_CYCLES: u32 = 57181;
+/// Cycles of consuming a P2ID note: 1 asset 18907, 16 assets 57970 (maximum).
+pub const P2ID_CONSUMPTION_CYCLES: u32 = 57970;
 
-/// Cycles of consuming a P2IDE note: claim 18588, claim with 16 assets 57306 (maximum), reclaim
-/// 18743.
-pub const P2IDE_CONSUMPTION_CYCLES: u32 = 57306;
+/// Cycles of consuming a P2IDE note: claim 19032, claim with 16 assets 58095 (maximum), reclaim
+/// 19187.
+pub const P2IDE_CONSUMPTION_CYCLES: u32 = 58095;
 
-/// Cycles of consuming a SWAP note: public payback 22504 (maximum), private payback 21990.
-pub const SWAP_CONSUMPTION_CYCLES: u32 = 22504;
+/// Cycles of consuming a SWAP note: public payback 23213 (maximum), private payback 22699.
+pub const SWAP_CONSUMPTION_CYCLES: u32 = 23213;
 
-/// Cycles of consuming a PSWAP note: full fill 25034, partial fill 28989 (maximum).
-pub const PSWAP_CONSUMPTION_CYCLES: u32 = 28989;
+/// Cycles of consuming a PSWAP note: full fill 25743, partial fill 29942 (maximum).
+pub const PSWAP_CONSUMPTION_CYCLES: u32 = 29942;
 
-/// Cycles of consuming a MINT note: fungible faucet 31783, non-fungible faucet 34662 (maximum).
-pub const MINT_CONSUMPTION_CYCLES: u32 = 34662;
+/// Cycles of consuming a MINT note: fungible faucet 32747, non-fungible faucet 35637 (maximum).
+pub const MINT_CONSUMPTION_CYCLES: u32 = 35637;
 
 /// Cycles of consuming a BURN note (single benchmarked path).
-pub const BURN_CONSUMPTION_CYCLES: u32 = 28445;
+pub const BURN_CONSUMPTION_CYCLES: u32 = 29040;
 
 /// Cycles of consuming a CONSTANT_FEE_POLICY_CONFIG note (single benchmarked path).
-pub const CONSTANT_FEE_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 19800;
+pub const CONSTANT_FEE_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 20316;
 
 /// Cycles of consuming a FAUCET_POLICY_CONFIG note (single benchmarked path).
-pub const FAUCET_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 28369;
+pub const FAUCET_POLICY_CONFIG_CONSUMPTION_CYCLES: u32 = 28896;
 
 /// Cycles of consuming a FAUCET_METADATA_CONFIG note (single benchmarked path).
-pub const FAUCET_METADATA_CONFIG_CONSUMPTION_CYCLES: u32 = 27190;
+pub const FAUCET_METADATA_CONFIG_CONSUMPTION_CYCLES: u32 = 27862;
 
 /// Cycles of consuming a MIN_BURN_AMOUNT_CONFIG note (single benchmarked path).
-pub const MIN_BURN_AMOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 25943;
+pub const MIN_BURN_AMOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 26207;
 
 /// Cycles of consuming an ALLOWLIST_CONFIG note (single benchmarked path).
-pub const ALLOWLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 26477;
+pub const ALLOWLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 26957;
 
 /// Cycles of consuming a BLOCKLIST_CONFIG note (single benchmarked path).
-pub const BLOCKLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 26477;
+pub const BLOCKLIST_CONFIG_CONSUMPTION_CYCLES: u32 = 26957;
 
 /// Cycles of consuming a PAUSE_CONFIG note (single benchmarked path).
-pub const PAUSE_CONFIG_CONSUMPTION_CYCLES: u32 = 18427;
+pub const PAUSE_CONFIG_CONSUMPTION_CYCLES: u32 = 18907;
 
 /// Cycles of consuming an OWNER_CONFIG note (single benchmarked path).
-pub const OWNER_CONFIG_CONSUMPTION_CYCLES: u32 = 18021;
+pub const OWNER_CONFIG_CONSUMPTION_CYCLES: u32 = 18501;
 
 /// Cycles of consuming an RBAC_CONFIG note (single benchmarked path).
-pub const RBAC_CONFIG_CONSUMPTION_CYCLES: u32 = 21283;
+pub const RBAC_CONFIG_CONSUMPTION_CYCLES: u32 = 21804;
 
 /// Cycles of consuming a NETWORK_ACCOUNT_CONFIG note (single benchmarked path).
-pub const NETWORK_ACCOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 18921;
+pub const NETWORK_ACCOUNT_CONFIG_CONSUMPTION_CYCLES: u32 = 19401;
 
 /// Cycles of consuming a FEE_SPONSORSHIP note (single benchmarked path).
-pub const FEE_SPONSORSHIP_CONSUMPTION_CYCLES: u32 = 21257;
+pub const FEE_SPONSORSHIP_CONSUMPTION_CYCLES: u32 = 21727;

--- a/crates/miden-testing/tests/auth/fee_payment/sponsorship.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/sponsorship.rs
@@ -8,7 +8,7 @@ use miden_protocol::asset::{Asset, AssetAmount, AssetId, FungibleAsset};
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::note::{Note, NoteScriptRoot, NoteTag, NoteType, PartialNote};
 use miden_protocol::testing::account_id::ACCOUNT_ID_FEE_FAUCET;
-use miden_protocol::transaction::RawOutputNote;
+use miden_protocol::transaction::{ExecutedTransaction, RawOutputNote};
 use miden_standards::account::auth::{
     AuthNetworkAccount,
     FeeConversionInfo,
@@ -108,14 +108,18 @@ fn p2id_network_note(
         .into())
 }
 
-// TESTS
-// ================================================================================================
+/// Returns whether the output note is a FEE_SPONSORSHIP note.
+fn is_sponsorship_note(note: &RawOutputNote) -> bool {
+    note.recipient().map(|recipient| recipient.script().root())
+        == Some(FeeSponsorshipNote::script_root())
+}
 
-/// When a fee-paying account creates a network output note, `pay_fee` sponsors it: a
-/// FEE_SPONSORSHIP note funded from the creator's vault is emitted alongside the network note,
-/// carrying exactly the fee the target account's policy prices the note at.
-#[tokio::test]
-async fn pay_fee_sponsors_network_output_note() -> anyhow::Result<()> {
+/// Has a signing wallet send a P2ID network note to a network account that prices the P2ID script
+/// root at `target_fee`, paying its fee through `pay_fee`. Returns the executed transaction, the
+/// network note it created and the target's ID.
+async fn send_network_note(
+    target_fee: u64,
+) -> anyhow::Result<(ExecutedTransaction, Note, AccountId)> {
     let mut rng = RandomCoin::new(Word::from([1u32, 2, 3, 4]));
     // a payload asset issued by a faucet other than the fee faucet, carried by the network note
     let payload_asset: Asset = FungibleAsset::mock(50);
@@ -129,11 +133,11 @@ async fn pay_fee_sponsors_network_output_note() -> anyhow::Result<()> {
         [fee_asset(1_000_000)?, payload_asset],
     )?;
 
-    // the target network account prices the P2ID script root at FEE_AMOUNT
+    // the target network account prices the P2ID script root at target_fee
     let target = network_account(
         [2; 32],
         [P2idNote::script_root(), FeeSponsorshipNote::script_root()],
-        &[(P2idNote::script_root(), FEE_AMOUNT)],
+        &[(P2idNote::script_root(), target_fee)],
         [],
         SponsorshipPolicy::default(),
     )?;
@@ -163,6 +167,19 @@ async fn pay_fee_sponsors_network_output_note() -> anyhow::Result<()> {
         .execute()
         .await?;
 
+    Ok((executed, network_note, target.id()))
+}
+
+// TESTS
+// ================================================================================================
+
+/// When a fee-paying account creates a network output note, `pay_fee` sponsors it: a
+/// FEE_SPONSORSHIP note funded from the creator's vault is emitted alongside the network note,
+/// carrying exactly the fee the target account's policy prices the note at.
+#[tokio::test]
+async fn pay_fee_sponsors_network_output_note() -> anyhow::Result<()> {
+    let (executed, network_note, target_id) = send_network_note(FEE_AMOUNT).await?;
+
     // three output notes: the network note, its sponsorship note, and the sponsor's fee note
     let output_notes = executed.output_notes();
     assert_eq!(output_notes.num_notes(), 3);
@@ -178,14 +195,11 @@ async fn pay_fee_sponsors_network_output_note() -> anyhow::Result<()> {
     // target network account
     let sponsorship = output_notes
         .iter()
-        .find(|note| {
-            note.recipient().map(|recipient| recipient.script().root())
-                == Some(FeeSponsorshipNote::script_root())
-        })
+        .find(|note| is_sponsorship_note(note))
         .expect("a sponsorship note should be created for the network note");
     let sponsorship_assets: Vec<Asset> = sponsorship.assets().iter().copied().collect();
     assert_eq!(sponsorship_assets, vec![fee_asset(FEE_AMOUNT)?]);
-    assert_eq!(sponsorship.metadata().tag(), NoteTag::with_account_target(target.id()));
+    assert_eq!(sponsorship.metadata().tag(), NoteTag::with_account_target(target_id));
 
     // the sponsor still pays its own fee, and the paid amount covers the fee required for the
     // transaction including the sponsorship note it just created
@@ -203,6 +217,25 @@ async fn pay_fee_sponsors_network_output_note() -> anyhow::Result<()> {
         paid.amount(),
         executed.compute_fee(),
     );
+
+    Ok(())
+}
+
+/// A network note priced to zero by its target needs no sponsorship: `pay_fee` creates no
+/// FEE_SPONSORSHIP note for it and still pays the sponsor's own fee.
+#[tokio::test]
+async fn pay_fee_does_not_sponsor_network_note_priced_to_zero() -> anyhow::Result<()> {
+    let (executed, network_note, _) = send_network_note(0).await?;
+
+    // two output notes: the network note and the sponsor's fee note
+    let output_notes = executed.output_notes();
+    assert_eq!(output_notes.num_notes(), 2);
+    assert_eq!(output_notes.get_note(0).id(), network_note.id());
+    assert!(
+        output_notes.iter().all(|note| !is_sponsorship_note(note)),
+        "a network note priced to zero should not be sponsored",
+    );
+    assert_eq!(output_notes.get_note(1).metadata().tag(), TxFeeNote::TAG);
 
     Ok(())
 }
@@ -256,10 +289,7 @@ async fn network_account_collects_sponsored_fee_single_hop() -> anyhow::Result<(
     let sponsorship_id = creation_tx
         .output_notes()
         .iter()
-        .find(|note| {
-            note.recipient().map(|recipient| recipient.script().root())
-                == Some(FeeSponsorshipNote::script_root())
-        })
+        .find(|note| is_sponsorship_note(note))
         .expect("a sponsorship note should be created")
         .id();
 
@@ -374,10 +404,7 @@ async fn spawned_network_note_sponsored_by_a_and_collected_by_b_multi_hop() -> a
     let sponsorship_id = spawn_tx
         .output_notes()
         .iter()
-        .find(|note| {
-            note.recipient().map(|recipient| recipient.script().root())
-                == Some(FeeSponsorshipNote::script_root())
-        })
+        .find(|note| is_sponsorship_note(note))
         .expect("A should sponsor the spawned note")
         .id();
 

--- a/crates/miden-testing/tests/auth/fee_payment/sponsorship.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/sponsorship.rs
@@ -110,8 +110,8 @@ fn p2id_network_note(
 
 /// Returns whether the output note is a FEE_SPONSORSHIP note.
 fn is_sponsorship_note(note: &RawOutputNote) -> bool {
-    note.recipient().map(|recipient| recipient.script().root())
-        == Some(FeeSponsorshipNote::script_root())
+    note.recipient()
+        .is_some_and(|recipient| recipient.script().root() == FeeSponsorshipNote::script_root())
 }
 
 /// Has a signing wallet send a P2ID network note to a network account that prices the P2ID script

--- a/crates/miden-testing/tests/scripts/fee_collection.rs
+++ b/crates/miden-testing/tests/scripts/fee_collection.rs
@@ -1256,11 +1256,23 @@ async fn sponsors_and_collects_multiple_notes() -> anyhow::Result<()> {
 // SPONSORSHIP POLICY
 // ================================================================================================
 
-/// Under [`SponsorshipPolicy::AtMostCollectedFees`], a sponsorship that no collected fee backs is
-/// rejected.
+/// Under [`SponsorshipPolicy::AtMostCollectedFees`], sponsorships the collected fees do not cover
+/// are rejected: one that nothing backs, and two whose summed amount exceeds the one collected fee.
+/// The latter pins that the cap compares the summed amount: a total that collapsed to the number
+/// of sponsorship notes would pass it.
+#[rstest]
+// (network notes created, collected notes consumed)
+#[case::nothing_collected(1, 0)]
+#[case::one_of_two_covered(2, 1)]
 #[tokio::test]
-async fn sponsoring_more_than_collected_is_rejected() -> anyhow::Result<()> {
-    let test = SponsorshipTest::builder().build()?;
+async fn sponsoring_more_than_collected_is_rejected(
+    #[case] num_network_notes: u32,
+    #[case] num_collected_notes: u32,
+) -> anyhow::Result<()> {
+    let test = SponsorshipTest::builder()
+        .num_network_notes(num_network_notes)
+        .num_collected_notes(num_collected_notes)
+        .build()?;
 
     let result = test.transaction()?.execute().await;
 


### PR DESCRIPTION
Splits fee estimation out of `pay_fee` so callers can learn what a transaction will cost before deciding to pay it. Behaviour-preserving: `pay_fee`'s inputs, output, panics and computed fee are unchanged.

- `estimate_fee(num_extra_cycles) -> (fee_amount, total_sponsored_fee_amount)` owns everything up to and including the single `tx::compute_fee`.
- `pay_fee` now calls it, then runs the unchanged conversion and note-creation body.
- Network-note sponsorship stays *inside* `estimate_fee` — it creates output notes, so it must precede the estimate or the estimate is silently low.

First of a three-PR stack requested in #3758; on its own it adds no caller and changes no behaviour.

<details>
<summary>Why sponsorship lives in the estimate</summary>

`fees::create_network_note_sponsorships` creates output notes; `apply_cycle_margins` reads `tx::get_num_output_notes` and the kernel's `compute_fee` reads `clk`. If sponsorship stayed in `pay_fee`, a caller composing estimate → bound → pay by hand would get an estimate omitting its own sponsorship notes and underpay — failing at the batch builder rather than at execution. The cost is a proc named "estimate" with a side effect, which the doc comment leads with.
</details>

<details>
<summary>Verification</summary>

`cargo build -p miden-standards`, `cargo +nightly fmt --all --check`, and `cargo test -p miden-testing --test lib -- auth::` all clean. Test count is **122 passed on this branch and 122 on the base commit** — no test added, none broken, which is the check that matters for a refactor claiming to preserve behaviour.
</details>

**Reviewers:** the stack walk in `estimate_fee` is the part worth your time — `swap` replaces the original `movdn.5` at the same point, both one cycle, so `compute_fee` sees an unchanged `clk` and the fee is bit-identical.
