### PR TITLE
chore: bump version to v0.16.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.16.0-rc.8"
+version = "0.16.0-rc.9"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -2188,7 +2188,7 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-rc.8"
+version = "0.16.0-rc.9"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-rc.8"
+version = "0.16.0-rc.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-build-utils"
-version = "0.16.0-rc.8"
+version = "0.16.0-rc.9"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-rc.8"
+version = "0.16.0-rc.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-rc.8"
+version = "0.16.0-rc.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-rc.8"
+version = "0.16.0-rc.9"
 dependencies = [
  "bon",
  "miden-agglayer",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-rc.8"
+version = "0.16.0-rc.9"
 dependencies = [
  "miden-processor",
  "miden-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.98"
-version      = "0.16.0-rc.0"
+version      = "0.16.0-rc.9"
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.96.1"
-version      = "0.16.0-rc.8"
+version      = "0.16.0-rc.9"
 
 [profile.release]
 codegen-units = 1
@@ -37,14 +37,14 @@ lto           = true
 
 [workspace.dependencies]
 # Workspace crates
-miden-agglayer             = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-rc.8" }
-miden-block-prover         = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-rc.8" }
-miden-protocol             = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-rc.8" }
-miden-protocol-build-utils = { default-features = false, path = "crates/miden-protocol-build-utils", version = "0.16.0-rc.8" }
-miden-standards            = { default-features = false, path = "crates/miden-standards", version = "0.16.0-rc.8" }
-miden-testing              = { default-features = false, path = "crates/miden-testing", version = "0.16.0-rc.8" }
-miden-tx                   = { default-features = false, path = "crates/miden-tx", version = "0.16.0-rc.8" }
-miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-rc.8" }
+miden-agglayer             = { default-features = false, path = "crates/miden-agglayer", version = "0.16.0-rc.9" }
+miden-block-prover         = { default-features = false, path = "crates/miden-block-prover", version = "0.16.0-rc.9" }
+miden-protocol             = { default-features = false, path = "crates/miden-protocol", version = "0.16.0-rc.9" }
+miden-protocol-build-utils = { default-features = false, path = "crates/miden-protocol-build-utils", version = "0.16.0-rc.9" }
+miden-standards            = { default-features = false, path = "crates/miden-standards", version = "0.16.0-rc.9" }
+miden-testing              = { default-features = false, path = "crates/miden-testing", version = "0.16.0-rc.9" }
+miden-tx                   = { default-features = false, path = "crates/miden-tx", version = "0.16.0-rc.9" }
+miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.16.0-rc.9" }
 
 # Miden dependencies
 miden-assembly         = { default-features = false, version = "0.29.1" }


### PR DESCRIPTION
Bumps the workspace version from `0.16.0-rc.8` to `0.16.0-rc.9`.