### PR TITLE
feat(standards): add fee::assert_fee_bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Added `fee::assert_fee_bound`, an opt-in helper a caller invokes between `fee::estimate_fee` and the payment to cap the payment at `num / den` times the computed fee and pin the payment asset to the transaction's fee faucet; `fee::pay_fee` applies no bound of its own, so the bound stays an application-level policy ([#3332](https://github.com/0xMiden/protocol/issues/3332)).
 - Added a genesis-only native fungible faucet factory that configures the faucet to pay fees in its own asset ([#3584](https://github.com/0xMiden/protocol/issues/3584)).
 - Added `note_costs` to the `NetworkNotePricer` builder, a supplied cost map that extends or shadows the built-in cost tables ([#3602](https://github.com/0xMiden/protocol/pull/3602)).
 - [BREAKING] AggLayer bridge and faucet accounts deploy with a priced fee policy and `ADMIN`-gated repricing; both code commitments change ([#3486](https://github.com/0xMiden/protocol/pull/3486)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Added `fee::assert_fee_bound`, an opt-in helper a caller invokes between `fee::estimate_fee` and the payment to cap the payment at `num / den` times the computed fee and pin the payment asset to the transaction's fee faucet; `fee::pay_fee` applies no bound of its own, so the bound stays an application-level policy ([#3332](https://github.com/0xMiden/protocol/issues/3332)).
+- Added `fee::assert_fee_bound`, an opt-in helper a caller invokes between `fee::estimate_fee` and the payment to cap the payment at `num / den` times the computed fee and pin the payment asset to the transaction's fee faucet ([#3332](https://github.com/0xMiden/protocol/issues/3332)).
 - Added a genesis-only native fungible faucet factory that configures the faucet to pay fees in its own asset ([#3584](https://github.com/0xMiden/protocol/issues/3584)).
 - Added `note_costs` to the `NetworkNotePricer` builder, a supplied cost map that extends or shadows the built-in cost tables ([#3602](https://github.com/0xMiden/protocol/pull/3602)).
 - [BREAKING] AggLayer bridge and faucet accounts deploy with a priced fee policy and `ADMIN`-gated repricing; both code commitments change ([#3486](https://github.com/0xMiden/protocol/pull/3486)).

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -250,17 +250,12 @@ pub proc convert_amount(amount: felt, rate: ConversionRate) -> felt
     # => [converted_amount]
 end
 
-#! Asserts that a fee payment is at most bound.num / bound.den times the computed fee, and returns
-#! the payment unchanged so it can be handed straight to the payment step.
+#! Asserts that a fee payment is at most bound times the computed fee.
 #!
-#! The bound is an application-level policy, so pay_fee does not apply one; the caller picks the
-#! fraction and invokes this between the fee estimate and the payment. It matters for callers whose
-#! authentication can be satisfied by less authority than an ordinary note transfer would need
-#! (the guarded multisig's guardian rotation path), where a host-supplied conversion rate would
-#! otherwise drain the vault through the fee note.
+#! The bound is an application-level policy; the caller picks the fraction and invokes this between
+#! the fee estimate and the payment.
 #!
-#! The payment faucet is pinned to the transaction's fee faucet, since the computed fee is
-#! denominated in the native fee asset and a payment in any other asset is not comparable to it.
+#! The payment faucet is pinned to the native fee asset.
 #!
 #! Inputs:  [bound_num, bound_den, payment_faucet_id_suffix, payment_faucet_id_prefix,
 #!           payment_amount, fee_amount]

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -289,8 +289,7 @@ pub proc assert_fee_bound(
     # => [fee_faucet_id_suffix, fee_faucet_id_prefix, bound_num, bound_den,
     #     payment_faucet_id_suffix, payment_faucet_id_prefix, payment_amount, fee_amount]
 
-    dup.4 assert_eq.err=ERR_FEE_PAYMENT_FAUCET_NOT_NATIVE
-    dup.4 assert_eq.err=ERR_FEE_PAYMENT_FAUCET_NOT_NATIVE
+    dup.5 dup.5 exec.account_id::eq assert.err=ERR_FEE_PAYMENT_FAUCET_NOT_NATIVE
     # => [bound_num, bound_den, payment_faucet_id_suffix, payment_faucet_id_prefix, payment_amount,
     #     fee_amount]
 

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -6,7 +6,7 @@ use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::protocol::output_note
 use miden::protocol::tx
-use {Asset} from miden::protocol::types
+use {AccountId, Asset} from miden::protocol::types
 use miden::standards::assets::fungible_asset
 use miden::standards::fees
 use miden::standards::notes::tx_fee
@@ -17,6 +17,9 @@ use miden::standards::notes::tx_fee
 #! A fee conversion rate, applied to an amount as ceil(amount * num / den). The numerator and
 #! denominator are arbitrary non-zero field elements.
 pub type ConversionRate = struct { num: felt, den: felt }
+
+#! An upper bound on a fee payment, expressed as the fraction num / den of the computed fee.
+pub type FeeBound = struct { num: felt, den: felt }
 
 #! Fee conversion info: the fungible faucet of the payment asset and the conversion rate from the
 #! native fee asset, laid out as [faucet_id_suffix, faucet_id_prefix, rate_num, rate_den].
@@ -80,6 +83,12 @@ const ERR_FEE_CONVERSION_RATE_DENOMINATOR_ZERO = "fee conversion rate denominato
 const ERR_FEE_CONVERSION_RATE_NUMERATOR_ZERO = "fee conversion rate numerator must be non-zero"
 
 const ERR_FEE_CONVERTED_AMOUNT_OVERFLOW = "converted fee amount does not fit into a fungible asset amount"
+
+const ERR_FEE_BOUND_DENOMINATOR_ZERO = "fee bound denominator must be non-zero"
+
+const ERR_FEE_PAYMENT_EXCEEDS_BOUND = "the fee payment exceeds the caller's bound on the computed fee"
+
+const ERR_FEE_PAYMENT_FAUCET_NOT_NATIVE = "the fee payment asset must be issued by the native fee faucet"
 
 # PROCEDURES
 # =================================================================================================
@@ -239,6 +248,69 @@ pub proc convert_amount(amount: felt, rate: ConversionRate) -> felt
     # recombine the limbs into a felt amount
     swap mul.U32_LIMB_MULTIPLIER add
     # => [converted_amount]
+end
+
+#! Asserts that a fee payment is at most bound.num / bound.den times the computed fee, and returns
+#! the payment unchanged so it can be handed straight to the payment step.
+#!
+#! The bound is an application-level policy, so pay_fee does not apply one; the caller picks the
+#! fraction and invokes this between the fee estimate and the payment. It matters for callers whose
+#! authentication can be satisfied by less authority than an ordinary note transfer would need
+#! (the guarded multisig's guardian rotation path), where a host-supplied conversion rate would
+#! otherwise drain the vault through the fee note.
+#!
+#! The payment faucet is pinned to the transaction's fee faucet, since the computed fee is
+#! denominated in the native fee asset and a payment in any other asset is not comparable to it.
+#!
+#! Inputs:  [bound_num, bound_den, payment_faucet_id_suffix, payment_faucet_id_prefix,
+#!           payment_amount, fee_amount]
+#! Outputs: [payment_faucet_id_suffix, payment_faucet_id_prefix, payment_amount]
+#!
+#! Where:
+#! - bound_num and bound_den are the numerator and denominator of the largest multiple of the
+#!   computed fee the caller accepts.
+#! - payment_faucet_id_{suffix,prefix} identify the faucet issuing the payment asset.
+#! - payment_amount is the amount about to be paid.
+#! - fee_amount is the fee computed by tx::compute_fee.
+#!
+#! Panics if:
+#! - bound_den is zero.
+#! - the payment faucet is not the transaction's fee faucet.
+#! - payment_amount exceeds fee_amount * bound_num / bound_den.
+#!
+#! Invocation: exec
+pub proc assert_fee_bound(
+    bound: FeeBound,
+    payment_faucet_id: AccountId,
+    payment_amount: felt,
+    fee_amount: felt,
+) -> (payment_faucet_id: AccountId, payment_amount: felt)
+    # a zero denominator would make the bound vacuous
+    dup.1 neq.0 assert.err=ERR_FEE_BOUND_DENOMINATOR_ZERO
+    # => [bound_num, bound_den, payment_faucet_id_suffix, payment_faucet_id_prefix, payment_amount,
+    #     fee_amount]
+
+    exec.tx::get_fee_faucet_id
+    # => [fee_faucet_id_suffix, fee_faucet_id_prefix, bound_num, bound_den,
+    #     payment_faucet_id_suffix, payment_faucet_id_prefix, payment_amount, fee_amount]
+
+    dup.4 assert_eq.err=ERR_FEE_PAYMENT_FAUCET_NOT_NATIVE
+    dup.4 assert_eq.err=ERR_FEE_PAYMENT_FAUCET_NOT_NATIVE
+    # => [bound_num, bound_den, payment_faucet_id_suffix, payment_faucet_id_prefix, payment_amount,
+    #     fee_amount]
+
+    # the bound holds iff payment_amount * bound_den <= fee_amount * bound_num; both sides are
+    # computed as 128-bit products, so the comparison is exact and cannot overflow
+    movup.5 u32split movup.2 u32split exec.u64::widening_mul
+    # => [max0, max1, max2, max3, bound_den, payment_faucet_id_suffix, payment_faucet_id_prefix,
+    #     payment_amount]
+
+    movup.4 u32split dup.8 u32split exec.u64::widening_mul
+    # => [paid0, paid1, paid2, paid3, max0, max1, max2, max3, payment_faucet_id_suffix,
+    #     payment_faucet_id_prefix, payment_amount]
+
+    swapw exec.u128::lte assert.err=ERR_FEE_PAYMENT_EXCEEDS_BOUND
+    # => [payment_faucet_id_suffix, payment_faucet_id_prefix, payment_amount]
 end
 
 #! Adds the internal cycle margins of a fee flow to the caller's estimate of remaining

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -2,6 +2,7 @@ use miden::core::crypto::hashes::poseidon2
 use miden::core::math::u64
 use miden::core::math::u128
 use miden::core::word
+use miden::protocol::account_id
 use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::protocol::output_note

--- a/crates/miden-testing/tests/auth/fee_payment/bound.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/bound.rs
@@ -1,0 +1,139 @@
+use miden_protocol::Word;
+use miden_protocol::account::AccountId;
+use miden_protocol::account::auth::AuthScheme;
+use miden_protocol::asset::FungibleAsset;
+use miden_protocol::testing::account_id::{
+    ACCOUNT_ID_FEE_FAUCET,
+    ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2,
+};
+use miden_standards::account::auth::{FeeConversionInfo, commit_fee_conversion_info};
+use miden_standards::code_builder::CodeBuilder;
+use miden_standards::errors::standards::{
+    ERR_FEE_BOUND_DENOMINATOR_ZERO,
+    ERR_FEE_PAYMENT_EXCEEDS_BOUND,
+    ERR_FEE_PAYMENT_FAUCET_NOT_NATIVE,
+};
+use miden_testing::{Auth, MockChain, assert_transaction_executor_error};
+use rstest::rstest;
+
+use super::VERIFICATION_BASE_FEE;
+
+/// Runs `fee::assert_fee_bound` inside a transaction script with the given inputs.
+async fn run_bound(
+    payment_faucet: AccountId,
+    payment_amount: u64,
+    fee_amount: u64,
+    bound_num: u64,
+    bound_den: u64,
+) -> anyhow::Result<Result<(), miden_tx::TransactionExecutorError>> {
+    let fee_faucet_id: AccountId = ACCOUNT_ID_FEE_FAUCET.try_into()?;
+    let fee_asset = FungibleAsset::new(fee_faucet_id, 1_000_000)?.into();
+
+    let mut builder = MockChain::builder().verification_base_fee(VERIFICATION_BASE_FEE);
+    let account = builder.add_existing_wallet_with_assets(
+        Auth::BasicAuth {
+            auth_scheme: AuthScheme::Falcon512Poseidon2,
+        },
+        [fee_asset],
+    )?;
+    let mock_chain = builder.build()?;
+
+    let src = format!(
+        r#"
+        use miden::standards::fee
+
+        @transaction_script
+        pub proc main
+            push.{fee_amount}.{payment_amount}
+            push.{prefix}.{suffix}
+            push.{bound_den}.{bound_num}
+            exec.fee::assert_fee_bound
+            # the payment must come back unchanged
+            push.{suffix} assert_eq
+            push.{prefix} assert_eq
+            push.{payment_amount} assert_eq
+        end
+        "#,
+        suffix = payment_faucet.suffix(),
+        prefix = payment_faucet.prefix().as_felt(),
+    );
+    let tx_script = CodeBuilder::default().compile_tx_script(&src)?;
+
+    let (args, advice_value) = commit_fee_conversion_info(
+        FeeConversionInfo::one_to_one(fee_faucet_id),
+        Word::from([9u32, 10, 11, 12]),
+    );
+
+    let result = mock_chain
+        .build_transaction(account.id())
+        .auth_args(args)
+        .add_advice_map_entry(args, advice_value)
+        .tx_script(tx_script)
+        .build()?
+        .execute()
+        .await;
+
+    Ok(result.map(|_| ()))
+}
+
+/// Payments at or below the bound are accepted; the boundary itself is inclusive.
+#[rstest]
+#[case::exact_one_to_one(100, 100, 1, 1)]
+#[case::exact_double(200, 100, 2, 1)]
+#[case::exact_three_halves(150, 100, 3, 2)]
+#[case::below_bound(1, 100, 2, 1)]
+#[case::zero_fee_zero_payment(0, 0, 2, 1)]
+// a naive u64 product would wrap 2^32 * 2^32 to zero and reject this
+#[case::wide_bound_product(1, 4294967296, 4294967296, 1)]
+#[tokio::test]
+async fn within_bound_passes(
+    #[case] paid: u64,
+    #[case] fee: u64,
+    #[case] num: u64,
+    #[case] den: u64,
+) -> anyhow::Result<()> {
+    let fee_faucet_id: AccountId = ACCOUNT_ID_FEE_FAUCET.try_into()?;
+    run_bound(fee_faucet_id, paid, fee, num, den)
+        .await?
+        .map_err(anyhow::Error::from)?;
+    Ok(())
+}
+
+/// Payments above the bound are rejected.
+#[rstest]
+#[case::one_over_double(201, 100, 2, 1)]
+#[case::one_over_three_halves(151, 100, 3, 2)]
+#[case::nonzero_payment_on_zero_fee(1, 0, 2, 1)]
+// a naive u64 product would wrap 2^32 * 2^32 to zero and accept this
+#[case::wide_payment_product(4294967296, 1, 1, 4294967296)]
+#[tokio::test]
+async fn exceeding_bound_aborts(
+    #[case] paid: u64,
+    #[case] fee: u64,
+    #[case] num: u64,
+    #[case] den: u64,
+) -> anyhow::Result<()> {
+    let fee_faucet_id: AccountId = ACCOUNT_ID_FEE_FAUCET.try_into()?;
+    let result = run_bound(fee_faucet_id, paid, fee, num, den).await?;
+    assert_transaction_executor_error!(result, ERR_FEE_PAYMENT_EXCEEDS_BOUND);
+    Ok(())
+}
+
+/// A zero denominator would make the bound vacuous, so it is rejected.
+#[tokio::test]
+async fn zero_denominator_aborts() -> anyhow::Result<()> {
+    let fee_faucet_id: AccountId = ACCOUNT_ID_FEE_FAUCET.try_into()?;
+    let result = run_bound(fee_faucet_id, 100, 100, 1, 0).await?;
+    assert_transaction_executor_error!(result, ERR_FEE_BOUND_DENOMINATOR_ZERO);
+    Ok(())
+}
+
+/// The bound compares against a fee denominated in the native fee asset, so a payment in any
+/// other asset is rejected.
+#[tokio::test]
+async fn non_native_payment_faucet_aborts() -> anyhow::Result<()> {
+    let payment_faucet: AccountId = ACCOUNT_ID_PUBLIC_FUNGIBLE_FAUCET_2.try_into()?;
+    let result = run_bound(payment_faucet, 1, 100, 1, 1).await?;
+    assert_transaction_executor_error!(result, ERR_FEE_PAYMENT_FAUCET_NOT_NATIVE);
+    Ok(())
+}

--- a/crates/miden-testing/tests/auth/fee_payment/mod.rs
+++ b/crates/miden-testing/tests/auth/fee_payment/mod.rs
@@ -4,6 +4,7 @@ use miden_protocol::testing::account_id::ACCOUNT_ID_FEE_FAUCET;
 use miden_protocol::transaction::ExecutedTransaction;
 use miden_standards::note::TxFeeNote;
 
+mod bound;
 mod multisig;
 mod network;
 mod no_auth;


### PR DESCRIPTION
Adds `fee::assert_fee_bound`, so a caller can cap what a transaction is allowed to pay before paying it. Deliberately **not** called from `pay_fee` — per review on #3758, the ceiling is an application-level constraint, not a one-size-fits-all standard.

- Takes the multiplier as **numerator and denominator**, so a caller can express 3/2 rather than only whole multiples.
- Rejects a payment above `fee * num / denom`; no overflow, no division by zero.
- New `tests/auth/fee_payment/bound.rs` covers both directions: an inflated payment is refused, a legitimate one admitted.

Second of a three-PR stack; stacked on #3784. Still no production caller — #3785 wires it up.

<details>
<summary>Why numerator/denominator rather than an integer</summary>

An integer multiplier can only say "at most 2×". Multisig coordination can span days and the fee can rise between signature collection and submission (#3332), so callers need headroom — but "2×" is a blunt ceiling for a mechanism whose whole purpose is bounding a drain. A rational bound lets each caller pick its own tolerance.
</details>

<details>
<summary>Verification</summary>

`cargo build -p miden-standards`, `cargo +nightly fmt --all --check`, `cargo test -p miden-testing --test lib -- auth::` — 134 passed, 0 failed (122 inherited from the base, 12 added here).
</details>

**Reviewers:** the shape of the assertion is the thing to check — specifically that the comparison cannot overflow for a large `num` and that a zero `denom` is rejected rather than trapping.
