### PR TITLE
chore: bump Cargo version to 1.97

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changes
 
+- [BREAKING] Incremented the MSRV to 1.97.
 - [BREAKING] Removed the `BlockProof` placeholder in favor of `ExecutionProof` on `ProvenBlock`, matching `ProvenTransaction` and `ProvenBatch`, and `LocalBlockProver::prove` now takes an `ExecutedBlock` ([#3703](https://github.com/0xMiden/protocol/pull/3703)).
 - Added the `miden::protocol::tx::before_block_witness_load` kernel event, emitted before a block other than the reference block is read from the partial blockchain ([#3699](https://github.com/0xMiden/protocol/pull/3699)).
 - [BREAKING] Refactored `AccountVaultDelta` to track generic assets. `FungibleAssetDelta`, `NonFungibleAssetDelta` and `NonFungibleDeltaAction` were removed ([#3485](https://github.com/0xMiden/protocol/pull/3485)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Changes
 
-- [BREAKING] Incremented the MSRV to 1.97.
+- [BREAKING] Incremented the MSRV to 1.98.
 - [BREAKING] Removed the `BlockProof` placeholder in favor of `ExecutionProof` on `ProvenBlock`, matching `ProvenTransaction` and `ProvenBatch`, and `LocalBlockProver::prove` now takes an `ExecutedBlock` ([#3703](https://github.com/0xMiden/protocol/pull/3703)).
 - Added the `miden::protocol::tx::before_block_witness_load` kernel event, emitted before a block other than the reference block is read from the partial blockchain ([#3699](https://github.com/0xMiden/protocol/pull/3699)).
 - [BREAKING] Refactored `AccountVaultDelta` to track generic assets. `FungibleAssetDelta`, `NonFungibleAssetDelta` and `NonFungibleDeltaAction` were removed ([#3485](https://github.com/0xMiden/protocol/pull/3485)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude      = [".github/"]
 homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
-rust-version = "1.97"
+rust-version = "1.98"
 version      = "0.17.0"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude      = [".github/"]
 homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
-rust-version = "1.96.1"
+rust-version = "1.97"
 version      = "0.17.0"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/protocol/blob/main/LICENSE)
 [![test](https://github.com/0xMiden/protocol/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/protocol/actions/workflows/test.yml)
 [![build](https://github.com/0xMiden/protocol/actions/workflows/build.yml/badge.svg)](https://github.com/0xMiden/protocol/actions/workflows/build.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.97+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.98+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![GitHub Release](https://img.shields.io/github/release/0xMiden/protocol)](https://github.com/0xMiden/protocol/releases/)
 
 Description and core structures for the Miden Rollup protocol.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/protocol/blob/main/LICENSE)
 [![test](https://github.com/0xMiden/protocol/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/protocol/actions/workflows/test.yml)
 [![build](https://github.com/0xMiden/protocol/actions/workflows/build.yml/badge.svg)](https://github.com/0xMiden/protocol/actions/workflows/build.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.96+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.97+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![GitHub Release](https://img.shields.io/github/release/0xMiden/protocol)](https://github.com/0xMiden/protocol/releases/)
 
 Description and core structures for the Miden Rollup protocol.

--- a/crates/miden-protocol/src/account/component/storage/toml/mod.rs
+++ b/crates/miden-protocol/src/account/component/storage/toml/mod.rs
@@ -289,8 +289,7 @@ impl RawStorageSlotSchema {
             ))
         })?;
 
-        let description =
-            description.and_then(|d| if d.trim().is_empty() { None } else { Some(d) });
+        let description = description.filter(|d| !d.trim().is_empty());
 
         let slot_prefix = StorageValueName::from_slot_name(&slot_name);
 

--- a/crates/miden-protocol/src/account/component/storage/toml/serde_impls.rs
+++ b/crates/miden-protocol/src/account/component/storage/toml/serde_impls.rs
@@ -68,13 +68,7 @@ impl<'de> Deserialize<'de> for FeltSchema {
 
         let felt_type = raw.r#type.unwrap_or_else(SchemaType::native_felt);
 
-        let description = raw.description.and_then(|description| {
-            if description.trim().is_empty() {
-                None
-            } else {
-                Some(description)
-            }
-        });
+        let description = raw.description.filter(|description| !description.trim().is_empty());
 
         if felt_type == SchemaType::void() {
             if raw.name.is_some() {

--- a/crates/miden-protocol/src/account/storage/header.rs
+++ b/crates/miden-protocol/src/account/storage/header.rs
@@ -168,7 +168,7 @@ impl AccountStorageHeader {
         }
 
         let mut slots = Vec::new();
-        for chunk in elements.chunks_exact(StorageSlot::NUM_ELEMENTS) {
+        for chunk in elements.as_chunks::<{ StorageSlot::NUM_ELEMENTS }>().0 {
             // The first element of each slot record is reserved and must be zero.
             if chunk[0] != Felt::ZERO {
                 return Err(AccountError::StorageSlotReservedElementNotZero(chunk[0]));

--- a/crates/miden-testing/src/kernel_tests/tx/test_account.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account.rs
@@ -157,9 +157,9 @@ pub async fn compute_commitment() -> anyhow::Result<()> {
             # => []
         end
     "#,
-        key = &key,
-        value = &value,
-        expected_commitment = &expected_commitment,
+        key = key,
+        value = value,
+        expected_commitment = expected_commitment,
     );
 
     let mock_tx_builder = TestTransactionBuilder::new(account);
@@ -482,7 +482,7 @@ async fn test_get_item() -> anyhow::Result<()> {
             end
             "#,
             slot_name = storage_item.name(),
-            item_value = &storage_item.content().value(),
+            item_value = storage_item.content().value(),
         );
 
         mock_tx.execute_code(&code).await.unwrap();
@@ -970,8 +970,8 @@ async fn test_set_map_item() -> anyhow::Result<()> {
         end
         "#,
         slot_name = slot.name(),
-        new_key = &new_key,
-        new_value = &new_value,
+        new_key = new_key,
+        new_value = new_value,
     );
 
     let exec_output = &mock_tx.execute_code(&code).await?;
@@ -1033,7 +1033,7 @@ async fn test_get_initial_storage_commitment() -> anyhow::Result<()> {
             assert_eqw.err="actual storage commitment is not equal to the expected one"
         end
         "#,
-        expected_storage_commitment = &mock_tx.account().storage().to_commitment(),
+        expected_storage_commitment = mock_tx.account().storage().to_commitment(),
     );
     mock_tx.execute_code(&code).await?;
 
@@ -1068,8 +1068,8 @@ async fn test_native_account_upgrade_stores_commitments() -> anyhow::Result<()> 
             dropw dropw dropw dropw
         end
         "#,
-        code_upgrade_commitment = &code_upgrade_commitment,
-        storage_upgrade_commitment = &storage_upgrade_commitment,
+        code_upgrade_commitment = code_upgrade_commitment,
+        storage_upgrade_commitment = storage_upgrade_commitment,
     );
 
     let exec_output = &mock_tx.execute_code(&code).await?;
@@ -1111,8 +1111,8 @@ async fn test_native_account_upgrade_from_tx_script_is_rejected() -> anyhow::Res
             exec.native_account::upgrade
         end
         "#,
-        code_upgrade_commitment = &code_upgrade_commitment,
-        storage_upgrade_commitment = &storage_upgrade_commitment,
+        code_upgrade_commitment = code_upgrade_commitment,
+        storage_upgrade_commitment = storage_upgrade_commitment,
     );
     let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(tx_script_source)?;
 
@@ -1329,7 +1329,7 @@ async fn test_get_vault_root() -> anyhow::Result<()> {
             assert_eqw.err="initial vault root mismatch"
         end
         "#,
-        expected_vault_root = &account.vault().root(),
+        expected_vault_root = account.vault().root(),
     );
     mock_tx.execute_code(&code).await?;
 
@@ -1363,7 +1363,7 @@ async fn test_get_vault_root() -> anyhow::Result<()> {
         "#,
         FUNGIBLE_ASSET_VALUE = fungible_asset.to_value_word(),
         FUNGIBLE_ASSET_ID = fungible_asset.to_id_word(),
-        expected_vault_root = &account.vault().root(),
+        expected_vault_root = account.vault().root(),
     );
     mock_tx.execute_code(&code).await?;
 
@@ -1754,7 +1754,7 @@ async fn test_authenticate_procedure() -> anyhow::Result<()> {
                 dropw
             end
             ",
-            root = &root,
+            root = root,
         );
 
         // Execution of this code will return an EventError(UnknownAccountProcedure) for procs
@@ -1857,7 +1857,7 @@ async fn transaction_executor_account_code_using_custom_package() -> anyhow::Res
         exec.native_account::set_item
         dropw dropw
       end"#,
-        mock_value_slot0 = &*MOCK_VALUE_SLOT0,
+        mock_value_slot0 = *MOCK_VALUE_SLOT0,
     );
 
     const ACCOUNT_COMPONENT_CODE: &str = "
@@ -2132,8 +2132,8 @@ async fn test_get_initial_item() -> anyhow::Result<()> {
             assert_eqw.err="initial value should remain unchanged"
         end
         "#,
-        mock_value_slot0 = &*MOCK_VALUE_SLOT0,
-        expected_initial_value = &AccountStorage::mock_value_slot0().content().value(),
+        mock_value_slot0 = *MOCK_VALUE_SLOT0,
+        expected_initial_value = AccountStorage::mock_value_slot0().content().value(),
     );
 
     mock_tx.execute_code(&code).await?;
@@ -2209,10 +2209,10 @@ async fn test_get_initial_map_item() -> anyhow::Result<()> {
             dropw dropw dropw
         end
         "#,
-        initial_key = &initial_key,
-        initial_value = &initial_value,
-        new_key = &new_key,
-        new_value = &new_value,
+        initial_key = initial_key,
+        initial_value = initial_value,
+        new_key = new_key,
+        new_value = new_value,
     );
 
     mock_tx.execute_code(&code).await.unwrap();
@@ -2343,7 +2343,7 @@ async fn merging_components_with_same_mast_root_succeeds() -> anyhow::Result<()>
                   swapw dropw
               end
             "#,
-            test_slot_name = &*TEST_SLOT_NAME
+            test_slot_name = *TEST_SLOT_NAME
         );
 
         let source_manager = Arc::new(DefaultSourceManager::default());
@@ -2378,7 +2378,7 @@ async fn merging_components_with_same_mast_root_succeeds() -> anyhow::Result<()>
                   swapw dropw
               end
             "#,
-            test_slot_name = &*TEST_SLOT_NAME
+            test_slot_name = *TEST_SLOT_NAME
         );
 
         let source_manager = Arc::new(DefaultSourceManager::default());

--- a/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_account_update.rs
@@ -651,8 +651,8 @@ async fn asset_and_storage_patch() -> anyhow::Result<()> {
             dropw dropw dropw dropw
         end
         "#,
-        mock_value_slot0 = &*MOCK_VALUE_SLOT0,
-        mock_map_slot = &*MOCK_MAP_SLOT,
+        mock_value_slot0 = *MOCK_VALUE_SLOT0,
+        mock_map_slot = *MOCK_MAP_SLOT,
     );
 
     let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(tx_script_src)?;

--- a/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
+++ b/crates/miden-testing/src/kernel_tests/tx/test_epilogue.rs
@@ -462,7 +462,7 @@ async fn test_epilogue_increment_nonce_success() -> anyhow::Result<()> {
             push.{expected_nonce} assert_eq.err="nonce mismatch"
         end
         "#,
-        mock_value_slot0 = &*MOCK_VALUE_SLOT0,
+        mock_value_slot0 = *MOCK_VALUE_SLOT0,
     );
 
     mock_tx.execute_code(code.as_str()).await?;
@@ -489,7 +489,7 @@ async fn epilogue_fails_on_account_state_change_without_nonce_increment() -> any
             dropw
         end
         "#,
-        mock_value_slot0 = &*MOCK_VALUE_SLOT0,
+        mock_value_slot0 = *MOCK_VALUE_SLOT0,
     );
 
     let tx_script = CodeBuilder::with_mock_packages().compile_tx_script(code)?;

--- a/crates/miden-testing/src/standards/account_upgrade.rs
+++ b/crates/miden-testing/src/standards/account_upgrade.rs
@@ -79,8 +79,8 @@ async fn test_upgrade_manager_stores_commitments_when_authorized() -> anyhow::Re
             dropw dropw dropw dropw
         end
         "#,
-        code_upgrade_commitment = &code_upgrade_commitment,
-        storage_upgrade_commitment = &storage_upgrade_commitment,
+        code_upgrade_commitment = code_upgrade_commitment,
+        storage_upgrade_commitment = storage_upgrade_commitment,
     );
 
     let exec_output = &mock_tx.execute_code(&code).await?;

--- a/crates/miden-tx/src/host/tx_event.rs
+++ b/crates/miden-tx/src/host/tx_event.rs
@@ -906,7 +906,9 @@ fn extract_note_attachment(
     }
 
     let words: Vec<Word> = elements
-        .chunks_exact(WORD_SIZE)
+        .as_chunks::<WORD_SIZE>()
+        .0
+        .iter()
         .map(|chunk| Word::from([chunk[0], chunk[1], chunk[2], chunk[3]]))
         .collect();
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel    = "1.97"
+channel    = "1.98"
 components = ["clippy", "rust-src", "rustfmt"]
 profile    = "minimal"
 targets    = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel    = "1.96.1"
+channel    = "1.97"
 components = ["clippy", "rust-src", "rustfmt"]
 profile    = "minimal"
 targets    = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Bumps the cargo version to `1.97` in the `rust-toolchain.toml` and the MSRV, also fixes some new clippy warnings.