### PR TITLE
masm: add semantic procedure signatures and typed pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+- Added type signatures where missing throughout the protocol and standards Miden Assembly libraries
+
 ## v0.17.0-pre.1 (2026-09-05)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2570665cc21c10d3b8681f5992070f2db91296db731cc0656ffeba9d26f84f5"
+checksum = "42e7f7a3e02a31f1c5690b60c529eed11de3a897af84754c0a4b99a3152ca463"
 dependencies = [
  "env_logger",
  "log",
@@ -2270,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a563c327987a9fa9238b6bf9d286157e51c7818cb47a90e25c7e5c47b184b"
+checksum = "37b3f2354462165f247c58c7c5216ba4f3938f673e9e0d6063ff0c4920137188"
 dependencies = [
  "env_logger",
  "log",
@@ -2324,9 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359ddf8ba29ab31924c9b71ff5ccf9b7c11c7aa0129a1e189aa4cd6f30b355dc"
+checksum = "2e21b43b9d95efd36333bcc4dbf978a54d923b2904ed922480e336cf990a2737"
 dependencies = [
  "derive_more",
  "log",
@@ -2343,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf796fb15f11e9770273b6d87d498692e643e1fce817ea63e6eca42e3de4d48"
+checksum = "559f199c9c6f827449f897cca48a1fbc766d7f2cc628a87a5a75dc1cb77ff06d"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -2364,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib-codegen"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fd10c163d02a2b7f945554075a1fda7558925f613812a45a5c00bf5449caea"
+checksum = "4a317014a6749628ea1c32e0b3f3800d994a73c7ada643a22e5dfad9564e273a"
 dependencies = [
  "miden-core",
  "miden-precompiles",
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba74f29ee9756631ed85794c0a15f5099a29758436526f57b607e1a1cadf293f"
+checksum = "b4756c2e871ecd7d995a1a7d3064bf37f9a0115c4f5b1a51ab99cc15b1006b59"
 dependencies = [
  "blake3",
  "cc",
@@ -2417,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7578de2aff9443eab6852c12b7a0fbf12e937a0a27e92c33605a3df1abd8da2"
+checksum = "5d2081b776d9bef188fcd3e41ebe8cae85fa19773e02b95370c89a45a703b08f"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -2512,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443ecb138aceaad1b03a0952675ec53807a768f1b466ef0b68adc3b9363f84d0"
+checksum = "8e376af0269a87f2b1fd82b24aeb723576bda9c63296d101618c7ce8f9982957"
 dependencies = [
  "hashbrown 0.17.1",
  "miden-assembly-syntax",
@@ -2579,9 +2579,9 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800a99645d14dbbb59c7e43dd28305cf7a3af8c82aee1fa2724f67f6e54a5346"
+checksum = "8444acad2bc21dc662a845d3fd57ccfb57b93abddeac3017e60781d15c89264a"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2595,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64ed605e6320c507ab620dda1edfeba66ef724b685d59b5424fc36d587bb3f0"
+checksum = "c189dae844624cfb0edf8d12203febc17ae47434f51d825bf7019d8dff5f7acf"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2661,9 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f06ff53be95356c8fba4b573e813be52dc2d1c0877786d8c9d3929f5503dc9"
+checksum = "b76c2477a17a83ac74a6956a2fec521b1f7a4847a617a318a6a4602fae856390"
 dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
@@ -2682,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f504225b1cc724198ac7fccba5ec4c763054f2b538cbb984657eb6e785bf49f"
+checksum = "4c576320a3dedda186b00c1429327d9f11d658c5986e0935bb4efedc76c864f8"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2772,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f2af66603361338c69cfe4b44dcd3475b65fac947b8bbb5e1f113812a7daea"
+checksum = "d9f27c87b47984f316fc5c9564a51392aaf6692a9e3e0d581a3bfc06e06fd5c4"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2937,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf61bdb8e94f0e9f7c59fcbf0c37faa092a98c2d19152377c1fc2044255bfd58"
+checksum = "3f3d0f89c457b8357e6d6b5da329999bfd763a61ab7fe3a71b04f3e363912a26"
 dependencies = [
  "lock_api",
  "loom",
@@ -2949,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4e5cd6450f03cbda2cb7addec584acca088e97d38ea9855e2f9b35604870df"
+checksum = "f5a615b3727fead78996884e4fa54bff951918e361955d09959cdab3ce88f232"
 dependencies = [
  "miden-air",
  "miden-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,20 +52,20 @@ miden-tx                   = { default-features = false, path = "crates/miden-tx
 miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.17.0-rc.4" }
 
 # Miden dependencies
-miden-assembly         = { default-features = false, version = "0.32.0" }
-miden-assembly-syntax  = { default-features = false, version = "0.32.0" }
-miden-core             = { default-features = false, version = "0.32.0" }
-miden-core-lib         = { default-features = false, version = "0.32.0" }
-miden-crypto           = { default-features = false, version = "0.32.0" }
-miden-crypto-derive    = { default-features = false, version = "0.32.0" }
-miden-mast-package     = { default-features = false, version = "0.32.0" }
-miden-package-registry = { default-features = false, version = "0.32.0" }
-miden-precompiles      = { default-features = false, version = "0.32.0" }
-miden-processor        = { default-features = false, version = "0.32.0" }
-miden-project          = { default-features = false, version = "0.32.0" }
-miden-prover           = { default-features = false, version = "0.32.0" }
-miden-utils-sync       = { default-features = false, version = "0.32.0" }
-miden-verifier         = { default-features = false, version = "0.32.0" }
+miden-assembly         = { default-features = false, version = "0.32.1" }
+miden-assembly-syntax  = { default-features = false, version = "0.32.1" }
+miden-core             = { default-features = false, version = "0.32.1" }
+miden-core-lib         = { default-features = false, version = "0.32.1" }
+miden-crypto           = { default-features = false, version = "0.32.1" }
+miden-crypto-derive    = { default-features = false, version = "0.32.1" }
+miden-mast-package     = { default-features = false, version = "0.32.1" }
+miden-package-registry = { default-features = false, version = "0.32.1" }
+miden-precompiles      = { default-features = false, version = "0.32.1" }
+miden-processor        = { default-features = false, version = "0.32.1" }
+miden-project          = { default-features = false, version = "0.32.1" }
+miden-prover           = { default-features = false, version = "0.32.1" }
+miden-utils-sync       = { default-features = false, version = "0.32.1" }
+miden-verifier         = { default-features = false, version = "0.32.1" }
 
 # External dependencies
 alloy-sol-types  = { default-features = false, version = "1.5" }

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_config.masm
@@ -1,3 +1,7 @@
+use {Keccak256Digest, NetworkId, AmountScale, OriginToken, FaucetConversionInfo, TokenRegistryValue}
+    from agglayer::types
+use {AccountId, StorageMapKey} from miden::protocol::types
+use {EthereumAddress} from miden::standards::interop::eth
 use miden::core::crypto::hashes::keccak256
 use miden::core::crypto::hashes::poseidon2
 use miden::core::word
@@ -83,7 +87,7 @@ const FAUCET_METADATA_SUBKEY_HASH_HI = 3  # METADATA_HASH_HI[4]
 #!
 #! Invocation: call
 @account_procedure
-pub proc update_ger
+pub proc update_ger(ger: Keccak256Digest)
     # assert the note sender is authorized for this procedure (holds the GER injector role).
     exec.authority::assert_authorized
     exec.pausable::assert_not_paused
@@ -131,7 +135,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc remove_ger
+pub proc remove_ger(ger: Keccak256Digest)
     # assert the note sender is authorized for this procedure (holds the GER remover role).
     exec.authority::assert_authorized
     # => [GER_LOWER[4], GER_UPPER[4], pad(8)]
@@ -181,7 +185,7 @@ end
 #! - the GER is not found in storage.
 #!
 #! Invocation: exec
-pub proc assert_valid_ger
+pub proc assert_valid_ger(ger: Keccak256Digest)
     # compute hash(GER)
     exec.poseidon2::merge
     # => [GER_HASH]
@@ -223,7 +227,13 @@ end
 #! Invocation: call
 @locals(14)
 @account_procedure
-pub proc register_faucet
+pub proc register_faucet(
+    origin_token_addr: EthereumAddress,
+    faucet_id: AccountId,
+    scale: AmountScale,
+    origin_network: NetworkId,
+    is_native: i1
+)
     # assert the note sender is authorized for this procedure (holds the faucet manager role).
     exec.authority::assert_authorized
     exec.pausable::assert_not_paused
@@ -385,7 +395,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc store_faucet_metadata_hash
+pub proc store_faucet_metadata_hash(faucet_id: AccountId, metadata_hash: Keccak256Digest)
     # assert the note sender is authorized for this procedure (holds the faucet manager role).
     exec.authority::assert_authorized
     exec.pausable::assert_not_paused
@@ -434,7 +444,7 @@ end
 #! Invocation: call
 @locals(2)
 @account_procedure
-pub proc deregister_faucet
+pub proc deregister_faucet(faucet_id: AccountId)
     # assert the note sender is authorized for this procedure (holds the faucet manager role).
     exec.authority::assert_authorized
     # => [faucet_id_suffix, faucet_id_prefix, pad(14)]
@@ -517,7 +527,7 @@ end
 #! - the token registry key does not point to the faucet.
 #!
 #! Invocation: exec
-proc clear_owned_token_key
+proc clear_owned_token_key(expected_faucet: TokenRegistryValue, token_addr_hash: StorageMapKey)
     dupw.1
     push.TOKEN_REGISTRY_MAP_SLOT[0..2]
     exec.active_account::get_map_item
@@ -547,7 +557,7 @@ end
 #! - the faucet is not registered in the faucet registry.
 #!
 #! Invocation: exec
-pub proc assert_faucet_registered
+pub proc assert_faucet_registered(faucet_id: AccountId)
     # Build KEY = [0, 0, faucet_id_suffix, faucet_id_prefix]
     push.0.0
     # => [0, 0, faucet_id_suffix, faucet_id_prefix]
@@ -571,7 +581,7 @@ end
 #! Outputs: [scale]
 #!
 #! Invocation: exec
-pub proc get_faucet_scale
+pub proc get_faucet_scale(faucet_id: AccountId) -> AmountScale
     # Build KEY = [SUBKEY_ADDR_HI, 0, faucet_id_suffix, faucet_id_prefix]
     push.0.FAUCET_METADATA_SUBKEY_ADDR_HI
     # => [SUBKEY_ADDR_HI, 0, faucet_id_suffix, faucet_id_prefix]
@@ -595,7 +605,7 @@ end
 #! Outputs: [origin_addr(5), origin_network, scale]
 #!
 #! Invocation: exec
-pub proc get_faucet_conversion_info
+pub proc get_faucet_conversion_info(faucet_id: AccountId) -> FaucetConversionInfo
     # Prepare the SUBKEY_ADDR_LO KEY underneath.
     push.0.FAUCET_METADATA_SUBKEY_ADDR_LO
     # => [SUBKEY_ADDR_LO, 0, faucet_id_suffix, faucet_id_prefix]
@@ -634,7 +644,7 @@ end
 #! Outputs: [METADATA_HASH_LO, METADATA_HASH_HI]
 #!
 #! Invocation: exec
-pub proc get_faucet_metadata_hash
+pub proc get_faucet_metadata_hash(faucet_id: AccountId) -> Keccak256Digest
     # Prepare the SUBKEY_HASH_LO KEY underneath.
     push.0.FAUCET_METADATA_SUBKEY_HASH_LO
     # => [SUBKEY_HASH_LO, 0, faucet_id_suffix, faucet_id_prefix]
@@ -666,7 +676,7 @@ end
 #! Outputs: [is_native]
 #!
 #! Invocation: exec
-pub proc is_faucet_native
+pub proc is_faucet_native(faucet_id: AccountId) -> i1
     # Build KEY = [0, 0, faucet_id_suffix, faucet_id_prefix]
     push.0.0
     # => [0, 0, faucet_id_suffix, faucet_id_prefix]
@@ -689,7 +699,7 @@ end
 #! Outputs: [is_registered]
 #!
 #! Invocation: exec
-pub proc is_faucet_registered
+pub proc is_faucet_registered(faucet_id: AccountId) -> i1
     # Build KEY = [0, 0, faucet_id_suffix, faucet_id_prefix]
     push.0.0
     # => [0, 0, faucet_id_suffix, faucet_id_prefix]
@@ -715,7 +725,7 @@ end
 #! - the (origin_token_address, origin_network) pair is not registered in the token registry.
 #!
 #! Invocation: exec
-pub proc lookup_faucet_by_token_address
+pub proc lookup_faucet_by_token_address(token: OriginToken) -> AccountId
     # Hash the (token address, origin network) pair
     exec.hash_token_address
     # => [TOKEN_ADDR_HASH]
@@ -749,7 +759,7 @@ end
 #!
 #! Invocation: exec
 @locals(8)
-proc hash_token_address
+proc hash_token_address(token: OriginToken) -> StorageMapKey
     # Write the (origin_token_addr, origin_network) felts to local memory for hashing
     loc_storew_le.TOKEN_ADDR_HASH_PTR dropw
     locaddr.TOKEN_ADDR_HASH_PTR add.4 mem_store
@@ -771,7 +781,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc update_removed_ger_hash_chain
+proc update_removed_ger_hash_chain(ger: Keccak256Digest)
     # load OLD_CHAIN above the GER preimage on the stack so that keccak256::merge produces
     # keccak256(OLD_CHAIN || GER), matching Solidity's
     # `removedGERHashChain = efficientKeccak256(removedGERHashChain, removedGER)`.
@@ -792,7 +802,7 @@ end
 #! Outputs: [OLD_CHAIN[8]]
 #!
 #! Invocation: exec
-proc load_removed_ger_hash_chain_data
+proc load_removed_ger_hash_chain_data() -> Keccak256Digest
     push.REMOVED_GER_HASH_CHAIN_HI_SLOT[0..2]
     exec.active_account::get_item
     # => [OLD_CHAIN_HI, GER_LOWER, GER_UPPER]
@@ -808,7 +818,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc store_removed_ger_hash_chain
+proc store_removed_ger_hash_chain(chain_hash: Keccak256Digest)
     push.REMOVED_GER_HASH_CHAIN_LO_SLOT[0..2]
     exec.native_account::set_item dropw
     # => [NEW_CHAIN_HI]
@@ -832,7 +842,7 @@ end
 #! - network_id is the u32 AggLayer network ID of this bridge.
 #!
 #! Invocation: exec
-pub proc load_network_id
+pub proc load_network_id() -> NetworkId
     push.NETWORK_ID_SLOT[0..2]
     exec.active_account::get_item
     # => [network_id, 0, 0, 0]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in.masm
@@ -1,3 +1,7 @@
+use {Keccak256Digest, GlobalIndex, EthereumAmount, NetworkId, AdviceMapKey, ClaimNullifier, OriginToken, ExitRoots}
+    from agglayer::types
+use {AccountId, AssetAmount} from miden::protocol::types
+use {EthereumAddress} from miden::standards::interop::eth
 use agglayer::bridge::bridge_config
 use agglayer::bridge::bridge_in_output
 use agglayer::bridge::leaf_utils
@@ -11,8 +15,6 @@ use miden::core::word
 use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::standards::access::pausable
-use {DoubleWord} from miden::protocol::types
-use {MemoryAddress} from miden::protocol::types
 use {ONE_WORD} from miden::standards::utils
 
 # ERRORS
@@ -42,7 +44,7 @@ const IS_CLAIMED_FLAG = ONE_WORD
 # Map entries: Poseidon2(leaf_index, source_bridge_network) => [1, 0, 0, 0]
 const CLAIM_NULLIFIERS_SLOT = word("agglayer::bridge::claim_nullifiers")
 
-# Storage slot constants for the CGI (claimed global index) chain hash. 
+# Storage slot constants for the CGI (claimed global index) chain hash.
 # It is stored in two separate value slots.
 const CGI_CHAIN_HASH_LO_SLOT_NAME = word("agglayer::bridge::cgi_chain_hash_lo")
 const CGI_CHAIN_HASH_HI_SLOT_NAME = word("agglayer::bridge::cgi_chain_hash_hi")
@@ -172,7 +174,11 @@ const CLAIM_DEST_ID_SUFFIX_LOCAL = 1
 #! Invocation: call
 @locals(2) # 0: dest_prefix, 1: dest_suffix
 @account_procedure
-pub proc claim
+pub proc claim(
+    proof_data_key: AdviceMapKey,
+    leaf_data_key: AdviceMapKey,
+    faucet_mint_amount: AssetAmount
+)
     exec.pausable::assert_not_paused
 
     # Write output note faucet amount to memory
@@ -259,7 +265,7 @@ end
 #! - the leaf type is not 0 (not an asset claim).
 #!
 #! Invocation: exec
-proc validate_leaf_type
+proc validate_leaf_type()
     mem_load.LEAF_TYPE_ADDRESS
     assertz.err=ERR_INVALID_LEAF_TYPE
 end
@@ -303,7 +309,7 @@ end
 #! - the Merkle proof for the provided leaf-index tuple against the computed GER is invalid.
 #!
 #! Invocation: exec
-proc verify_leaf_bridge
+proc verify_leaf_bridge(leaf_data_key: AdviceMapKey, proof_data_key: AdviceMapKey)
     # get the leaf value. We have all the necessary leaf data in the advice map
     exec.get_leaf_value
     # => [LEAF_VALUE[8], PROOF_DATA_KEY]
@@ -335,9 +341,9 @@ end
 #! - the rollup index is not 0.
 #!
 #! Invocation: exec
-pub proc process_global_index_mainnet
+pub proc process_global_index_mainnet(global_index: GlobalIndex) -> u32
     # the top 191 bits of the global index are zero
-    repeat.5 
+    repeat.5
         assertz.err=ERR_LEADING_BITS_NON_ZERO
     end
 
@@ -369,9 +375,9 @@ end
 #! - the mainnet flag is not 0.
 #!
 #! Invocation: exec
-pub proc process_global_index_rollup
+pub proc process_global_index_rollup(global_index: GlobalIndex) -> (u32, u32)
     # the top 191 bits of the global index are zero
-    repeat.5 
+    repeat.5
         assertz.err=ERR_LEADING_BITS_NON_ZERO
     end
     # => [mainnet_flag_le, rollup_index_le, leaf_index_le]
@@ -393,14 +399,14 @@ end
 
 #! Computes the Global Exit Tree (GET) root from the mainnet and rollup exit roots.
 #!
-#! The mainnet exit root is expected at `exit_roots_ptr` and the rollup exit root is expected at 
+#! The mainnet exit root is expected at `exit_roots_ptr` and the rollup exit root is expected at
 #! `exit_roots_ptr + 8`.
 #!
 #! Inputs: [exit_roots_ptr]
 #! Outputs: [GER_ROOT[8]]
 #!
 #! Invocation: exec
-pub proc compute_ger(exit_roots_ptr: MemoryAddress) -> DoubleWord
+pub proc compute_ger(exit_roots_ptr: ptr<ExitRoots>) -> Keccak256Digest
     push.64 swap
     # => [exit_roots_ptr, len_bytes]
 
@@ -425,10 +431,10 @@ end
 #! - [ROOT_LO, ROOT_HI] is the calculated root.
 #! - verification_flag is the binary flag indicating whether the verification was successful.
 pub proc verify_merkle_proof(
-    leaf_value: DoubleWord,
-    merkle_path_ptr: MemoryAddress,
+    leaf_value: Keccak256Digest,
+    merkle_path_ptr: ptr<Keccak256Digest>,
     leaf_idx: u32,
-    expected_root_ptr: MemoryAddress
+    expected_root_ptr: ptr<Keccak256Digest>
 ) -> i1
     # calculate the root of the SMT
     exec.calculate_root
@@ -462,7 +468,7 @@ end
 #! - the faucet_mint_amount does not match the expected scaled-down value.
 #!
 #! Invocation: exec
-proc verify_claim_amount
+proc verify_claim_amount(faucet_id: AccountId)
     # Step 1: Read scale from bridge's faucet_metadata_map
     exec.bridge_config::get_faucet_scale
     # => [scale]
@@ -503,7 +509,7 @@ end
 #! Outputs: [LEAF_VALUE[8]]
 #!
 #! Invocation: exec
-pub proc get_leaf_value(leaf_data_key: word) -> DoubleWord
+pub proc get_leaf_value(leaf_data_key: AdviceMapKey) -> Keccak256Digest
     adv.push_mapval
     # => [LEAF_DATA_KEY]
 
@@ -529,7 +535,7 @@ end
 #! - the claim has already been spent.
 #!
 #! Invocation: exec
-proc verify_leaf
+proc verify_leaf(leaf_value: Keccak256Digest, proof_data_key: AdviceMapKey)
     movupw.2
     # => [PROOF_DATA_KEY, LEAF_VALUE[8]]
 
@@ -544,7 +550,7 @@ proc verify_leaf
     # 1. compute GER from mainnet + rollup exit roots
     push.EXIT_ROOTS_PTR
     # => [exit_roots_ptr, LEAF_VALUE[8]]
-    
+
     exec.compute_ger
     # => [GER[8], LEAF_VALUE[8]]
 
@@ -561,7 +567,7 @@ proc verify_leaf
     # [gi0, gi1, gi2, gi3, gi4, mainnet_flag_le, rollup_index_le, leaf_index_le]
     # gi0 is on top (position 0). The mainnet flag is at stack position 5.
 
-    # Duplicate the mainnet flag element, byte-swap from LE to BE, assert it is a valid boolean 
+    # Duplicate the mainnet flag element, byte-swap from LE to BE, assert it is a valid boolean
     # (0 or 1), then use it to branch.
     dup.5 exec.utils::swap_u32_bytes dup
     # => [mainnet_flag, mainnet_flag, GLOBAL_INDEX[8], LEAF_VALUE[8]]
@@ -610,7 +616,7 @@ proc verify_leaf
         # mem[CLAIM_SOURCE_BRIDGE_NETWORK_MEM_ADDR] = rollup_index (temporarily, updated below)
         dup mem_store.CLAIM_LEAF_INDEX_MEM_ADDR
         # => [leaf_index, rollup_index, LEAF_VALUE[8]]
-        
+
         dup.1 mem_store.CLAIM_SOURCE_BRIDGE_NETWORK_MEM_ADDR
         # => [leaf_index, rollup_index, LEAF_VALUE[8]]
 
@@ -629,7 +635,7 @@ proc verify_leaf
         # Step 2: verify_merkle_proof(localExitRoot, smtProofRollupExitRoot, rollupIndex, rollupExitRootPtr)
         push.ROLLUP_EXIT_ROOT_PTR movdn.9
         # => [LOCAL_EXIT_ROOT_LO, LOCAL_EXIT_ROOT_HI, rollup_index, rollup_exit_root_ptr]
-        
+
         push.SMT_PROOF_ROLLUP_EXIT_ROOT_PTR movdn.8
         # => [LOCAL_EXIT_ROOT[8], smt_proof_rollup_ptr, rollup_index, rollup_exit_root_ptr]
 
@@ -671,7 +677,7 @@ end
 #! - the CLAIM note has already been spent (nullifier already exists in the nullifier map).
 #!
 #! Invocation: exec
-proc set_and_check_claimed
+proc set_and_check_claimed(leaf_index: u32, source_bridge_network: NetworkId)
     # Write both values to memory for hashing
     # mem[CLAIM_LEAF_INDEX_MEM_ADDR] = leaf_index
     # mem[CLAIM_SOURCE_BRIDGE_NETWORK_MEM_ADDR] = source_bridge_network
@@ -703,7 +709,7 @@ end
 #! - the CLAIM note has already been spent (nullifier already exists in the nullifier map).
 #!
 #! Invocation: exec
-proc assert_claim_not_spent(nullifier: word)
+proc assert_claim_not_spent(nullifier: ClaimNullifier)
     push.IS_CLAIMED_FLAG
     # => [IS_CLAIMED_FLAG, NULLIFIER]
 
@@ -723,7 +729,7 @@ end
 
 # Inputs: [PROOF_DATA_KEY, LEAF_DATA_KEY]
 # Outputs: []
-proc claim_batch_pipe_double_words
+proc claim_batch_pipe_double_words(proof_data_key: AdviceMapKey, leaf_data_key: AdviceMapKey)
     # 1) Verify PROOF_DATA_KEY
     mem_storew_be.CLAIM_PROOF_DATA_KEY_MEM_ADDR
     adv.push_mapval
@@ -751,7 +757,7 @@ end
 #! Outputs: [address[5]]
 #!
 #! Invocation: exec
-proc load_destination_address
+proc load_destination_address() -> EthereumAddress
     mem_load.DESTINATION_ADDRESS_4
     # => [address_4]
 
@@ -765,7 +771,7 @@ end
 #! Outputs: [U256_LO, U256_HI]
 #!
 #! Invocation: exec
-proc load_raw_claim_amount
+proc load_raw_claim_amount() -> EthereumAmount
     mem_load.OUTPUT_NOTE_ASSET_AMOUNT_MEM_ADDR_7
     mem_load.OUTPUT_NOTE_ASSET_AMOUNT_MEM_ADDR_6
     mem_load.OUTPUT_NOTE_ASSET_AMOUNT_MEM_ADDR_5
@@ -784,7 +790,7 @@ end
 #! Outputs: [origin_token_addr(5), origin_network]
 #!
 #! Invocation: exec
-proc load_origin_token_address_and_network
+proc load_origin_token_address_and_network() -> OriginToken
     mem_load.ORIGIN_NETWORK_ADDRESS
     mem_load.ORIGIN_TOKEN_ADDRESS_4
     mem_load.ORIGIN_TOKEN_ADDRESS_3
@@ -807,10 +813,10 @@ end
 #! - [ROOT_LO, ROOT_HI] is the calculated root.
 @locals(8) # current hash
 proc calculate_root(
-    leaf_value: DoubleWord,
-    merkle_path_ptr: MemoryAddress,
+    leaf_value: Keccak256Digest,
+    merkle_path_ptr: ptr<Keccak256Digest>,
     leaf_idx: u32
-) -> DoubleWord
+) -> Keccak256Digest
     # Local memory stores the current hash. It is initialized to the leaf value
     loc_storew_le.CUR_HASH_LO_LOCAL dropw loc_storew_le.CUR_HASH_HI_LOCAL dropw
     # => [merkle_path_ptr, leaf_idx]
@@ -872,7 +878,7 @@ end
 #! Updates the claimed global index (CGI) chain hash by recomputing it and storing into the
 #! corresponding storage slot.
 #!
-#! The resulting hash is computed as a sequential hash of leaf value, global index, and previous 
+#! The resulting hash is computed as a sequential hash of leaf value, global index, and previous
 #! value of the CGI chain hash:
 #! NEW_CGI_CHAIN_HASH[8] = Keccak256(OLD_CGI_CHAIN_HASH[8], Keccak256(GLOBAL_INDEX[8], LEAF_VALUE[8]))
 #!
@@ -880,7 +886,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc update_cgi_chain_hash
+proc update_cgi_chain_hash(leaf_value: Keccak256Digest)
     # load the required CGI chain data values onto the stack
     exec.load_cgi_chain_hash_data
     # => [GLOBAL_INDEX[8], LEAF_VALUE[8], OLD_CGI_CHAIN_HASH[8]]
@@ -904,7 +910,9 @@ end
 #! Outputs: [GLOBAL_INDEX[8], LEAF_VALUE[8], OLD_CGI_CHAIN_HASH[8]]
 #!
 #! Invocation: exec
-proc load_cgi_chain_hash_data
+proc load_cgi_chain_hash_data(
+    leaf_value: Keccak256Digest
+) -> (GlobalIndex, Keccak256Digest, Keccak256Digest)
     # load the old CGI chain hash onto the stack
     push.CGI_CHAIN_HASH_HI_SLOT_NAME[0..2]
     exec.active_account::get_item
@@ -929,7 +937,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc store_cgi_chain_hash
+proc store_cgi_chain_hash(chain_hash: Keccak256Digest)
     push.CGI_CHAIN_HASH_LO_SLOT_NAME[0..2]
     exec.native_account::set_item dropw
     # => [NEW_CGI_CHAIN_HASH_HI]
@@ -952,7 +960,7 @@ end
 #! - the leaf destination network does not match the bridge's configured network ID.
 #!
 #! Invocation: exec
-proc assert_claim_leaf_destination_network
+proc assert_claim_leaf_destination_network()
     # load the destination network ID onto the stack
     mem_load.DESTINATION_NETWORK_ID_MEM_ADDR
     # => [destination_network_id_le]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_in_output.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_in_output.masm
@@ -1,3 +1,4 @@
+use {AccountId, NoteRecipient} from miden::protocol::types
 use {CLAIM_OUTPUT_NOTE_FAUCET_AMOUNT} from agglayer::bridge::bridge_in
 use {CLAIM_PROOF_DATA_KEY_MEM_ADDR} from agglayer::bridge::bridge_in
 use miden::protocol::native_account
@@ -64,7 +65,7 @@ const UNLOCK_DEST_PREFIX_LOC = 9
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc build_mint_output_note
+pub proc build_mint_output_note(destination_id: AccountId, faucet_id: AccountId)
     # Step 1: Write all 22 MINT note storage items to global memory
     exec.write_mint_note_storage
     # => [faucet_id_suffix, faucet_id_prefix]
@@ -98,7 +99,7 @@ end
 #!
 #! Invocation: exec
 @locals(10)
-pub proc unlock_and_send
+pub proc unlock_and_send(destination_id: AccountId, faucet_id: AccountId)
     # Stash destination to locals so we can reload it later, after `native_account::remove_asset`
     # has consumed the stack copy.
     loc_store.UNLOCK_DEST_SUFFIX_LOC loc_store.UNLOCK_DEST_PREFIX_LOC
@@ -179,7 +180,7 @@ end
 #! Outputs: [faucet_id_suffix, faucet_id_prefix]
 #!
 #! Invocation: exec
-proc write_mint_note_storage
+proc write_mint_note_storage(destination_id: AccountId, faucet_id: AccountId) -> AccountId
     # write P2ID destination first so we can consume destination_id_prefix for the tag.
     # destination_id_suffix [20]
     dup mem_store.MINT_NOTE_STORAGE_OUTPUT_NOTE_SUFFIX
@@ -250,7 +251,7 @@ end
 #! Outputs: [MINT_RECIPIENT]
 #!
 #! Invocation: exec
-proc build_mint_recipient
+proc build_mint_recipient() -> NoteRecipient
     # Get the MINT note script root
     procref.::miden::standards::notes::mint::main
     # => [MINT_SCRIPT_ROOT]
@@ -281,7 +282,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc create_mint_note_with_attachment
+proc create_mint_note_with_attachment(recipient: NoteRecipient, faucet_id: AccountId)
     # Create the MINT output note targeting the faucet
     push.NOTE_TYPE_PUBLIC
     # => [note_type, MINT_RECIPIENT, faucet_id_suffix, faucet_id_prefix]

--- a/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/bridge_out.masm
@@ -1,3 +1,5 @@
+use {Keccak256Digest, NetworkId, ConvertedAsset, LeafData} from agglayer::types
+use {Asset, AssetId, NoteSerialNumber} from miden::protocol::types
 use miden::protocol::active_note
 use miden::protocol::active_account
 use miden::protocol::asset
@@ -8,7 +10,6 @@ use miden::standards::data_structures::double_word_array
 use miden::standards::attachments::network_account_target
 use {DEFAULT_TAG} from miden::standards::note::note_tag
 use {ALWAYS} from miden::standards::note::execution_hint
-use {MemoryAddress} from miden::protocol::types
 use miden::protocol::output_note
 use miden::core::crypto::hashes::poseidon2
 use miden::standards::access::pausable
@@ -115,7 +116,7 @@ const BURN_NOTE_NUM_STORAGE_ITEMS=8
 #! Invocation: call
 @locals(15)
 @account_procedure
-pub proc bridge_out
+pub proc bridge_out(asset: Asset, dest_network_id: NetworkId, dest_address: EthereumAddress)
     exec.pausable::assert_not_paused
 
     exec.active_note::is_public assert.err=ERR_B2AGG_NOTE_MUST_BE_PUBLIC
@@ -264,7 +265,7 @@ end
 #! - the destination network ID equals the bridge's configured network ID.
 #!
 #! Invocation: exec
-proc assert_destination_id_not_miden_id
+proc assert_destination_id_not_miden_id(dest_network_id: NetworkId)
     # change the endianness to BE to compare it with the network ID
     exec.utils::swap_u32_bytes
     # => [destination_network_id_be]
@@ -295,7 +296,7 @@ end
 #! - The faucet is not registered in the faucet registry.
 #!
 #! Invocation: exec
-proc convert_asset
+proc convert_asset(asset: Asset) -> ConvertedAsset
     swapw exec.fungible_asset::value_into_amount_unchecked movdn.4
     # => [ASSET_ID, amount]
 
@@ -346,7 +347,7 @@ end
 #! ]
 #!
 #! Invocation: exec
-proc add_leaf_bridge(leaf_data_start_ptr: MemoryAddress)
+proc add_leaf_bridge(leaf_data_start_ptr: ptr<LeafData>)
     exec.leaf_utils::compute_leaf_value
     # => [LEAF_VALUE_LO, LEAF_VALUE_HI]
 
@@ -408,7 +409,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc load_let_frontier_selective
+proc load_let_frontier_selective()
     # 1. Load num_leaves from its value slot
     push.LET_NUM_LEAVES_SLOT[0..2]
     exec.active_account::get_item
@@ -460,7 +461,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc save_let_root_and_num_leaves
+proc save_let_root_and_num_leaves(root: Keccak256Digest, new_leaf_count: u32)
     # 1. Save root lo word to its value slot
     push.LET_ROOT_LO_SLOT[0..2]
     exec.native_account::set_item
@@ -514,7 +515,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc save_let_frontier_selective
+proc save_let_frontier_selective()
     # Get old_num_leaves = new_num_leaves - 1
     push.LET_FRONTIER_MEM_PTR mem_load sub.1
     # => [old_num_leaves]
@@ -557,7 +558,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc write_address_to_memory(mem_ptr: MemoryAddress, address: EthereumAddress)
+proc write_address_to_memory(mem_ptr: ptr<EthereumAddress>, address: EthereumAddress)
     dup movdn.6 mem_store movup.4 add.1
     # => [mem_ptr+1, address(4)]
 
@@ -587,7 +588,7 @@ end
 #! - num_leaves is the number of leaves in the Local Exit Tree, post-append.
 #!
 #! Invocation: exec
-proc compute_burn_note_serial_num
+proc compute_burn_note_serial_num(asset_id: AssetId) -> NoteSerialNumber
     exec.active_note::get_serial_number
     # => [B2AGG_SERIAL_NUM, ASSET_ID]
 
@@ -617,7 +618,7 @@ end
 #!
 #! Invocation: exec
 @locals(14)
-proc create_burn_note
+proc create_burn_note(asset: Asset)
     swapw dupw.1
     # => [ASSET_ID, ASSET_VALUE, ASSET_ID]
 
@@ -691,7 +692,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc lock_asset
+proc lock_asset(asset: Asset)
     exec.native_account::add_asset
     # => [FINAL_ASSET_VALUE]
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/canonical_zeros.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/canonical_zeros.masm
@@ -102,11 +102,12 @@ const ZERO_31_L = [2340505732, 1648733876, 2660540036, 3759582231]
 const ZERO_31_R = [2389186238, 4049365781, 1653344606, 2840985724]
 
 use {mem_store_double_word} from miden::standards::utils
+use {Keccak256Digest} from agglayer::types
 
 
 #! Inputs:  [zeros_ptr]
 #! Outputs: []
-pub proc load_zeros_to_memory
+pub proc load_zeros_to_memory(zeros_ptr: ptr<Keccak256Digest>)
 	push.ZERO_0_R.ZERO_0_L exec.mem_store_double_word dropw dropw add.8
 	push.ZERO_1_R.ZERO_1_L exec.mem_store_double_word dropw dropw add.8
 	push.ZERO_2_R.ZERO_2_L exec.mem_store_double_word dropw dropw add.8

--- a/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/leaf_utils.masm
@@ -1,6 +1,5 @@
+use {Keccak256Digest, LeafData} from agglayer::types
 use miden::core::crypto::hashes::keccak256
-use {DoubleWord} from miden::protocol::types
-use {MemoryAddress} from miden::protocol::types
 
 # CONSTANTS
 # =================================================================================================
@@ -24,7 +23,7 @@ const PACKED_DATA_NUM_ELEMENTS = 29
 #! Outputs: [LEAF_VALUE[8]]
 #!
 #! Invocation: exec
-pub proc compute_leaf_value(leaf_data_start_ptr: MemoryAddress) -> DoubleWord
+pub proc compute_leaf_value(leaf_data_start_ptr: ptr<LeafData>) -> Keccak256Digest
     dup
     # => [leaf_data_start_ptr, leaf_data_start_ptr]
     
@@ -74,7 +73,7 @@ end
 #!
 #! Invocation: exec
 @locals(1) # start_ptr
-pub proc pack_leaf_data(leaf_data_start_ptr: MemoryAddress)
+pub proc pack_leaf_data(leaf_data_start_ptr: ptr<LeafData>)
     loc_store.PACKING_START_PTR_LOCAL
     # => []
 

--- a/crates/miden-agglayer/asm/agglayer/bridge/merkle_tree_frontier.masm
+++ b/crates/miden-agglayer/asm/agglayer/bridge/merkle_tree_frontier.masm
@@ -1,3 +1,4 @@
+use {Keccak256Digest, MerkleTreeFrontier} from agglayer::types
 use miden::core::crypto::hashes::keccak256
 use {load_zeros_to_memory} from agglayer::bridge::canonical_zeros
 use {mem_store_double_word} from miden::standards::utils
@@ -144,7 +145,10 @@ const CANONICAL_ZEROES_LOCAL = 8
 #! Panics if:
 #! - The number of leaves in the MTF has reached the maximum limit of 2^32.
 @locals(264) # new_leaf/curr_hash + canonical_zeros
-pub proc append_and_update_frontier
+pub proc append_and_update_frontier(
+    new_leaf: Keccak256Digest,
+    mtf_ptr: ptr<MerkleTreeFrontier>
+) -> (Keccak256Digest, u32)
     # set CUR_HASH = NEW_LEAF and store to local memory
     loc_storew_le.CUR_HASH_LO_LOCAL dropw
     loc_storew_le.CUR_HASH_HI_LOCAL dropw

--- a/crates/miden-agglayer/asm/agglayer/mod.masm
+++ b/crates/miden-agglayer/asm/agglayer/mod.masm
@@ -1,2 +1,3 @@
 pub mod bridge
 pub mod notes
+pub mod types

--- a/crates/miden-agglayer/asm/agglayer/notes/b2agg.masm
+++ b/crates/miden-agglayer/asm/agglayer/notes/b2agg.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use agglayer::bridge::bridge_out
 use miden::protocol::account_id
 use miden::protocol::active_account
@@ -53,7 +54,7 @@ const ERR_B2AGG_TARGET_ACCOUNT_MISMATCH="B2AGG note attachment target account do
 #! - The note is not public (enforced by `bridge_out`).
 #! - The destination network ID equals Miden's AggLayer network ID.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 

--- a/crates/miden-agglayer/asm/agglayer/notes/claim.masm
+++ b/crates/miden-agglayer/asm/agglayer/notes/claim.masm
@@ -1,3 +1,5 @@
+use {NoteArgs} from miden::protocol::types
+use {AdviceMapKey} from agglayer::types
 use agglayer::bridge::bridge_in as bridge
 use miden::protocol::active_note
 use miden::core::crypto::hashes::poseidon2
@@ -80,7 +82,7 @@ const ERR_CLAIM_TARGET_ACCT_MISMATCH = "CLAIM note attachment target account doe
 #! - note attachment target account does not match the consuming account.
 #! - the note carries more than CLAIM_NOTE_NUM_STORAGE_ITEMS storage items.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -108,7 +110,7 @@ pub proc main
     # => [pad(16), pad(9)]
 
     # a call invocation consumes and returns 16 elements, but we had trailing padding
-    dropw dropw drop 
+    dropw dropw drop
 
     # => [pad(16)]
 end
@@ -145,7 +147,7 @@ end
 #! ]
 #!
 #! Invocation: exec
-proc write_claim_data_into_advice_map_by_key
+proc write_claim_data_into_advice_map_by_key() -> (AdviceMapKey, AdviceMapKey)
     # 1) Get LEAF_DATA_KEY
     push.LEAF_DATA_SIZE push.LEAF_DATA_START_PTR
     exec.poseidon2::hash_elements

--- a/crates/miden-agglayer/asm/agglayer/notes/config_agg_bridge.masm
+++ b/crates/miden-agglayer/asm/agglayer/notes/config_agg_bridge.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use agglayer::bridge::bridge_config
 use miden::standards::utils
 use miden::protocol::active_note
@@ -74,7 +75,7 @@ const ERR_CONFIG_AGG_BRIDGE_TARGET_ACCOUNT_MISMATCH = "CONFIG_AGG_BRIDGE note at
 #! - The note does not contain exactly 18 storage items.
 #! - The account does not expose the register_faucet or store_faucet_metadata_hash procedures.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 

--- a/crates/miden-agglayer/asm/agglayer/notes/deregister_agg_faucet.masm
+++ b/crates/miden-agglayer/asm/agglayer/notes/deregister_agg_faucet.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use agglayer::bridge::bridge_config
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
@@ -39,7 +40,7 @@ const ERR_DEREGISTER_AGG_FAUCET_TARGET_ACCOUNT_MISMATCH = "DEREGISTER_AGG_FAUCET
 #! - The account does not expose the deregister_faucet procedure.
 #! - The faucet is not currently registered (panics inside deregister_faucet).
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 

--- a/crates/miden-agglayer/asm/agglayer/notes/remove_ger.masm
+++ b/crates/miden-agglayer/asm/agglayer/notes/remove_ger.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use agglayer::bridge::bridge_config
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
@@ -42,7 +43,7 @@ const ERR_REMOVE_GER_TARGET_ACCOUNT_MISMATCH = "REMOVE_GER note attachment targe
 #! - the note sender is not the global exit root remover.
 #! - the GER is not currently registered in the bridge's GER map.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 

--- a/crates/miden-agglayer/asm/agglayer/notes/update_ger.masm
+++ b/crates/miden-agglayer/asm/agglayer/notes/update_ger.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use agglayer::bridge::bridge_config
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
@@ -41,7 +42,7 @@ const ERR_UPDATE_GER_TARGET_ACCOUNT_MISMATCH = "UPDATE_GER note attachment targe
 #! - number of note storage items is not exactly 8.
 #! - the GER has already been registered in storage.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -62,7 +63,7 @@ pub proc main
     # Load GER_LOWER and GER_UPPER from note storage
     mem_loadw_le.STORAGE_PTR_GER_UPPER
     # => [GER_UPPER[4], pad(12)]
-    
+
     swapw mem_loadw_le.STORAGE_PTR_GER_LOWER
     # => [GER_LOWER[4], GER_UPPER[4], pad(8)]
 

--- a/crates/miden-agglayer/asm/agglayer/types.masm
+++ b/crates/miden-agglayer/asm/agglayer/types.masm
@@ -1,6 +1,7 @@
 # Semantic bridge values. Stack records list the top field first; LeafData describes memory order.
 
 use {AccountId} from ::miden::protocol::types
+use {Digest as Poseidon2Commitment} from ::miden::core::crypto::hashes::poseidon2
 use {EthereumAddress, EthereumBytes32} from ::miden::standards::interop::eth
 
 # Keccak digests use eight u32 limbs in byte-stream order.
@@ -11,7 +12,8 @@ pub type GlobalIndex = Keccak256Digest
 pub type EthereumAmount = struct { limbs: [u32; 8] }
 pub type NetworkId = u32
 pub type AmountScale = u8
-pub type AdviceMapKey = word
+#! Poseidon2 commitment to the leaf or proof data stored in the advice map.
+pub type AdviceMapKey = Poseidon2Commitment
 pub type ClaimNullifier = word
 
 pub type OriginToken = struct {

--- a/crates/miden-agglayer/asm/agglayer/types.masm
+++ b/crates/miden-agglayer/asm/agglayer/types.masm
@@ -1,0 +1,58 @@
+# Semantic bridge values. Stack records list the top field first; LeafData describes memory order.
+
+use {AccountId} from ::miden::protocol::types
+use {EthereumAddress, EthereumBytes32} from ::miden::standards::interop::eth
+
+# Keccak digests use eight u32 limbs in byte-stream order.
+pub type Keccak256Digest = EthereumBytes32
+pub type GlobalIndex = Keccak256Digest
+
+# Token amounts use big-endian byte order, packed into eight little-endian u32 limbs.
+pub type EthereumAmount = struct { limbs: [u32; 8] }
+pub type NetworkId = u32
+pub type AmountScale = u8
+pub type AdviceMapKey = word
+pub type ClaimNullifier = word
+
+pub type OriginToken = struct {
+    address: EthereumAddress,
+    network: NetworkId
+}
+
+pub type FaucetConversionInfo = struct {
+    token: OriginToken,
+    scale: AmountScale
+}
+
+pub type ConvertedAsset = struct {
+    amount: EthereumAmount,
+    token: OriginToken
+}
+
+pub type TokenRegistryValue = struct {
+    padding: [felt; 2],
+    faucet_id: AccountId
+}
+
+# Unpacked leaf memory, before pack_leaf_data rewrites it into packed u32 limbs.
+pub type LeafData = struct {
+    leaf_type: u8,
+    origin_network: NetworkId,
+    origin_token_address: EthereumAddress,
+    destination_network: NetworkId,
+    destination_address: EthereumAddress,
+    amount: EthereumAmount,
+    metadata_hash: Keccak256Digest,
+    padding: [felt; 3]
+}
+
+pub type ExitRoots = struct {
+    mainnet: Keccak256Digest,
+    rollup: Keccak256Digest
+}
+
+pub type MerkleTreeFrontier = struct {
+    num_leaves: u32,
+    padding: [felt; 3],
+    nodes: [Keccak256Digest; 32]
+}

--- a/crates/miden-agglayer/build.rs
+++ b/crates/miden-agglayer/build.rs
@@ -326,11 +326,12 @@ fn ensure_canonical_zeros(target_dir: &Path) -> Result<()> {
     zero_constants.push_str(
         "
 use {mem_store_double_word} from miden::standards::utils
+use {Keccak256Digest} from agglayer::types
 
 
 #! Inputs:  [zeros_ptr]
 #! Outputs: []
-pub proc load_zeros_to_memory\n",
+pub proc load_zeros_to_memory(zeros_ptr: ptr<Keccak256Digest>)\n",
     );
 
     for zero_index in 0..32 {

--- a/crates/miden-protocol/asm/kernels/batch/miden-project.toml
+++ b/crates/miden-protocol/asm/kernels/batch/miden-project.toml
@@ -4,3 +4,6 @@ version.workspace = true
 
 [[bin]]
 path = "src/main.masm"
+
+[dependencies]
+miden-protocol-utils.workspace = true

--- a/crates/miden-protocol/asm/kernels/batch/src/main.masm
+++ b/crates/miden-protocol/asm/kernels/batch/src/main.masm
@@ -1,3 +1,5 @@
+type Digest = word
+type BlockNumber = u32
 # MAIN
 # =================================================================================================
 
@@ -32,7 +34,7 @@
 #! - batch_expiration_block_num will be the minimum of every transaction's
 #!   `expiration_block_num`. In this skeleton it is zero.
 #!
-proc main
+proc main(block_commitment: Digest, batch_id: word, padding: [felt; 8]) -> (Digest, Digest, BlockNumber, [felt; 7])
     dropw dropw
 end
 

--- a/crates/miden-protocol/asm/kernels/batch/src/main.masm
+++ b/crates/miden-protocol/asm/kernels/batch/src/main.masm
@@ -1,5 +1,14 @@
-type Digest = word
-type BlockNumber = u32
+use {BlockCommitment, BlockNumber} from miden::protocol_utils::types
+
+#! Commitment to the transactions in a batch.
+type BatchId = word
+
+#! Sequential commitment to the input notes of the batch's transactions.
+type InputNotesCommitment = word
+
+#! Root of the batch note tree over the transactions' output notes.
+type BatchNoteTreeRoot = word
+
 # MAIN
 # =================================================================================================
 
@@ -34,7 +43,7 @@ type BlockNumber = u32
 #! - batch_expiration_block_num will be the minimum of every transaction's
 #!   `expiration_block_num`. In this skeleton it is zero.
 #!
-proc main(block_commitment: Digest, batch_id: word, padding: [felt; 8]) -> (Digest, Digest, BlockNumber, [felt; 7])
+proc main(block_commitment: BlockCommitment, batch_id: BatchId, padding: [felt; 8]) -> (InputNotesCommitment, BatchNoteTreeRoot, BlockNumber, [felt; 7])
     dropw dropw
 end
 

--- a/crates/miden-protocol/asm/kernels/block/miden-project.toml
+++ b/crates/miden-protocol/asm/kernels/block/miden-project.toml
@@ -4,3 +4,6 @@ version.workspace = true
 
 [[bin]]
 path = "src/main.masm"
+
+[dependencies]
+miden-protocol-utils.workspace = true

--- a/crates/miden-protocol/asm/kernels/block/src/main.masm
+++ b/crates/miden-protocol/asm/kernels/block/src/main.masm
@@ -1,3 +1,4 @@
+type Digest = word
 # MAIN
 # =================================================================================================
 
@@ -21,7 +22,7 @@
 #! - NULLIFIER_COMMITMENT is the commitment to the set of nullifiers created in this block. In
 #!   this skeleton it is the empty word.
 #!
-proc main
+proc main(prev_block_commitment: Digest, batches_commitment: Digest, padding: [felt; 8]) -> (Digest, Digest, [felt; 8])
     dropw dropw
     # => [pad(16)]
 end

--- a/crates/miden-protocol/asm/kernels/block/src/main.masm
+++ b/crates/miden-protocol/asm/kernels/block/src/main.masm
@@ -1,4 +1,11 @@
-type Digest = word
+use {BlockCommitment} from miden::protocol_utils::types
+
+#! Sequential commitment to the ordered batch IDs in a block.
+type BatchesCommitment = word
+
+#! Commitment to the nullifiers created in a block.
+type NullifierCommitment = word
+
 # MAIN
 # =================================================================================================
 
@@ -22,7 +29,7 @@ type Digest = word
 #! - NULLIFIER_COMMITMENT is the commitment to the set of nullifiers created in this block. In
 #!   this skeleton it is the empty word.
 #!
-proc main(prev_block_commitment: Digest, batches_commitment: Digest, padding: [felt; 8]) -> (Digest, Digest, [felt; 8])
+proc main(prev_block_commitment: BlockCommitment, batches_commitment: BatchesCommitment, padding: [felt; 8]) -> (BlockCommitment, NullifierCommitment, [felt; 8])
     dropw dropw
     # => [pad(16)]
 end

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -1,3 +1,14 @@
+use {
+    AccountId,
+    AccountProcedureRoot,
+    Asset,
+    AssetId,
+    AssetValue,
+    Bool,
+    StorageMapKey,
+    StorageSlotId,
+} from miden::protocol_utils::types
+use {AccountData, Digest, StorageSlot} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account_update
 use miden::protocol_utils::account_id
 use miden::tx_kernel_core::asset_vault
@@ -206,7 +217,7 @@ const ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT = event("miden::protocol::account::push
 #!
 #! Where:
 #! - max_num_storage_slots is the maximum number of account storage slots.
-pub proc get_max_num_storage_slots
+pub proc get_max_num_storage_slots() -> u8
     push.MAX_NUM_STORAGE_SLOTS
 end
 
@@ -217,7 +228,7 @@ end
 #!
 #! Where:
 #! - max_num_procedures is the maximum number of account interface procedures.
-pub proc get_max_num_procedures
+pub proc get_max_num_procedures() -> u16
     push.MAX_NUM_PROCEDURES
 end
 
@@ -238,7 +249,7 @@ pub use {get_account_nonce as get_nonce} from miden::tx_kernel_core::memory
 #!
 #! Panics if:
 #! - the nonce has already been incremented.
-pub proc incr_nonce
+pub proc incr_nonce() -> felt
     exec.account_update::was_nonce_incremented
     # => [was_nonce_incremented]
 
@@ -287,7 +298,7 @@ pub use {get_init_account_commitment as get_initial_commitment} from miden::tx_k
 #!
 #! Where:
 #! - ACCOUNT_COMMITMENT is the commitment of the account data.
-pub proc compute_commitment
+pub proc compute_commitment() -> Digest
     # if outdated, recompute the storage commitment and store it in the memory
     exec.refresh_storage_commitment
     # => []
@@ -328,7 +339,7 @@ pub use {get_init_account_storage_commitment as get_initial_storage_commitment}
 #!
 #! Where:
 #! - STORAGE_COMMITMENT is the commitment of the active account storage.
-pub proc compute_storage_commitment
+pub proc compute_storage_commitment() -> Digest
     # if outdated, recompute the storage commitment and store it in the memory
     exec.refresh_storage_commitment
 
@@ -357,7 +368,7 @@ pub use {get_init_native_account_vault_root as get_initial_vault_root}
 #!
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
-pub proc get_item
+pub proc get_item(slot_id: StorageSlotId) -> word
     # get the active account storage slots section offset and its slot count
     exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
@@ -385,7 +396,7 @@ end
 #!   the first two felts of the hashed slot name.
 #! - is_found is 1 if the slot was found, 0 otherwise.
 #! - VALUE is the value of the item, or the empty word if the slot was not found.
-pub proc find_item
+pub proc find_item(slot_id: StorageSlotId) -> (Bool, word)
     # get the active account storage slots section offset and its slot count
     exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
@@ -419,7 +430,7 @@ end
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
 #! - has_slot is 1 if a slot with the provided slot ID exists, 0 otherwise.
-pub proc has_storage_slot
+pub proc has_storage_slot(slot_id: StorageSlotId) -> Bool
     # get the active account storage slots section offset and its slot count
     exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
@@ -446,7 +457,7 @@ end
 #!
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
-pub proc get_typed_item
+pub proc get_typed_item(slot_id: StorageSlotId) -> (word, u8)
     # get the active account storage slots section offset and its slot count
     exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
@@ -475,7 +486,7 @@ end
 #!
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
-pub proc get_initial_item
+pub proc get_initial_item(slot_id: StorageSlotId) -> word
     # get the native account initial storage slots section offset and the native slot count
     exec.memory::get_native_num_storage_slots
     exec.memory::get_native_account_initial_storage_slots_ptr
@@ -503,7 +514,7 @@ end
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
 #! - the storage slot type is not value.
-pub proc set_item
+pub proc set_item(slot_id: StorageSlotId, value: word) -> word
     emit.ACCOUNT_STORAGE_BEFORE_SET_ITEM_EVENT
     # => [slot_id_suffix, slot_id_prefix, VALUE]
 
@@ -555,7 +566,7 @@ end
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
 #! - the requested storage slot type is not map.
-pub proc get_map_item
+pub proc get_map_item(slot_id: StorageSlotId, key: StorageMapKey) -> word
     exec.memory::get_num_storage_slots
     exec.memory::get_account_active_storage_slots_section_ptr
     # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix, KEY]
@@ -577,7 +588,7 @@ end
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
 #! - the requested storage slot type is not map.
-pub proc get_initial_map_item
+pub proc get_initial_map_item(slot_id: StorageSlotId, key: StorageMapKey) -> word
     exec.memory::get_native_num_storage_slots
     exec.memory::get_native_account_initial_storage_slots_ptr
     # => [native_initial_storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix, KEY]
@@ -603,7 +614,7 @@ end
 #! - a slot with the provided slot ID does not exist in account storage.
 #! - the storage slot type is not map.
 #! - no map with the root of the slot is found.
-pub proc set_map_item
+pub proc set_map_item(slot_id: StorageSlotId, key: StorageMapKey, new_value: word) -> word
     exec.memory::get_native_num_storage_slots
     exec.memory::get_native_account_active_storage_slots_ptr
     # => [storage_slots_ptr, num_storage_slots, slot_id_suffix, slot_id_prefix, KEY, NEW_VALUE]
@@ -635,7 +646,7 @@ end
 #! Where:
 #! - index is the location in memory of the storage slot.
 #! - slot_type is the type of the storage slot.
-pub proc get_native_storage_slot_type
+pub proc get_native_storage_slot_type(index: u8) -> u8
     # convert the index into a memory offset
     mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH
     # => [offset]
@@ -671,7 +682,7 @@ end
 #! - the total value of the fungible asset is greater than or equal to 2^63 after the new asset was
 #!   added.
 #! - the vault already contains the same non-fungible asset.
-pub proc add_asset_to_vault
+pub proc add_asset_to_vault(asset: Asset) -> AssetValue
     # retain the original asset while the callback validates a copy
     dupw.1 dupw.1
     # => [ASSET_ID, ASSET_VALUE, ASSET_ID, ASSET_VALUE]
@@ -720,7 +731,7 @@ end
 #! - the fungible asset is not found in the vault.
 #! - the amount of the fungible asset in the vault is less than the amount to be removed.
 #! - the non-fungible asset is not found in the vault.
-pub proc remove_asset_from_vault
+pub proc remove_asset_from_vault(asset: Asset) -> AssetValue
     # duplicate the asset ID for the later event and delta update
     swapw dupw.1
     # => [ASSET_ID, ASSET_VALUE, ASSET_ID]
@@ -756,7 +767,7 @@ end
 #! Where:
 #! - ASSET_ID is the asset ID of the asset to fetch.
 #! - ASSET_VALUE is the value of the asset from the vault, which can be the EMPTY_WORD if it isn't present.
-pub proc get_asset
+pub proc get_asset(asset_id: AssetId) -> AssetValue
     # get the vault root ptr
     exec.memory::get_account_vault_root_ptr movdn.4
     # => [ASSET_ID, vault_root_ptr]
@@ -779,7 +790,7 @@ end
 #! Where:
 #! - ASSET_ID is the asset ID of the asset to fetch.
 #! - ASSET_VALUE is the value of the asset from the vault, which can be the EMPTY_WORD if it isn't present.
-pub proc get_initial_asset
+pub proc get_initial_asset(asset_id: AssetId) -> AssetValue
     # get the initial vault root ptr of the native account
     exec.memory::get_init_native_account_vault_root_ptr movdn.4
     # => [ASSET_ID, init_native_vault_root_ptr]
@@ -811,7 +822,7 @@ end
 #!
 #! Panics if:
 #! - the procedure root is not part of the account code.
-pub proc authenticate_procedure
+pub proc authenticate_procedure(proc_root: AccountProcedureRoot)
     # verify that the procedure is part of the account code and get its index
     exec.assert_procedure_in_active_account
     # => [proc_idx]
@@ -846,7 +857,7 @@ end
 #!
 #! Panics if:
 #! - the procedure root is not part of the active account's code.
-pub proc assert_procedure_in_active_account
+pub proc assert_procedure_in_active_account(proc_root: AccountProcedureRoot) -> u8
     # load procedure index
     emit.ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT adv_push
     # => [proc_idx, PROC_ROOT]
@@ -870,7 +881,7 @@ end
 #!
 #! Panics if:
 #! - the procedure root is not the authentication procedure.
-pub proc assert_auth_procedure
+pub proc assert_auth_procedure(proc_root: AccountProcedureRoot)
     # authentication procedure is always at index 0
     push.0
     # => [auth_proc_idx, PROC_ROOT]
@@ -906,7 +917,7 @@ end
 #! Where:
 #! - ACCOUNT_ID_KEY is the map key constructed from the native account ID.
 #! - SEED is the account seed used to derive the account ID.
-pub proc validate_seed
+pub proc validate_seed()
     # Compute the hash of (SEED, CODE_COMMITMENT, STORAGE_COMMITMENT, EMPTY_WORD).
     # ---------------------------------------------------------------------------------------------
     # initialize capacity of the hasher and rate1 with the code commitment
@@ -972,7 +983,7 @@ end
 #!    - this ensures sorting and uniqueness among slot IDs.
 #! - any slot has a type that is not a supported storage slot type.
 #! - any slot's reserved element is not zero.
-pub proc validate_storage
+pub proc validate_storage()
     exec.memory::get_native_num_storage_slots
     # => [num_slots]
 
@@ -1042,7 +1053,7 @@ end
 #!
 #! Inputs:  [prev_slot_id_suffix, prev_slot_id_prefix, curr_slot_id_suffix, curr_slot_id_prefix]
 #! Outputs: [is_prev_lt_curr]
-pub proc is_slot_id_lt
+pub proc is_slot_id_lt(prev_slot_id: StorageSlotId, curr_slot_id: StorageSlotId) -> Bool
     movup.2
     # => [curr_slot_id_suffix, prev_slot_id_suffix, prev_slot_id_prefix, curr_slot_id_prefix]
 
@@ -1086,7 +1097,7 @@ end
 #! - the procedure roots are not sorted.
 #! - the procedure roots are not unique.
 #! - the root of the auth procedure appears at an index other than 0.
-pub proc validate_procedures
+pub proc validate_procedures()
     exec.memory::get_num_account_procedures sub.1
     # => [curr_proc_idx]
 
@@ -1179,7 +1190,7 @@ end
 #! - the computed account storage commitment does not match the provided account storage commitment.
 #! - the foreign account ID obtained from the advice map doesn't match the ID provided to the
 #!   procedure.
-pub proc load_foreign_account
+pub proc load_foreign_account(account_id: AccountId)
     emit.ACCOUNT_BEFORE_FOREIGN_LOAD_EVENT
     # => [account_id_suffix, account_id_prefix]
 
@@ -1263,7 +1274,7 @@ end
 #! Panics if:
 #! - the number of account storage slots exceeded the maximum limit of 255.
 #! - the computed account storage commitment does not match the provided account storage commitment.
-pub proc save_account_storage_data
+pub proc save_account_storage_data(storage_commitment: Digest)
     # move storage slot data from the advice map to the advice stack
     adv.push_mapvaln
     # OS => [STORAGE_COMMITMENT]
@@ -1333,7 +1344,7 @@ end
 #! Panics if:
 #! - the number of account procedures exceeded the maximum limit of 256.
 #! - the computed account code commitment does not match the provided account code commitment.
-pub proc save_account_procedure_data
+pub proc save_account_procedure_data(code_commitment: Digest)
     # move procedure data from the advice map to the advice stack
     adv.push_mapvaln
     # OS => [CODE_COMMITMENT]
@@ -1396,7 +1407,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-pub proc insert_new_storage
+pub proc insert_new_storage()
     exec.memory::get_native_num_storage_slots
     # => [num_slots]
 
@@ -1444,7 +1455,7 @@ end
 #!   Operand stack: [slot_idx]
 #!   Advice map: { MAP_ROOT: [MAP_ENTRIES] }
 #! Outputs: []
-proc insert_and_validate_storage_map
+proc insert_and_validate_storage_map(slot_idx: u8)
     mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH
     exec.memory::get_native_account_active_storage_slots_ptr
     add
@@ -1541,7 +1552,7 @@ end
 #!   the first two felts of the hashed slot name.
 #! - INITIAL_VALUE is the initial value of the item at the beginning of the transaction.
 #! - CURRENT_VALUE is the current value of the item.
-pub proc get_item_patch
+pub proc get_item_patch(index: u8) -> (word, word, StorageSlotId)
     # convert the index into a memory offset
     mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH
     # => [offset]
@@ -1586,7 +1597,7 @@ end
 #! - index is the index of the slot.
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
-pub proc get_native_slot_id
+pub proc get_native_slot_id(index: u8) -> StorageSlotId
     # convert the index into a memory offset
     mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH
     # => [offset]
@@ -1610,7 +1621,7 @@ end
 #! - index is the index of the slot.
 #! - reserved is the reserved element of the slot record, which must be zero per the canonical
 #!   encoding.
-proc get_native_slot_reserved
+proc get_native_slot_reserved(index: u8) -> felt
     # convert the index into a memory offset
     mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH
     # => [offset]
@@ -1635,7 +1646,7 @@ end
 #! - slot_ptr is the pointer to a slot.
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
-proc get_slot_id_inner
+proc get_slot_id_inner(slot_ptr: ptr<StorageSlot>) -> StorageSlotId
     dup add.ACCOUNT_SLOT_ID_PREFIX_OFFSET mem_load
     # => [slot_id_prefix, slot_ptr]
 
@@ -1656,7 +1667,7 @@ end
 #! Where:
 #! - slot_ptr is the pointer to a slot.
 #! - VALUE is the new value of the item.
-proc set_item_raw
+proc set_item_raw(slot_ptr: ptr<StorageSlot>, value: word)
     add.ACCOUNT_SLOT_VALUE_OFFSET mem_storew_le dropw
     # => []
 
@@ -1688,7 +1699,7 @@ end
 #! - 0: slot_ptr
 #! - 4..8: OLD_MAP_VALUE
 @locals(8)
-proc set_map_item_raw
+proc set_map_item_raw(slot_ptr: ptr<StorageSlot>, key: StorageMapKey, new_value: word) -> word
     # store slot_ptr until the end of the procedure
     dup loc_store.0
     # => [slot_ptr, KEY, NEW_VALUE]
@@ -1753,7 +1764,7 @@ end
 #! Where:
 #! - slot_ptr is the pointer to a slot.
 #! - VALUE is the value of the item.
-proc get_item_raw
+proc get_item_raw(slot_ptr: ptr<StorageSlot>) -> word
     # offset the pointer to point to the VALUE in the slot
     add.ACCOUNT_SLOT_VALUE_OFFSET
     # => [slot_value_ptr]
@@ -1780,7 +1791,12 @@ end
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
 #! - the requested storage slot type is not map.
-proc get_map_item_raw
+proc get_map_item_raw(
+    storage_slots_ptr: ptr<StorageSlot>,
+    num_storage_slots: u8,
+    slot_id: StorageSlotId,
+    key: StorageMapKey
+) -> word
     exec.get_storage_slot_ptr
     # => [slot_ptr, KEY]
 
@@ -1826,7 +1842,11 @@ end
 #! - slot_ptr is the pointer to the resolved storage slot.
 #! - slot_id_{suffix, prefix} are the suffix and prefix felts of the slot identifier, which are
 #!   the first two felts of the hashed slot name.
-proc find_storage_slot
+proc find_storage_slot(
+    storage_slots_ptr: ptr<StorageSlot>,
+    num_storage_slots: u8,
+    slot_id: StorageSlotId
+) -> (Bool, ptr<StorageSlot>)
     # construct the end pointer of the storage slots section in which we will search
     swap mul.ACCOUNT_STORAGE_SLOT_DATA_LENGTH dup.1 add
     # => [storage_slots_end_ptr, storage_slots_start_ptr, slot_id_suffix, slot_id_prefix]
@@ -1857,7 +1877,11 @@ end
 #!
 #! Panics if:
 #! - a slot with the provided slot ID does not exist in account storage.
-proc get_storage_slot_ptr
+proc get_storage_slot_ptr(
+    storage_slots_ptr: ptr<StorageSlot>,
+    num_storage_slots: u8,
+    slot_id: StorageSlotId
+) -> ptr<StorageSlot>
     exec.find_storage_slot
     # => [is_found, slot_ptr]
 
@@ -1876,7 +1900,7 @@ end
 #! Where:
 #! - slot_ptr is the pointer to a "current" storage slot in the native account's memory section.
 #! - slot_idx is the index of the storage slot.
-proc slot_ptr_to_index
+proc slot_ptr_to_index(slot_ptr: ptr<StorageSlot>) -> u8
     exec.memory::get_native_account_active_storage_slots_ptr
     sub
     # => [slot_offset]
@@ -1897,7 +1921,7 @@ end
 #!
 #! Panics if:
 #! - the procedure index is out of bounds.
-pub proc get_procedure_root
+pub proc get_procedure_root(index: u8) -> AccountProcedureRoot
     dup exec.memory::get_num_account_procedures
     u32assert2.err=ERR_ACCOUNT_PROC_INDEX_OUT_OF_BOUNDS
     u32lt assert.err=ERR_ACCOUNT_PROC_INDEX_OUT_OF_BOUNDS
@@ -1928,7 +1952,7 @@ end
 #!
 #! Panics if:
 #! - the maximum allowed number of foreign accounts to be loaded (63) was exceeded.
-pub proc get_account_data_ptr
+pub proc get_account_data_ptr(foreign_account_id: AccountId) -> (Bool, ptr<AccountData>, AccountId)
     # move pointer one account block back so that the first account pointer in the cycle will point
     # to the native account
     push.NATIVE_ACCOUNT_DATA_PTR push.ACCOUNT_DATA_LENGTH sub
@@ -1989,7 +2013,7 @@ end
 #! Panics if:
 #! - the commitment of the loaded foreign account does not match the commitment stored in the
 #!   account tree.
-pub proc validate_active_foreign_account
+pub proc validate_active_foreign_account()
     # get the account database root
     exec.memory::get_account_db_root
     # => [ACCOUNT_DB_ROOT]
@@ -2022,7 +2046,7 @@ end
 #!
 #! Inputs:  [KEY]
 #! Outputs: [HASHED_KEY]
-proc hash_map_key
+proc hash_map_key(key: StorageMapKey) -> Digest
     exec.poseidon2::hash
     # => [HASHED_KEY]
 end
@@ -2036,7 +2060,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-proc refresh_storage_commitment
+proc refresh_storage_commitment()
     # First we should determine whether the storage commitment should be recomputed. We should do so
     # if the active account is native and the storage commitment is outdated (the dirty flag equals
     # 1). Otherwise the commitment value is guaranteed to be up-to-date.
@@ -2108,7 +2132,7 @@ end
 #!
 #! Panics if:
 #! - the procedure root is not part of the account code.
-pub proc was_procedure_called
+pub proc was_procedure_called(proc_root: AccountProcedureRoot) -> Bool
     # load procedure index
     emit.ACCOUNT_PUSH_PROCEDURE_INDEX_EVENT adv_push
     # => [index, PROC_ROOT]
@@ -2141,7 +2165,7 @@ end
 #!
 #! Inputs:  [proc_idx]
 #! Outputs: []
-pub proc set_was_procedure_called
+pub proc set_was_procedure_called(proc_idx: u8)
     exec.memory::get_account_procedures_call_tracking_ptr
     # => [was_called_offset, proc_idx]
 
@@ -2161,7 +2185,7 @@ end
 #! - PROC_ROOT is the hash of the procedure of interest.
 #! - is_procedure_available is the binary flag indicating whether the procedure with PROC_ROOT is 
 #!   available on the active account.
-pub proc has_procedure
+pub proc has_procedure(proc_root: AccountProcedureRoot) -> Bool
     # get the end pointer of the procedure section (where we should stop iterating)
     exec.memory::get_num_account_procedures
     exec.memory::get_account_procedure_ptr
@@ -2225,7 +2249,7 @@ end
 #! Where:
 #! - account_id_{suffix,prefix} are the suffix and prefix felts of the account ID.
 #! - ACCOUNT_ID_KEY is the key word built from the provided account ID.
-proc create_id_key
+proc create_id_key(account_id: AccountId) -> Digest
     push.0.0
     # => [0, 0, account_id_suffix, account_id_prefix]
     # => [ACCOUNT_ID_KEY]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account.masm
@@ -8,7 +8,7 @@ use {
     StorageMapKey,
     StorageSlotId,
 } from miden::protocol_utils::types
-use {AccountData, Digest, StorageSlot} from miden::tx_kernel_core::types
+use {AccountData, Commitment, StorageSlot} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account_update
 use miden::protocol_utils::account_id
 use miden::tx_kernel_core::asset_vault
@@ -298,7 +298,7 @@ pub use {get_init_account_commitment as get_initial_commitment} from miden::tx_k
 #!
 #! Where:
 #! - ACCOUNT_COMMITMENT is the commitment of the account data.
-pub proc compute_commitment() -> Digest
+pub proc compute_commitment() -> Commitment
     # if outdated, recompute the storage commitment and store it in the memory
     exec.refresh_storage_commitment
     # => []
@@ -339,7 +339,7 @@ pub use {get_init_account_storage_commitment as get_initial_storage_commitment}
 #!
 #! Where:
 #! - STORAGE_COMMITMENT is the commitment of the active account storage.
-pub proc compute_storage_commitment() -> Digest
+pub proc compute_storage_commitment() -> Commitment
     # if outdated, recompute the storage commitment and store it in the memory
     exec.refresh_storage_commitment
 
@@ -1274,7 +1274,7 @@ end
 #! Panics if:
 #! - the number of account storage slots exceeded the maximum limit of 255.
 #! - the computed account storage commitment does not match the provided account storage commitment.
-pub proc save_account_storage_data(storage_commitment: Digest)
+pub proc save_account_storage_data(storage_commitment: Commitment)
     # move storage slot data from the advice map to the advice stack
     adv.push_mapvaln
     # OS => [STORAGE_COMMITMENT]
@@ -1344,7 +1344,7 @@ end
 #! Panics if:
 #! - the number of account procedures exceeded the maximum limit of 256.
 #! - the computed account code commitment does not match the provided account code commitment.
-pub proc save_account_procedure_data(code_commitment: Digest)
+pub proc save_account_procedure_data(code_commitment: Commitment)
     # move procedure data from the advice map to the advice stack
     adv.push_mapvaln
     # OS => [CODE_COMMITMENT]
@@ -2046,7 +2046,7 @@ end
 #!
 #! Inputs:  [KEY]
 #! Outputs: [HASHED_KEY]
-proc hash_map_key(key: StorageMapKey) -> Digest
+proc hash_map_key(key: StorageMapKey) -> Commitment
     exec.poseidon2::hash
     # => [HASHED_KEY]
 end
@@ -2249,7 +2249,7 @@ end
 #! Where:
 #! - account_id_{suffix,prefix} are the suffix and prefix felts of the account ID.
 #! - ACCOUNT_ID_KEY is the key word built from the provided account ID.
-proc create_id_key(account_id: AccountId) -> Digest
+proc create_id_key(account_id: AccountId) -> Commitment
     push.0.0
     # => [0, 0, account_id_suffix, account_id_prefix]
     # => [ACCOUNT_ID_KEY]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
@@ -1,5 +1,5 @@
 use {Asset, AssetId, AssetValue, Bool, StorageMapKey} from miden::protocol_utils::types
-use {Digest, HashState} from miden::tx_kernel_core::types
+use {Commitment, HasherState} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::asset
 use miden::tx_kernel_core::link_map
@@ -127,7 +127,7 @@ const MAX_ASSETS_PER_DELTA_OP = 1024
 #!
 #! Panics if:
 #! - the vault patch or storage patch is not empty but the nonce increment is zero.
-pub proc compute_patch_commitment() -> Digest
+pub proc compute_patch_commitment() -> Commitment
     # domain-separate the patch commitment through the hasher capacity
     push.0.0.DOMAIN_PATCH.0
     # => [CAPACITY]
@@ -196,7 +196,7 @@ end
 #!
 #! Panics if:
 #! - the vault delta or storage patch is not empty but the nonce increment is zero.
-pub proc compute_delta_commitment() -> Digest
+pub proc compute_delta_commitment() -> Commitment
     # domain-separate the delta commitment through the hasher capacity
     push.0.0.DOMAIN_DELTA.0
     # => [CAPACITY]
@@ -255,7 +255,7 @@ end
 #!
 #! Inputs:  [RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc commit_storage_patch(state: HashState) -> HashState
+proc commit_storage_patch(state: HasherState) -> HasherState
     exec.memory::get_native_num_storage_slots movdn.12
     # => [RATE0, RATE1, CAPACITY, num_storage_slots]
 
@@ -296,7 +296,7 @@ end
 #!
 #! Inputs:  [slot_idx, RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc commit_slot_patch(slot_idx: u8, state: HashState) -> HashState
+proc commit_slot_patch(slot_idx: u8, state: HasherState) -> HasherState
     dup exec.account::get_native_storage_slot_type
     # => [storage_slot_type, slot_idx, RATE0, RATE1, CAPACITY]
 
@@ -337,7 +337,7 @@ end
 #!
 #! Inputs:  [slot_idx, RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc commit_value_slot_patch(slot_idx: u8, state: HashState) -> HashState
+proc commit_value_slot_patch(slot_idx: u8, state: HasherState) -> HasherState
     exec.account::get_item_patch
     # => [INIT_VALUE, CURRENT_VALUE, slot_id_suffix, slot_id_prefix, RATE0, RATE1, CAPACITY]
 
@@ -391,7 +391,7 @@ end
 #! - 3: iter
 #! - 4: num_changed_entries
 @locals(5)
-proc commit_map_slot_patch(slot_idx: u8, state: HashState) -> HashState
+proc commit_map_slot_patch(slot_idx: u8, state: HasherState) -> HasherState
     # initialize num_changed_entries = 0
     # this is necessary because this procedure can be called multiple times and the second
     # invocation shouldn't reuse the first invocation's value
@@ -511,7 +511,7 @@ end
 #! - 3: num_removed_assets
 #! - 4..8196: removed_assets (MAX_ASSETS_PER_DELTA_OP * ASSET_SIZE elements)
 @locals(8196)
-proc commit_asset_delta(state: HashState) -> HashState
+proc commit_asset_delta(state: HasherState) -> HasherState
     # initialize num_added_assets = 0 and num_removed_assets = 0
     # this is necessary because this procedure can be called multiple times and the second
     # invocation shouldn't reuse the first invocation's values
@@ -664,7 +664,7 @@ end
 #! Where:
 #! - delta_op is the delta operation (DELTA_OP_ADD or DELTA_OP_REMOVE).
 #! - num_assets is the number of assets affected by delta_op (added or removed).
-proc commit_asset_count_trailer(delta_op: u8, num_assets: u32, state: HashState) -> HashState
+proc commit_asset_count_trailer(delta_op: u8, num_assets: u32, state: HasherState) -> HasherState
     dup.1 neq.0
     # => [is_non_zero, delta_op, num_assets, RATE0, RATE1, CAPACITY]
 
@@ -704,7 +704,7 @@ end
 #! - 1: iter
 #! - 2: num_changed_assets
 @locals(3)
-proc commit_asset_patch(state: HashState) -> HashState
+proc commit_asset_patch(state: HasherState) -> HasherState
     # initialize num_changed_assets = 0
     # this is necessary because this procedure can be called multiple times and the second
     # invocation shouldn't reuse the first invocation's values

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/account_update.masm
@@ -1,3 +1,5 @@
+use {Asset, AssetId, AssetValue, Bool, StorageMapKey} from miden::protocol_utils::types
+use {Digest, HashState} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::asset
 use miden::tx_kernel_core::link_map
@@ -125,7 +127,7 @@ const MAX_ASSETS_PER_DELTA_OP = 1024
 #!
 #! Panics if:
 #! - the vault patch or storage patch is not empty but the nonce increment is zero.
-pub proc compute_patch_commitment
+pub proc compute_patch_commitment() -> Digest
     # domain-separate the patch commitment through the hasher capacity
     push.0.0.DOMAIN_PATCH.0
     # => [CAPACITY]
@@ -194,7 +196,7 @@ end
 #!
 #! Panics if:
 #! - the vault delta or storage patch is not empty but the nonce increment is zero.
-pub proc compute_delta_commitment
+pub proc compute_delta_commitment() -> Digest
     # domain-separate the delta commitment through the hasher capacity
     push.0.0.DOMAIN_DELTA.0
     # => [CAPACITY]
@@ -253,7 +255,7 @@ end
 #!
 #! Inputs:  [RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc commit_storage_patch
+proc commit_storage_patch(state: HashState) -> HashState
     exec.memory::get_native_num_storage_slots movdn.12
     # => [RATE0, RATE1, CAPACITY, num_storage_slots]
 
@@ -294,7 +296,7 @@ end
 #!
 #! Inputs:  [slot_idx, RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc commit_slot_patch
+proc commit_slot_patch(slot_idx: u8, state: HashState) -> HashState
     dup exec.account::get_native_storage_slot_type
     # => [storage_slot_type, slot_idx, RATE0, RATE1, CAPACITY]
 
@@ -324,7 +326,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: [patch_op]
-proc get_storage_slot_patch_op
+proc get_storage_slot_patch_op() -> u8
     # negate the is_new_account flag to get the patch operation
     # `is_new_account` maps to Create = 0
     # `!is_new_account` maps to Update = 1
@@ -335,7 +337,7 @@ end
 #!
 #! Inputs:  [slot_idx, RATE0, RATE1, CAPACITY]
 #! Outputs: [RATE0, RATE1, CAPACITY]
-proc commit_value_slot_patch
+proc commit_value_slot_patch(slot_idx: u8, state: HashState) -> HashState
     exec.account::get_item_patch
     # => [INIT_VALUE, CURRENT_VALUE, slot_id_suffix, slot_id_prefix, RATE0, RATE1, CAPACITY]
 
@@ -389,7 +391,7 @@ end
 #! - 3: iter
 #! - 4: num_changed_entries
 @locals(5)
-proc commit_map_slot_patch
+proc commit_map_slot_patch(slot_idx: u8, state: HashState) -> HashState
     # initialize num_changed_entries = 0
     # this is necessary because this procedure can be called multiple times and the second
     # invocation shouldn't reuse the first invocation's value
@@ -509,7 +511,7 @@ end
 #! - 3: num_removed_assets
 #! - 4..8196: removed_assets (MAX_ASSETS_PER_DELTA_OP * ASSET_SIZE elements)
 @locals(8196)
-proc commit_asset_delta
+proc commit_asset_delta(state: HashState) -> HashState
     # initialize num_added_assets = 0 and num_removed_assets = 0
     # this is necessary because this procedure can be called multiple times and the second
     # invocation shouldn't reuse the first invocation's values
@@ -662,7 +664,7 @@ end
 #! Where:
 #! - delta_op is the delta operation (DELTA_OP_ADD or DELTA_OP_REMOVE).
 #! - num_assets is the number of assets affected by delta_op (added or removed).
-proc commit_asset_count_trailer
+proc commit_asset_count_trailer(delta_op: u8, num_assets: u32, state: HashState) -> HashState
     dup.1 neq.0
     # => [is_non_zero, delta_op, num_assets, RATE0, RATE1, CAPACITY]
 
@@ -702,7 +704,7 @@ end
 #! - 1: iter
 #! - 2: num_changed_assets
 @locals(3)
-proc commit_asset_patch
+proc commit_asset_patch(state: HashState) -> HashState
     # initialize num_changed_assets = 0
     # this is necessary because this procedure can be called multiple times and the second
     # invocation shouldn't reuse the first invocation's values
@@ -794,7 +796,7 @@ end
 #!
 #! Where:
 #! - was_nonce_incremented is the boolean flag indicating whether the account nonce was incremented.
-pub proc was_nonce_incremented
+pub proc was_nonce_incremented() -> Bool
     exec.memory::get_init_nonce
     # => [init_nonce]
 
@@ -816,7 +818,11 @@ end
 #! - ASSET_ID is the asset ID of the asset that is added.
 #! - INITIAL_ASSET_VALUE is the value of the asset before the update.
 #! - FINAL_ASSET_VALUE is the value of the asset after the update.
-pub proc update_asset
+pub proc update_asset(
+    asset_id: AssetId,
+    initial_asset_value: AssetValue,
+    final_asset_value: AssetValue
+)
     swapw dupw.1 push.ACCOUNT_UPDATE_ASSET_PTR
     # => [asset_delta_map_ptr, ASSET_ID, INITIAL_ASSET_VALUE, ASSET_ID, FINAL_ASSET_VALUE]
 
@@ -876,7 +882,11 @@ end
 #!
 #! Panics if:
 #! - the asset's composition is Custom (not yet supported).
-proc compute_asset_delta
+proc compute_asset_delta(
+    initial_asset_value: AssetValue,
+    final_asset_value: AssetValue,
+    asset_id: AssetId
+) -> (u8, Asset)
     dupw.2
     # => [ASSET_ID, INITIAL_ASSET_VALUE, FINAL_ASSET_VALUE, ASSET_ID]
 
@@ -957,7 +967,7 @@ end
 #! - PREV_VALUE is the previous value of the key in the storage map that is being updated.
 #! - NEW_VALUE is the new value of the key in the storage map that is being updated.
 @locals(8)
-pub proc set_map_item
+pub proc set_map_item(slot_index: u8, key: StorageMapKey, prev_value: word, new_value: word)
     # retrieve the link map ptr to the storage map patch for the provided index
     exec.memory::get_account_patch_storage_map_ptr
     # => [account_patch_storage_map_ptr, KEY, PREV_VALUE, NEW_VALUE]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/asset.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/asset.masm
@@ -1,3 +1,11 @@
+use {
+    AccountId,
+    Asset,
+    AssetComposition,
+    AssetId,
+    AssetValue,
+    Bool,
+} from miden::protocol_utils::types
 use miden::protocol_utils::account_id
 use miden::tx_kernel_core::fungible_asset
 use miden::protocol_utils::asset as asset_utils
@@ -32,7 +40,7 @@ pub use {ASSET_SIZE, ASSET_VALUE_MEMORY_OFFSET, COMPOSITION_CUSTOM, COMPOSITION_
 #! Where:
 #! - ASSET_ID is the asset ID from which to extract the metadata.
 #! - has_callbacks is 1 if callbacks are enabled and 0 if disabled.
-pub proc id_to_has_callbacks
+pub proc id_to_has_callbacks(asset_id: AssetId) -> (Bool, AssetId)
     # => [asset_class_suffix, asset_class_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix]
     dup.3 exec.account_id::asset_callback_flag
     # => [has_callbacks, ASSET_ID]
@@ -46,7 +54,7 @@ end
 #! Where:
 #! - ASSET_ID is the asset ID of the asset to check.
 #! - is_fungible_asset is a boolean indicating whether the asset is fungible.
-pub proc is_fungible_asset_id
+pub proc is_fungible_asset_id(asset_id: AssetId) -> (Bool, AssetId)
     # => [ASSET_ID]
     exec.id_to_composition
     # => [asset_composition, ASSET_ID]
@@ -66,7 +74,7 @@ end
 #! Panics if:
 #! - the asset is fungible and its ID is not valid (see fungible_asset::validate_id).
 #! - the asset's issuer or metadata is not valid (see validate_issuer).
-pub proc validate_id
+pub proc validate_id(asset_id: AssetId) -> AssetId
     # check if the asset ID is fungible
     exec.is_fungible_asset_id
     # => [is_fungible_asset, ASSET_ID]
@@ -93,7 +101,7 @@ end
 #! Panics if:
 #! - the asset metadata is invalid (not 0 or 1).
 #! - the faucet ID in the key is not a valid account ID.
-pub proc validate_issuer
+pub proc validate_issuer(asset_id: AssetId) -> AssetId
     # => [asset_class_suffix, asset_class_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix]
     dup.3 dup.3 exec.asset_utils::split_suffix_and_metadata
     # => [asset_metadata, faucet_id_suffix, faucet_id_prefix, ASSET_ID]
@@ -115,7 +123,7 @@ end
 #!
 #! Panics if:
 #! - the asset's composition is Custom.
-pub proc assert_supported_composition
+pub proc assert_supported_composition(asset_id: AssetId) -> AssetId
     exec.id_to_composition
     # => [asset_composition, ASSET_ID]
 
@@ -138,7 +146,7 @@ end
 #! Panics if:
 #! - the asset is fungible and not valid (see fungible_asset::validate).
 #! - the asset's issuer or metadata is not valid (see validate_issuer).
-pub proc validate
+pub proc validate(asset: Asset) -> Asset
     # check if the asset is fungible
     exec.is_fungible_asset_id
     # => [is_fungible_asset, ASSET_ID, ASSET_VALUE]
@@ -168,7 +176,7 @@ end
 #! Panics if:
 #! - the asset is not well formed (see validate).
 #! - the asset's faucet ID does not match the provided faucet_id.
-pub proc validate_origin
+pub proc validate_origin(faucet_id: AccountId, asset: Asset) -> Asset
     movdn.9 movdn.9
     # => [ASSET_ID, ASSET_VALUE, faucet_id_suffix, faucet_id_prefix]
 
@@ -204,7 +212,11 @@ end
 #! - the asset's composition is None.
 #! - the asset's composition is Custom (not yet supported).
 #! - the underlying merge operation panics (see fungible_asset::merge).
-pub proc merge
+pub proc merge(
+    asset_composition: AssetComposition,
+    current_asset_value: AssetValue,
+    other_asset_value: AssetValue
+) -> AssetValue
     dup neq.COMPOSITION_NONE assert.err=ERR_VAULT_MERGE_COMPOSITION_NONE
     # => [asset_composition, CURRENT_ASSET_VALUE, OTHER_ASSET_VALUE]
 
@@ -238,7 +250,11 @@ end
 #! - the asset's composition is None.
 #! - the asset's composition is Custom (not yet supported).
 #! - the underlying split operation panics (see fungible_asset::split).
-pub proc split
+pub proc split(
+    asset_composition: AssetComposition,
+    current_asset_value: AssetValue,
+    other_asset_value: AssetValue
+) -> AssetValue
     dup neq.COMPOSITION_NONE assert.err=ERR_VAULT_SPLIT_COMPOSITION_NONE
     # => [asset_composition, CURRENT_ASSET_VALUE, OTHER_ASSET_VALUE]
 
@@ -270,7 +286,11 @@ end
 #! Panics if:
 #! - the asset's composition is None.
 #! - the asset's composition is Custom (not yet supported).
-pub proc lt
+pub proc lt(
+    asset_id: AssetId,
+    current_asset_value: AssetValue,
+    other_asset_value: AssetValue
+) -> Bool
     exec.id_to_composition
     # => [asset_composition, ASSET_ID, CURRENT_ASSET_VALUE, OTHER_ASSET_VALUE]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/asset_vault.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/asset_vault.masm
@@ -1,3 +1,5 @@
+use {Asset, AssetId, AssetValue} from miden::protocol_utils::types
+use {Digest} from miden::tx_kernel_core::types
 use miden::core::collections::smt
 use miden::core::crypto::hashes::poseidon2
 use miden::core::word
@@ -46,7 +48,7 @@ const REMOVE_ASSET_ASSET_COMPOSITION_LOC = 1
 #!
 #! Panics if:
 #! - the asset's composition is Custom.
-pub proc get_asset
+pub proc get_asset(asset_id: AssetId, vault_root_ptr: ptr<Digest>) -> AssetValue
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, vault_root_ptr]
@@ -90,7 +92,7 @@ end
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
 #! - ASSET_ID_HASH is the hashed asset ID of the asset to fetch (see hash_asset_id).
 #! - ASSET_VALUE is the retrieved asset.
-pub proc peek_asset
+pub proc peek_asset(asset_id_hash: Digest, vault_root_ptr: ptr<Digest>) -> AssetValue
     # load the asset vault root from memory
     padw movup.8 mem_loadw_le
     # => [ASSET_VAULT_ROOT, ASSET_ID_HASH]
@@ -141,7 +143,7 @@ end
 #! - 0: vault_root_ptr
 #! - 1: asset_composition
 @locals(2)
-pub proc add_asset
+pub proc add_asset(asset: Asset, vault_root_ptr: ptr<Digest>) -> (AssetValue, AssetValue)
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, ASSET_VALUE, vault_root_ptr]
@@ -263,7 +265,7 @@ end
 #! - 0: vault_root_ptr
 #! - 1: asset_composition
 @locals(2)
-pub proc remove_asset
+pub proc remove_asset(asset: Asset, vault_root_ptr: ptr<Digest>) -> (AssetValue, AssetValue)
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, ASSET_VALUE, vault_root_ptr]
@@ -355,7 +357,7 @@ end
 #!
 #! Inputs:  [ASSET_ID]
 #! Outputs: [ASSET_ID_HASH]
-proc hash_asset_id
+proc hash_asset_id(asset_id: AssetId) -> Digest
     exec.poseidon2::hash
     # => [ASSET_ID_HASH]
 end

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/asset_vault.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/asset_vault.masm
@@ -1,5 +1,5 @@
 use {Asset, AssetId, AssetValue} from miden::protocol_utils::types
-use {Digest} from miden::tx_kernel_core::types
+use {Commitment} from miden::tx_kernel_core::types
 use miden::core::collections::smt
 use miden::core::crypto::hashes::poseidon2
 use miden::core::word
@@ -48,7 +48,7 @@ const REMOVE_ASSET_ASSET_COMPOSITION_LOC = 1
 #!
 #! Panics if:
 #! - the asset's composition is Custom.
-pub proc get_asset(asset_id: AssetId, vault_root_ptr: ptr<Digest>) -> AssetValue
+pub proc get_asset(asset_id: AssetId, vault_root_ptr: ptr<Commitment>) -> AssetValue
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, vault_root_ptr]
@@ -92,7 +92,7 @@ end
 #! - vault_root_ptr is a pointer to the memory location at which the vault root is stored.
 #! - ASSET_ID_HASH is the hashed asset ID of the asset to fetch (see hash_asset_id).
 #! - ASSET_VALUE is the retrieved asset.
-pub proc peek_asset(asset_id_hash: Digest, vault_root_ptr: ptr<Digest>) -> AssetValue
+pub proc peek_asset(asset_id_hash: Commitment, vault_root_ptr: ptr<Commitment>) -> AssetValue
     # load the asset vault root from memory
     padw movup.8 mem_loadw_le
     # => [ASSET_VAULT_ROOT, ASSET_ID_HASH]
@@ -143,7 +143,7 @@ end
 #! - 0: vault_root_ptr
 #! - 1: asset_composition
 @locals(2)
-pub proc add_asset(asset: Asset, vault_root_ptr: ptr<Digest>) -> (AssetValue, AssetValue)
+pub proc add_asset(asset: Asset, vault_root_ptr: ptr<Commitment>) -> (AssetValue, AssetValue)
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, ASSET_VALUE, vault_root_ptr]
@@ -265,7 +265,7 @@ end
 #! - 0: vault_root_ptr
 #! - 1: asset_composition
 @locals(2)
-pub proc remove_asset(asset: Asset, vault_root_ptr: ptr<Digest>) -> (AssetValue, AssetValue)
+pub proc remove_asset(asset: Asset, vault_root_ptr: ptr<Commitment>) -> (AssetValue, AssetValue)
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, ASSET_VALUE, vault_root_ptr]
@@ -357,7 +357,7 @@ end
 #!
 #! Inputs:  [ASSET_ID]
 #! Outputs: [ASSET_ID_HASH]
-proc hash_asset_id(asset_id: AssetId) -> Digest
+proc hash_asset_id(asset_id: AssetId) -> Commitment
     exec.poseidon2::hash
     # => [ASSET_ID_HASH]
 end

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/callbacks.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/callbacks.masm
@@ -1,3 +1,4 @@
+use {AccountId, AccountProcedureRoot, Asset, Bool, StorageSlotId} from miden::protocol_utils::types
 use miden::tx_kernel_core::tx
 use miden::tx_kernel_core::asset
 use miden::tx_kernel_core::account
@@ -47,7 +48,7 @@ const ERR_FAUCET_CALLBACK_PROC_ROOT_NOT_PART_OF_ACCOUNT_CODE =
 #! Where:
 #! - ASSET_ID is the asset ID of the asset being added.
 #! - ASSET_VALUE is the value of the asset being added.
-pub proc on_before_asset_added_to_account
+pub proc on_before_asset_added_to_account(asset: Asset)
     # derive the callback flag from the asset metadata, carried in the asset ID
     exec.asset::id_to_has_callbacks
     # => [has_callbacks, ASSET_ID, ASSET_VALUE]
@@ -82,7 +83,7 @@ end
 #! - ASSET_ID is the asset ID of the asset being added.
 #! - ASSET_VALUE is the value of the asset being added.
 #! - note_idx is the index of the output note the asset is being added to.
-pub proc on_before_asset_added_to_note
+pub proc on_before_asset_added_to_note(asset: Asset, note_idx: u16)
     # derive the callback flag from the asset metadata, carried in the asset ID
     exec.asset::id_to_has_callbacks
     # => [has_callbacks, ASSET_ID, ASSET_VALUE, note_idx]
@@ -117,7 +118,7 @@ end
 #! - ASSET_ID is the asset ID of the asset being added.
 #! - ASSET_VALUE is the value of the asset being added.
 @locals(4)
-proc invoke_callback
+proc invoke_callback(slot_id: StorageSlotId, asset: Asset, custom_data: felt)
     exec.maybe_start_faucet_callback_context
     # => [was_foreign_context_started, should_invoke_callback, PROC_ROOT, ASSET_ID, ASSET_VALUE, custom_data]
 
@@ -179,7 +180,10 @@ end
 #! - should_invoke_callback is 1 if the callback should be invoked, 0 otherwise.
 #! - PROC_ROOT is the procedure root of the callback, or the empty word if not found.
 #! - was_foreign_context_started is 1 if the faucet is not the active account, 0 otherwise.
-proc maybe_start_faucet_callback_context
+proc maybe_start_faucet_callback_context(
+    slot_id: StorageSlotId,
+    asset: Asset
+) -> (Bool, Bool, AccountProcedureRoot, Asset)
     # move slot IDs past ASSET_ID and ASSET_VALUE
     movdn.9 movdn.9
     # => [ASSET_ID, ASSET_VALUE, slot_id_suffix, slot_id_prefix]
@@ -237,7 +241,7 @@ end
 #!
 #! Where:
 #! - was_foreign_context_started is 1 if a foreign context was started, 0 otherwise.
-proc maybe_end_faucet_callback_context
+proc maybe_end_faucet_callback_context(was_foreign_context_started: Bool)
     # if a foreign context was started, end it
     if.true
         exec.tx::end_foreign_context
@@ -249,7 +253,7 @@ end
 #!
 #! Inputs:  [faucet_id_suffix, faucet_id_prefix]
 #! Outputs: [should_start_foreign_context]
-proc should_start_foreign_context
+proc should_start_foreign_context(faucet_id: AccountId) -> Bool
     exec.account::get_id
     # => [active_account_id_suffix, active_account_id_prefix, faucet_id_suffix, faucet_id_prefix]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/epilogue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/epilogue.masm
@@ -1,5 +1,5 @@
 use {BlockNumber} from miden::protocol_utils::types
-use {Digest} from miden::tx_kernel_core::types
+use {Commitment} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::account_update
 use miden::tx_kernel_core::asset
@@ -58,7 +58,7 @@ const EPILOGUE_AUTH_PROC_END_EVENT = event("miden::protocol::epilogue::auth_proc
 #! - output_note_ptr is the start boundary of the output notes section.
 #! - output_notes_end_ptr is the end boundary of the output notes section.
 #! - mem[i] is the memory value stored at some address i.
-proc copy_output_notes_to_advice_map(output_notes_commitment: Digest) -> Digest
+proc copy_output_notes_to_advice_map(output_notes_commitment: Commitment) -> Commitment
     # get the number of notes created by the transaction
     exec.memory::get_num_output_notes
     # => [num_notes, OUTPUT_NOTES_COMMITMENT]
@@ -257,7 +257,7 @@ end
 #!   changing the account's state. The latter is validated as part of computing the account patch
 #!   commitment.
 @locals(8)
-pub proc finalize_transaction() -> (Digest, Digest, BlockNumber)
+pub proc finalize_transaction() -> (Commitment, Commitment, BlockNumber)
     # make sure that the context was switched back to the native account
     exec.memory::assert_native_account
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/epilogue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/epilogue.masm
@@ -1,3 +1,5 @@
+use {BlockNumber} from miden::protocol_utils::types
+use {Digest} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::account_update
 use miden::tx_kernel_core::asset
@@ -56,7 +58,7 @@ const EPILOGUE_AUTH_PROC_END_EVENT = event("miden::protocol::epilogue::auth_proc
 #! - output_note_ptr is the start boundary of the output notes section.
 #! - output_notes_end_ptr is the end boundary of the output notes section.
 #! - mem[i] is the memory value stored at some address i.
-proc copy_output_notes_to_advice_map
+proc copy_output_notes_to_advice_map(output_notes_commitment: Digest) -> Digest
     # get the number of notes created by the transaction
     exec.memory::get_num_output_notes
     # => [num_notes, OUTPUT_NOTES_COMMITMENT]
@@ -97,7 +99,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-proc build_output_vault
+proc build_output_vault()
     # copy final account vault root to output account vault root
     exec.memory::get_native_account_vault_root exec.memory::set_output_vault_root dropw
     # => []
@@ -183,7 +185,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-proc execute_auth_procedure
+proc execute_auth_procedure()
     emit.EPILOGUE_AUTH_PROC_START_EVENT
 
     padw padw padw
@@ -255,7 +257,7 @@ end
 #!   changing the account's state. The latter is validated as part of computing the account patch
 #!   commitment.
 @locals(8)
-pub proc finalize_transaction
+pub proc finalize_transaction() -> (Digest, Digest, BlockNumber)
     # make sure that the context was switched back to the native account
     exec.memory::assert_native_account
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/faucet.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/faucet.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol_utils::types
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::asset
 use miden::tx_kernel_core::asset_vault
@@ -33,7 +34,7 @@ const ACCOUNT_VAULT_BEFORE_BURN_ASSET_EVENT =
 #! Panics if:
 #! - the asset issuer is not the faucet the transaction is being executed against.
 #! - the asset is not well formed.
-pub proc mint
+pub proc mint(asset: Asset)
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, ASSET_VALUE]
@@ -77,7 +78,7 @@ end
 #!   transaction.
 #! - For non-fungible faucets if the non-fungible asset being burned does not exist or was not
 #!   provided as input to the transaction via a note or the accounts vault.
-pub proc burn
+pub proc burn(asset: Asset)
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, ASSET_VALUE]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/fungible_asset.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/fungible_asset.masm
@@ -1,3 +1,4 @@
+use {AccountId, Asset, AssetId, AssetValue, Bool} from miden::protocol_utils::types
 # Contains procedures for the built-in fungible asset.
 
 use miden::protocol_utils::account_id
@@ -48,7 +49,7 @@ const ERR_VAULT_FUNGIBLE_ASSET_AMOUNT_LESS_THAN_AMOUNT_TO_WITHDRAW =
 #!
 #! Panics if:
 #! - adding the two asset values would exceed MAX_AMOUNT.
-pub proc merge
+pub proc merge(asset_value_0: AssetValue, asset_value_1: AssetValue) -> AssetValue
     # extract amounts from assets
     exec.asset::fungible_value_into_amount_unchecked movdn.4 exec.asset::fungible_value_into_amount_unchecked
     # => [amount_1, amount_0]
@@ -86,7 +87,7 @@ end
 #!
 #! Panics if:
 #! - ASSET_VALUE_0 does not contain at least the amount of ASSET_VALUE_1.
-pub proc split
+pub proc split(asset_value_1: AssetValue, asset_value_0: AssetValue) -> AssetValue
     # extract amounts from assets
     exec.asset::fungible_value_into_amount_unchecked movdn.4 exec.asset::fungible_value_into_amount_unchecked swap
     # => [amount_1, amount_0]
@@ -117,7 +118,7 @@ end
 #! Where:
 #! - ASSET_VALUE_{0, 1} are the assets to compare.
 #! - is_lt is 1 if ASSET_VALUE_0 is less than ASSET_VALUE_1.
-pub proc lt
+pub proc lt(asset_value_1: AssetValue, asset_value_0: AssetValue) -> Bool
     exec.asset::fungible_value_into_amount_unchecked movdn.4 exec.asset::fungible_value_into_amount_unchecked swap
     # => [amount_1, amount_0]
 
@@ -138,7 +139,7 @@ end
 #! - the asset ID is invalid (see validate_id).
 #! - the three most significant elements in the value are not 0.
 #! - the amount exceeds MAX_AMOUNT.
-pub proc validate
+pub proc validate(asset: Asset) -> Asset
     exec.validate_id
     # => [ASSET_ID, ASSET_VALUE]
 
@@ -172,7 +173,7 @@ end
 #! - the asset ID's account ID is not valid.
 #! - the asset ID's metadata is not valid.
 #! - the asset ID's composition is not fungible.
-pub proc validate_id
+pub proc validate_id(asset_id: AssetId) -> AssetId
     exec.asset::validate_issuer
     # => [ASSET_ID]
 
@@ -197,7 +198,7 @@ end
 #! - faucet_id_{suffix,prefix} are the suffix and prefix of the faucet's account ID.
 #! - ASSET_ID is the asset ID of the asset to validate.
 #! - ASSET_VALUE is the value of the asset to validate.
-pub proc validate_origin
+pub proc validate_origin(faucet_id: AccountId, asset: Asset) -> Asset
     movdn.9 movdn.9
     # => [ASSET_ID, ASSET_VALUE, faucet_id_suffix, faucet_id_prefix]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/input_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/input_note.masm
@@ -1,3 +1,5 @@
+use {Asset, AssetValue, NoteAssetsCommitment} from miden::protocol_utils::types
+use {InputNoteData} from miden::tx_kernel_core::types
 use miden::core::crypto::hashes::poseidon2
 use miden::core::word
 use miden::tx_kernel_core::asset
@@ -48,7 +50,7 @@ const ERR_INPUT_NOTE_NON_FUNGIBLE_ASSET_TO_REMOVE_NOT_FOUND =
 #! - input_note_ptr is the memory address of the data segment for the requested input note.
 #! - num_assets is the number of assets the note was created with.
 #! - ASSETS_COMMITMENT is a sequential hash of the assets the note was created with.
-pub proc get_initial_assets_info
+pub proc get_initial_assets_info(input_note_ptr: ptr<InputNoteData>) -> (NoteAssetsCommitment, u8)
     # get the number of assets in the note
     dup exec.memory::get_input_note_num_assets
     # => [num_assets, input_note_ptr]
@@ -76,7 +78,7 @@ end
 #!
 #! Panics if:
 #! - the asset index is greater or equal to the number of assets in the note.
-pub proc get_asset
+pub proc get_asset(input_note_ptr: ptr<InputNoteData>, asset_index: u8) -> Asset
     # assert the requested asset index is less than the number of assets in the note
     dup.1 dup.1 exec.memory::get_input_note_num_assets
     # => [num_assets, asset_index, input_note_ptr, asset_index]
@@ -119,7 +121,7 @@ end
 #! - the asset is not present in the note.
 #! - the asset is not composable and is not present in the note with the exact value.
 #! - the amount of the fungible asset in the note is less than the amount to be removed.
-pub proc remove_asset
+pub proc remove_asset(asset: Asset, input_note_ptr: ptr<InputNoteData>) -> AssetValue
     # reject the empty asset ID explicitly so that the linear scan doesn't report it as found
     exec.word::testz not assert.err=ERR_INPUT_NOTE_ASSET_ID_TO_REMOVE_IS_EMPTY
     # => [ASSET_ID, ASSET_VALUE, input_note_ptr]
@@ -260,7 +262,7 @@ end
 #! - 2: number of removed (i.e. previously remaining) assets
 #! - 4..132: buffer of the removed assets (MAX_ASSETS_PER_NOTE * ASSET_SIZE elements)
 @locals(132)
-pub proc remove_all_assets
+pub proc remove_all_assets(input_note_ptr: ptr<InputNoteData>) -> (NoteAssetsCommitment, u8)
     # initialize the number of remaining assets to zero; this is necessary because this procedure
     # can be invoked multiple times and locals may hold values from a previous invocation
     push.0 loc_store.REMOVE_ALL_ASSETS_NUM_REMAINING_LOC
@@ -356,7 +358,7 @@ end
 #!
 #! Inputs:  [note_index]
 #! Outputs: [note_index]
-pub proc assert_note_index_in_bounds
+pub proc assert_note_index_in_bounds(note_index: u16) -> u16
     # assert that the provided note index is less than the total number of notes
     dup exec.memory::get_num_input_notes
     # => [input_notes_num, note_index, note_index]
@@ -378,7 +380,7 @@ end
 #!
 #! Panics if:
 #! - the note index is greater or equal to the total number of input notes.
-pub proc get_input_note_ptr
+pub proc get_input_note_ptr(idx: u16) -> ptr<InputNoteData>
     # asset that the provided input note index is valid
     exec.assert_note_index_in_bounds
     # => [idx]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/link_map.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/link_map.masm
@@ -1,3 +1,5 @@
+use {Bool} from miden::protocol_utils::types
+use {LinkMapEntry} from miden::tx_kernel_core::types
 use miden::core::word
 use {LINK_MAP_ENTRY_SIZE, LINK_MAP_REGION_END_PTR, LINK_MAP_REGION_START_PTR, link_map_malloc}
     from miden::tx_kernel_core::memory
@@ -211,7 +213,7 @@ const LINK_MAP_GET_EVENT = event("miden::protocol::link_map::get")
 #! Panics if:
 #! - the host provides faulty advice. See panic sections of assert_entry_ptr_is_valid,
 #!   update_entry, insert_at_head, insert_after_entry and assert_empty_map_op_is_at_head.
-pub proc set
+pub proc set(map_ptr: ptr<ptr<LinkMapEntry>>, key: word, value0: word, value1: word) -> Bool
     emit.LINK_MAP_SET_EVENT
     adv_push adv_push
     # => [operation, entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
@@ -287,7 +289,7 @@ end
 #! - the host provides faulty advice. See panic sections of assert_entry_ptr_is_valid,
 #!   get_existing_value, assert_absent_at_head, assert_absent_after_entry and
 #!   assert_empty_map_op_is_at_head.
-pub proc get
+pub proc get(map_ptr: ptr<ptr<LinkMapEntry>>, key: word) -> (Bool, word, word)
     emit.LINK_MAP_GET_EVENT
     adv_push adv_push
     # => [get_operation, entry_ptr, map_ptr, KEY]
@@ -354,7 +356,7 @@ end
 #!
 #! Inputs:  [map_ptr]
 #! Outputs: [is_empty]
-pub proc is_empty
+pub proc is_empty(map_ptr: ptr<ptr<LinkMapEntry>>) -> Bool
     mem_load eq.0
 end
 
@@ -364,7 +366,7 @@ end
 #!
 #! Inputs:  [map_ptr]
 #! Outputs: [has_next, iter]
-pub proc iter
+pub proc iter(map_ptr: ptr<ptr<LinkMapEntry>>) -> (Bool, ptr<LinkMapEntry>)
     exec.get_head
     # => [entry_ptr]
 
@@ -385,7 +387,9 @@ end
 #!
 #! Inputs:  [iter]
 #! Outputs: [KEY, VALUE0, VALUE1, has_next, next_iter]
-pub proc next_key_double_value
+pub proc next_key_double_value(
+    iter: ptr<LinkMapEntry>
+) -> (word, word, word, Bool, ptr<LinkMapEntry>)
     dup exec.next_key
     # => [KEY, has_next, next_entry_ptr, entry_ptr = iter]
 
@@ -403,7 +407,7 @@ end
 #!
 #! Inputs:  [iter]
 #! Outputs: [KEY, VALUE0, has_next, next_iter]
-pub proc next_key_value
+pub proc next_key_value(iter: ptr<LinkMapEntry>) -> (word, word, Bool, ptr<LinkMapEntry>)
     dup exec.next_key
     # => [KEY, has_next, next_entry_ptr, entry_ptr = iter]
 
@@ -421,7 +425,7 @@ end
 #!
 #! Inputs:  [iter]
 #! Outputs: [KEY, has_next, next_iter]
-pub proc next_key
+pub proc next_key(iter: ptr<LinkMapEntry>) -> (word, Bool, ptr<LinkMapEntry>)
     dup exec.get_next_entry_ptr
     # => [next_entry_ptr, entry_ptr = iter]
 
@@ -442,7 +446,7 @@ end
 #!
 #! Panics if:
 #! - the KEY is not less than the key in the head of the map, unless the map is empty.
-proc insert_at_head
+proc insert_at_head(map_ptr: ptr<ptr<LinkMapEntry>>, key: word, value0: word, value1: word)
     exec.link_map_malloc
     # => [entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
 
@@ -501,7 +505,7 @@ end
 #!
 #! Panics if:
 #! - the key in the entry does not match the provided KEY.
-proc update_entry
+proc update_entry(entry_ptr: ptr<LinkMapEntry>, key: word, value0: word, value1: word)
     dup movdn.5
     # => [entry_ptr, KEY, entry_ptr, VALUE0, VALUE1]
 
@@ -521,7 +525,13 @@ end
 #! - the KEY is not greater than the key in the prev entry.
 #! - the KEY is not less than the key in prev_entry.next_entry, unless the prev entry is the last
 #!   one in the map.
-proc insert_after_entry
+proc insert_after_entry(
+    prev_entry_ptr: ptr<LinkMapEntry>,
+    map_ptr: ptr<ptr<LinkMapEntry>>,
+    key: word,
+    value0: word,
+    value1: word
+)
     movdn.5
     # => [map_ptr, KEY, prev_entry_ptr, VALUE0, VALUE1]
 
@@ -602,7 +612,13 @@ end
 #!
 #! Inputs:  [entry_ptr, map_ptr, KEY, VALUE0, VALUE1]
 #! Outputs: []
-proc insert_pair
+proc insert_pair(
+    entry_ptr: ptr<LinkMapEntry>,
+    map_ptr: ptr<ptr<LinkMapEntry>>,
+    key: word,
+    value0: word,
+    value1: word
+)
     swap dup.1
     # => [entry_ptr, map_ptr, entry_ptr, KEY, VALUE0, VALUE1]
 
@@ -632,7 +648,7 @@ end
 #!
 #! Panics if:
 #! - the KEY is not less than the key in the head of the map, unless the map is empty.
-proc assert_absent_at_head
+proc assert_absent_at_head(map_ptr: ptr<ptr<LinkMapEntry>>, key: word)
     dup exec.is_empty
     # => [is_empty, map_ptr, KEY]
 
@@ -661,7 +677,7 @@ end
 #! Panics if:
 #! - the KEY is not greater than the key in the entry.
 #! - the KEY is not less than the key in entry.next_entry, unless the entry is the last one in the map.
-proc assert_absent_after_entry
+proc assert_absent_after_entry(entry_ptr: ptr<LinkMapEntry>, key: word)
     movdn.4 dupw
     # => [KEY, KEY, entry_ptr]
 
@@ -697,7 +713,7 @@ end
 #!
 #! Panics if:
 #! - the key in the entry does not match KEY.
-proc get_existing_value
+proc get_existing_value(entry_ptr: ptr<LinkMapEntry>, key: word) -> (word, word)
     movdn.4 dup.4
     # => [entry_ptr, KEY, entry_ptr]
 
@@ -715,7 +731,7 @@ end
 #!
 #! Inputs:  [entry_ptr]
 #! Outputs: [has_next]
-proc has_next
+proc has_next(entry_ptr: ptr<LinkMapEntry>) -> Bool
     exec.get_next_entry_ptr eq.0 not
 end
 
@@ -723,7 +739,7 @@ end
 #!
 #! Inputs:  [entry_ptr, next_entry_ptr]
 #! Outputs: []
-proc set_next_entry_ptr
+proc set_next_entry_ptr(entry_ptr: ptr<LinkMapEntry>, next_entry_ptr: ptr<LinkMapEntry>)
     add.NEXT_ENTRY_PTR_OFFSET mem_store
     # => []
 end
@@ -732,7 +748,7 @@ end
 #!
 #! Inputs:  [entry_ptr]
 #! Outputs: [next_entry_ptr]
-proc get_next_entry_ptr
+proc get_next_entry_ptr(entry_ptr: ptr<LinkMapEntry>) -> ptr<LinkMapEntry>
     add.NEXT_ENTRY_PTR_OFFSET mem_load
     # => [next_entry_ptr]
 end
@@ -741,7 +757,7 @@ end
 #!
 #! Inputs:  [entry_ptr, prev_entry_ptr]
 #! Outputs: []
-proc set_prev_entry_ptr
+proc set_prev_entry_ptr(entry_ptr: ptr<LinkMapEntry>, prev_entry_ptr: ptr<LinkMapEntry>)
     add.PREV_ENTRY_PTR_OFFSET mem_store
     # => []
 end
@@ -750,7 +766,7 @@ end
 #!
 #! Inputs:  [entry_ptr, VALUE0, VALUE1]
 #! Outputs: []
-proc set_value
+proc set_value(entry_ptr: ptr<LinkMapEntry>, value0: word, value1: word)
     dup movdn.5
     # => [entry_ptr, VALUE0, entry_ptr, VALUE1]
 
@@ -765,7 +781,7 @@ end
 #!
 #! Inputs:  [entry_ptr]
 #! Outputs: [VALUE0, VALUE1]
-proc get_values
+proc get_values(entry_ptr: ptr<LinkMapEntry>) -> (word, word)
     dup exec.get_value1
     # => [VALUE1, entry_ptr]
 
@@ -777,7 +793,7 @@ end
 #!
 #! Inputs:  [entry_ptr]
 #! Outputs: [VALUE0]
-proc get_value0
+proc get_value0(entry_ptr: ptr<LinkMapEntry>) -> word
     padw movup.4
     # => [entry_ptr, pad(4)]
 
@@ -789,7 +805,7 @@ end
 #!
 #! Inputs:  [entry_ptr]
 #! Outputs: [VALUE1]
-proc get_value1
+proc get_value1(entry_ptr: ptr<LinkMapEntry>) -> word
     padw movup.4
     # => [entry_ptr, pad(4)]
 
@@ -801,7 +817,7 @@ end
 #!
 #! Inputs:  [entry_ptr, KEY]
 #! Outputs: []
-proc set_key
+proc set_key(entry_ptr: ptr<LinkMapEntry>, key: word)
     add.KEY_OFFSET mem_storew_le dropw
 end
 
@@ -809,7 +825,7 @@ end
 #!
 #! Inputs:  [entry_ptr]
 #! Outputs: [KEY]
-proc get_key
+proc get_key(entry_ptr: ptr<LinkMapEntry>) -> word
     padw movup.4
     # => [entry_ptr, pad(4)]
 
@@ -821,7 +837,7 @@ end
 #!
 #! Inputs:  [map_ptr, entry_ptr]
 #! Outputs: []
-proc set_head
+proc set_head(map_ptr: ptr<ptr<LinkMapEntry>>, entry_ptr: ptr<LinkMapEntry>)
     mem_store
 end
 
@@ -829,7 +845,7 @@ end
 #!
 #! Inputs:  [map_ptr]
 #! Outputs: [entry_ptr]
-proc get_head
+proc get_head(map_ptr: ptr<ptr<LinkMapEntry>>) -> ptr<LinkMapEntry>
     mem_load
 end
 
@@ -837,7 +853,7 @@ end
 #!
 #! Inputs:  [entry_ptr, map_ptr]
 #! Outputs: []
-proc set_map_ptr
+proc set_map_ptr(entry_ptr: ptr<LinkMapEntry>, map_ptr: ptr<ptr<LinkMapEntry>>)
     mem_store
 end
 
@@ -845,7 +861,7 @@ end
 #!
 #! Inputs:  [entry_ptr]
 #! Outputs: [map_ptr]
-proc get_map_ptr
+proc get_map_ptr(entry_ptr: ptr<LinkMapEntry>) -> ptr<ptr<LinkMapEntry>>
     mem_load
 end
 
@@ -856,7 +872,7 @@ end
 #!
 #! Inputs:  [entry_ptr, KEY]
 #! Outputs: []
-proc assert_key_is_equal
+proc assert_key_is_equal(entry_ptr: ptr<LinkMapEntry>, key: word)
     exec.get_key swapw
     # => [KEY, ENTRY_KEY]
 
@@ -868,7 +884,7 @@ end
 #!
 #! Inputs:  [entry_ptr, KEY]
 #! Outputs: []
-proc assert_key_is_greater
+proc assert_key_is_greater(entry_ptr: ptr<LinkMapEntry>, key: word)
     exec.get_key
     # => [ENTRY_KEY, KEY]
 
@@ -879,7 +895,7 @@ end
 #!
 #! Inputs:  [entry_ptr, KEY]
 #! Outputs: []
-proc assert_key_is_less
+proc assert_key_is_less(entry_ptr: ptr<LinkMapEntry>, key: word)
     exec.get_key
     # => [ENTRY_KEY, KEY]
 
@@ -906,7 +922,7 @@ end
 #!
 #! Panics if:
 #! - the map is empty and the provided operation is not the *AT_HEAD variant.
-proc assert_empty_map_op_is_at_head
+proc assert_empty_map_op_is_at_head(map_ptr: ptr<ptr<LinkMapEntry>>, is_at_head_op: Bool)
     exec.is_empty
     # => [is_empty_map, is_at_head_op]
 
@@ -928,7 +944,7 @@ end
 #!   - entry ptr is "link map entry"-aligned, i.e. entry_ptr % LINK_MAP_ENTRY_SIZE == 0. This
 #!     works because every entry ptr is a multiple of LINK_MAP_ENTRY_SIZE.
 #!   - entry's map ptr is equal to the given map_ptr.
-proc assert_entry_ptr_is_valid
+proc assert_entry_ptr_is_valid(entry_ptr: ptr<LinkMapEntry>, map_ptr: ptr<ptr<LinkMapEntry>>)
     # Check entry pointer is in valid memory range.
     # -------------------------------------------------------------------------------------------------
     # memory pointers must fit into a u32

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
@@ -1,7 +1,34 @@
+use {
+    AccountId,
+    AccountProcedureRoot,
+    Asset,
+    AssetId,
+    BlockNumber,
+    Bool,
+    NoteArgs,
+    NoteAssetsCommitment,
+    NoteAttachmentCommitment,
+    NoteAttachmentsCommitment,
+    NoteId,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScriptRoot,
+    NoteSerialNumber,
+    NoteStorageCommitment,
+    TransactionScriptRoot,
+} from miden::protocol_utils::types
+use {
+    AccountData,
+    AccountMetadata,
+    Digest,
+    InputNoteData,
+    LinkMapEntry,
+    OutputNoteData,
+    StorageSlot,
+} from miden::tx_kernel_core::types
 use miden::core::mem
 use {ACCOUNT_PROCEDURE_DATA_LENGTH, MAX_ASSETS_PER_NOTE, NOTE_MEM_SIZE, WORD_NUM_ELEMENTS}
     from miden::tx_kernel_core::constants
-use {AccountId} from miden::protocol_utils::types
 
 # ERRORS
 # =================================================================================================
@@ -362,7 +389,7 @@ pub const LINK_MAP_ENTRY_SIZE = 16
 #!
 #! Where:
 #! - num_output_notes is the number of output notes created in this transaction so far.
-pub proc get_num_output_notes
+pub proc get_num_output_notes() -> u16
     mem_load.NUM_OUTPUT_NOTES_PTR
 end
 
@@ -373,7 +400,7 @@ end
 #!
 #! Where:
 #! - num_output_notes is the number of output notes.
-pub proc set_num_output_notes
+pub proc set_num_output_notes(num_output_notes: u16)
     mem_store.NUM_OUTPUT_NOTES_PTR
 end
 
@@ -384,7 +411,7 @@ end
 #!
 #! Where:
 #! - note_ptr is the memory address of the data segment for the active note.
-pub proc get_active_input_note_ptr
+pub proc get_active_input_note_ptr() -> ptr<InputNoteData>
     mem_load.ACTIVE_INPUT_NOTE_PTR
 end
 
@@ -395,7 +422,7 @@ end
 #!
 #! Where:
 #! - note_ptr is the new memory address of the data segment for the input note.
-pub proc set_active_input_note_ptr
+pub proc set_active_input_note_ptr(note_ptr: ptr<InputNoteData>)
     mem_store.ACTIVE_INPUT_NOTE_PTR
 end
 
@@ -406,7 +433,7 @@ end
 #!
 #! Where:
 #! - INPUT_VAULT_ROOT is the input vault root.
-pub proc get_input_vault_root
+pub proc get_input_vault_root() -> Digest
     padw mem_loadw_le.INPUT_VAULT_ROOT_PTR
 end
 
@@ -417,7 +444,7 @@ end
 #!
 #! Where:
 #! - INPUT_VAULT_ROOT is the input vault root.
-pub proc set_input_vault_root
+pub proc set_input_vault_root(input_vault_root: Digest) -> Digest
     mem_storew_le.INPUT_VAULT_ROOT_PTR
 end
 
@@ -428,7 +455,7 @@ end
 #!
 #! Where:
 #! - OUTPUT_VAULT_ROOT is the output vault root.
-pub proc get_output_vault_root
+pub proc get_output_vault_root() -> Digest
     padw mem_loadw_le.OUTPUT_VAULT_ROOT_PTR
 end
 
@@ -439,7 +466,7 @@ end
 #!
 #! Where:
 #! - OUTPUT_VAULT_ROOT is the output vault root.
-pub proc set_output_vault_root
+pub proc set_output_vault_root(output_vault_root: Digest) -> Digest
     mem_storew_le.OUTPUT_VAULT_ROOT_PTR
 end
 
@@ -485,7 +512,7 @@ end
 #! Where:
 #! - FOREIGN_PROC_ROOT is the root of the foreign procedure which will be executed during the FPI
 #!   call.
-pub proc set_fpi_procedure_root(foreign_proc_root: word) -> word
+pub proc set_fpi_procedure_root(foreign_proc_root: AccountProcedureRoot) -> AccountProcedureRoot
     mem_storew_le.UPCOMING_FOREIGN_PROCEDURE_PTR
 end
 
@@ -499,7 +526,7 @@ end
 #!
 #! Where:
 #! - BLOCK_COMMITMENT is the commitment of the transaction reference block.
-pub proc set_block_commitment
+pub proc set_block_commitment(block_commitment: Digest) -> Digest
     mem_storew_le.BLOCK_COMMITMENT_PTR
 end
 
@@ -510,7 +537,7 @@ end
 #!
 #! Where:
 #! - BLOCK_COMMITMENT is the commitment of the transaction reference block.
-pub proc get_ref_block_commitment
+pub proc get_ref_block_commitment() -> Digest
     padw mem_loadw_le.BLOCK_COMMITMENT_PTR
 end
 
@@ -521,7 +548,7 @@ end
 #!
 #! Where:
 #! - account_id_{prefix,suffix} are the prefix and suffix felts of the account ID.
-pub proc set_global_account_id
+pub proc set_global_account_id(account_id: AccountId)
     mem_store.GLOBAL_ACCOUNT_ID_SUFFIX_PTR
     mem_store.GLOBAL_ACCOUNT_ID_PREFIX_PTR
     # => []
@@ -534,7 +561,7 @@ end
 #!
 #! Where:
 #! - account_id_{prefix,suffix} are the prefix and suffix felts of the account ID.
-pub proc get_global_account_id
+pub proc get_global_account_id() -> AccountId
     mem_load.GLOBAL_ACCOUNT_ID_PREFIX_PTR
     mem_load.GLOBAL_ACCOUNT_ID_SUFFIX_PTR
     # => [account_id_suffix, account_id_prefix]
@@ -547,7 +574,7 @@ end
 #!
 #! Where:
 #! - INIT_ACCOUNT_COMMITMENT is the initial account commitment.
-pub proc set_init_account_commitment
+pub proc set_init_account_commitment(init_account_commitment: Digest) -> Digest
     mem_storew_le.INIT_ACCOUNT_COMMITMENT_PTR
 end
 
@@ -558,7 +585,7 @@ end
 #!
 #! Where:
 #! - INIT_ACCOUNT_COMMITMENT is the initial account commitment.
-pub proc get_init_account_commitment
+pub proc get_init_account_commitment() -> Digest
     padw mem_loadw_le.INIT_ACCOUNT_COMMITMENT_PTR
 end
 
@@ -569,7 +596,7 @@ end
 #!
 #! Where:
 #! - init_nonce is the initial account nonce.
-pub proc set_init_nonce
+pub proc set_init_nonce(init_nonce: felt)
     mem_store.INIT_NONCE_PTR
 end
 
@@ -580,7 +607,7 @@ end
 #!
 #! Where:
 #! - init_nonce is the initial account nonce.
-pub proc get_init_nonce
+pub proc get_init_nonce() -> felt
     mem_load.INIT_NONCE_PTR
 end
 
@@ -591,7 +618,7 @@ end
 #!
 #! Where:
 #! - INIT_NATIVE_ACCOUNT_VAULT_ROOT is the initial vault root of the native account.
-pub proc set_init_native_account_vault_root
+pub proc set_init_native_account_vault_root(init_native_account_vault_root: Digest) -> Digest
     mem_storew_le.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
 end
 
@@ -602,7 +629,7 @@ end
 #!
 #! Where:
 #! - INIT_NATIVE_ACCOUNT_VAULT_ROOT is the initial vault root of the native account.
-pub proc get_init_native_account_vault_root
+pub proc get_init_native_account_vault_root() -> Digest
     padw mem_loadw_le.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
 end
 
@@ -615,7 +642,7 @@ end
 #! Where:
 #! - native_account_initial_vault_root_ptr is the memory pointer to the initial vault root of the
 #!   native account.
-pub proc get_init_native_account_vault_root_ptr
+pub proc get_init_native_account_vault_root_ptr() -> ptr<Digest>
     push.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
 end
 
@@ -626,7 +653,9 @@ end
 #!
 #! Where:
 #! - INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT is the initial storage commitment of the native account.
-pub proc set_init_account_storage_commitment
+pub proc set_init_account_storage_commitment(
+    init_native_account_storage_commitment: Digest
+) -> Digest
     mem_storew_le.INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT_PTR
 end
 
@@ -637,7 +666,7 @@ end
 #!
 #! Where:
 #! - INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT is the initial storage commitment of the native account.
-pub proc get_init_account_storage_commitment
+pub proc get_init_account_storage_commitment() -> Digest
     padw mem_loadw_le.INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT_PTR
 end
 
@@ -650,7 +679,7 @@ end
 #!
 #! Where:
 #! - INPUT_NOTES_COMMITMENT is the input notes commitment.
-pub proc get_input_notes_commitment
+pub proc get_input_notes_commitment() -> Digest
     padw mem_loadw_le.INPUT_NOTES_COMMITMENT_PTR
 end
 
@@ -661,7 +690,7 @@ end
 #!
 #! Where:
 #! - INPUT_NOTES_COMMITMENT is the notes' commitment.
-pub proc set_nullifier_commitment
+pub proc set_nullifier_commitment(input_notes_commitment: Digest) -> Digest
     mem_storew_le.INPUT_NOTES_COMMITMENT_PTR
 end
 
@@ -672,7 +701,7 @@ end
 #!
 #! Where:
 #! - TX_SCRIPT_ROOT is the transaction script root.
-pub proc set_tx_script_root
+pub proc set_tx_script_root(tx_script_root: TransactionScriptRoot) -> TransactionScriptRoot
     mem_storew_le.TX_SCRIPT_ROOT_PTR
 end
 
@@ -684,7 +713,7 @@ end
 #! Where:
 #! - TX_SCRIPT_ROOT is the transaction script root, or the empty word if no transaction script was
 #!   executed.
-pub proc get_tx_script_root
+pub proc get_tx_script_root() -> TransactionScriptRoot
     padw mem_loadw_le.TX_SCRIPT_ROOT_PTR
 end
 
@@ -696,7 +725,7 @@ end
 #! Where:
 #! - TX_SCRIPT_ARGS is the word of values which could be used directly or could be used to obtain
 #!   some values associated with it from the advice map.
-pub proc get_tx_script_args
+pub proc get_tx_script_args() -> word
     padw mem_loadw_le.TX_SCRIPT_ARGS_PTR
 end
 
@@ -708,7 +737,7 @@ end
 #! Where:
 #! - TX_SCRIPT_ARGS is the word of values which could be used directly or could be used to obtain
 #!   some values associated with it from the advice map.
-pub proc set_tx_script_args
+pub proc set_tx_script_args(tx_script_args: word) -> word
     mem_storew_le.TX_SCRIPT_ARGS_PTR
 end
 
@@ -719,7 +748,7 @@ end
 #!
 #! Where:
 #! - AUTH_ARGS is the argument passed to the auth procedure.
-pub proc get_auth_args
+pub proc get_auth_args() -> word
     padw mem_loadw_le.AUTH_ARGS_PTR
 end
 
@@ -730,7 +759,7 @@ end
 #!
 #! Where:
 #! - AUTH_ARGS is the argument passed to the auth procedure.
-pub proc set_auth_args
+pub proc set_auth_args(auth_args: word) -> word
     mem_storew_le.AUTH_ARGS_PTR
 end
 
@@ -744,7 +773,7 @@ end
 #!
 #! Where:
 #! - PREV_BLOCK_COMMITMENT_PTR is the block commitment of the transaction reference block.
-pub proc get_prev_block_commitment
+pub proc get_prev_block_commitment() -> Digest
     padw mem_loadw_le.PREV_BLOCK_COMMITMENT_PTR
 end
 
@@ -755,7 +784,7 @@ end
 #!
 #! Where:
 #! - blk_num is the block number of the transaction reference block.
-pub proc get_blk_num
+pub proc get_blk_num() -> BlockNumber
     mem_load.BLOCK_METADATA_NUMBER_PTR
 end
 
@@ -766,7 +795,7 @@ end
 #!
 #! Where:
 #! - version is the format version of the transaction reference block's header.
-pub proc get_blk_version
+pub proc get_blk_version() -> u8
     mem_load.BLOCK_METADATA_VERSION_PTR
 end
 
@@ -777,7 +806,7 @@ end
 #!
 #! Where:
 #! - timestamp is the timestamp of the reference block for this transaction.
-pub proc get_blk_timestamp
+pub proc get_blk_timestamp() -> u32
     mem_load.BLOCK_METADATA_TIMESTAMP_PTR
 end
 
@@ -789,7 +818,7 @@ end
 #! Where:
 #! - verification_base_fee is the base fee capturing the cost for the verification of a
 #!   transaction.
-pub proc get_verification_base_fee
+pub proc get_verification_base_fee() -> u32
     mem_load.VERIFICATION_BASE_FEE_PTR
 end
 
@@ -800,7 +829,7 @@ end
 #!
 #! Where:
 #! - FEE_ASSET_ID is the ID of the asset that fees are paid in.
-pub proc get_fee_asset_id
+pub proc get_fee_asset_id() -> AssetId
     padw mem_loadw_le.FEE_ASSET_ID_PTR
 end
 
@@ -811,7 +840,7 @@ end
 #!
 #! Where:
 #! - CHAIN_COMMITMENT is the chain commitment of the transaction reference block.
-pub proc get_chain_commitment
+pub proc get_chain_commitment() -> Digest
     padw mem_loadw_le.CHAIN_COMMITMENT_PTR
 end
 
@@ -822,7 +851,7 @@ end
 #!
 #! Where:
 #! - ACCT_DB_ROOT is the account database root of the transaction reference block.
-pub proc get_account_db_root
+pub proc get_account_db_root() -> Digest
     padw mem_loadw_le.ACCT_DB_ROOT_PTR
 end
 
@@ -833,7 +862,7 @@ end
 #!
 #! Where:
 #! - NULLIFIER_ROOT is the nullifier root of the transaction reference block.
-pub proc get_nullifier_db_root
+pub proc get_nullifier_db_root() -> Digest
     padw mem_loadw_le.NULLIFIER_ROOT_PTR
 end
 
@@ -844,7 +873,7 @@ end
 #!
 #! Where:
 #! - TX_COMMITMENT is the tx commitment of the transaction reference block.
-pub proc get_tx_commitment
+pub proc get_tx_commitment() -> Digest
     padw mem_loadw_le.TX_COMMITMENT_PTR
 end
 
@@ -855,7 +884,7 @@ end
 #!
 #! Where:
 #! - PROTOCOL_CONFIG_COMMITMENT is the commitment to the chain's protocol config.
-pub proc get_protocol_config_commitment
+pub proc get_protocol_config_commitment() -> Digest
     padw mem_loadw_le.PROTOCOL_CONFIG_COMMITMENT_PTR
 end
 
@@ -867,7 +896,7 @@ end
 #! Where:
 #! - TX_KERNEL_CONFIG_COMMITMENT is the commitment to the transaction kernel's main procedure root
 #!   and its exposed procedure roots.
-pub proc get_tx_kernel_config_commitment
+pub proc get_tx_kernel_config_commitment() -> Digest
     padw mem_loadw_le.TX_KERNEL_CONFIG_COMMITMENT_PTR
 end
 
@@ -878,7 +907,7 @@ end
 #!
 #! Where:
 #! - NOTE_ROOT is the note root of the transaction reference block.
-pub proc get_note_root
+pub proc get_note_root() -> Digest
     padw mem_loadw_le.NOTE_ROOT_PTR
 end
 
@@ -889,7 +918,7 @@ end
 #!
 #! Where:
 #! - NOTE_ROOT is the note root of the transaction reference block.
-pub proc set_note_root
+pub proc set_note_root(note_root: Digest) -> Digest
     mem_storew_le.NOTE_ROOT_PTR
 end
 
@@ -903,7 +932,7 @@ end
 #!
 #! Where:
 #! - num_leaves is the number of leaves in the partial blockchain.
-pub proc set_partial_blockchain_num_leaves
+pub proc set_partial_blockchain_num_leaves(num_leaves: u32)
     mem_store.PARTIAL_BLOCKCHAIN_NUM_LEAVES_PTR
 end
 
@@ -914,7 +943,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-pub proc set_active_account_data_ptr_to_native_account
+pub proc set_active_account_data_ptr_to_native_account()
     # store the native account data pointer into the first account stack element.
     push.NATIVE_ACCOUNT_DATA_PTR mem_store.MIN_ACCOUNT_STACK_PTR
     # => []
@@ -931,7 +960,7 @@ end
 #!
 #! Where:
 #! - active_account_data_ptr is the memory address at which the data of the active account begins.
-pub proc get_active_account_data_ptr
+pub proc get_active_account_data_ptr() -> ptr<AccountData>
     mem_load.ACCOUNT_STACK_TOP_PTR
     # => [account_stack_top_ptr]
 
@@ -953,7 +982,7 @@ end
 #! Panics if:
 #! - the account stack is full, containing 64 accounts total.
 #! - the provided account data pointer is equal to the native account data pointer.
-pub proc push_ptr_to_account_stack
+pub proc push_ptr_to_account_stack(curr_account_data_ptr: ptr<AccountData>)
     # check that the account stack is not full
     mem_load.ACCOUNT_STACK_TOP_PTR dup
     # => [account_stack_top_ptr, account_stack_top_ptr, curr_account_data_ptr]
@@ -982,7 +1011,7 @@ end
 #!
 #! Panics if:
 #! - the account stack contains only native account.
-pub proc pop_ptr_from_account_stack
+pub proc pop_ptr_from_account_stack()
     # check that the account stack always is at least of size 1, that is, it contains at least the
     # native account
     mem_load.ACCOUNT_STACK_TOP_PTR dup
@@ -1005,7 +1034,7 @@ end
 #!
 #! Panics if:
 #! - the active account data pointer is not equal to native account data pointer (8192).
-pub proc assert_native_account
+pub proc assert_native_account()
     exec.is_native_account assert.err=ERR_ACCOUNT_IS_NOT_NATIVE
 end
 
@@ -1014,7 +1043,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: [is_native_account]
-pub proc is_native_account
+pub proc is_native_account() -> Bool
     exec.get_active_account_data_ptr
     # => [active_account_data_ptr]
 
@@ -1030,7 +1059,7 @@ end
 #!
 #! Where:
 #! - is_epilogue_auth_in_progress is 1 while the epilogue runs the auth procedure, 0 otherwise.
-pub proc set_epilogue_auth_in_progress_flag
+pub proc set_epilogue_auth_in_progress_flag(is_epilogue_auth_in_progress: Bool)
     mem_store.EPILOGUE_AUTH_IN_PROGRESS_FLAG_PTR
     # => []
 end
@@ -1039,7 +1068,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: [is_epilogue_auth_in_progress]
-pub proc is_epilogue_auth_in_progress
+pub proc is_epilogue_auth_in_progress() -> Bool
     mem_load.EPILOGUE_AUTH_IN_PROGRESS_FLAG_PTR
     # => [is_epilogue_auth_in_progress]
 end
@@ -1048,7 +1077,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: [is_new_account]
-pub proc is_new_account
+pub proc is_new_account() -> Bool
     # the account is new if its nonce is zero
     # use get_init_nonce so this procedure works correctly even after the account's nonce was
     # incremented
@@ -1062,7 +1091,7 @@ end
 #!
 #! Where:
 #! - ptr is the memory address at which the core account data ends.
-pub proc get_core_account_data_end_ptr
+pub proc get_core_account_data_end_ptr() -> ptr<AccountData>
     exec.get_active_account_data_ptr add.ACCT_CORE_DATA_SECTION_END_OFFSET
 end
 
@@ -1075,7 +1104,7 @@ end
 #!
 #! Where:
 #! - account_id_{prefix,suffix} are the prefix and suffix felts of the ID of the active account.
-pub proc get_account_id
+pub proc get_account_id() -> AccountId
     exec.get_active_account_data_ptr
     # => [active_account_data_ptr]
 
@@ -1094,7 +1123,7 @@ end
 #! Where:
 #! - account_id_{prefix,suffix} are the prefix and suffix felts of the ID of the native account
 #!   of the transaction.
-pub proc get_native_account_id
+pub proc get_native_account_id() -> AccountId
     mem_load.NATIVE_ACCOUNT_ID_PREFIX_PTR
     mem_load.NATIVE_ACCOUNT_ID_SUFFIX_PTR
     # => [account_id_suffix, account_id_prefix]
@@ -1109,7 +1138,7 @@ end
 #! - account_version is the version of the active account's metadata encoding.
 #! - nonce is the nonce of the active account.
 #! - account_id_{prefix,suffix} are the prefix and suffix felts of the ID of the active account.
-pub proc set_active_account_metadata
+pub proc set_active_account_metadata(metadata: AccountMetadata) -> AccountMetadata
     exec.get_active_account_data_ptr add.ACCT_METADATA_OFFSET
     mem_storew_le
 end
@@ -1121,7 +1150,7 @@ end
 #!
 #! Where:
 #! - account_version is the version of the native account's metadata encoding.
-pub proc get_native_account_version
+pub proc get_native_account_version() -> u8
     mem_load.NATIVE_ACCOUNT_VERSION_PTR
 end
 
@@ -1132,7 +1161,7 @@ end
 #!
 #! Where:
 #! - nonce is the nonce of the active account.
-pub proc get_account_nonce
+pub proc get_account_nonce() -> felt
     exec.get_active_account_data_ptr add.ACCT_NONCE_OFFSET
     mem_load
 end
@@ -1144,7 +1173,7 @@ end
 #!
 #! Where:
 #! - nonce is the nonce of the native account of the transaction.
-pub proc get_native_account_nonce
+pub proc get_native_account_nonce() -> felt
     push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_NONCE_OFFSET
     mem_load
 end
@@ -1156,7 +1185,7 @@ end
 #!
 #! Where:
 #! - nonce is the new nonce of the native account.
-pub proc set_native_account_nonce
+pub proc set_native_account_nonce(nonce: felt)
     push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_NONCE_OFFSET
     mem_store
 end
@@ -1170,7 +1199,7 @@ end
 #!
 #! Where:
 #! - account_vault_root_ptr is the memory pointer to the account asset vault root.
-pub proc get_account_vault_root_ptr
+pub proc get_account_vault_root_ptr() -> ptr<Digest>
     exec.get_active_account_data_ptr add.ACCT_VAULT_ROOT_OFFSET
 end
 
@@ -1181,7 +1210,7 @@ end
 #!
 #! Where:
 #! - ACCT_VAULT_ROOT is the account asset vault root.
-pub proc get_account_vault_root
+pub proc get_account_vault_root() -> Digest
     padw
     exec.get_active_account_data_ptr add.ACCT_VAULT_ROOT_OFFSET
     mem_loadw_le
@@ -1194,7 +1223,7 @@ end
 #!
 #! Where:
 #! - ACCT_VAULT_ROOT is the account vault root to be set.
-pub proc set_account_vault_root
+pub proc set_account_vault_root(acct_vault_root: Digest) -> Digest
     exec.get_active_account_data_ptr add.ACCT_VAULT_ROOT_OFFSET
     mem_storew_le
 end
@@ -1206,7 +1235,7 @@ end
 #!
 #! Where:
 #! - account_vault_root_ptr is the memory pointer to the native account's asset vault root.
-pub proc get_native_account_vault_root_ptr
+pub proc get_native_account_vault_root_ptr() -> ptr<Digest>
     push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_VAULT_ROOT_OFFSET
 end
 
@@ -1217,7 +1246,7 @@ end
 #!
 #! Where:
 #! - ACCT_VAULT_ROOT is the native account's asset vault root.
-pub proc get_native_account_vault_root
+pub proc get_native_account_vault_root() -> Digest
     padw exec.get_native_account_vault_root_ptr mem_loadw_le
 end
 
@@ -1230,7 +1259,7 @@ end
 #!
 #! Where:
 #! - CODE_COMMITMENT is the code commitment of the account.
-pub proc get_account_code_commitment
+pub proc get_account_code_commitment() -> Digest
     padw
     exec.get_active_account_data_ptr add.ACCT_CODE_COMMITMENT_OFFSET
     mem_loadw_le
@@ -1243,7 +1272,7 @@ end
 #!
 #! Where:
 #! - CODE_COMMITMENT is the code commitment to be set.
-pub proc set_account_code_commitment
+pub proc set_account_code_commitment(code_commitment: Digest) -> Digest
     exec.get_active_account_data_ptr add.ACCT_CODE_COMMITMENT_OFFSET
     mem_storew_le
 end
@@ -1255,7 +1284,7 @@ end
 #!
 #! Where:
 #! - tx_expiration_block_num is the number of the transaction expiration block.
-pub proc set_expiration_block_num
+pub proc set_expiration_block_num(tx_expiration_block_num: BlockNumber)
     mem_store.TX_EXPIRATION_BLOCK_NUM_PTR
 end
 
@@ -1266,7 +1295,7 @@ end
 #!
 #! Where:
 #! - tx_expiration_block_num is the number of the transaction expiration block.
-pub proc get_expiration_block_num
+pub proc get_expiration_block_num() -> BlockNumber
     mem_load.TX_EXPIRATION_BLOCK_NUM_PTR
 end
 
@@ -1277,7 +1306,7 @@ end
 #!
 #! Where:
 #! - num_procedures is the number of procedures contained in the account code.
-pub proc get_num_account_procedures
+pub proc get_num_account_procedures() -> u16
     exec.get_active_account_data_ptr add.ACCT_NUM_PROCEDURES_OFFSET
     mem_load
 end
@@ -1289,7 +1318,7 @@ end
 #!
 #! Where:
 #! - num_procedures is the number of procedures contained in the account code.
-pub proc set_num_account_procedures
+pub proc set_num_account_procedures(num_procedures: u16)
     exec.get_active_account_data_ptr add.ACCT_NUM_PROCEDURES_OFFSET
     mem_store
 end
@@ -1301,7 +1330,7 @@ end
 #!
 #! Where:
 #! - account_procedures_section_ptr is the memory pointer to the account procedures section.
-pub proc get_account_procedures_section_ptr
+pub proc get_account_procedures_section_ptr() -> ptr<AccountProcedureRoot>
     exec.get_active_account_data_ptr add.ACCT_PROCEDURES_SECTION_OFFSET
 end
 
@@ -1312,7 +1341,7 @@ end
 #!
 #! Where:
 #! - procedures_call_tracking_ptr is the memory pointer to the procedure call tracking section.
-pub proc get_account_procedures_call_tracking_ptr
+pub proc get_account_procedures_call_tracking_ptr() -> ptr<Bool>
     exec.get_active_account_data_ptr add.ACCT_PROCEDURES_CALL_TRACKING_OFFSET
 end
 
@@ -1324,7 +1353,7 @@ end
 #! Where:
 #! - proc_idx is the index of the account procedure.
 #! - proc_ptr is the memory pointer to the account procedure at the specified index.
-pub proc get_account_procedure_ptr
+pub proc get_account_procedure_ptr(proc_idx: u8) -> ptr<AccountProcedureRoot>
     mul.ACCOUNT_PROCEDURE_DATA_LENGTH exec.get_account_procedures_section_ptr add
 end
 
@@ -1337,7 +1366,7 @@ end
 #!
 #! Where:
 #! - STORAGE_COMMITMENT is the account storage commitment.
-pub proc get_account_storage_commitment
+pub proc get_account_storage_commitment() -> Digest
     padw
     exec.get_active_account_data_ptr add.ACCT_STORAGE_COMMITMENT_OFFSET
     mem_loadw_le
@@ -1350,7 +1379,7 @@ end
 #!
 #! Where:
 #! - STORAGE_COMMITMENT is the account storage commitment.
-pub proc set_account_storage_commitment
+pub proc set_account_storage_commitment(storage_commitment: Digest) -> Digest
     exec.get_active_account_data_ptr add.ACCT_STORAGE_COMMITMENT_OFFSET
     mem_storew_le
 end
@@ -1362,7 +1391,7 @@ end
 #!
 #! Where:
 #! - CODE_UPGRADE_COMMITMENT is the commitment to the account code upgrade.
-pub proc set_code_upgrade_commitment
+pub proc set_code_upgrade_commitment(code_upgrade_commitment: Digest)
     mem_storew_le.CODE_UPGRADE_COMMITMENT_PTR dropw
 end
 
@@ -1373,7 +1402,7 @@ end
 #!
 #! Where:
 #! - STORAGE_UPGRADE_COMMITMENT is the commitment to the account storage upgrade.
-pub proc set_storage_upgrade_commitment
+pub proc set_storage_upgrade_commitment(storage_upgrade_commitment: Digest)
     mem_storew_le.STORAGE_UPGRADE_COMMITMENT_PTR dropw
 end
 
@@ -1387,7 +1416,7 @@ end
 #!
 #! Where:
 #! - dirty_flag is the flag indicating whether the storage commitment is outdated.
-pub proc set_native_account_storage_commitment_dirty_flag
+pub proc set_native_account_storage_commitment_dirty_flag(dirty_flag: Bool)
     push.NATIVE_ACCT_STORAGE_COMMITMENT_DIRTY_FLAG_PTR mem_store
     # => []
 end
@@ -1402,7 +1431,7 @@ end
 #! Where:
 #! - should_recompute_storage_commitment is the flag indicating whether the storage commitment
 #!   should be recomputed.
-pub proc get_recompute_storage_commitment_flag
+pub proc get_recompute_storage_commitment_flag() -> Bool
     # get the is_native_account flag
     exec.is_native_account
     # => [is_native_account]
@@ -1423,7 +1452,7 @@ end
 #!
 #! Where:
 #! - num_storage_slots is the number of storage slots contained in the account storage.
-pub proc get_num_storage_slots
+pub proc get_num_storage_slots() -> u8
     exec.get_active_account_data_ptr add.ACCT_NUM_STORAGE_SLOTS_OFFSET
     mem_load
 end
@@ -1435,7 +1464,7 @@ end
 #!
 #! Where:
 #! - num_storage_slots is the number of storage slots contained in the native account's storage.
-pub proc get_native_num_storage_slots
+pub proc get_native_num_storage_slots() -> u8
     mem_load.NATIVE_ACCOUNT_NUM_STORAGE_SLOTS_PTR
 end
 
@@ -1446,7 +1475,7 @@ end
 #!
 #! Where:
 #! - num_storage_slots is the number of storage slots contained in the account storage.
-pub proc set_num_storage_slots
+pub proc set_num_storage_slots(num_storage_slots: u8)
     exec.get_active_account_data_ptr add.ACCT_NUM_STORAGE_SLOTS_OFFSET
     mem_store
 end
@@ -1458,7 +1487,7 @@ end
 #!
 #! Where:
 #! - storage_slots_section_ptr is the memory pointer to the account storage slots section.
-pub proc get_account_active_storage_slots_section_ptr
+pub proc get_account_active_storage_slots_section_ptr() -> ptr<StorageSlot>
     exec.get_active_account_data_ptr add.ACCT_ACTIVE_STORAGE_SLOTS_SECTION_OFFSET
 end
 
@@ -1469,7 +1498,7 @@ end
 #!
 #! Where:
 #! - storage_slots_section_ptr is the memory pointer to the native account's storage slots section.
-pub proc get_native_account_active_storage_slots_ptr
+pub proc get_native_account_active_storage_slots_ptr() -> ptr<StorageSlot>
     push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_ACTIVE_STORAGE_SLOTS_SECTION_OFFSET
 end
 
@@ -1480,7 +1509,7 @@ end
 #!
 #! Where:
 #! - account_initial_storage_slots_ptr is the memory pointer to the initial storage slot values.
-pub proc get_native_account_initial_storage_slots_ptr
+pub proc get_native_account_initial_storage_slots_ptr() -> ptr<StorageSlot>
     push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_INITIAL_STORAGE_SLOTS_SECTION_OFFSET
 end
 
@@ -1494,7 +1523,7 @@ end
 #! Where:
 #! - account_patch_storage_map_ptr is the link map pointer to the storage map patch for the
 #!   requested slot index.
-pub proc get_account_patch_storage_map_ptr
+pub proc get_account_patch_storage_map_ptr(slot_idx: u8) -> ptr<ptr<LinkMapEntry>>
     add.ACCOUNT_PATCH_STORAGE_MAP_SECTION
 end
 
@@ -1502,7 +1531,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-pub proc mem_copy_native_account_initial_storage_slots
+pub proc mem_copy_native_account_initial_storage_slots()
     exec.get_native_account_initial_storage_slots_ptr
     exec.get_native_account_active_storage_slots_ptr
     # => [active_storage_slots_ptr, initial_storage_slots_ptr]
@@ -1525,7 +1554,7 @@ end
 #!
 #! Where:
 #! - num_input_notes is the total number of input notes consumed by this transaction.
-pub proc get_num_input_notes
+pub proc get_num_input_notes() -> u16
     mem_load.NUM_INPUT_NOTES_PTR
 end
 
@@ -1536,7 +1565,7 @@ end
 #!
 #! Where:
 #! - num_input_notes is the total number of input notes consumed by this transaction.
-pub proc set_num_input_notes
+pub proc set_num_input_notes(num_input_notes: u16)
     mem_store.NUM_INPUT_NOTES_PTR
 end
 
@@ -1549,7 +1578,7 @@ end
 #! Where:
 #! - idx is the index of the input note.
 #! - note_ptr is the memory address of the data segment for the input note with `idx`.
-pub proc get_input_note_ptr
+pub proc get_input_note_ptr(idx: u16) -> ptr<InputNoteData>
     push.NOTE_MEM_SIZE mul add.INPUT_NOTE_DATA_SECTION_OFFSET
 end
 
@@ -1561,7 +1590,10 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data segment begins.
 #! - NOTE_DETAILS_COMMITMENT is the commitment to the note's details.
-pub proc set_input_note_details_commitment
+pub proc set_input_note_details_commitment(
+    note_ptr: ptr<InputNoteData>,
+    note_details_commitment: Digest
+) -> Digest
     mem_storew_le
 end
 
@@ -1573,7 +1605,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data segment begins.
 #! - NOTE_ID is the ID of the input note.
-pub proc set_input_note_id
+pub proc set_input_note_id(note_ptr: ptr<InputNoteData>, note_id: NoteId) -> NoteId
     add.INPUT_NOTE_ID_OFFSET
     mem_storew_le
 end
@@ -1586,7 +1618,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data segment begins.
 #! - NOTE_ID is the ID of the input note.
-pub proc get_input_note_id
+pub proc get_input_note_id(note_ptr: ptr<InputNoteData>) -> NoteId
     padw
     movup.4 add.INPUT_NOTE_ID_OFFSET
     mem_loadw_le
@@ -1600,7 +1632,7 @@ end
 #! Where:
 #! - idx is the index of the input note.
 #! - NULLIFIER is the nullifier of the input note.
-pub proc set_input_note_nullifier
+pub proc set_input_note_nullifier(idx: u16, nullifier: Digest) -> Digest
     mul.4 add.INPUT_NOTE_NULLIFIER_SECTION_PTR mem_storew_le
 end
 
@@ -1613,7 +1645,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - note_data_ptr is the memory address at which the input note core data begins.
-pub proc get_input_note_core_ptr
+pub proc get_input_note_core_ptr(note_ptr: ptr<InputNoteData>) -> ptr<word>
     add.INPUT_NOTE_CORE_DATA_OFFSET
 end
 
@@ -1625,7 +1657,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - SCRIPT_ROOT is the script root of the input note.
-pub proc get_input_note_script_root
+pub proc get_input_note_script_root(note_ptr: ptr<InputNoteData>) -> NoteScriptRoot
     padw
     movup.4 add.INPUT_NOTE_SCRIPT_ROOT_OFFSET
     mem_loadw_le
@@ -1639,7 +1671,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - script_root_ptr is the memory address where script root of the input note is stored.
-pub proc get_input_note_script_root_ptr
+pub proc get_input_note_script_root_ptr(note_ptr: ptr<InputNoteData>) -> ptr<NoteScriptRoot>
     add.INPUT_NOTE_SCRIPT_ROOT_OFFSET
 end
 
@@ -1651,7 +1683,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - STORAGE_COMMITMENT is the inputs commitment of the input note.
-pub proc get_input_note_storage_commitment
+pub proc get_input_note_storage_commitment(note_ptr: ptr<InputNoteData>) -> NoteStorageCommitment
     padw
     movup.4 add.INPUT_NOTE_STORAGE_COMMITMENT_OFFSET
     mem_loadw_le
@@ -1665,7 +1697,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - NOTE_METADATA is the metadata of the input note.
-pub proc get_input_note_metadata
+pub proc get_input_note_metadata(note_ptr: ptr<InputNoteData>) -> NoteMetadata
     padw
     movup.4 add.INPUT_NOTE_METADATA_OFFSET
     mem_loadw_le
@@ -1679,7 +1711,9 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - NOTE_ATTACHMENTS_COMMITMENT is the commitment to all attachments of the input note.
-pub proc get_input_note_attachments_commitment
+pub proc get_input_note_attachments_commitment(
+    note_ptr: ptr<InputNoteData>
+) -> NoteAttachmentsCommitment
     padw
     movup.4 add.INPUT_NOTE_ATTACHMENTS_COMMITMENT_OFFSET
     mem_loadw_le
@@ -1693,7 +1727,7 @@ end
 #! Where:
 #! - note_ptr is the start memory address of the note.
 #! - NOTE_ARGS are the note's args.
-pub proc get_input_note_args
+pub proc get_input_note_args(note_ptr: ptr<InputNoteData>) -> NoteArgs
     padw
     movup.4 add.INPUT_NOTE_ARGS_OFFSET
     mem_loadw_le
@@ -1707,7 +1741,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - NOTE_ARGS are optional note args of the input note.
-pub proc set_input_note_args
+pub proc set_input_note_args(note_ptr: ptr<InputNoteData>, note_args: NoteArgs) -> NoteArgs
     add.INPUT_NOTE_ARGS_OFFSET
     mem_storew_le
 end
@@ -1720,7 +1754,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - num_storage_items is the number of storage items of the input note.
-pub proc get_input_note_num_storage_items
+pub proc get_input_note_num_storage_items(note_ptr: ptr<InputNoteData>) -> u16
     add.INPUT_NOTE_NUM_STORAGE_ITEMS_OFFSET
     mem_load
 end
@@ -1733,7 +1767,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - num_storage_items is the number of storage items of the input note.
-pub proc set_input_note_num_storage_items
+pub proc set_input_note_num_storage_items(note_ptr: ptr<InputNoteData>, num_storage_items: u16)
     add.INPUT_NOTE_NUM_STORAGE_ITEMS_OFFSET
     mem_store
 end
@@ -1746,7 +1780,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - num_assets is the number of assets in the input note.
-pub proc get_input_note_num_assets
+pub proc get_input_note_num_assets(note_ptr: ptr<InputNoteData>) -> u8
     add.INPUT_NOTE_NUM_ASSETS_OFFSET
     mem_load
 end
@@ -1759,7 +1793,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - num_assets is the number of assets in the input note.
-pub proc set_input_note_num_assets
+pub proc set_input_note_num_assets(note_ptr: ptr<InputNoteData>, num_assets: u8)
     add.INPUT_NOTE_NUM_ASSETS_OFFSET
     mem_store
 end
@@ -1773,7 +1807,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - assets_ptr is the memory address at which the assets segment for the input note begins.
-pub proc get_input_note_assets_ptr
+pub proc get_input_note_assets_ptr(note_ptr: ptr<InputNoteData>) -> ptr<Asset>
     add.INPUT_NOTE_ASSETS_OFFSET
 end
 
@@ -1785,7 +1819,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - RECIPIENT is the commitment to the note's script, storage and the serial number.
-pub proc get_input_note_recipient
+pub proc get_input_note_recipient(note_ptr: ptr<InputNoteData>) -> NoteRecipient
     padw
     movup.4 add.INPUT_NOTE_RECIPIENT_OFFSET
     mem_loadw_le
@@ -1799,7 +1833,10 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the output note data begins.
 #! - RECIPIENT is the commitment to the note's script, storage and the serial number.
-pub proc set_input_note_recipient
+pub proc set_input_note_recipient(
+    note_ptr: ptr<InputNoteData>,
+    recipient: NoteRecipient
+) -> NoteRecipient
     add.INPUT_NOTE_RECIPIENT_OFFSET
     mem_storew_le
 end
@@ -1812,7 +1849,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - ASSET_COMMITMENT is the sequential hash of the padded assets of an input note.
-pub proc get_input_note_assets_commitment
+pub proc get_input_note_assets_commitment(note_ptr: ptr<InputNoteData>) -> NoteAssetsCommitment
     padw
     movup.4 add.INPUT_NOTE_ASSETS_COMMITMENT_OFFSET
     mem_loadw_le
@@ -1826,7 +1863,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the input note data begins.
 #! - SERIAL_NUMBER is the input note's serial number.
-pub proc get_input_note_serial_num
+pub proc get_input_note_serial_num(note_ptr: ptr<InputNoteData>) -> NoteSerialNumber
     padw
     movup.4 add.INPUT_NOTE_SERIAL_NUM_OFFSET
     mem_loadw_le
@@ -1844,7 +1881,7 @@ end
 #! Where:
 #! - i is the index of the output note.
 #! - ptr is the memory address of the data segment for output note i.
-pub proc get_output_note_ptr
+pub proc get_output_note_ptr(i: u16) -> ptr<OutputNoteData>
     push.NOTE_MEM_SIZE mul add.OUTPUT_NOTE_SECTION_OFFSET
 end
 
@@ -1856,7 +1893,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the output note data begins.
 #! - RECIPIENT is the commitment to the note's script, storage and the serial number.
-pub proc get_output_note_recipient
+pub proc get_output_note_recipient(note_ptr: ptr<OutputNoteData>) -> NoteRecipient
     padw
     movup.4 add.OUTPUT_NOTE_RECIPIENT_OFFSET
     mem_loadw_le
@@ -1870,7 +1907,10 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the output note data begins.
 #! - RECIPIENT is the commitment to the note's script, storage and the serial number.
-pub proc set_output_note_recipient
+pub proc set_output_note_recipient(
+    note_ptr: ptr<OutputNoteData>,
+    recipient: NoteRecipient
+) -> NoteRecipient
     add.OUTPUT_NOTE_RECIPIENT_OFFSET
     mem_storew_le
 end
@@ -1883,7 +1923,7 @@ end
 #! Where:
 #! - METADATA is the note metadata.
 #! - note_ptr is the memory address at which the output note data begins.
-pub proc get_output_note_metadata
+pub proc get_output_note_metadata(note_ptr: ptr<OutputNoteData>) -> NoteMetadata
     padw
     # => [0, 0, 0, 0, note_ptr]
     movup.4 add.OUTPUT_NOTE_METADATA_OFFSET
@@ -1900,7 +1940,10 @@ end
 #! Where:
 #! - METADATA is the note metadata.
 #! - note_ptr is the memory address at which the output note data begins.
-pub proc set_output_note_metadata
+pub proc set_output_note_metadata(
+    note_ptr: ptr<OutputNoteData>,
+    metadata: NoteMetadata
+) -> NoteMetadata
     add.OUTPUT_NOTE_METADATA_OFFSET
     mem_storew_le
 end
@@ -1918,7 +1961,10 @@ end
 #! - note_ptr is the memory address at which the output note data begins.
 #! - attachment_idx is the index of the attachment in the note.
 #! - ATTACHMENT_COMMITMENT is the note attachment commitment.
-pub proc get_output_note_attachment_commitment
+pub proc get_output_note_attachment_commitment(
+    note_ptr: ptr<OutputNoteData>,
+    attachment_idx: u8
+) -> NoteAttachmentCommitment
     add.OUTPUT_NOTE_ATTACHMENT_0_OFFSET
     # => [note_ptr + attachment_0_offset, attachment_idx]
 
@@ -1937,7 +1983,9 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the output note data begins.
 #! - attachment_data_ptr is the memory address of the first attachment slot.
-pub proc get_output_note_attachment_commitment_ptr
+pub proc get_output_note_attachment_commitment_ptr(
+    note_ptr: ptr<OutputNoteData>
+) -> ptr<NoteAttachmentCommitment>
     add.OUTPUT_NOTE_ATTACHMENT_0_OFFSET
 end
 
@@ -1950,7 +1998,11 @@ end
 #! - note_ptr is the memory address at which the output note data begins.
 #! - attachment_idx is the index of the attachment slot (0..3).
 #! - ATTACHMENT_COMMITMENT is the note attachment word.
-pub proc set_output_note_attachment_commitment
+pub proc set_output_note_attachment_commitment(
+    note_ptr: ptr<OutputNoteData>,
+    attachment_idx: u8,
+    attachment_commitment: NoteAttachmentCommitment
+)
     add.OUTPUT_NOTE_ATTACHMENT_0_OFFSET
     # => [note_ptr + base_offset, attachment_idx, ATTACHMENT_COMMITMENT]
 
@@ -1969,7 +2021,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the output note data begins.
 #! - num_attachments is the number of attachments in the output note.
-pub proc get_output_note_num_attachments
+pub proc get_output_note_num_attachments(note_ptr: ptr<OutputNoteData>) -> u8
     add.OUTPUT_NOTE_NUM_ATTACHMENTS_OFFSET mem_load
 end
 
@@ -1981,7 +2033,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the output note data begins.
 #! - num_attachments is the number of attachments in the output note.
-pub proc set_output_note_num_attachments
+pub proc set_output_note_num_attachments(note_ptr: ptr<OutputNoteData>, num_attachments: u8)
     add.OUTPUT_NOTE_NUM_ATTACHMENTS_OFFSET mem_store
 end
 
@@ -1993,7 +2045,7 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the output note data begins.
 #! - total_num_attachment_words is the total number of words across all attachments.
-pub proc get_output_note_total_attachment_words
+pub proc get_output_note_total_attachment_words(note_ptr: ptr<OutputNoteData>) -> u16
     add.OUTPUT_NOTE_TOTAL_ATTACHMENT_WORDS_OFFSET mem_load
 end
 
@@ -2005,7 +2057,10 @@ end
 #! Where:
 #! - note_ptr is the memory address at which the output note data begins.
 #! - total_num_attachment_words is the total number of words across all attachments.
-pub proc set_output_note_total_attachment_words
+pub proc set_output_note_total_attachment_words(
+    note_ptr: ptr<OutputNoteData>,
+    total_num_attachment_words: u16
+)
     add.OUTPUT_NOTE_TOTAL_ATTACHMENT_WORDS_OFFSET mem_store
 end
 
@@ -2017,7 +2072,7 @@ end
 #! Where:
 #! - note_ptr is a pointer to the memory address at which the output note is stored.
 #! - num_assets is the number of assets in the output note.
-pub proc get_output_note_num_assets
+pub proc get_output_note_num_assets(note_ptr: ptr<OutputNoteData>) -> u8
     add.OUTPUT_NOTE_NUM_ASSETS_OFFSET mem_load
 end
 
@@ -2032,7 +2087,7 @@ end
 #!
 #! Panics if:
 #! - the number of assets exceeds the maximum allowed number of assets per note.
-pub proc set_output_note_num_assets
+pub proc set_output_note_num_assets(note_ptr: ptr<OutputNoteData>, num_assets: u8)
     add.OUTPUT_NOTE_NUM_ASSETS_OFFSET
     # => [note_ptr + offset, num_assets]
 
@@ -2052,7 +2107,7 @@ end
 #!
 #! Panics if:
 #! - the number of assets exceeds the maximum allowed number of assets per note.
-pub proc increment_output_note_num_assets
+pub proc increment_output_note_num_assets(note_ptr: ptr<OutputNoteData>)
     dup exec.get_output_note_num_assets add.1
     # => [num_assets + 1, note_ptr]
 
@@ -2071,7 +2126,7 @@ end
 #! Where:
 #! - output_note_data_ptr is the memory address at which the output note data begins.
 #! - dirty_flag is the flag indicating whether the assets commitment is outdated.
-pub proc get_output_note_dirty_flag
+pub proc get_output_note_dirty_flag(output_note_data_ptr: ptr<OutputNoteData>) -> Bool
     add.OUTPUT_NOTE_DIRTY_FLAG_OFFSET mem_load
 end
 
@@ -2086,7 +2141,7 @@ end
 #! Where:
 #! - output_note_data_ptr is the memory address at which the output note data begins.
 #! - dirty_flag is the flag indicating whether the assets commitment is outdated.
-pub proc set_output_note_dirty_flag
+pub proc set_output_note_dirty_flag(output_note_data_ptr: ptr<OutputNoteData>, dirty_flag: Bool)
     add.OUTPUT_NOTE_DIRTY_FLAG_OFFSET mem_store
 end
 
@@ -2098,7 +2153,7 @@ end
 #! Where:
 #! - output_note_data_ptr is the memory address at which the output note data begins.
 #! - asset_data_ptr is the memory address at which the output note asset data begins.
-pub proc get_output_note_asset_data_ptr
+pub proc get_output_note_asset_data_ptr(output_note_data_ptr: ptr<OutputNoteData>) -> ptr<Asset>
     add.OUTPUT_NOTE_ASSETS_OFFSET
 end
 
@@ -2110,7 +2165,9 @@ end
 #! Where:
 #! - output_note_data_ptr is the memory address at which the output note data begins.
 #! - ASSETS_COMMITMENT is the sequential hash of the padded assets of an output note.
-pub proc get_output_note_assets_commitment
+pub proc get_output_note_assets_commitment(
+    output_note_data_ptr: ptr<OutputNoteData>
+) -> NoteAssetsCommitment
     padw
     movup.4 add.OUTPUT_NOTE_ASSETS_COMMITMENT_OFFSET
     mem_loadw_le
@@ -2125,7 +2182,10 @@ end
 #! Where:
 #! - output_note_data_ptr is the memory address at which the output note data begins.
 #! - ASSETS_COMMITMENT is the sequential hash of the padded assets of an output note.
-pub proc set_output_note_assets_commitment
+pub proc set_output_note_assets_commitment(
+    output_note_data_ptr: ptr<OutputNoteData>,
+    assets_commitment: NoteAssetsCommitment
+) -> NoteAssetsCommitment
     add.OUTPUT_NOTE_ASSETS_COMMITMENT_OFFSET
     mem_storew_le
 end
@@ -2140,7 +2200,7 @@ end
 #!
 #! Where:
 #! - num_kernel_procedures is the number of the procedures of the selected kernel.
-pub proc set_num_kernel_procedures
+pub proc set_num_kernel_procedures(num_kernel_procedures: u16)
     mem_store.NUM_KERNEL_PROCEDURES_PTR
 end
 
@@ -2154,7 +2214,7 @@ end
 #!
 #! Panics if:
 #! - the allocation exceeds the maximum possible number of link map entries.
-pub proc link_map_malloc
+pub proc link_map_malloc() -> ptr<LinkMapEntry>
     # retrieve the current memory size
     mem_load.LINK_MAP_USED_MEMORY_SIZE dup
     # => [current_mem_size, current_mem_size]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/memory.masm
@@ -20,7 +20,7 @@ use {
 use {
     AccountData,
     AccountMetadata,
-    Digest,
+    Commitment,
     InputNoteData,
     LinkMapEntry,
     OutputNoteData,
@@ -433,7 +433,7 @@ end
 #!
 #! Where:
 #! - INPUT_VAULT_ROOT is the input vault root.
-pub proc get_input_vault_root() -> Digest
+pub proc get_input_vault_root() -> Commitment
     padw mem_loadw_le.INPUT_VAULT_ROOT_PTR
 end
 
@@ -444,7 +444,7 @@ end
 #!
 #! Where:
 #! - INPUT_VAULT_ROOT is the input vault root.
-pub proc set_input_vault_root(input_vault_root: Digest) -> Digest
+pub proc set_input_vault_root(input_vault_root: Commitment) -> Commitment
     mem_storew_le.INPUT_VAULT_ROOT_PTR
 end
 
@@ -455,7 +455,7 @@ end
 #!
 #! Where:
 #! - OUTPUT_VAULT_ROOT is the output vault root.
-pub proc get_output_vault_root() -> Digest
+pub proc get_output_vault_root() -> Commitment
     padw mem_loadw_le.OUTPUT_VAULT_ROOT_PTR
 end
 
@@ -466,7 +466,7 @@ end
 #!
 #! Where:
 #! - OUTPUT_VAULT_ROOT is the output vault root.
-pub proc set_output_vault_root(output_vault_root: Digest) -> Digest
+pub proc set_output_vault_root(output_vault_root: Commitment) -> Commitment
     mem_storew_le.OUTPUT_VAULT_ROOT_PTR
 end
 
@@ -526,7 +526,7 @@ end
 #!
 #! Where:
 #! - BLOCK_COMMITMENT is the commitment of the transaction reference block.
-pub proc set_block_commitment(block_commitment: Digest) -> Digest
+pub proc set_block_commitment(block_commitment: Commitment) -> Commitment
     mem_storew_le.BLOCK_COMMITMENT_PTR
 end
 
@@ -537,7 +537,7 @@ end
 #!
 #! Where:
 #! - BLOCK_COMMITMENT is the commitment of the transaction reference block.
-pub proc get_ref_block_commitment() -> Digest
+pub proc get_ref_block_commitment() -> Commitment
     padw mem_loadw_le.BLOCK_COMMITMENT_PTR
 end
 
@@ -574,7 +574,7 @@ end
 #!
 #! Where:
 #! - INIT_ACCOUNT_COMMITMENT is the initial account commitment.
-pub proc set_init_account_commitment(init_account_commitment: Digest) -> Digest
+pub proc set_init_account_commitment(init_account_commitment: Commitment) -> Commitment
     mem_storew_le.INIT_ACCOUNT_COMMITMENT_PTR
 end
 
@@ -585,7 +585,7 @@ end
 #!
 #! Where:
 #! - INIT_ACCOUNT_COMMITMENT is the initial account commitment.
-pub proc get_init_account_commitment() -> Digest
+pub proc get_init_account_commitment() -> Commitment
     padw mem_loadw_le.INIT_ACCOUNT_COMMITMENT_PTR
 end
 
@@ -618,7 +618,7 @@ end
 #!
 #! Where:
 #! - INIT_NATIVE_ACCOUNT_VAULT_ROOT is the initial vault root of the native account.
-pub proc set_init_native_account_vault_root(init_native_account_vault_root: Digest) -> Digest
+pub proc set_init_native_account_vault_root(init_native_account_vault_root: Commitment) -> Commitment
     mem_storew_le.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
 end
 
@@ -629,7 +629,7 @@ end
 #!
 #! Where:
 #! - INIT_NATIVE_ACCOUNT_VAULT_ROOT is the initial vault root of the native account.
-pub proc get_init_native_account_vault_root() -> Digest
+pub proc get_init_native_account_vault_root() -> Commitment
     padw mem_loadw_le.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
 end
 
@@ -642,7 +642,7 @@ end
 #! Where:
 #! - native_account_initial_vault_root_ptr is the memory pointer to the initial vault root of the
 #!   native account.
-pub proc get_init_native_account_vault_root_ptr() -> ptr<Digest>
+pub proc get_init_native_account_vault_root_ptr() -> ptr<Commitment>
     push.INIT_NATIVE_ACCOUNT_VAULT_ROOT_PTR
 end
 
@@ -654,8 +654,8 @@ end
 #! Where:
 #! - INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT is the initial storage commitment of the native account.
 pub proc set_init_account_storage_commitment(
-    init_native_account_storage_commitment: Digest
-) -> Digest
+    init_native_account_storage_commitment: Commitment
+) -> Commitment
     mem_storew_le.INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT_PTR
 end
 
@@ -666,7 +666,7 @@ end
 #!
 #! Where:
 #! - INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT is the initial storage commitment of the native account.
-pub proc get_init_account_storage_commitment() -> Digest
+pub proc get_init_account_storage_commitment() -> Commitment
     padw mem_loadw_le.INIT_NATIVE_ACCOUNT_STORAGE_COMMITMENT_PTR
 end
 
@@ -679,7 +679,7 @@ end
 #!
 #! Where:
 #! - INPUT_NOTES_COMMITMENT is the input notes commitment.
-pub proc get_input_notes_commitment() -> Digest
+pub proc get_input_notes_commitment() -> Commitment
     padw mem_loadw_le.INPUT_NOTES_COMMITMENT_PTR
 end
 
@@ -690,7 +690,7 @@ end
 #!
 #! Where:
 #! - INPUT_NOTES_COMMITMENT is the notes' commitment.
-pub proc set_nullifier_commitment(input_notes_commitment: Digest) -> Digest
+pub proc set_nullifier_commitment(input_notes_commitment: Commitment) -> Commitment
     mem_storew_le.INPUT_NOTES_COMMITMENT_PTR
 end
 
@@ -773,7 +773,7 @@ end
 #!
 #! Where:
 #! - PREV_BLOCK_COMMITMENT_PTR is the block commitment of the transaction reference block.
-pub proc get_prev_block_commitment() -> Digest
+pub proc get_prev_block_commitment() -> Commitment
     padw mem_loadw_le.PREV_BLOCK_COMMITMENT_PTR
 end
 
@@ -840,7 +840,7 @@ end
 #!
 #! Where:
 #! - CHAIN_COMMITMENT is the chain commitment of the transaction reference block.
-pub proc get_chain_commitment() -> Digest
+pub proc get_chain_commitment() -> Commitment
     padw mem_loadw_le.CHAIN_COMMITMENT_PTR
 end
 
@@ -851,7 +851,7 @@ end
 #!
 #! Where:
 #! - ACCT_DB_ROOT is the account database root of the transaction reference block.
-pub proc get_account_db_root() -> Digest
+pub proc get_account_db_root() -> Commitment
     padw mem_loadw_le.ACCT_DB_ROOT_PTR
 end
 
@@ -862,7 +862,7 @@ end
 #!
 #! Where:
 #! - NULLIFIER_ROOT is the nullifier root of the transaction reference block.
-pub proc get_nullifier_db_root() -> Digest
+pub proc get_nullifier_db_root() -> Commitment
     padw mem_loadw_le.NULLIFIER_ROOT_PTR
 end
 
@@ -873,7 +873,7 @@ end
 #!
 #! Where:
 #! - TX_COMMITMENT is the tx commitment of the transaction reference block.
-pub proc get_tx_commitment() -> Digest
+pub proc get_tx_commitment() -> Commitment
     padw mem_loadw_le.TX_COMMITMENT_PTR
 end
 
@@ -884,7 +884,7 @@ end
 #!
 #! Where:
 #! - PROTOCOL_CONFIG_COMMITMENT is the commitment to the chain's protocol config.
-pub proc get_protocol_config_commitment() -> Digest
+pub proc get_protocol_config_commitment() -> Commitment
     padw mem_loadw_le.PROTOCOL_CONFIG_COMMITMENT_PTR
 end
 
@@ -896,7 +896,7 @@ end
 #! Where:
 #! - TX_KERNEL_CONFIG_COMMITMENT is the commitment to the transaction kernel's main procedure root
 #!   and its exposed procedure roots.
-pub proc get_tx_kernel_config_commitment() -> Digest
+pub proc get_tx_kernel_config_commitment() -> Commitment
     padw mem_loadw_le.TX_KERNEL_CONFIG_COMMITMENT_PTR
 end
 
@@ -907,7 +907,7 @@ end
 #!
 #! Where:
 #! - NOTE_ROOT is the note root of the transaction reference block.
-pub proc get_note_root() -> Digest
+pub proc get_note_root() -> Commitment
     padw mem_loadw_le.NOTE_ROOT_PTR
 end
 
@@ -918,7 +918,7 @@ end
 #!
 #! Where:
 #! - NOTE_ROOT is the note root of the transaction reference block.
-pub proc set_note_root(note_root: Digest) -> Digest
+pub proc set_note_root(note_root: Commitment) -> Commitment
     mem_storew_le.NOTE_ROOT_PTR
 end
 
@@ -1199,7 +1199,7 @@ end
 #!
 #! Where:
 #! - account_vault_root_ptr is the memory pointer to the account asset vault root.
-pub proc get_account_vault_root_ptr() -> ptr<Digest>
+pub proc get_account_vault_root_ptr() -> ptr<Commitment>
     exec.get_active_account_data_ptr add.ACCT_VAULT_ROOT_OFFSET
 end
 
@@ -1210,7 +1210,7 @@ end
 #!
 #! Where:
 #! - ACCT_VAULT_ROOT is the account asset vault root.
-pub proc get_account_vault_root() -> Digest
+pub proc get_account_vault_root() -> Commitment
     padw
     exec.get_active_account_data_ptr add.ACCT_VAULT_ROOT_OFFSET
     mem_loadw_le
@@ -1223,7 +1223,7 @@ end
 #!
 #! Where:
 #! - ACCT_VAULT_ROOT is the account vault root to be set.
-pub proc set_account_vault_root(acct_vault_root: Digest) -> Digest
+pub proc set_account_vault_root(acct_vault_root: Commitment) -> Commitment
     exec.get_active_account_data_ptr add.ACCT_VAULT_ROOT_OFFSET
     mem_storew_le
 end
@@ -1235,7 +1235,7 @@ end
 #!
 #! Where:
 #! - account_vault_root_ptr is the memory pointer to the native account's asset vault root.
-pub proc get_native_account_vault_root_ptr() -> ptr<Digest>
+pub proc get_native_account_vault_root_ptr() -> ptr<Commitment>
     push.NATIVE_ACCOUNT_DATA_PTR add.ACCT_VAULT_ROOT_OFFSET
 end
 
@@ -1246,7 +1246,7 @@ end
 #!
 #! Where:
 #! - ACCT_VAULT_ROOT is the native account's asset vault root.
-pub proc get_native_account_vault_root() -> Digest
+pub proc get_native_account_vault_root() -> Commitment
     padw exec.get_native_account_vault_root_ptr mem_loadw_le
 end
 
@@ -1259,7 +1259,7 @@ end
 #!
 #! Where:
 #! - CODE_COMMITMENT is the code commitment of the account.
-pub proc get_account_code_commitment() -> Digest
+pub proc get_account_code_commitment() -> Commitment
     padw
     exec.get_active_account_data_ptr add.ACCT_CODE_COMMITMENT_OFFSET
     mem_loadw_le
@@ -1272,7 +1272,7 @@ end
 #!
 #! Where:
 #! - CODE_COMMITMENT is the code commitment to be set.
-pub proc set_account_code_commitment(code_commitment: Digest) -> Digest
+pub proc set_account_code_commitment(code_commitment: Commitment) -> Commitment
     exec.get_active_account_data_ptr add.ACCT_CODE_COMMITMENT_OFFSET
     mem_storew_le
 end
@@ -1353,7 +1353,7 @@ end
 #! Where:
 #! - proc_idx is the index of the account procedure.
 #! - proc_ptr is the memory pointer to the account procedure at the specified index.
-pub proc get_account_procedure_ptr(proc_idx: u8) -> ptr<AccountProcedureRoot>
+pub proc get_account_procedure_ptr(proc_idx: u16) -> ptr<AccountProcedureRoot>
     mul.ACCOUNT_PROCEDURE_DATA_LENGTH exec.get_account_procedures_section_ptr add
 end
 
@@ -1366,7 +1366,7 @@ end
 #!
 #! Where:
 #! - STORAGE_COMMITMENT is the account storage commitment.
-pub proc get_account_storage_commitment() -> Digest
+pub proc get_account_storage_commitment() -> Commitment
     padw
     exec.get_active_account_data_ptr add.ACCT_STORAGE_COMMITMENT_OFFSET
     mem_loadw_le
@@ -1379,7 +1379,7 @@ end
 #!
 #! Where:
 #! - STORAGE_COMMITMENT is the account storage commitment.
-pub proc set_account_storage_commitment(storage_commitment: Digest) -> Digest
+pub proc set_account_storage_commitment(storage_commitment: Commitment) -> Commitment
     exec.get_active_account_data_ptr add.ACCT_STORAGE_COMMITMENT_OFFSET
     mem_storew_le
 end
@@ -1391,7 +1391,7 @@ end
 #!
 #! Where:
 #! - CODE_UPGRADE_COMMITMENT is the commitment to the account code upgrade.
-pub proc set_code_upgrade_commitment(code_upgrade_commitment: Digest)
+pub proc set_code_upgrade_commitment(code_upgrade_commitment: Commitment)
     mem_storew_le.CODE_UPGRADE_COMMITMENT_PTR dropw
 end
 
@@ -1402,7 +1402,7 @@ end
 #!
 #! Where:
 #! - STORAGE_UPGRADE_COMMITMENT is the commitment to the account storage upgrade.
-pub proc set_storage_upgrade_commitment(storage_upgrade_commitment: Digest)
+pub proc set_storage_upgrade_commitment(storage_upgrade_commitment: Commitment)
     mem_storew_le.STORAGE_UPGRADE_COMMITMENT_PTR dropw
 end
 
@@ -1592,8 +1592,8 @@ end
 #! - NOTE_DETAILS_COMMITMENT is the commitment to the note's details.
 pub proc set_input_note_details_commitment(
     note_ptr: ptr<InputNoteData>,
-    note_details_commitment: Digest
-) -> Digest
+    note_details_commitment: Commitment
+) -> Commitment
     mem_storew_le
 end
 
@@ -1632,7 +1632,7 @@ end
 #! Where:
 #! - idx is the index of the input note.
 #! - NULLIFIER is the nullifier of the input note.
-pub proc set_input_note_nullifier(idx: u16, nullifier: Digest) -> Digest
+pub proc set_input_note_nullifier(idx: u16, nullifier: Commitment) -> Commitment
     mul.4 add.INPUT_NOTE_NULLIFIER_SECTION_PTR mem_storew_le
 end
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/mod.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/mod.masm
@@ -20,3 +20,4 @@ pub mod note
 pub mod output_note
 pub mod prologue
 pub mod tx
+pub mod types

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/note.masm
@@ -1,3 +1,5 @@
+use {NoteArgs, NoteScriptRoot} from miden::protocol_utils::types
+use {Digest, InputNoteData, OutputNoteData} from miden::tx_kernel_core::types
 use miden::core::crypto::hashes::poseidon2
 
 use {ASSET_SIZE} from miden::tx_kernel_core::asset
@@ -29,7 +31,7 @@ const OUTPUT_NOTE_HASHING_MEM_DIFF = 1016
 #!
 #! Where:
 #! - active_input_note_ptr is the pointer to the next note to be processed.
-pub proc increment_active_input_note_ptr
+pub proc increment_active_input_note_ptr() -> ptr<InputNoteData>
     # get the active input note pointer
     exec.memory::get_active_input_note_ptr
     # => [orig_input_note_ptr]
@@ -48,7 +50,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-pub proc note_processing_teardown
+pub proc note_processing_teardown()
     # set the active input note pointer to 0
     push.0 exec.memory::set_active_input_note_ptr
     # => []
@@ -64,7 +66,7 @@ end
 #! Where:
 #! - note_script_root_ptr is the memory address where note's script root is stored.
 #! - NOTE_ARGS is the note's arguments.
-pub proc prepare_note
+pub proc prepare_note() -> (ptr<NoteScriptRoot>, NoteArgs, [felt; 11])
     padw padw push.0.0.0
     # => [pad(11)]
 
@@ -94,7 +96,7 @@ end
 #! Where:
 #! - note_ptr is a pointer to the data section of the output note.
 #! - ATTACHMENTS_COMMITMENT is the commitment of the note's attachments.
-pub proc compute_attachments_commitment
+pub proc compute_attachments_commitment(note_ptr: ptr<OutputNoteData>) -> Digest
     dup exec.memory::get_output_note_num_attachments
     # => [num_attachments, note_ptr]
 
@@ -124,7 +126,7 @@ end
 #! Where:
 #! - note_data_ptr is a pointer to the data section of the output note.
 #! - ASSETS_COMMITMENT is the commitment of the assets of the output note located at note_data_ptr.
-pub proc compute_output_note_assets_commitment
+pub proc compute_output_note_assets_commitment(note_data_ptr: ptr<OutputNoteData>) -> Digest
     # get the assets commitment dirty flag and decide whether we need to recompute the commitment
     dup exec.memory::get_output_note_dirty_flag
     # => [dirty_flag, note_data_ptr]
@@ -177,7 +179,7 @@ end
 #! Where:
 #! - note_data_ptr is a pointer to the data section of the output note.
 #! - NOTE_DETAILS_COMMITMENT is the commitment to the note's details.
-proc compute_output_note_details_commitment
+proc compute_output_note_details_commitment(note_data_ptr: ptr<OutputNoteData>) -> Digest
     # compute assets commitment
     dup exec.compute_output_note_assets_commitment
     # => [ASSETS_COMMITMENT, note_data_ptr]
@@ -202,7 +204,7 @@ end
 #!
 #! Where:
 #! - OUTPUT_NOTES_COMMITMENT is the commitment to the notes output by the transaction.
-pub proc compute_output_notes_commitment
+pub proc compute_output_notes_commitment() -> Digest
     # get the number of output notes from memory
     exec.memory::get_num_output_notes
     # => [num_notes]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/note.masm
@@ -1,5 +1,5 @@
 use {NoteArgs, NoteScriptRoot} from miden::protocol_utils::types
-use {Digest, InputNoteData, OutputNoteData} from miden::tx_kernel_core::types
+use {Commitment, InputNoteData, OutputNoteData} from miden::tx_kernel_core::types
 use miden::core::crypto::hashes::poseidon2
 
 use {ASSET_SIZE} from miden::tx_kernel_core::asset
@@ -96,7 +96,7 @@ end
 #! Where:
 #! - note_ptr is a pointer to the data section of the output note.
 #! - ATTACHMENTS_COMMITMENT is the commitment of the note's attachments.
-pub proc compute_attachments_commitment(note_ptr: ptr<OutputNoteData>) -> Digest
+pub proc compute_attachments_commitment(note_ptr: ptr<OutputNoteData>) -> Commitment
     dup exec.memory::get_output_note_num_attachments
     # => [num_attachments, note_ptr]
 
@@ -126,7 +126,7 @@ end
 #! Where:
 #! - note_data_ptr is a pointer to the data section of the output note.
 #! - ASSETS_COMMITMENT is the commitment of the assets of the output note located at note_data_ptr.
-pub proc compute_output_note_assets_commitment(note_data_ptr: ptr<OutputNoteData>) -> Digest
+pub proc compute_output_note_assets_commitment(note_data_ptr: ptr<OutputNoteData>) -> Commitment
     # get the assets commitment dirty flag and decide whether we need to recompute the commitment
     dup exec.memory::get_output_note_dirty_flag
     # => [dirty_flag, note_data_ptr]
@@ -179,7 +179,7 @@ end
 #! Where:
 #! - note_data_ptr is a pointer to the data section of the output note.
 #! - NOTE_DETAILS_COMMITMENT is the commitment to the note's details.
-proc compute_output_note_details_commitment(note_data_ptr: ptr<OutputNoteData>) -> Digest
+proc compute_output_note_details_commitment(note_data_ptr: ptr<OutputNoteData>) -> Commitment
     # compute assets commitment
     dup exec.compute_output_note_assets_commitment
     # => [ASSETS_COMMITMENT, note_data_ptr]
@@ -204,7 +204,7 @@ end
 #!
 #! Where:
 #! - OUTPUT_NOTES_COMMITMENT is the commitment to the notes output by the transaction.
-pub proc compute_output_notes_commitment() -> Digest
+pub proc compute_output_notes_commitment() -> Commitment
     # get the number of output notes from memory
     exec.memory::get_num_output_notes
     # => [num_notes]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/output_note.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/output_note.masm
@@ -1,3 +1,14 @@
+use {
+    Asset,
+    NoteAssetsCommitment,
+    NoteAttachmentCommitment,
+    NoteAttachmentsCommitment,
+    NoteMetadata,
+    NoteRecipient,
+    NoteTag,
+    NoteType,
+} from miden::protocol_utils::types
+use {OutputNoteData} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::asset
 use {ASSET_SIZE, ASSET_VALUE_MEMORY_OFFSET} from miden::tx_kernel_core::asset
@@ -100,7 +111,7 @@ const NOTE_BEFORE_ADD_ATTACHMENT_EVENT = event("miden::protocol::note::before_ad
 #! - the note_type is unknown.
 #! - the note tag is not a u32.
 #! - the number of output notes exceeds the maximum limit of 1024.
-pub proc create
+pub proc create(tag: NoteTag, note_type: NoteType, recipient: NoteRecipient) -> u16
     emit.NOTE_BEFORE_CREATED_EVENT
     # => [tag, note_type, RECIPIENT]
 
@@ -144,7 +155,7 @@ end
 #! - note_index is the index of the output note whose assets info should be returned.
 #! - num_assets is the number of assets in the specified note.
 #! - ASSETS_COMMITMENT is a sequential hash of the assets in the specified note.
-pub proc get_assets_info
+pub proc get_assets_info(note_index: u16) -> (NoteAssetsCommitment, u8)
     # get the note data pointer based on the index of the requested note
     exec.memory::get_output_note_ptr
     # => [note_data_ptr]
@@ -194,7 +205,7 @@ end
 #! Where:
 #! - note_index is the index of the output note whose attachments commitment should be returned.
 #! - ATTACHMENTS_COMMITMENT is the commitment to all attachments of the note.
-pub proc get_attachments_commitment
+pub proc get_attachments_commitment(note_index: u16) -> NoteAttachmentsCommitment
     # get the note data pointer based on the index of the requested note
     exec.memory::get_output_note_ptr
     # => [note_ptr]
@@ -236,7 +247,7 @@ end
 #! - the max amount of fungible assets is exceeded.
 #! - the non-fungible asset already exists in the note.
 #! - the total number of ASSETs exceeds the maximum of 16.
-pub proc add_asset
+pub proc add_asset(asset: Asset, note_idx: u16)
     # reject assets with a Custom composition; only None and Fungible are supported today
     exec.asset::assert_supported_composition
     # => [ASSET_ID, ASSET_VALUE, note_idx]
@@ -302,7 +313,11 @@ end
 #! - the number of elements is not a multiple of 4, or num_words is zero or exceeds 256.
 #! - the computed hash of fetched attachment elements does not match ATTACHMENT_COMMITMENT.
 #! - the note already has 4 attachments.
-pub proc add_attachment
+pub proc add_attachment(
+    attachment_scheme: u16,
+    attachment_commitment: NoteAttachmentCommitment,
+    note_idx: u16
+)
     # validate attachment_scheme does not exceed max
     dup u32assert.err=ERR_OUTPUT_NOTE_ATTACHMENT_SCHEME_MAX_EXCEEDED
     u32lte.MAX_ATTACHMENT_SCHEME assert.err=ERR_OUTPUT_NOTE_ATTACHMENT_SCHEME_MAX_EXCEEDED
@@ -378,7 +393,7 @@ end
 #!
 #! Inputs:  [note_index]
 #! Outputs: [note_index]
-pub proc assert_note_index_in_bounds
+pub proc assert_note_index_in_bounds(note_index: u16) -> u16
     # assert that the provided note index is less than the total number of notes
     dup exec.memory::get_num_output_notes
     # => [output_notes_num, note_index, note_index]
@@ -408,7 +423,7 @@ end
 #! - the number of elements is not a multiple of 4, or num_words is zero or exceeds 256.
 #! - the computed hash of fetched elements does not match ATTACHMENT_COMMITMENT.
 @locals(1024)
-proc validate_attachment
+proc validate_attachment(attachment_commitment: NoteAttachmentCommitment) -> u16
     # push the attachment elements from the advice map onto the advice stack
     adv.push_mapvaln
     # OS => [ATTACHMENT_COMMITMENT]
@@ -465,7 +480,7 @@ end
 #! - note_type is the type of the note, which defines how the note is to be stored (e.g., on-chain
 #!   or off-chain).
 #! - NOTE_METADATA is the metadata associated with a note.
-pub proc build_metadata
+pub proc build_metadata(tag: NoteTag, note_type: NoteType) -> NoteMetadata
     # Validate that note type is private (0) or public (1).
     # --------------------------------------------------------------------------------------------
     dup.1
@@ -512,7 +527,11 @@ end
 #! - num_attachments is the number of attachments the note had before this attachment was added.
 #! - attachment_scheme is the user-defined scheme of the attachment.
 #! - note_ptr is the memory address at which the output note data begins.
-proc set_attachment_schemes
+proc set_attachment_schemes(
+    num_attachments: u8,
+    note_ptr: ptr<OutputNoteData>,
+    attachment_scheme: u16
+)
     # the schemes are stored as follows in the third felt:
     # 3rd felt: [
     #   attachment_3_scheme (16 bits) | attachment_2_scheme (16 bits) |
@@ -559,7 +578,7 @@ end
 #!
 #! Where:
 #! - note_idx is the index of the next note to be created.
-proc increment_num_output_notes
+proc increment_num_output_notes() -> u16
     # get the current number of output notes
     exec.memory::get_num_output_notes
     # => [note_idx]
@@ -594,7 +613,7 @@ end
 #! Panics if
 #! - asset is fungible and adding the two asset values would exceed FUNGIBLE_ASSET_MAX_AMOUNT.
 #! - asset is non-fungible and the note already contains an asset with the same ID.
-proc add_asset_raw
+proc add_asset_raw(asset: Asset, note_ptr: ptr<OutputNoteData>)
     dup.8 exec.memory::get_output_note_asset_data_ptr movdn.8
     # => [ASSET_ID, ASSET_VALUE, asset_ptr, note_ptr]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
@@ -1,5 +1,5 @@
 use {AccountId, BlockNumber, NoteId} from miden::protocol_utils::types
-use {Digest, HashState, InputNoteData} from miden::tx_kernel_core::types
+use {Commitment, HasherState, InputNoteData} from miden::tx_kernel_core::types
 use miden::core::mem
 use miden::core::collections::mmr
 use miden::core::crypto::hashes::poseidon2
@@ -121,7 +121,7 @@ const ERR_PROLOGUE_KERNEL_PROCEDURE_COMMITMENT_MISMATCH =
 #!   accounts.
 #! - INPUT_NOTES_COMMITMENT is the commitment to the input notes. See the
 #!   `tx_get_input_notes_commitment` kernel procedure for details.
-proc process_global_inputs(block_commitment: Digest, initial_account_commitment: Digest, input_notes_commitment: Digest, account_id: AccountId, block_num: BlockNumber) -> BlockNumber
+proc process_global_inputs(block_commitment: Commitment, initial_account_commitment: Commitment, input_notes_commitment: Commitment, account_id: AccountId, block_num: BlockNumber) -> BlockNumber
     exec.memory::set_block_commitment dropw
     exec.memory::set_init_account_commitment dropw
     exec.memory::set_nullifier_commitment dropw
@@ -726,7 +726,7 @@ end
 #! - NOTE_METADATA is the note's metadata.
 #! - NOTE_ATTACHMENTS_COMMITMENT is the note's attachments commitment.
 #! - NULLIFIER is the nullifier of the input note.
-proc process_input_note_details(idx: u16) -> Digest
+proc process_input_note_details(idx: u16) -> Commitment
     # get the input note core data pointer
     dup exec.memory::get_input_note_ptr exec.memory::get_input_note_core_ptr
     # => [note_data_ptr, idx]
@@ -783,7 +783,7 @@ end
 #! Panics if:
 #! - the metadata encodes an unknown version.
 #! - the metadata has its reserved bit set.
-proc process_note_metadata(note_ptr: ptr<InputNoteData>) -> Digest
+proc process_note_metadata(note_ptr: ptr<InputNoteData>) -> Commitment
     # load the attachments commitment onto the stack
     dup exec.memory::get_input_note_attachments_commitment
     # => [NOTE_ATTACHMENTS_COMMITMENT, note_ptr]
@@ -979,7 +979,7 @@ end
 #! Where:
 #! - note_ptr is the memory location for the input note.
 #! - NOTE_DETAILS_COMMITMENT is the commitment of the input note details.
-proc compute_input_note_details_commitment(note_ptr: ptr<InputNoteData>) -> Digest
+proc compute_input_note_details_commitment(note_ptr: ptr<InputNoteData>) -> Commitment
     # load all inputs on the stack
     dup exec.memory::get_input_note_assets_commitment
     dup.4 exec.memory::get_input_note_storage_commitment
@@ -1062,7 +1062,7 @@ end
 #!   - BLOCK_SUB_COMMITMENT is the block's sub_commitment for which the note was created.
 #!   - NOTE_ROOT is the merkle root of the note's tree.
 #!   - note_index is the input note's position in the notes tree.
-proc process_input_note(idx: u16, capacity: word) -> HashState
+proc process_input_note(idx: u16, capacity: word) -> HasherState
     # note args
     # ---------------------------------------------------------------------------------------------
     dup exec.memory::get_input_note_ptr
@@ -1378,7 +1378,7 @@ end
 #! - data provided by the advice provider does not match global inputs.
 #! - the account data is invalid.
 #! - any of the input notes do note exist in the note db.
-pub proc prepare_transaction(block_commitment: Digest, initial_account_commitment: Digest, input_notes_commitment: Digest, account_id: AccountId, block_num: BlockNumber)
+pub proc prepare_transaction(block_commitment: Commitment, initial_account_commitment: Commitment, input_notes_commitment: Commitment, account_id: AccountId, block_num: BlockNumber)
     exec.process_global_inputs
     # => [block_num]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/prologue.masm
@@ -1,3 +1,5 @@
+use {AccountId, BlockNumber, NoteId} from miden::protocol_utils::types
+use {Digest, HashState, InputNoteData} from miden::tx_kernel_core::types
 use miden::core::mem
 use miden::core::collections::mmr
 use miden::core::crypto::hashes::poseidon2
@@ -106,7 +108,7 @@ const ERR_PROLOGUE_KERNEL_PROCEDURE_COMMITMENT_MISMATCH =
 #!   BLOCK_COMMITMENT,
 #!   INITIAL_ACCOUNT_COMMITMENT,
 #!   INPUT_NOTES_COMMITMENT,
-#!   account_id_prefix, account_id_suffix, block_num
+#!   account_id_suffix, account_id_prefix, block_num
 #! ]
 #! Outputs: [block_num]
 #!
@@ -119,7 +121,7 @@ const ERR_PROLOGUE_KERNEL_PROCEDURE_COMMITMENT_MISMATCH =
 #!   accounts.
 #! - INPUT_NOTES_COMMITMENT is the commitment to the input notes. See the
 #!   `tx_get_input_notes_commitment` kernel procedure for details.
-proc process_global_inputs
+proc process_global_inputs(block_commitment: Digest, initial_account_commitment: Digest, input_notes_commitment: Digest, account_id: AccountId, block_num: BlockNumber) -> BlockNumber
     exec.memory::set_block_commitment dropw
     exec.memory::set_init_account_commitment dropw
     exec.memory::set_nullifier_commitment dropw
@@ -149,7 +151,7 @@ end
 #! Panics if:
 #! - the provided protocol config does not match the commitment in the reference block header.
 #! - the fee asset ID is not a fungible asset ID.
-proc process_protocol_config
+proc process_protocol_config()
     # move the protocol config elements from the advice map to the advice stack
     exec.memory::get_protocol_config_commitment
     adv.push_mapval
@@ -203,7 +205,7 @@ end
 #! Panics if:
 #! - the provided kernel config does not match the commitment in the protocol config.
 #! - the provided kernel procedures do not match the commitment in the kernel config.
-proc process_kernel_data
+proc process_kernel_data()
     # move the kernel config elements from the advice map to the advice stack
     exec.memory::get_tx_kernel_config_commitment
     adv.push_mapval
@@ -297,7 +299,7 @@ end
 #! - verification_base_fee is the base fee capturing the cost for the verification of a
 #!   transaction.
 #! - NOTE_ROOT is the root of the tree with all notes created in the block.
-proc process_block_data
+proc process_block_data(block_num: BlockNumber)
     push.BLOCK_METADATA_PTR
     # => [block_data_ptr, block_num]
 
@@ -366,7 +368,7 @@ end
 #! - PARTIAL_BLOCKCHAIN_COMMITMENT is the sequential hash of the padded MMR peaks.
 #! - num_blocks is the number of blocks in the MMR.
 #! - PEAK_1 .. PEAK_N are the MMR peaks.
-proc process_chain_data
+proc process_chain_data()
     push.PARTIAL_BLOCKCHAIN_PTR dup
     # => [partial_blockchain_ptr, partial_blockchain_ptr]
 
@@ -405,7 +407,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-proc validate_new_account
+proc validate_new_account()
     # Assert the account ID of the account is valid
     exec.memory::get_native_account_id exec.account_id::validate
     # => []
@@ -473,7 +475,7 @@ end
 #!
 #! Panics if:
 #! - the account's storage contains an asset callback slot but its asset callback flag is disabled.
-proc validate_asset_callbacks
+proc validate_asset_callbacks()
     push.ON_BEFORE_ASSET_ADDED_TO_ACCOUNT_PROC_ROOT_SLOT[0..2] exec.account::has_storage_slot
     # => [has_account_callback_slot]
 
@@ -525,7 +527,7 @@ end
 #! - ACCOUNT_VAULT_ROOT is the account's vault root.
 #! - ACCOUNT_STORAGE_COMMITMENT is the account's storage commitment.
 #! - ACCOUNT_CODE_COMMITMENT is the account's code commitment.
-proc process_account_data
+proc process_account_data()
     # Initialize the active account data pointer in the bookkeeping section with the native offset
     # (2048)
     exec.memory::set_active_account_data_ptr_to_native_account
@@ -648,7 +650,7 @@ end
 #! - NOTE_ROOT is the merkle root of the notes tree containing the input note.
 #! - note_index is the input note's position in the notes tree.
 @locals(8)
-proc authenticate_note
+proc authenticate_note(note_id: NoteId)
     # Load the BLOCK_COMMITMENT from the PARTIAL_BLOCKCHAIN
     # ---------------------------------------------------------------------------------------------
     push.PARTIAL_BLOCKCHAIN_PTR adv_push
@@ -724,7 +726,7 @@ end
 #! - NOTE_METADATA is the note's metadata.
 #! - NOTE_ATTACHMENTS_COMMITMENT is the note's attachments commitment.
 #! - NULLIFIER is the nullifier of the input note.
-proc process_input_note_details
+proc process_input_note_details(idx: u16) -> Digest
     # get the input note core data pointer
     dup exec.memory::get_input_note_ptr exec.memory::get_input_note_core_ptr
     # => [note_data_ptr, idx]
@@ -762,7 +764,7 @@ end
 #! Where:
 #! - note_ptr is the memory location for the input note.
 #! - NOTE_ARGS are the user arguments passed to the note.
-proc process_note_args
+proc process_note_args(note_ptr: ptr<InputNoteData>) -> ptr<InputNoteData>
     padw adv_loadw dup.4 exec.memory::set_input_note_args dropw
     # => [note_ptr]
 end
@@ -781,7 +783,7 @@ end
 #! Panics if:
 #! - the metadata encodes an unknown version.
 #! - the metadata has its reserved bit set.
-proc process_note_metadata
+proc process_note_metadata(note_ptr: ptr<InputNoteData>) -> Digest
     # load the attachments commitment onto the stack
     dup exec.memory::get_input_note_attachments_commitment
     # => [NOTE_ATTACHMENTS_COMMITMENT, note_ptr]
@@ -825,7 +827,7 @@ end
 #! - the number of storage items from the advice map does not match the note's declared count.
 #! - the note's storage does not match its storage commitment.
 @locals(1024)
-proc process_note_num_storage_items
+proc process_note_num_storage_items(note_ptr: ptr<InputNoteData>) -> ptr<InputNoteData>
     # move the number of storage items from the advice stack to the operand stack
     adv_push
     # => [num_storage_items, note_ptr]
@@ -880,7 +882,7 @@ end
 #! - note_ptr is the memory location for the input note.
 #! - num_assets is the number of note assets.
 #! - ASSET_ID_0, ASSET_VALUE_0, ..., ASSET_ID_N, ASSET_VALUE_N are the note's assets.
-proc process_note_assets
+proc process_note_assets(note_ptr: ptr<InputNoteData>)
     # Validate num_assets and setup commitment computation.
     # ---------------------------------------------------------------------------------------------
     adv_push
@@ -925,7 +927,7 @@ end
 #!
 #! Where:
 #! - note_ptr is the memory location for the input note.
-proc add_input_note_assets_to_vault
+proc add_input_note_assets_to_vault(note_ptr: ptr<InputNoteData>)
     # prepare the stack
     # ---------------------------------------------------------------------------------------------
     push.INPUT_VAULT_ROOT_PTR
@@ -977,7 +979,7 @@ end
 #! Where:
 #! - note_ptr is the memory location for the input note.
 #! - NOTE_DETAILS_COMMITMENT is the commitment of the input note details.
-proc compute_input_note_details_commitment
+proc compute_input_note_details_commitment(note_ptr: ptr<InputNoteData>) -> Digest
     # load all inputs on the stack
     dup exec.memory::get_input_note_assets_commitment
     dup.4 exec.memory::get_input_note_storage_commitment
@@ -1060,7 +1062,7 @@ end
 #!   - BLOCK_SUB_COMMITMENT is the block's sub_commitment for which the note was created.
 #!   - NOTE_ROOT is the merkle root of the note's tree.
 #!   - note_index is the input note's position in the notes tree.
-proc process_input_note
+proc process_input_note(idx: u16, capacity: word) -> HashState
     # note args
     # ---------------------------------------------------------------------------------------------
     dup exec.memory::get_input_note_ptr
@@ -1162,7 +1164,7 @@ end
 #! - INPUT_NOTES_COMMITMENT, see `transaction::api::get_input_notes_commitment`.
 #! - NOTE_DATA is the input notes' args, nullifier preimages, assets, and authentication data; for
 #!   format see `prologue::process_input_note`.
-proc process_input_notes_data
+proc process_input_notes_data()
     # get the number of input notes from the advice stack
     adv_push
     # => [num_notes]
@@ -1265,7 +1267,7 @@ end
 #! - TX_SCRIPT_ROOT is the transaction's script root.
 #! - TX_SCRIPT_ARGS is the word of values which could be used directly or could be used to obtain
 #!   some values associated with it from the advice map.
-proc process_tx_script_data
+proc process_tx_script_data()
     # read the transaction script root from the advice stack
     padw adv_loadw
     # => [TX_SCRIPT_ROOT]
@@ -1296,7 +1298,7 @@ end
 #!
 #! Where:
 #! - AUTH_ARGS is the argument passed to the auth procedure.
-proc process_auth_procedure_data
+proc process_auth_procedure_data()
     # read the auth procedure args from the advice stack
     padw adv_loadw
     # => [AUTH_ARGS]
@@ -1320,7 +1322,7 @@ end
 #!     BLOCK_COMMITMENT,
 #!     INITIAL_ACCOUNT_COMMITMENT,
 #!     INPUT_NOTES_COMMITMENT,
-#!     account_id_prefix, account_id_suffix, block_num,
+#!     account_id_suffix, account_id_prefix, block_num,
 #!   ]
 #!   Advice stack: [
 #!     BLOCK_HEADER_ELEMENTS,
@@ -1376,7 +1378,7 @@ end
 #! - data provided by the advice provider does not match global inputs.
 #! - the account data is invalid.
 #! - any of the input notes do note exist in the note db.
-pub proc prepare_transaction
+pub proc prepare_transaction(block_commitment: Digest, initial_account_commitment: Digest, input_notes_commitment: Digest, account_id: AccountId, block_num: BlockNumber)
     exec.process_global_inputs
     # => [block_num]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/tx.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/tx.masm
@@ -1,5 +1,5 @@
 use {AccountId, AssetAmount, BlockNumber} from miden::protocol_utils::types
-use {Digest} from miden::tx_kernel_core::types
+use {Commitment} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::memory
 use miden::core::collections::mmr
@@ -93,7 +93,7 @@ pub use {get_tx_script_root} from miden::tx_kernel_core::memory
 #! - block_number exceeds the transaction reference block number.
 #!
 #! Invocation: exec
-pub proc get_block_commitment(block_number: BlockNumber) -> Digest
+pub proc get_block_commitment(block_number: BlockNumber) -> Commitment
     u32assert.err=ERR_TX_BLOCK_NUMBER_NOT_U32
     # => [block_number]
 
@@ -304,7 +304,7 @@ end
 #!   unsorted or contains duplicates).
 #!
 #! Invocation: exec
-pub proc compute_fee(num_extra_cycles: u32, exclude_notes_commitment: Digest) -> AssetAmount
+pub proc compute_fee(num_extra_cycles: u32, exclude_notes_commitment: Commitment) -> AssetAmount
     # make sure the number of extra cycles is a u32 so the addition below cannot overflow the field
     u32assert.err=ERR_TX_COMPUTE_FEE_EXTRA_CYCLES_NOT_U32
     # => [num_extra_cycles, EXCLUDE_NOTES_COMMITMENT]
@@ -360,7 +360,7 @@ end
 #!
 #! Invocation: exec
 @locals(1024)
-proc compute_output_notes_fee(exclude_notes_commitment: Digest) -> AssetAmount
+proc compute_output_notes_fee(exclude_notes_commitment: Commitment) -> AssetAmount
     locaddr.0 movdn.4
     # => [EXCLUDE_NOTES_COMMITMENT, exclude_notes_ptr]
 
@@ -401,7 +401,7 @@ end
 #! - the committed indices do not match EXCLUDE_NOTES_COMMITMENT.
 #!
 #! Invocation: exec
-proc write_exclude_notes(exclude_notes_commitment: Digest, exclude_notes_ptr: ptr<u16>) -> u16
+proc write_exclude_notes(exclude_notes_commitment: Commitment, exclude_notes_ptr: ptr<u16>) -> u16
     # an empty commitment means there are no notes to exclude
     exec.word::testz
     # => [is_empty, EXCLUDE_NOTES_COMMITMENT, exclude_notes_ptr]

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/tx.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/tx.masm
@@ -1,3 +1,5 @@
+use {AccountId, AssetAmount, BlockNumber} from miden::protocol_utils::types
+use {Digest} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::memory
 use miden::core::collections::mmr
@@ -91,7 +93,7 @@ pub use {get_tx_script_root} from miden::tx_kernel_core::memory
 #! - block_number exceeds the transaction reference block number.
 #!
 #! Invocation: exec
-pub proc get_block_commitment
+pub proc get_block_commitment(block_number: BlockNumber) -> Digest
     u32assert.err=ERR_TX_BLOCK_NUMBER_NOT_U32
     # => [block_number]
 
@@ -136,7 +138,7 @@ end
 #!
 #! Where:
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
-pub proc update_expiration_block_delta
+pub proc update_expiration_block_delta(block_height_delta: u16)
     # Ensure block_height_delta is between 1 and 0xFFFF (inclusive)
     dup neq.0 assert.err=ERR_TX_INVALID_EXPIRATION_DELTA
     # => [block_height_delta]
@@ -171,7 +173,7 @@ end
 #!
 #! Where:
 #! - block_height_delta is the stored expiration time delta (1 to 0xFFFF).
-pub proc get_expiration_delta
+pub proc get_expiration_delta() -> u16
     exec.memory::get_expiration_block_num
     # => [stored_expiration_block_num]
 
@@ -220,7 +222,7 @@ end
 #! - foreign context is created against the native account.
 #!
 #! Invocation: exec
-pub proc start_foreign_context
+pub proc start_foreign_context(foreign_account_id: AccountId)
     # get the memory address and a flag whether this account was already loaded.
     exec.account::get_account_data_ptr
     # OS => [was_loaded, ptr, foreign_account_id_suffix, foreign_account_id_prefix]
@@ -255,7 +257,7 @@ end
 #! - the active account is the native account.
 #!
 #! Invocation: dynexec
-pub proc end_foreign_context
+pub proc end_foreign_context()
     exec.memory::pop_ptr_from_account_stack
     # => []
 end
@@ -265,7 +267,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: []
-pub proc clear_fpi_memory
+pub proc clear_fpi_memory()
     # set the upcoming foreign account ID to zero
     push.0 push.0 exec.memory::set_fpi_account_id
     # => []
@@ -302,7 +304,7 @@ end
 #!   unsorted or contains duplicates).
 #!
 #! Invocation: exec
-pub proc compute_fee
+pub proc compute_fee(num_extra_cycles: u32, exclude_notes_commitment: Digest) -> AssetAmount
     # make sure the number of extra cycles is a u32 so the addition below cannot overflow the field
     u32assert.err=ERR_TX_COMPUTE_FEE_EXTRA_CYCLES_NOT_U32
     # => [num_extra_cycles, EXCLUDE_NOTES_COMMITMENT]
@@ -358,7 +360,7 @@ end
 #!
 #! Invocation: exec
 @locals(1024)
-proc compute_output_notes_fee
+proc compute_output_notes_fee(exclude_notes_commitment: Digest) -> AssetAmount
     locaddr.0 movdn.4
     # => [EXCLUDE_NOTES_COMMITMENT, exclude_notes_ptr]
 
@@ -399,7 +401,7 @@ end
 #! - the committed indices do not match EXCLUDE_NOTES_COMMITMENT.
 #!
 #! Invocation: exec
-proc write_exclude_notes
+proc write_exclude_notes(exclude_notes_commitment: Digest, exclude_notes_ptr: ptr<u16>) -> u16
     # an empty commitment means there are no notes to exclude
     exec.word::testz
     # => [is_empty, EXCLUDE_NOTES_COMMITMENT, exclude_notes_ptr]
@@ -459,7 +461,7 @@ end
 #! - the excluded indices are not sorted in ascending order and free of duplicates.
 #!
 #! Invocation: exec
-proc assert_exclude_notes_sorted_and_unique
+proc assert_exclude_notes_sorted_and_unique(exclude_notes_ptr: ptr<u16>, num_excluded_notes: u16)
     dup.1 neq.0
     # => [has_non_zero_entries, exclude_notes_ptr, num_excluded_notes]
 

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/types.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/types.masm
@@ -5,10 +5,10 @@ pub use {AccountProcedureRoot} from ::miden::protocol_utils::types
 use {AccountId, StorageSlotId} from ::miden::protocol_utils::types
 
 #! A cryptographic commitment or Merkle root.
-pub type Digest = word
+pub type Commitment = word
 
 #! Poseidon2 sponge state in operand-stack order.
-pub type HashState = struct { rate0: word, rate1: word, capacity: word }
+pub type HasherState = struct { rate0: word, rate1: word, capacity: word }
 
 #! Account header in memory and operand-stack order.
 pub type AccountMetadata = struct {
@@ -28,20 +28,20 @@ pub type StorageSlot = struct {
 #! The fixed header at the beginning of an account's memory segment.
 pub type AccountData = struct {
     metadata: AccountMetadata,
-    vault_root: Digest,
-    storage_commitment: Digest,
-    code_commitment: Digest,
+    vault_root: Commitment,
+    storage_commitment: Commitment,
+    code_commitment: Commitment,
 }
 
 #! The fixed header at the beginning of an input note's memory segment.
 pub type InputNoteData = struct {
-    details_commitment: Digest,
+    details_commitment: Commitment,
     serial_number: word,
     script_root: word,
-    storage_commitment: Digest,
-    assets_commitment: Digest,
+    storage_commitment: Commitment,
+    assets_commitment: Commitment,
     metadata: word,
-    attachments_commitment: Digest,
+    attachments_commitment: Commitment,
     recipient: word,
     id: word,
     args: word,
@@ -53,7 +53,7 @@ pub type InputNoteData = struct {
 
 #! The fixed header at the beginning of an output note's memory segment.
 pub type OutputNoteData = struct {
-    details_commitment: Digest,
+    details_commitment: Commitment,
     metadata: word,
     recipient: word,
     # Each flag/count occupies a separate felt in kernel memory.
@@ -65,8 +65,8 @@ pub type OutputNoteData = struct {
     num_attachments_padding: [u8; 3],
     total_attachment_words: u16,
     total_attachment_words_padding: [u8; 2],
-    attachment_commitments: [Digest; 4],
-    assets_commitment: Digest,
+    attachment_commitments: [Commitment; 4],
+    assets_commitment: Commitment,
 }
 
 #! A sorted link-map entry, including the ownership and linkage metadata.

--- a/crates/miden-protocol/asm/kernels/transaction-core/src/types.masm
+++ b/crates/miden-protocol/asm/kernels/transaction-core/src/types.masm
@@ -1,0 +1,81 @@
+# Shared representations used by the transaction kernel's internal interfaces.
+
+pub use {AccountProcedureRoot} from ::miden::protocol_utils::types
+
+use {AccountId, StorageSlotId} from ::miden::protocol_utils::types
+
+#! A cryptographic commitment or Merkle root.
+pub type Digest = word
+
+#! Poseidon2 sponge state in operand-stack order.
+pub type HashState = struct { rate0: word, rate1: word, capacity: word }
+
+#! Account header in memory and operand-stack order.
+pub type AccountMetadata = struct {
+    version: u8,
+    nonce: felt,
+    id: AccountId,
+}
+
+#! A storage slot's metadata followed by its value or map root.
+pub type StorageSlot = struct {
+    reserved: felt,
+    slot_type: u8,
+    id: StorageSlotId,
+    value: word,
+}
+
+#! The fixed header at the beginning of an account's memory segment.
+pub type AccountData = struct {
+    metadata: AccountMetadata,
+    vault_root: Digest,
+    storage_commitment: Digest,
+    code_commitment: Digest,
+}
+
+#! The fixed header at the beginning of an input note's memory segment.
+pub type InputNoteData = struct {
+    details_commitment: Digest,
+    serial_number: word,
+    script_root: word,
+    storage_commitment: Digest,
+    assets_commitment: Digest,
+    metadata: word,
+    attachments_commitment: Digest,
+    recipient: word,
+    id: word,
+    args: word,
+    num_storage_items: u16,
+    storage_padding: [felt; 3],
+    num_assets: u8,
+    assets_padding: [felt; 3],
+}
+
+#! The fixed header at the beginning of an output note's memory segment.
+pub type OutputNoteData = struct {
+    details_commitment: Digest,
+    metadata: word,
+    recipient: word,
+    # Each flag/count occupies a separate felt in kernel memory.
+    dirty: i1,
+    dirty_padding: [u8; 3],
+    num_assets: u8,
+    num_assets_padding: [u8; 3],
+    num_attachments: u8,
+    num_attachments_padding: [u8; 3],
+    total_attachment_words: u16,
+    total_attachment_words_padding: [u8; 2],
+    attachment_commitments: [Digest; 4],
+    assets_commitment: Digest,
+}
+
+#! A sorted link-map entry, including the ownership and linkage metadata.
+pub type LinkMapEntry = struct {
+    map: ptr<ptr<LinkMapEntry>>,
+    previous: ptr<LinkMapEntry>,
+    next: ptr<LinkMapEntry>,
+    reserved: felt,
+    key: word,
+    value0: word,
+    value1: word,
+}

--- a/crates/miden-protocol/asm/kernels/transaction/bin/main.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/bin/main.masm
@@ -1,5 +1,5 @@
 use {AccountId, BlockNumber} from miden::protocol_utils::types
-use {Digest} from miden::tx_kernel_core::types
+use {Commitment} from miden::tx_kernel_core::types
 use miden::core::word
 
 use miden::tx_kernel_core::epilogue
@@ -73,7 +73,7 @@ const EPILOGUE_END_EVENT = event("miden::protocol::tx::epilogue_end")
 #!   patch commitment.
 #! - tx_expiration_block_num is the transaction expiration block number.
 @locals(1)
-proc main(block_commitment: Digest, initial_account_commitment: Digest, input_notes_commitment: Digest, account_id: AccountId, block_num: BlockNumber, padding: [felt; 1]) -> (Digest, Digest, BlockNumber, [felt; 7])
+proc main(block_commitment: Commitment, initial_account_commitment: Commitment, input_notes_commitment: Commitment, account_id: AccountId, block_num: BlockNumber, padding: [felt; 1]) -> (Commitment, Commitment, BlockNumber, [felt; 7])
     # Prologue
     # ---------------------------------------------------------------------------------------------
     emit.PROLOGUE_START_EVENT

--- a/crates/miden-protocol/asm/kernels/transaction/bin/main.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/bin/main.masm
@@ -1,3 +1,5 @@
+use {AccountId, BlockNumber} from miden::protocol_utils::types
+use {Digest} from miden::tx_kernel_core::types
 use miden::core::word
 
 use miden::tx_kernel_core::epilogue
@@ -71,7 +73,7 @@ const EPILOGUE_END_EVENT = event("miden::protocol::tx::epilogue_end")
 #!   patch commitment.
 #! - tx_expiration_block_num is the transaction expiration block number.
 @locals(1)
-proc main
+proc main(block_commitment: Digest, initial_account_commitment: Digest, input_notes_commitment: Digest, account_id: AccountId, block_num: BlockNumber, padding: [felt; 1]) -> (Digest, Digest, BlockNumber, [felt; 7])
     # Prologue
     # ---------------------------------------------------------------------------------------------
     emit.PROLOGUE_START_EVENT

--- a/crates/miden-protocol/asm/kernels/transaction/bin/tx_script_main.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/bin/tx_script_main.masm
@@ -1,3 +1,5 @@
+use {Digest} from miden::tx_kernel_core::types
+use {AccountId, BlockNumber} from miden::protocol_utils::types
 use miden::core::word
 
 use miden::tx_kernel_core::prologue
@@ -34,7 +36,14 @@ const ERR_TX_TRANSACTION_SCRIPT_IS_MISSING = "the transaction script is missing"
 #! - account_id is the account that the transaction is being executed against.
 #! - INITIAL_ACCOUNT_COMMITMENT is the account state prior to the transaction, EMPTY_WORD for new accounts.
 #! - INPUT_NOTES_COMMITMENT, see `transaction::api::get_input_notes_commitment`.
-proc main
+proc main(
+    block_commitment: Digest,
+    initial_account_commitment: Digest,
+    input_notes_commitment: Digest,
+    account_id: AccountId,
+    block_num: BlockNumber,
+    padding: [felt; 1]
+) -> ...
     # Prologue
     # ---------------------------------------------------------------------------------------------
     exec.prologue::prepare_transaction

--- a/crates/miden-protocol/asm/kernels/transaction/bin/tx_script_main.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/bin/tx_script_main.masm
@@ -1,4 +1,4 @@
-use {Digest} from miden::tx_kernel_core::types
+use {Commitment} from miden::tx_kernel_core::types
 use {AccountId, BlockNumber} from miden::protocol_utils::types
 use miden::core::word
 
@@ -37,9 +37,9 @@ const ERR_TX_TRANSACTION_SCRIPT_IS_MISSING = "the transaction script is missing"
 #! - INITIAL_ACCOUNT_COMMITMENT is the account state prior to the transaction, EMPTY_WORD for new accounts.
 #! - INPUT_NOTES_COMMITMENT, see `transaction::api::get_input_notes_commitment`.
 proc main(
-    block_commitment: Digest,
-    initial_account_commitment: Digest,
-    input_notes_commitment: Digest,
+    block_commitment: Commitment,
+    initial_account_commitment: Commitment,
+    input_notes_commitment: Commitment,
     account_id: AccountId,
     block_num: BlockNumber,
     padding: [felt; 1]

--- a/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
@@ -17,7 +17,7 @@ use {
     StorageSlotId,
     TransactionScriptRoot,
 } from miden::protocol_utils::types
-use {Digest, InputNoteData} from miden::tx_kernel_core::types
+use {Commitment, InputNoteData} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::asset
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::account_update
@@ -141,7 +141,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc account_get_initial_commitment(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
 
@@ -170,7 +170,7 @@ end
 #! - the invocation of this procedure does not originate from the account context.
 #!
 #! Invocation: dynexec
-pub proc account_compute_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc account_compute_commitment(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -207,7 +207,7 @@ end
 #! - the vault delta or storage patch is not empty but the nonce increment is zero.
 #!
 #! Invocation: dynexec
-pub proc account_compute_delta_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc account_compute_delta_commitment(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # These two checks are strictly redundant here: a non-empty delta requires the nonce to be
     # incremented, which is already gated to the auth procedure, and an empty delta only ever
     # commits to the (public) empty word. We keep them for consistency with the other account
@@ -240,7 +240,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_upgrade(code_upgrade_commitment: Digest, storage_upgrade_commitment: Digest, padding: [felt; 8]) -> [felt; 16]
+pub proc account_upgrade(code_upgrade_commitment: Commitment, storage_upgrade_commitment: Commitment, padding: [felt; 8]) -> [felt; 16]
     # TODO(code_upgrades): Account upgrades must ensure the same conditions hold for an upgraded
     # account as validated in account::{validate_storage, validate_procedures}.
     # The same applies to the asset callback rule validated in
@@ -381,7 +381,7 @@ end
 #! - CODE_COMMITMENT is the commitment of the account code.
 #!
 #! Invocation: dynexec
-pub proc account_get_code_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc account_get_code_commitment(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # assert that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -408,7 +408,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_storage_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc account_get_initial_storage_commitment(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
 
@@ -434,7 +434,7 @@ end
 #! - STORAGE_COMMITMENT is the commitment of the account storage.
 #!
 #! Invocation: dynexec
-pub proc account_compute_storage_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc account_compute_storage_commitment(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -652,7 +652,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_vault_root(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc account_get_initial_vault_root(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
 
@@ -681,7 +681,7 @@ end
 #! - the invocation of this procedure does not originate from the account context.
 #!
 #! Invocation: dynexec
-pub proc account_get_vault_root(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc account_get_vault_root(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -1405,7 +1405,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_storage_info(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (Digest, u16, [felt; 11])
+pub proc input_note_get_storage_info(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (Commitment, u16, [felt; 11])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1489,7 +1489,7 @@ end
 #!   attachments from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_attachments_commitment(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (Digest, [felt; 12])
+pub proc input_note_get_attachments_commitment(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (Commitment, [felt; 12])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1644,7 +1644,7 @@ end
 #! - the note index is greater or equal to the total number of output notes.
 #!
 #! Invocation: dynexec
-pub proc output_note_get_attachments_commitment(note_index: u16, padding: [felt; 15]) -> (Digest, [felt; 12])
+pub proc output_note_get_attachments_commitment(note_index: u16, padding: [felt; 15]) -> (Commitment, [felt; 12])
     # assert that the provided note index is less than the total number of output notes
     exec.output_note::assert_note_index_in_bounds
     # => [note_index, pad(15)]
@@ -1738,7 +1738,7 @@ end
 #! - INPUT_NOTES_COMMITMENT is the input notes commitment hash.
 #!
 #! Invocation: dynexec
-pub proc tx_get_input_notes_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc tx_get_input_notes_commitment(padding: [felt; 16]) -> (Commitment, [felt; 12])
     exec.tx::get_input_notes_commitment
     # => [INPUT_NOTES_COMMITMENT, pad(16)]
 
@@ -1757,7 +1757,7 @@ end
 #! - OUTPUT_NOTES_COMMITMENT is the output notes commitment.
 #!
 #! Invocation: dynexec
-pub proc tx_get_output_notes_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
+pub proc tx_get_output_notes_commitment(padding: [felt; 16]) -> (Commitment, [felt; 12])
     # get the output notes commitment
     exec.tx::get_output_notes_commitment
     # => [OUTPUT_NOTES_COMMITMENT, pad(16)]
@@ -1838,7 +1838,7 @@ end
 #! - fee_amount is the computed fee amount of the transaction in the fee asset.
 #!
 #! Invocation: dynexec
-pub proc tx_compute_fee(num_extra_cycles: u32, exclude_notes_commitment: Digest, padding: [felt; 11]) -> (felt, [felt; 15])
+pub proc tx_compute_fee(num_extra_cycles: u32, exclude_notes_commitment: Commitment, padding: [felt; 11]) -> (felt, [felt; 15])
     # compute the fee, consuming num_extra_cycles and the exclude notes commitment
     exec.tx::compute_fee
     # => [fee_amount, pad(15)]
@@ -1877,7 +1877,7 @@ end
 #! - block_number exceeds the transaction reference block number.
 #!
 #! Invocation: dynexec
-pub proc tx_get_block_commitment(block_number: BlockNumber, padding: [felt; 15]) -> (Digest, [felt; 12])
+pub proc tx_get_block_commitment(block_number: BlockNumber, padding: [felt; 15]) -> (Commitment, [felt; 12])
     exec.tx::get_block_commitment
     # => [BLOCK_COMMITMENT, pad(15)]
 

--- a/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/api.masm
@@ -1,3 +1,23 @@
+use {
+    AccountId,
+    AccountProcedureRoot,
+    Asset,
+    AssetId,
+    AssetValue,
+    BlockNumber,
+    Bool,
+    NoteAssetsCommitment,
+    NoteId,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScriptRoot,
+    NoteSerialNumber,
+    NoteTag,
+    NoteType,
+    StorageSlotId,
+    TransactionScriptRoot,
+} from miden::protocol_utils::types
+use {Digest, InputNoteData} from miden::tx_kernel_core::types
 use miden::tx_kernel_core::asset
 use miden::tx_kernel_core::account
 use miden::tx_kernel_core::account_update
@@ -12,7 +32,6 @@ use {
     UPCOMING_FOREIGN_PROC_INPUT_VALUE_15_PTR,
     UPCOMING_FOREIGN_PROCEDURE_PTR,
 } from miden::tx_kernel_core::memory
-use {AccountId} from miden::protocol_utils::types
 
 # PROCEDURE VISIBILITY & INVOCATION
 # =================================================================================================
@@ -72,7 +91,7 @@ const ERR_FOREIGN_ACCOUNT_ID_IS_ZERO =
 #! - the invocation of the kernel procedure does not originate from the account context.
 #!
 #! Invocation: exec
-proc authenticate_account_origin
+proc authenticate_account_origin()
     # get the hash of the caller
     padw caller
     # => [CALLER]
@@ -93,7 +112,7 @@ end
 #!   of the account.
 #!
 #! Invocation: exec
-proc assert_auth_procedure_origin
+proc assert_auth_procedure_origin()
     # get the hash of the caller
     padw caller
     # => [CALLER]
@@ -122,7 +141,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_commitment
+pub proc account_get_initial_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
 
@@ -151,7 +170,7 @@ end
 #! - the invocation of this procedure does not originate from the account context.
 #!
 #! Invocation: dynexec
-pub proc account_compute_commitment
+pub proc account_compute_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -188,7 +207,7 @@ end
 #! - the vault delta or storage patch is not empty but the nonce increment is zero.
 #!
 #! Invocation: dynexec
-pub proc account_compute_delta_commitment
+pub proc account_compute_delta_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
     # These two checks are strictly redundant here: a non-empty delta requires the nonce to be
     # incremented, which is already gated to the auth procedure, and an empty delta only ever
     # commits to the (public) empty word. We keep them for consistency with the other account
@@ -221,7 +240,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_upgrade
+pub proc account_upgrade(code_upgrade_commitment: Digest, storage_upgrade_commitment: Digest, padding: [felt; 8]) -> [felt; 16]
     # TODO(code_upgrades): Account upgrades must ensure the same conditions hold for an upgraded
     # account as validated in account::{validate_storage, validate_procedures}.
     # The same applies to the asset callback rule validated in
@@ -256,7 +275,7 @@ end
 #!   (native or active, depending on the is_native flag).
 #!
 #! Invocation: dynexec
-pub proc account_get_id
+pub proc account_get_id(is_native: Bool, padding: [felt; 15]) -> (AccountId, [felt; 14])
     # get the native account ID
     exec.memory::get_native_account_id
     # => [native_account_id_suffix, native_account_id_prefix, is_native, pad(15)]
@@ -305,7 +324,7 @@ end
 #! - the invocation of this procedure does not originate from the account context.
 #!
 #! Invocation: dynexec
-pub proc account_get_nonce
+pub proc account_get_nonce(padding: [felt; 16]) -> (felt, [felt; 15])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -335,7 +354,7 @@ end
 #! - the nonce has already been incremented.
 #!
 #! Invocation: dynexec
-pub proc account_incr_nonce
+pub proc account_incr_nonce(padding: [felt; 16]) -> (felt, [felt; 15])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [pad(16)]
@@ -362,7 +381,7 @@ end
 #! - CODE_COMMITMENT is the commitment of the account code.
 #!
 #! Invocation: dynexec
-pub proc account_get_code_commitment
+pub proc account_get_code_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
     # assert that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -389,7 +408,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_storage_commitment
+pub proc account_get_initial_storage_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
 
@@ -415,7 +434,7 @@ end
 #! - STORAGE_COMMITMENT is the commitment of the account storage.
 #!
 #! Invocation: dynexec
-pub proc account_compute_storage_commitment
+pub proc account_compute_storage_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -443,7 +462,7 @@ end
 #! - a slot with the provided slot ID does not exist in account storage.
 #!
 #! Invocation: dynexec
-pub proc account_get_item
+pub proc account_get_item(slot_id: StorageSlotId, padding: [felt; 14]) -> (word, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [slot_id_suffix, slot_id_prefix, pad(14)]
@@ -474,7 +493,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_set_item
+pub proc account_set_item(slot_id: StorageSlotId, value: word, padding: [felt; 10]) -> (word, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [slot_id_suffix, slot_id_prefix, VALUE, pad(10)]
@@ -504,7 +523,7 @@ end
 #! - the requested storage slot type is not map.
 #!
 #! Invocation: dynexec
-pub proc account_get_map_item
+pub proc account_get_map_item(slot_id: StorageSlotId, key: word, padding: [felt; 10]) -> (word, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [slot_id_suffix, slot_id_prefix, KEY, pad(10)]
@@ -530,7 +549,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_item
+pub proc account_get_initial_item(slot_id: StorageSlotId, padding: [felt; 14]) -> (word, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [slot_id_suffix, slot_id_prefix, pad(14)]
@@ -567,7 +586,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_map_item
+pub proc account_get_initial_map_item(slot_id: StorageSlotId, key: word, padding: [felt; 10]) -> (word, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [slot_id_suffix, slot_id_prefix, KEY, pad(10)]
@@ -602,7 +621,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_set_map_item
+pub proc account_set_map_item(slot_id: StorageSlotId, key: word, new_value: word, padding: [felt; 6]) -> (word, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [slot_id_suffix, slot_id_prefix, KEY, NEW_VALUE, pad(6)]
@@ -633,7 +652,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_vault_root
+pub proc account_get_initial_vault_root(padding: [felt; 16]) -> (Digest, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
 
@@ -662,7 +681,7 @@ end
 #! - the invocation of this procedure does not originate from the account context.
 #!
 #! Invocation: dynexec
-pub proc account_get_vault_root
+pub proc account_get_vault_root(padding: [felt; 16]) -> (Digest, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -698,7 +717,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_add_asset
+pub proc account_add_asset(asset: Asset, padding: [felt; 8]) -> (AssetValue, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [ASSET_ID, ASSET_VALUE, pad(8)]
@@ -730,7 +749,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_remove_asset
+pub proc account_remove_asset(asset: Asset, padding: [felt; 8]) -> (AssetValue, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [ASSET_ID, ASSET_VALUE, pad(8)]
@@ -758,7 +777,7 @@ end
 #! - the invocation of this procedure does not originate from the account context.
 #!
 #! Invocation: dynexec
-pub proc account_get_asset
+pub proc account_get_asset(asset_id: AssetId, padding: [felt; 12]) -> (AssetValue, [felt; 12])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [ASSET_ID, pad(12)]
@@ -785,7 +804,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_get_initial_asset
+pub proc account_get_initial_asset(asset_id: AssetId, padding: [felt; 12]) -> (AssetValue, [felt; 12])
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
 
@@ -815,7 +834,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: dynexec
-pub proc account_was_procedure_called
+pub proc account_was_procedure_called(proc_root: AccountProcedureRoot, padding: [felt; 12]) -> (Bool, [felt; 15])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [PROC_ROOT, pad(12)]
@@ -841,7 +860,7 @@ end
 #! - the invocation of this procedure does not originate from the account context.
 #!
 #! Invocation: dynexec
-pub proc account_get_num_procedures
+pub proc account_get_num_procedures(padding: [felt; 16]) -> (u16, [felt; 15])
     # assert that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [pad(16)]
@@ -869,7 +888,7 @@ end
 #! - the procedure index is out of bounds.
 #!
 #! Invocation: dynexec
-pub proc account_get_procedure_root
+pub proc account_get_procedure_root(index: u16, padding: [felt; 15]) -> (AccountProcedureRoot, [felt; 12])
     # assert that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [index, pad(15)]
@@ -900,7 +919,7 @@ end
 #! - the invocation of this procedure does not originate from the account context.
 #!
 #! Invocation: dynexec
-pub proc account_has_procedure
+pub proc account_has_procedure(proc_root: AccountProcedureRoot, padding: [felt; 12]) -> (Bool, [felt; 15])
     # assert that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [PROC_ROOT, pad(12)]
@@ -924,7 +943,7 @@ end
 #! - has_slot is 1 if a slot with the provided slot ID exists, 0 otherwise.
 #!
 #! Invocation: dynexec
-pub proc account_has_storage_slot
+pub proc account_has_storage_slot(slot_id: StorageSlotId, padding: [felt; 14]) -> (Bool, [felt; 15])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [slot_id_suffix, slot_id_prefix, pad(14)]
@@ -953,7 +972,7 @@ end
 #! - the asset is not well formed.
 #!
 #! Invocation: dynexec
-pub proc faucet_mint_asset
+pub proc faucet_mint_asset(asset: Asset, padding: [felt; 8]) -> [felt; 16]
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [ASSET_ID, ASSET_VALUE, pad(8)]
@@ -988,7 +1007,7 @@ end
 #!     transaction via a note or the accounts vault.
 #!
 #! Invocation: dynexec
-pub proc faucet_burn_asset
+pub proc faucet_burn_asset(asset: Asset, padding: [felt; 8]) -> [felt; 16]
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [ASSET_ID, ASSET_VALUE, pad(8)]
@@ -1027,7 +1046,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_initial_assets_info
+pub proc input_note_get_initial_assets_info(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (NoteAssetsCommitment, u8, [felt; 11])
     # get the input note pointer depending on whether the requested note is the active one or if it
     # was requested by index.
     exec.get_requested_note_ptr
@@ -1070,7 +1089,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_asset
+pub proc input_note_get_asset(is_active_note: Bool, asset_index: u8, note_index: u16, padding: [felt; 13]) -> (Asset, [felt; 8])
     # bring note_index directly above is_active_note so the note pointer can be resolved
     movup.2 swap
     # => [is_active_note, note_index, asset_index, pad(13)]
@@ -1127,7 +1146,7 @@ end
 #! - the amount of the fungible asset in the note is less than the amount to be removed.
 #!
 #! Invocation: dynexec
-pub proc input_note_remove_asset
+pub proc input_note_remove_asset(is_active_note: Bool, asset: Asset, note_index: u16, padding: [felt; 6]) -> (AssetValue, [felt; 12])
     # bring note_index directly above is_active_note so the note pointer can be resolved
     movup.9 swap
     # => [is_active_note, note_index, ASSET_ID, ASSET_VALUE, pad(6)]
@@ -1184,7 +1203,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_remove_all_assets
+pub proc input_note_remove_all_assets(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (NoteAssetsCommitment, u8, [felt; 11])
     exec.authenticate_indexed_input_note_asset_removal
     # => [is_active_note, note_index, pad(14)]
 
@@ -1225,7 +1244,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_recipient
+pub proc input_note_get_recipient(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (NoteRecipient, [felt; 12])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1263,7 +1282,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_metadata
+pub proc input_note_get_metadata(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (NoteMetadata, [felt; 12])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1305,7 +1324,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_serial_number
+pub proc input_note_get_serial_number(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (NoteSerialNumber, [felt; 12])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1345,7 +1364,7 @@ end
 #!   from an incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_note_id
+pub proc input_note_get_note_id(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (NoteId, [felt; 12])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1386,7 +1405,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_storage_info
+pub proc input_note_get_storage_info(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (Digest, u16, [felt; 11])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1430,7 +1449,7 @@ end
 #!   from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_script_root
+pub proc input_note_get_script_root(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (NoteScriptRoot, [felt; 12])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1470,7 +1489,7 @@ end
 #!   attachments from incorrect context).
 #!
 #! Invocation: dynexec
-pub proc input_note_get_attachments_commitment
+pub proc input_note_get_attachments_commitment(is_active_note: Bool, note_index: u16, padding: [felt; 14]) -> (Digest, [felt; 12])
     # get the input note pointer depending on whether the requested note is current or it was
     # requested by index.
     exec.get_requested_note_ptr
@@ -1511,7 +1530,7 @@ end
 #! - the active account is not the native account.
 #!
 #! Invocation: dynexec
-pub proc output_note_create
+pub proc output_note_create(tag: NoteTag, note_type: NoteType, recipient: NoteRecipient, padding: [felt; 10]) -> (u16, [felt; 15])
     # authenticate that the procedure invocation originates from the account context
     exec.authenticate_account_origin
     # => [tag, note_type, RECIPIENT, pad(10)]
@@ -1539,7 +1558,7 @@ end
 #! - the note index points to a non-existent output note.
 #!
 #! Invocation: dynexec
-pub proc output_note_add_asset
+pub proc output_note_add_asset(asset: Asset, note_idx: u16, padding: [felt; 7]) -> [felt; 16]
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
     # => [ASSET_ID, ASSET_VALUE, note_idx, pad(7)]
@@ -1553,7 +1572,7 @@ end
 
 #! Adds an attachment to the note specified by the index.
 #!
-#! Inputs:  [attachment_scheme, ATTACHMENT, note_idx, pad(9)]
+#! Inputs:  [attachment_scheme, ATTACHMENT, note_idx, pad(10)]
 #! Outputs: [pad(16)]
 #!
 #! Where:
@@ -1569,14 +1588,14 @@ end
 #! - the note already has 4 attachments.
 #!
 #! Invocation: dynexec
-pub proc output_note_add_attachment
+pub proc output_note_add_attachment(attachment_scheme: u16, attachment: word, note_idx: u16, padding: [felt; 10]) -> [felt; 16]
     # assert that the provided note index is less than the total number of output notes
     dup.5 exec.output_note::assert_note_index_in_bounds drop
-    # => [attachment_scheme, ATTACHMENT, note_idx, pad(9)]
+    # => [attachment_scheme, ATTACHMENT, note_idx, pad(10)]
 
     # check that this procedure was executed against the native account
     exec.memory::assert_native_account
-    # => [attachment_scheme, ATTACHMENT, note_idx, pad(9)]
+    # => [attachment_scheme, ATTACHMENT, note_idx, pad(10)]
 
     exec.output_note::add_attachment
     # => [pad(16)]
@@ -1596,7 +1615,7 @@ end
 #! - the note index is greater or equal to the total number of output notes.
 #!
 #! Invocation: dynexec
-pub proc output_note_get_assets_info
+pub proc output_note_get_assets_info(note_index: u16, padding: [felt; 15]) -> (NoteAssetsCommitment, u8, [felt; 11])
     # assert that the provided note index is less than the total number of output notes
     exec.output_note::assert_note_index_in_bounds
     # => [note_index, pad(15)]
@@ -1625,7 +1644,7 @@ end
 #! - the note index is greater or equal to the total number of output notes.
 #!
 #! Invocation: dynexec
-pub proc output_note_get_attachments_commitment
+pub proc output_note_get_attachments_commitment(note_index: u16, padding: [felt; 15]) -> (Digest, [felt; 12])
     # assert that the provided note index is less than the total number of output notes
     exec.output_note::assert_note_index_in_bounds
     # => [note_index, pad(15)]
@@ -1652,7 +1671,7 @@ end
 #! - the note index is greater or equal to the total number of output notes.
 #!
 #! Invocation: dynexec
-pub proc output_note_get_recipient
+pub proc output_note_get_recipient(note_index: u16, padding: [felt; 15]) -> (NoteRecipient, [felt; 12])
     # assert that the provided note index is less than the total number of output notes
     exec.output_note::assert_note_index_in_bounds
     # => [note_index, pad(15)]
@@ -1683,7 +1702,7 @@ end
 #! - the note index is greater or equal to the total number of output notes.
 #!
 #! Invocation: dynexec
-pub proc output_note_get_metadata
+pub proc output_note_get_metadata(note_index: u16, padding: [felt; 15]) -> (NoteMetadata, [felt; 12])
     # assert that the provided note index is less than the total number of output notes
     exec.output_note::assert_note_index_in_bounds
     # => [note_index, pad(15)]
@@ -1719,7 +1738,7 @@ end
 #! - INPUT_NOTES_COMMITMENT is the input notes commitment hash.
 #!
 #! Invocation: dynexec
-pub proc tx_get_input_notes_commitment
+pub proc tx_get_input_notes_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
     exec.tx::get_input_notes_commitment
     # => [INPUT_NOTES_COMMITMENT, pad(16)]
 
@@ -1738,7 +1757,7 @@ end
 #! - OUTPUT_NOTES_COMMITMENT is the output notes commitment.
 #!
 #! Invocation: dynexec
-pub proc tx_get_output_notes_commitment
+pub proc tx_get_output_notes_commitment(padding: [felt; 16]) -> (Digest, [felt; 12])
     # get the output notes commitment
     exec.tx::get_output_notes_commitment
     # => [OUTPUT_NOTES_COMMITMENT, pad(16)]
@@ -1757,7 +1776,7 @@ end
 #! - num_input_notes is the total number of input notes consumed by this transaction.
 #!
 #! Invocation: dynexec
-pub proc tx_get_num_input_notes
+pub proc tx_get_num_input_notes(padding: [felt; 16]) -> (u16, [felt; 15])
     # get the number of input notes
     exec.tx::get_num_input_notes
     # => [num_input_notes, pad(16)]
@@ -1777,7 +1796,7 @@ end
 #!   executed.
 #!
 #! Invocation: dynexec
-pub proc tx_get_tx_script_root
+pub proc tx_get_tx_script_root(padding: [felt; 16]) -> (TransactionScriptRoot, [felt; 12])
     # get the tx script root
     exec.tx::get_tx_script_root
     # => [TX_SCRIPT_ROOT, pad(16)]
@@ -1796,7 +1815,7 @@ end
 #! - num_output_notes is the number of output notes created in this transaction so far.
 #!
 #! Invocation: dynexec
-pub proc tx_get_num_output_notes
+pub proc tx_get_num_output_notes(padding: [felt; 16]) -> (u16, [felt; 15])
     # get the number of input notes
     exec.tx::get_num_output_notes
     # => [num_output_notes, pad(16)]
@@ -1819,7 +1838,7 @@ end
 #! - fee_amount is the computed fee amount of the transaction in the fee asset.
 #!
 #! Invocation: dynexec
-pub proc tx_compute_fee
+pub proc tx_compute_fee(num_extra_cycles: u32, exclude_notes_commitment: Digest, padding: [felt; 11]) -> (felt, [felt; 15])
     # compute the fee, consuming num_extra_cycles and the exclude notes commitment
     exec.tx::compute_fee
     # => [fee_amount, pad(15)]
@@ -1834,7 +1853,7 @@ end
 #! - FEE_ASSET_ID is the ID of the asset that fees are paid in.
 #!
 #! Invocation: dynexec
-pub proc tx_get_fee_asset_id
+pub proc tx_get_fee_asset_id(padding: [felt; 16]) -> (AssetId, [felt; 12])
     exec.memory::get_fee_asset_id
     # => [FEE_ASSET_ID, pad(16)]
 
@@ -1858,7 +1877,7 @@ end
 #! - block_number exceeds the transaction reference block number.
 #!
 #! Invocation: dynexec
-pub proc tx_get_block_commitment
+pub proc tx_get_block_commitment(block_number: BlockNumber, padding: [felt; 15]) -> (Digest, [felt; 12])
     exec.tx::get_block_commitment
     # => [BLOCK_COMMITMENT, pad(15)]
 
@@ -1876,7 +1895,7 @@ end
 #! - num is the transaction reference block number.
 #!
 #! Invocation: dynexec
-pub proc tx_get_reference_block_number
+pub proc tx_get_reference_block_number(padding: [felt; 16]) -> (BlockNumber, [felt; 15])
     # get the block number
     exec.tx::get_reference_block_number
     # => [num, pad(16)]
@@ -1893,7 +1912,7 @@ end
 #!
 #! Where:
 #! - timestamp is the timestamp of the reference block for this transaction.
-pub proc tx_get_block_timestamp
+pub proc tx_get_block_timestamp(padding: [felt; 16]) -> (u32, [felt; 15])
     # get the transaction reference block timestamp
     exec.tx::get_block_timestamp
     # => [timestamp, pad(16)]
@@ -1926,9 +1945,10 @@ end
 #! Invocation: dynexec
 pub proc tx_prepare_fpi(
     foreign_account_id: AccountId,
-    foreign_proc_root: word,
-    foreign_procedure_input_15: felt
-)
+    foreign_proc_root: AccountProcedureRoot,
+    foreign_procedure_input_15: felt,
+    padding: [felt; 9]
+) -> [felt; 16]
     # validate the provided foreign account ID
     dup.1 dup.1 exec.account_id::validate
     # => [foreign_account_id_suffix, foreign_account_id_prefix, FOREIGN_PROC_ROOT, foreign_proc_input_value_15, pad(9)]
@@ -1966,7 +1986,7 @@ end
 #! - the root of the foreign procedure is not part of the foreign account's code.
 #!
 #! Invocation: dynexec
-pub proc tx_exec_foreign_proc
+pub proc tx_exec_foreign_proc(...) -> ...
     # move up the pad value to the top of the stack so we could drop it later
     movup.15
     # => [pad, foreign_procedure_inputs(15)]
@@ -2033,7 +2053,7 @@ end
 #! - block_height_delta is the desired expiration time delta (1 to 0xFFFF).
 #!
 #! Invocation: dynexec
-pub proc tx_update_expiration_block_delta
+pub proc tx_update_expiration_block_delta(block_height_delta: u16, padding: [felt; 15]) -> [felt; 16]
     exec.tx::update_expiration_block_delta
     # => [pad(16)]
 end
@@ -2047,7 +2067,7 @@ end
 #! - block_height_delta is the stored expiration time delta (1 to 0xFFFF).
 #!
 #! Invocation: dynexec
-pub proc tx_get_expiration_delta
+pub proc tx_get_expiration_delta(padding: [felt; 16]) -> (u16, [felt; 15])
     exec.tx::get_expiration_delta
     # => [block_height_delta, pad(16)]
 
@@ -2075,7 +2095,7 @@ end
 #! Panics if:
 #! - is_active_note is false and the active account is not the native account.
 #! - is_active_note is false and the invocation does not originate from the account context.
-proc authenticate_indexed_input_note_asset_removal
+proc authenticate_indexed_input_note_asset_removal(is_active_note: Bool) -> Bool
     dup eq.0
     if.true
         exec.memory::assert_native_account
@@ -2101,7 +2121,7 @@ end
 #!
 #! Panics if:
 #! - the note index is greater or equal to the total number of input notes.
-proc get_requested_note_ptr
+proc get_requested_note_ptr(is_active_note: Bool, note_index: u16) -> ptr<InputNoteData>
     # get the memory pointer to the note with the specified index and verify it is valid
     swap exec.input_note::get_input_note_ptr swap
     # => [is_active_note, indexed_input_note_ptr]

--- a/crates/miden-protocol/asm/kernels/transaction/lib/dispatcher.masm
+++ b/crates/miden-protocol/asm/kernels/transaction/lib/dispatcher.masm
@@ -38,7 +38,7 @@ const ERR_KERNEL_PROCEDURE_OFFSET_OUT_OF_BOUNDS =
 #! - the provided procedure offset exceeds the number of kernel procedures.
 #!
 #! Invocation: syscall
-pub proc exec_kernel_proc
+pub proc exec_kernel_proc(procedure_offset: u16, ...) -> ...
     # check that the provided procedure offset is within expected bounds
     #
     # the number of procedures is read from memory here instead of through a `memory` accessor so

--- a/crates/miden-protocol/asm/protocol/src/active_account.masm
+++ b/crates/miden-protocol/asm/protocol/src/active_account.masm
@@ -1,8 +1,16 @@
+use {
+    AccountId,
+    AccountProcedureRoot,
+    AssetId,
+    AssetValue,
+    Bool,
+    NoteStorageCommitment,
+    StorageMapKey,
+    StorageSlotId,
+} from miden::protocol::types
 use {ACCOUNT_GET_ID_OFFSET, ACCOUNT_GET_NONCE_OFFSET, ACCOUNT_COMPUTE_COMMITMENT_OFFSET, ACCOUNT_GET_CODE_COMMITMENT_OFFSET, ACCOUNT_COMPUTE_STORAGE_COMMITMENT_OFFSET, ACCOUNT_GET_VAULT_ROOT_OFFSET, ACCOUNT_GET_ITEM_OFFSET, ACCOUNT_HAS_STORAGE_SLOT_OFFSET, ACCOUNT_GET_MAP_ITEM_OFFSET, ACCOUNT_GET_ASSET_OFFSET, ACCOUNT_GET_NUM_PROCEDURES_OFFSET, ACCOUNT_GET_PROCEDURE_ROOT_OFFSET, ACCOUNT_HAS_PROCEDURE_OFFSET}
     from miden::protocol::kernel_proc_offsets
 use miden::core::word
-use {AccountId, AccountProcedureRoot, AssetId, AssetValue, Bool, StorageMapKey, StorageSlotId}
-    from miden::protocol::types
 
 # ACTIVE ACCOUNT PROCEDURES
 # =================================================================================================
@@ -158,7 +166,7 @@ end
 #! - STORAGE_COMMITMENT is the commitment of the account storage.
 #!
 #! Invocation: exec
-pub proc compute_storage_commitment() -> word
+pub proc compute_storage_commitment() -> NoteStorageCommitment
     # pad the stack
     padw padw padw push.0.0.0
     # => [pad(15)]

--- a/crates/miden-protocol/asm/protocol/src/active_note.masm
+++ b/crates/miden-protocol/asm/protocol/src/active_note.masm
@@ -1,10 +1,23 @@
+use {
+    AccountId,
+    Asset,
+    AssetValue,
+    Bool,
+    NoteAssetsCommitment,
+    NoteAttachmentCommitment,
+    NoteAttachmentsCommitment,
+    NoteId,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScriptRoot,
+    NoteSerialNumber,
+    NoteStorageCommitment,
+} from miden::protocol::types
 use miden::protocol_utils::mem
 use miden::protocol::note
 use miden::protocol::input_note_internal
 use miden::protocol::note_internal
 use {NOTE_TYPE_PRIVATE, NOTE_TYPE_PUBLIC} from miden::protocol::note
-use {AccountId, Bool, MemoryAddress, NoteId, NoteMetadata, NoteRecipient, NoteScriptRoot}
-    from miden::protocol::types
 
 # ERRORS
 # =================================================================================================
@@ -47,7 +60,7 @@ const ERR_NOTE_TOO_MANY_STORAGE_ITEMS =
 #! - no note is currently active.
 #!
 #! Invocation: exec
-pub proc get_initial_assets(dest_ptr: MemoryAddress) -> u8
+pub proc get_initial_assets(dest_ptr: ptr<Asset>) -> u8
     # push a placeholder note_index and the active note flag
     push.0.1
     # => [is_active_note = 1, note_index = 0, dest_ptr]
@@ -72,7 +85,7 @@ end
 #! - no note is currently active.
 #!
 #! Invocation: exec
-pub proc get_initial_assets_info
+pub proc get_initial_assets_info() -> (NoteAssetsCommitment, u8)
     # push a placeholder note_index and the active note flag
     push.0.1
     # => [is_active_note = 1, note_index = 0]
@@ -96,7 +109,7 @@ end
 #! - no note is currently active.
 #!
 #! Invocation: exec
-pub proc get_initial_num_assets
+pub proc get_initial_num_assets() -> u8
     exec.get_initial_assets_info
     # => [ASSETS_COMMITMENT, num_assets]
 
@@ -122,7 +135,7 @@ end
 #! - the asset index is greater or equal to the number of assets in the note.
 #!
 #! Invocation: exec
-pub proc get_asset
+pub proc get_asset(asset_index: u8) -> Asset
     # push a placeholder note_index below asset_index and the active note flag on top
     push.0 swap push.1
     # => [is_active_note = 1, asset_index, note_index = 0]
@@ -158,7 +171,7 @@ end
 #! - the amount of the fungible asset in the note is less than the amount to be removed.
 #!
 #! Invocation: exec
-pub proc remove_asset
+pub proc remove_asset(asset: Asset) -> AssetValue
     # push a placeholder note_index below the asset and the active note flag on top
     push.0 movdn.8 push.1
     # => [is_active_note = 1, ASSET_ID, ASSET_VALUE, note_index = 0]
@@ -194,7 +207,7 @@ end
 #! - no note is currently active.
 #!
 #! Invocation: exec
-pub proc remove_all_assets
+pub proc remove_all_assets(dest_ptr: ptr<Asset>) -> u8
     # push a placeholder note_index and the active note flag
     push.0.1
     # => [is_active_note = 1, note_index = 0, dest_ptr]
@@ -258,7 +271,7 @@ end
 #! - no note is currently active.
 #!
 #! Invocation: exec
-pub proc get_storage_info() -> (word, u16)
+pub proc get_storage_info() -> (NoteStorageCommitment, u16)
     # push a placeholder note_index (ignored when is_active_note = 1) and the active note flag
     push.0.1
     # => [is_active_note = 1, note_index = 0]
@@ -284,7 +297,7 @@ end
 #! - no note is currently active.
 #!
 #! Invocation: exec
-pub proc get_storage(dest_ptr: MemoryAddress) -> u16
+pub proc get_storage(dest_ptr: ptr<felt>) -> u16
     # push a placeholder note_index (ignored when is_active_note = 1) and the active note flag
     push.0.1
     # => [is_active_note = 1, note_index = 0, dest_ptr]
@@ -322,7 +335,7 @@ end
 #! - num_storage_items is greater than max_num_storage_items.
 #!
 #! Invocation: exec
-pub proc get_bounded_storage(dest_ptr: MemoryAddress, max_num_storage_items: u16) -> u16
+pub proc get_bounded_storage(dest_ptr: ptr<felt>, max_num_storage_items: u16) -> u16
     exec.get_storage_info
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr, max_num_storage_items]
 
@@ -439,7 +452,7 @@ end
 #! - no note is currently active.
 #!
 #! Invocation: exec
-pub proc get_serial_number() -> word
+pub proc get_serial_number() -> NoteSerialNumber
     # push a placeholder note_index (ignored when is_active_note = 1) and the active note flag
     push.0.1
     # => [is_active_note = 1, note_index = 0]
@@ -488,7 +501,11 @@ end
 #! - the items written to memory do not match NOTE_STORAGE_COMMITMENT.
 #!
 #! Invocation: exec
-pub proc write_storage_to_memory
+pub proc write_storage_to_memory(
+    storage_commitment: NoteStorageCommitment,
+    num_storage_items: u16,
+    dest_ptr: ptr<felt>
+)
     # load the inputs from the advice map to the advice stack, padded to the next multiple of 8 so
     # they can be written with `pipe_elements_preimage_to_memory`
     adv.push_mapvaln.8
@@ -533,7 +550,7 @@ end
 #! - no note is currently active.
 #!
 #! Invocation: exec
-pub proc get_attachments_commitment() -> word
+pub proc get_attachments_commitment() -> NoteAttachmentsCommitment
     # push a placeholder note_index (ignored when is_active_note = 1) and the active note flag
     push.0.1
     # => [is_active_note = 1, note_index = 0]
@@ -557,7 +574,7 @@ end
 #!   attachments commitment.
 #!
 #! Invocation: exec
-pub proc write_attachment_commitments_to_memory(dest_ptr: MemoryAddress) -> u8
+pub proc write_attachment_commitments_to_memory(dest_ptr: ptr<NoteAttachmentCommitment>) -> u8
     exec.get_attachments_commitment
     # => [ATTACHMENTS_COMMITMENT, dest_ptr]
 
@@ -584,7 +601,7 @@ end
 #!
 #! Invocation: exec
 @locals(16)
-pub proc write_attachment_to_memory(dest_ptr: MemoryAddress, attachment_idx: u8) -> u16
+pub proc write_attachment_to_memory(dest_ptr: ptr<word>, attachment_idx: u8) -> u16
     # write the attachment commitments to local memory
     # we allocate 16 elements of memory (max num attachments * WORD_SIZE) to store all
     # four attachment commitments

--- a/crates/miden-protocol/asm/protocol/src/faucet.masm
+++ b/crates/miden-protocol/asm/protocol/src/faucet.masm
@@ -1,5 +1,5 @@
-use {FAUCET_BURN_ASSET_OFFSET, FAUCET_MINT_ASSET_OFFSET} from miden::protocol::kernel_proc_offsets
 use {Asset} from miden::protocol::types
+use {FAUCET_BURN_ASSET_OFFSET, FAUCET_MINT_ASSET_OFFSET} from miden::protocol::kernel_proc_offsets
 
 #! Mint an asset from the faucet the transaction is being executed against.
 #!

--- a/crates/miden-protocol/asm/protocol/src/input_note.masm
+++ b/crates/miden-protocol/asm/protocol/src/input_note.masm
@@ -1,10 +1,23 @@
+use {
+    AccountId,
+    Asset,
+    AssetValue,
+    Bool,
+    NoteAssetsCommitment,
+    NoteAttachmentCommitment,
+    NoteAttachmentsCommitment,
+    NoteId,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScriptRoot,
+    NoteSerialNumber,
+    NoteStorageCommitment,
+} from miden::protocol::types
 use miden::core::word
 use miden::protocol::input_note_internal
 use miden::protocol::note
 use miden::protocol::note_internal
 use miden::protocol::tx
-use {AccountId, Bool, MemoryAddress, NoteId, NoteMetadata, NoteRecipient, NoteScriptRoot}
-    from miden::protocol::types
 
 # EVENTS
 # =================================================================================================
@@ -50,7 +63,7 @@ const ERR_INPUT_NOTE_INDEX_LOOKUP_INVALID = "input note index lookup result from
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_initial_assets
+pub proc get_initial_assets(dest_ptr: ptr<Asset>, note_index: u16) -> u8
     swap push.0
     # => [is_active_note = 0, note_index, dest_ptr]
 
@@ -75,7 +88,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_initial_assets_info(note_index: u16) -> (word, u8)
+pub proc get_initial_assets_info(note_index: u16) -> (NoteAssetsCommitment, u8)
     push.0
     # => [is_active_note = 0, note_index]
 
@@ -99,7 +112,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_initial_num_assets
+pub proc get_initial_num_assets(note_index: u16) -> u8
     exec.get_initial_assets_info
     # => [ASSETS_COMMITMENT, num_assets]
 
@@ -126,7 +139,7 @@ end
 #! - the asset index is greater or equal to the number of assets in the note.
 #!
 #! Invocation: exec
-pub proc get_asset
+pub proc get_asset(asset_index: u8, note_index: u16) -> Asset
     push.0
     # => [is_active_note = 0, asset_index, note_index]
 
@@ -163,7 +176,7 @@ end
 #! - the amount of the fungible asset in the note is less than the amount to be removed.
 #!
 #! Invocation: exec
-pub proc remove_asset
+pub proc remove_asset(asset: Asset, note_index: u16) -> AssetValue
     push.0
     # => [is_active_note = 0, ASSET_ID, ASSET_VALUE, note_index]
 
@@ -200,7 +213,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc remove_all_assets
+pub proc remove_all_assets(dest_ptr: ptr<Asset>, note_index: u16) -> u8
     swap push.0
     # => [is_active_note = 0, note_index, dest_ptr]
 
@@ -382,7 +395,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_storage_info(note_index: u16) -> (word, u16)
+pub proc get_storage_info(note_index: u16) -> (NoteStorageCommitment, u16)
     push.0
     # => [is_active_note = 0, note_index]
 
@@ -424,7 +437,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_serial_number(note_index: u16) -> word
+pub proc get_serial_number(note_index: u16) -> NoteSerialNumber
     push.0
     # => [is_active_note = 0, note_index]
 
@@ -449,7 +462,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_attachments_commitment(note_index: u16) -> word
+pub proc get_attachments_commitment(note_index: u16) -> NoteAttachmentsCommitment
     push.0
     # => [is_active_note = 0, note_index]
 
@@ -474,7 +487,10 @@ end
 #!   attachments commitment.
 #!
 #! Invocation: exec
-pub proc write_attachment_commitments_to_memory(dest_ptr: MemoryAddress, note_index: u16) -> u8
+pub proc write_attachment_commitments_to_memory(
+    dest_ptr: ptr<NoteAttachmentCommitment>,
+    note_index: u16
+) -> u8
     swap exec.get_attachments_commitment
     # => [ATTACHMENTS_COMMITMENT, dest_ptr]
 
@@ -503,7 +519,7 @@ end
 #! Invocation: exec
 @locals(16)
 pub proc write_attachment_to_memory(
-    dest_ptr: MemoryAddress,
+    dest_ptr: ptr<word>,
     attachment_idx: u8,
     note_index: u16
 ) -> u16

--- a/crates/miden-protocol/asm/protocol/src/input_note_internal.masm
+++ b/crates/miden-protocol/asm/protocol/src/input_note_internal.masm
@@ -1,8 +1,19 @@
+use {
+    Asset,
+    AssetValue,
+    Bool,
+    NoteAssetsCommitment,
+    NoteAttachmentsCommitment,
+    NoteId,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScriptRoot,
+    NoteSerialNumber,
+    NoteStorageCommitment,
+} from miden::protocol::types
 use {INPUT_NOTE_GET_ASSET_OFFSET, INPUT_NOTE_GET_ATTACHMENTS_COMMITMENT_OFFSET, INPUT_NOTE_GET_INITIAL_ASSETS_INFO_OFFSET, INPUT_NOTE_GET_METADATA_OFFSET, INPUT_NOTE_GET_NOTE_ID_OFFSET, INPUT_NOTE_GET_RECIPIENT_OFFSET, INPUT_NOTE_GET_SCRIPT_ROOT_OFFSET, INPUT_NOTE_GET_SERIAL_NUMBER_OFFSET, INPUT_NOTE_GET_STORAGE_INFO_OFFSET, INPUT_NOTE_REMOVE_ALL_ASSETS_OFFSET, INPUT_NOTE_REMOVE_ASSET_OFFSET}
     from miden::protocol::kernel_proc_offsets
 use miden::protocol::note_internal
-use {Asset, AssetId, AssetValue, Bool, MemoryAddress, NoteId, NoteMetadata, NoteRecipient, NoteScriptRoot}
-    from miden::protocol::types
 
 # PROCEDURES
 # =================================================================================================
@@ -35,7 +46,7 @@ use {Asset, AssetId, AssetValue, Bool, MemoryAddress, NoteId, NoteMetadata, Note
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_initial_assets_raw(is_active_note: Bool, note_index: u16, dest_ptr: MemoryAddress) -> u8
+pub proc get_initial_assets_raw(is_active_note: Bool, note_index: u16, dest_ptr: ptr<Asset>) -> u8
     exec.get_initial_assets_info_raw
     # => [ASSETS_COMMITMENT, num_assets, dest_ptr]
 
@@ -67,7 +78,10 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_initial_assets_info_raw(is_active_note: Bool, note_index: u16) -> (word, u8)
+pub proc get_initial_assets_info_raw(
+    is_active_note: Bool,
+    note_index: u16
+) -> (NoteAssetsCommitment, u8)
     push.0 movdn.2
     # => [is_active_note, note_index, 0]
 
@@ -156,8 +170,7 @@ end
 #! Invocation: exec
 pub proc remove_asset_raw(
     is_active_note: Bool,
-    asset_id: AssetId,
-    asset_value: AssetValue,
+    asset: Asset,
     note_index: u16
 ) -> AssetValue
     push.INPUT_NOTE_REMOVE_ASSET_OFFSET
@@ -199,7 +212,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc remove_all_assets_raw(is_active_note: Bool, note_index: u16, dest_ptr: MemoryAddress) -> u8
+pub proc remove_all_assets_raw(is_active_note: Bool, note_index: u16, dest_ptr: ptr<Asset>) -> u8
     push.0 movdn.2
     # => [is_active_note, note_index, 0, dest_ptr]
 
@@ -325,7 +338,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_storage_info_raw(is_active_note: Bool, note_index: u16) -> (word, u16)
+pub proc get_storage_info_raw(is_active_note: Bool, note_index: u16) -> (NoteStorageCommitment, u16)
     push.0 movdn.2
     # => [is_active_note, note_index, 0]
 
@@ -402,7 +415,7 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_serial_number_raw(is_active_note: Bool, note_index: u16) -> word
+pub proc get_serial_number_raw(is_active_note: Bool, note_index: u16) -> NoteSerialNumber
     push.0 movdn.2
     # => [is_active_note, note_index, 0]
 
@@ -480,7 +493,10 @@ end
 #! - the note index is greater or equal to the total number of input notes.
 #!
 #! Invocation: exec
-pub proc get_attachments_commitment_raw(is_active_note: Bool, note_index: u16) -> word
+pub proc get_attachments_commitment_raw(
+    is_active_note: Bool,
+    note_index: u16
+) -> NoteAttachmentsCommitment
     push.0 movdn.2
     # => [is_active_note, note_index, 0]
 

--- a/crates/miden-protocol/asm/protocol/src/native_account.masm
+++ b/crates/miden-protocol/asm/protocol/src/native_account.masm
@@ -1,9 +1,17 @@
+use {
+    AccountId,
+    AccountProcedureRoot,
+    Asset,
+    AssetId,
+    AssetValue,
+    Bool,
+    StorageMapKey,
+    StorageSlotId,
+} from miden::protocol::types
 use {ACCOUNT_ADD_ASSET_OFFSET, ACCOUNT_COMPUTE_DELTA_COMMITMENT_OFFSET, ACCOUNT_GET_ID_OFFSET, ACCOUNT_GET_INITIAL_ASSET_OFFSET, ACCOUNT_GET_INITIAL_COMMITMENT_OFFSET, ACCOUNT_GET_INITIAL_ITEM_OFFSET, ACCOUNT_GET_INITIAL_MAP_ITEM_OFFSET, ACCOUNT_GET_INITIAL_STORAGE_COMMITMENT_OFFSET, ACCOUNT_GET_INITIAL_VAULT_ROOT_OFFSET, ACCOUNT_INCR_NONCE_OFFSET, ACCOUNT_REMOVE_ASSET_OFFSET, ACCOUNT_SET_ITEM_OFFSET, ACCOUNT_SET_MAP_ITEM_OFFSET, ACCOUNT_UPGRADE_OFFSET, ACCOUNT_WAS_PROCEDURE_CALLED_OFFSET}
     from miden::protocol::kernel_proc_offsets
 use miden::protocol::active_account
 use miden::core::word
-use {AccountId, AccountProcedureRoot, Asset, AssetId, AssetValue, Bool, StorageMapKey, StorageSlotId}
-    from miden::protocol::types
 
 # NATIVE ACCOUNT PROCEDURES
 # =================================================================================================

--- a/crates/miden-protocol/asm/protocol/src/note.masm
+++ b/crates/miden-protocol/asm/protocol/src/note.masm
@@ -1,7 +1,16 @@
+use {
+    AccountId,
+    Bool,
+    NoteMetadata,
+    NoteRecipient,
+    NoteScriptRoot,
+    NoteSerialNumber,
+    NoteStorageCommitment,
+    NoteTag,
+    NoteType,
+} from miden::protocol::types
 use miden::protocol::account_id
 use miden::core::crypto::hashes::poseidon2
-use {AccountId, Bool, MemoryAddress, NoteMetadata, NoteRecipient, NoteScriptRoot, NoteTag, NoteType}
-    from miden::protocol::types
 
 pub use {ATTACHMENT_SCHEME_NONE, MAX_ATTACHMENT_SCHEME, MAX_ATTACHMENT_TOTAL_WORDS, MAX_ATTACHMENT_WORDS, MAX_NOTE_STORAGE_ITEMS, NOTE_TYPE_PRIVATE, NOTE_TYPE_PUBLIC}
     from miden::protocol_utils::note
@@ -34,7 +43,10 @@ const ERR_PROLOGUE_NOTE_NUM_STORAGE_ITEMS_EXCEEDED_LIMIT =
 #! - num_storage_items is greater than 1024.
 #!
 #! Invocation: exec
-pub proc compute_storage_commitment(storage_ptr: MemoryAddress, num_storage_items: u16) -> word
+pub proc compute_storage_commitment(
+    storage_ptr: ptr<felt>,
+    num_storage_items: u16
+) -> NoteStorageCommitment
     # check that number of storage items is less than or equal to MAX_NOTE_STORAGE_ITEMS
     dup.1 push.MAX_NOTE_STORAGE_ITEMS
     u32assert2.err=ERR_PROLOGUE_NOTE_NUM_STORAGE_ITEMS_EXCEEDED_LIMIT
@@ -79,9 +91,9 @@ end
 #!
 #! Invocation: exec
 pub proc compute_and_store_recipient(
-    storage_ptr: MemoryAddress,
+    storage_ptr: ptr<felt>,
     num_storage_items: u16,
-    serial_num: word,
+    serial_num: NoteSerialNumber,
     script_root: NoteScriptRoot
 ) -> NoteRecipient
     dup.1 dup.1
@@ -134,9 +146,9 @@ end
 #!
 #! Invocation: exec
 pub proc compute_recipient(
-    serial_num: word,
+    serial_num: NoteSerialNumber,
     script_root: NoteScriptRoot,
-    storage_commitment: word
+    storage_commitment: NoteStorageCommitment
 ) -> NoteRecipient
     padw swapw
     # => [SERIAL_NUM, EMPTY_WORD, SCRIPT_ROOT, STORAGE_COMMITMENT]

--- a/crates/miden-protocol/asm/protocol/src/note_internal.masm
+++ b/crates/miden-protocol/asm/protocol/src/note_internal.masm
@@ -1,6 +1,12 @@
+use {
+    Asset,
+    NoteAssetsCommitment,
+    NoteAttachmentCommitment,
+    NoteAttachmentsCommitment,
+} from miden::protocol::types
 use miden::core::mem
 use {WORD_NUM_ELEMENTS} from miden::protocol::constants
-use {MemoryAddress} from miden::protocol::types
+
 
 # ERRORS
 # =================================================================================================
@@ -23,7 +29,11 @@ const ERR_NOTE_ATTACHMENT_IDX_OUT_OF_BOUNDS = "attachment index out of bounds"
 #!   }
 #! Outputs:
 #!   Operand stack: []
-pub proc write_assets_to_memory(assets_commitment: word, num_assets: u8, dest_ptr: MemoryAddress)
+pub proc write_assets_to_memory(
+    assets_commitment: NoteAssetsCommitment,
+    num_assets: u8,
+    dest_ptr: ptr<Asset>
+)
     # load the asset data from the advice map to the advice stack
     adv.push_mapval
     # OS => [ASSETS_COMMITMENT, num_assets, dest_ptr]
@@ -56,8 +66,8 @@ end
 #! Outputs:
 #!   Operand stack: [num_attachments]
 pub proc write_attachment_commitments_to_memory(
-    attachments_commitment: word,
-    dest_ptr: MemoryAddress
+    attachments_commitment: NoteAttachmentsCommitment,
+    dest_ptr: ptr<NoteAttachmentCommitment>
 ) -> u8
     # push the individual ATTACHMENT commitments from the advice map onto the advice stack
     adv.push_mapvaln
@@ -102,7 +112,10 @@ end
 #! - ATTACHMENT_COMMITMENT is the hash commitment to the attachment elements.
 #! - dest_ptr is the memory address to which to write the attachment data.
 #! - num_words is the number of words in the attachment.
-pub proc write_attachment_to_memory(attachment_commitment: word, dest_ptr: MemoryAddress) -> u16
+pub proc write_attachment_to_memory(
+    attachment_commitment: NoteAttachmentCommitment,
+    dest_ptr: ptr<word>
+) -> u16
     # push the number of attachment elements from the advice map onto the advice stack
     adv.push_mapvaln
     # OS => [ATTACHMENT_COMMITMENT, dest_ptr]
@@ -151,9 +164,9 @@ end
 #! Invocation: exec
 pub proc write_indexed_attachment_to_memory(
     num_attachments: u8,
-    attachment_commitments_ptr: MemoryAddress,
+    attachment_commitments_ptr: ptr<NoteAttachmentCommitment>,
     attachment_idx: u8,
-    dest_ptr: MemoryAddress
+    dest_ptr: ptr<word>
 ) -> u16
     # assert attachment_idx < num_attachments
     dup.2 swap u32assert2.err=ERR_NOTE_ATTACHMENT_IDX_OUT_OF_BOUNDS

--- a/crates/miden-protocol/asm/protocol/src/output_note.masm
+++ b/crates/miden-protocol/asm/protocol/src/output_note.masm
@@ -1,9 +1,18 @@
+use {
+    Asset,
+    Bool,
+    NoteAttachmentCommitment,
+    NoteAttachmentsCommitment,
+    NoteId,
+    NoteMetadata,
+    NoteRecipient,
+    NoteTag,
+    NoteType,
+} from miden::protocol::types
 use miden::protocol::note
 use miden::protocol::note_internal
 use miden::core::crypto::hashes::poseidon2
 use {WORD_NUM_ELEMENTS} from miden::protocol::constants
-use {Asset, Bool, MemoryAddress, NoteId, NoteMetadata, NoteRecipient, NoteTag, NoteType}
-    from miden::protocol::types
 use {OUTPUT_NOTE_ADD_ASSET_OFFSET, OUTPUT_NOTE_ADD_ATTACHMENT_OFFSET, OUTPUT_NOTE_CREATE_OFFSET, OUTPUT_NOTE_GET_ASSETS_INFO_OFFSET, OUTPUT_NOTE_GET_ATTACHMENTS_COMMITMENT_OFFSET, OUTPUT_NOTE_GET_METADATA_OFFSET, OUTPUT_NOTE_GET_RECIPIENT_OFFSET}
     from miden::protocol::kernel_proc_offsets
 
@@ -110,7 +119,7 @@ end
 #! - the note index is greater or equal to the total number of output notes.
 #!
 #! Invocation: exec
-pub proc get_assets(dest_ptr: MemoryAddress, note_index: u16) -> u8
+pub proc get_assets(dest_ptr: ptr<Asset>, note_index: u16) -> u8
     # get the assets commitment and assets number
     swap exec.get_assets_info
     # => [ASSETS_COMMITMENT, num_assets, dest_ptr]
@@ -138,7 +147,7 @@ end
 #! - the note index is greater or equal to the total number of output notes.
 #!
 #! Invocation: exec
-pub proc get_attachments_commitment(note_index: u16) -> word
+pub proc get_attachments_commitment(note_index: u16) -> NoteAttachmentsCommitment
     # start padding the stack
     push.0.0 movup.2
     # => [note_index, 0, 0]
@@ -215,7 +224,11 @@ end
 #! - the total number of attachment words in the note exceeds 512.
 #!
 #! Invocation: exec
-pub proc add_attachment(attachment_scheme: u16, attachment_commitment: word, note_idx: u16)
+pub proc add_attachment(
+    attachment_scheme: u16,
+    attachment_commitment: NoteAttachmentCommitment,
+    note_idx: u16
+)
     push.OUTPUT_NOTE_ADD_ATTACHMENT_OFFSET
     # => [offset, attachment_scheme, ATTACHMENT_COMMITMENT, note_idx]
 
@@ -315,7 +328,7 @@ end
 pub proc add_attachment_from_memory(
     attachment_scheme: u16,
     num_words: u16,
-    attachment_ptr: MemoryAddress,
+    attachment_ptr: ptr<word>,
     note_idx: u16
 )
     # Compute num_elements = num_words * WORD_NUM_ELEMENTS
@@ -502,7 +515,10 @@ end
 #!   attachments commitment.
 #!
 #! Invocation: exec
-pub proc write_attachment_commitments_to_memory(dest_ptr: MemoryAddress, note_index: u16) -> u8
+pub proc write_attachment_commitments_to_memory(
+    dest_ptr: ptr<NoteAttachmentCommitment>,
+    note_index: u16
+) -> u8
     swap exec.get_attachments_commitment
     # => [ATTACHMENTS_COMMITMENT, dest_ptr]
 
@@ -531,7 +547,7 @@ end
 #! Invocation: exec
 @locals(16)
 pub proc write_attachment_to_memory(
-    dest_ptr: MemoryAddress,
+    dest_ptr: ptr<word>,
     attachment_idx: u8,
     note_index: u16
 ) -> u16

--- a/crates/miden-protocol/asm/protocol/src/tx.masm
+++ b/crates/miden-protocol/asm/protocol/src/tx.masm
@@ -1,7 +1,12 @@
+use {
+    AccountId,
+    AccountProcedureRoot,
+    AssetId,
+    BlockNumber,
+    TransactionScriptRoot,
+} from miden::protocol::types
 use {TX_EXEC_FOREIGN_PROC_OFFSET, TX_GET_BLOCK_COMMITMENT_OFFSET, TX_GET_REFERENCE_BLOCK_NUMBER_OFFSET, TX_GET_BLOCK_TIMESTAMP_OFFSET, TX_GET_EXPIRATION_DELTA_OFFSET, TX_GET_FEE_ASSET_ID_OFFSET, TX_GET_INPUT_NOTES_COMMITMENT_OFFSET, TX_GET_NUM_INPUT_NOTES_OFFSET, TX_GET_NUM_OUTPUT_NOTES_OFFSET, TX_GET_OUTPUT_NOTES_COMMITMENT_OFFSET, TX_GET_TX_SCRIPT_ROOT_OFFSET, TX_PREPARE_FPI_OFFSET, TX_UPDATE_EXPIRATION_BLOCK_DELTA_OFFSET, TX_COMPUTE_FEE_OFFSET}
     from miden::protocol::kernel_proc_offsets
-use {AccountId, AccountProcedureRoot, AssetId, BlockNumber, TransactionScriptRoot}
-    from miden::protocol::types
 
 #! Returns the block number of the transaction reference block.
 #!
@@ -261,10 +266,8 @@ end
 pub proc execute_foreign_procedure(
     foreign_account_id: AccountId,
     foreign_proc_root: AccountProcedureRoot,
-    foreign_procedure_inputs : [
-        felt ; 16
-    ]
-) -> [felt ; 16]
+    ...
+) -> ...
     # store the foreign account ID and foreign procedure root to the local memory
     # this will allow us to get the 16th element of the foreign procedure inputs to pass it to the
     # `tx_prepare_fpi` kernel procedure

--- a/crates/miden-protocol/asm/protocol/src/types.masm
+++ b/crates/miden-protocol/asm/protocol/src/types.masm
@@ -19,6 +19,7 @@ pub use {
     NoteTag,
     NoteType,
     BlockNumber,
+    BlockCommitment,
     DoubleWord,
     AssetClass,
     AssetMetadata,

--- a/crates/miden-protocol/asm/protocol/src/types.masm
+++ b/crates/miden-protocol/asm/protocol/src/types.masm
@@ -1,35 +1,30 @@
-# TYPE ALIASES
-# =================================================================================================
-# Semantic aliases for values that protocol procedures move on the operand stack. Names mirror the
-# corresponding Rust types so signatures read as the Rust API does.
-
-# AccountId is shared with the transaction kernel, so it lives in the common base library.
-pub use {AccountId} from miden::protocol_utils::types
-
-# Two-felt identifier (suffix on top of the stack, prefix below).
-pub type StorageSlotId = struct { suffix: felt, prefix: felt }
-
-# Word-sized domain values that wrap a `Word` in Rust.
-pub type AssetId = word
-pub type NoteId = word
-pub type AssetValue = word
-pub type AccountProcedureRoot = word
-pub type StorageMapKey = word
-pub type NoteRecipient = word
-pub type NoteMetadata = word
-pub type NoteScriptRoot = word
-pub type TransactionScriptRoot = word
-
-# Full asset: the asset ID (an AssetId) on top of the stack, the asset value (an AssetValue)
-# below it.
-pub type Asset = struct { id: word, value: word }
-
-# Scalar domain values.
-pub type Bool = i1
-pub type AssetAmount = felt
-pub type NoteTag = u32
-pub type NoteType = u8
-pub type BlockNumber = u32
-
-pub type DoubleWord = struct { word_lo: word, word_hi: word }
-pub type MemoryAddress = u32
+# Semantic types shared by the protocol API and transaction kernel.
+pub use {
+    AccountId,
+    StorageSlotId,
+    AssetId,
+    NoteArgs,
+    NoteSerialNumber,
+    NoteId,
+    AssetValue,
+    AccountProcedureRoot,
+    StorageMapKey,
+    NoteRecipient,
+    NoteMetadata,
+    NoteScriptRoot,
+    TransactionScriptRoot,
+    Asset,
+    Bool,
+    AssetAmount,
+    NoteTag,
+    NoteType,
+    BlockNumber,
+    DoubleWord,
+    AssetClass,
+    AssetMetadata,
+    AssetComposition,
+    NoteAssetsCommitment,
+    NoteStorageCommitment,
+    NoteAttachmentCommitment,
+    NoteAttachmentsCommitment,
+} from miden::protocol_utils::types

--- a/crates/miden-protocol/asm/protocol_utils/src/account_id.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/account_id.masm
@@ -1,3 +1,5 @@
+use {AccountId, Bool} from miden::protocol_utils::types
+
 # ERRORS
 # =================================================================================================
 
@@ -38,7 +40,7 @@ const VERSION_1 = 1
 #! - other_account_id_{suffix,prefix} are the suffix and prefix felts of the other account ID to
 #!   compare against.
 #! - is_id_equal is a boolean indicating whether the account IDs are equal.
-pub proc eq
+pub proc eq(account_id: AccountId, other_account_id: AccountId) -> Bool
     movup.2 eq
     # => [is_suffix_equal, account_id_prefix, other_account_id_prefix]
     movdn.2 eq
@@ -59,7 +61,7 @@ end
 #! Where:
 #! - account_id_{suffix,prefix} are the suffix and prefix felts of the account ID.
 #! - is_zero is a boolean indicating whether the account ID is the zero address.
-pub proc testz
+pub proc testz(account_id: AccountId) -> (Bool, AccountId)
     dup.1 eq.0 dup.1 eq.0 and
     # => [is_zero, account_id_suffix, account_id_prefix]
 end
@@ -72,7 +74,7 @@ end
 #! Where:
 #! - account_id_{suffix,prefix} are the suffix and prefix felts of an account ID.
 #! - is_zero is a boolean indicating whether both felts of the account ID are zero.
-pub proc eqz
+pub proc eqz(account_id: AccountId) -> Bool
     eq.0 swap eq.0 and
     # => [is_zero]
 end
@@ -93,7 +95,7 @@ end
 #! - account_id_prefix has a zero version.
 #! - account_id_suffix does not have its most significant bit set to zero.
 #! - account_id_suffix does not have its lower 8 bits set to zero.
-pub proc validate_structure
+pub proc validate_structure(account_id: AccountId)
     # Validate the version is non-zero, so that the zero account ID remains invalid.
     # ---------------------------------------------------------------------------------------------
     dup.1 exec.id_version neq.0
@@ -138,7 +140,7 @@ end
 #! - account_id_prefix does not contain version one.
 #! - account_id_suffix does not have its most significant bit set to zero.
 #! - account_id_suffix does not have its lower 8 bits set to zero.
-pub proc validate
+pub proc validate(account_id: AccountId)
     # Validate version in prefix. For now only version 1 is supported.
     # ---------------------------------------------------------------------------------------------
     dup.1 exec.id_version
@@ -162,7 +164,7 @@ end
 #! - seed_digest_suffix is the suffix of the digest that should be shaped into the suffix
 #!   of an account ID.
 #! - account_id_suffix is the suffix of an account ID.
-pub proc shape_suffix
+pub proc shape_suffix(seed_digest_suffix: felt) -> felt
     u32split
     # => [seed_digest_suffix_lo, seed_digest_suffix_hi]
 
@@ -186,7 +188,7 @@ end
 #! Where:
 #! - account_id_prefix is the prefix of an account ID.
 #! - id_version is the version number of the ID.
-proc id_version
+proc id_version(account_id_prefix: felt) -> u8
     # extract the lower 32 bits
     u32split swap drop
     # => [account_id_prefix_lo]
@@ -204,7 +206,7 @@ end
 #! Where:
 #! - account_id_prefix is the prefix of an account ID.
 #! - has_callbacks is a boolean indicating whether the account's assets trigger callbacks.
-pub proc asset_callback_flag
+pub proc asset_callback_flag(account_id_prefix: felt) -> Bool
     # extract the lower 32 bits
     u32split swap drop
     # => [account_id_prefix_lo]

--- a/crates/miden-protocol/asm/protocol_utils/src/asset.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/asset.masm
@@ -1,3 +1,5 @@
+use {AccountId, Asset, AssetId, AssetValue, AssetClass, AssetMetadata, AssetComposition, AssetAmount} from miden::protocol_utils::types
+
 # ERRORS
 # =================================================================================================
 
@@ -64,7 +66,7 @@ const METADATA_RESERVED_MASK = 0xffffffc0 # lower 8 bits: 0b1100_0000
 #! - ptr is the memory address where the asset will be stored.
 #! - ASSET_ID is the 4-element word representing the asset ID.
 #! - ASSET_VALUE is the 4-element word representing the asset value.
-pub proc store
+pub proc store(dest: ptr<Asset>, asset: Asset)
     # store asset ID
     movdn.4 dup.4
     # => [ptr, ASSET_ID, ptr, ASSET_VALUE]
@@ -86,7 +88,7 @@ end
 #! - ptr is the memory address of the asset.
 #! - ASSET_ID is the 4-element word representing the asset ID.
 #! - ASSET_VALUE is the 4-element word representing the asset value.
-pub proc load
+pub proc load(src: ptr<Asset>) -> Asset
     # load asset value
     padw dup.4 add.ASSET_VALUE_MEMORY_OFFSET mem_loadw_le
     # => [ASSET_VALUE, ptr]
@@ -106,7 +108,7 @@ end
 #! Where:
 #! - faucet_id is the account ID in the asset ID.
 #! - ASSET_ID is the asset ID from which to extract the faucet ID.
-pub proc id_to_faucet_id
+pub proc id_to_faucet_id(asset_id: AssetId) -> (AccountId, AssetId)
     # => [asset_class_suffix, asset_class_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix]
     dup.3 dup.3
     # => [faucet_id_suffix_and_metadata, faucet_id_prefix, ASSET_ID]
@@ -125,7 +127,7 @@ end
 #! Where:
 #! - faucet_id is the account ID in the asset ID.
 #! - ASSET_ID is the asset ID from which to extract the faucet ID.
-pub proc id_into_faucet_id
+pub proc id_into_faucet_id(asset_id: AssetId) -> AccountId
     # => [asset_class_suffix, asset_class_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix]
     drop drop
     # => [faucet_id_suffix_and_metadata, faucet_id_prefix]
@@ -142,7 +144,7 @@ end
 #! Where:
 #! - asset_class is the asset class in the asset ID.
 #! - ASSET_ID is the asset ID from which to extract the asset class.
-pub proc id_to_asset_class
+pub proc id_to_asset_class(asset_id: AssetId) -> (AssetClass, AssetId)
     # => [asset_class_suffix, asset_class_prefix, faucet_id_suffix, faucet_id_prefix]
     dup.1 dup.1
     # => [asset_class_suffix, asset_class_prefix, ASSET_ID]
@@ -156,7 +158,7 @@ end
 #! Where:
 #! - asset_class is the asset class in the asset ID.
 #! - ASSET_ID is the asset ID from which to extract the asset class.
-pub proc id_into_asset_class
+pub proc id_into_asset_class(asset_id: AssetId) -> AssetClass
     # => [asset_class_suffix, asset_class_prefix, faucet_id_suffix, faucet_id_prefix]
     movup.2 drop movup.2 drop
     # => [asset_class_suffix, asset_class_prefix]
@@ -171,7 +173,7 @@ end
 #! - faucet_id_suffix_and_metadata is the faucet ID suffix merged with the asset metadata.
 #! - faucet_id_suffix is the suffix of the account ID.
 #! - asset_metadata is the asset metadata.
-pub proc split_suffix_and_metadata
+pub proc split_suffix_and_metadata(faucet_id_suffix_and_metadata: felt) -> (AssetMetadata, felt)
     u32split
     # => [suffix_metadata_lo, suffix_metadata_hi]
 
@@ -204,7 +206,7 @@ end
 #! - encodes an unknown asset ID version.
 #! - has reserved bits 6 or 7 set.
 #! - encodes an unknown asset composition.
-pub proc validate_metadata
+pub proc validate_metadata(asset_metadata: felt)
     # assert that the metadata fits in a u8
     u32split swap
     # => [hi, asset_metadata]
@@ -240,7 +242,7 @@ end
 #! Where:
 #! - asset_metadata is the asset metadata.
 #! - asset_composition is the composition value (see COMPOSITION_* constants).
-proc metadata_into_composition
+proc metadata_into_composition(asset_metadata: AssetMetadata) -> AssetComposition
     # extract composition bits from the metadata
     u32and.COMPOSITION_MASK u32shr.COMPOSITION_SHIFT
     # => [asset_composition]
@@ -254,7 +256,7 @@ end
 #! Where:
 #! - ASSET_ID is the asset ID from which to extract the composition.
 #! - asset_composition is the composition value (see COMPOSITION_* constants).
-pub proc id_to_composition
+pub proc id_to_composition(asset_id: AssetId) -> (AssetComposition, AssetId)
     # => [asset_class_suffix, asset_class_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix]
     dup.2
     # => [faucet_id_suffix_and_metadata, ASSET_ID]
@@ -274,7 +276,7 @@ end
 #! Where:
 #! - ASSET_ID is the asset ID from which to extract the composition.
 #! - asset_composition is the composition value (see COMPOSITION_* constants).
-pub proc id_into_composition
+pub proc id_into_composition(asset_id: AssetId) -> AssetComposition
     # => [asset_class_suffix, asset_class_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix]
     drop drop
     # => [faucet_id_suffix_and_metadata, faucet_id_prefix]
@@ -299,7 +301,7 @@ end
 #! Where:
 #! - ASSET_VALUE is the fungible asset from which to extract the balance.
 #! - balance is the amount of the fungible asset.
-pub proc fungible_value_into_amount_unchecked
+pub proc fungible_value_into_amount_unchecked(asset_value: AssetValue) -> AssetAmount
     movdn.3 drop drop drop
     # => [balance]
 end

--- a/crates/miden-protocol/asm/protocol_utils/src/mem.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/mem.masm
@@ -24,7 +24,7 @@ use {WORD_NUM_ELEMENTS} from miden::protocol_utils::constants
 #! - COMPUTED_COMMITMENT is the commitment over the written elements.
 #!
 #! Invocation: exec
-pub proc pipe_elements_preimage_to_memory
+pub proc pipe_elements_preimage_to_memory(num_elements: u32, dest_ptr: ptr<felt>) -> word
     # compute the number of words required to store the elements: ceil(num_elements / 4)
     dup u32divmod.WORD_NUM_ELEMENTS neq.0 add
     # => [num_words, num_elements, dest_ptr]

--- a/crates/miden-protocol/asm/protocol_utils/src/note.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/note.masm
@@ -1,3 +1,5 @@
+use {NoteMetadata, Bool} from miden::protocol_utils::types
+
 # ERRORS
 # =================================================================================================
 
@@ -52,7 +54,7 @@ pub const ATTACHMENT_SCHEME_NONE = 1
 #! Where:
 #! - METADATA is the metadata of a note.
 #! - version is the version of the note metadata encoding.
-pub proc metadata_into_version
+pub proc metadata_into_version(metadata: NoteMetadata) -> u8
     movdn.3 drop drop drop
     # => [sender_id_suffix_type_version]
 
@@ -71,7 +73,7 @@ end
 #! Where:
 #! - METADATA is the metadata of a note.
 #! - reserved_bit is 1 if the reserved bit is set, 0 otherwise.
-proc metadata_into_reserved_bit
+proc metadata_into_reserved_bit(metadata: NoteMetadata) -> Bool
     movdn.3 drop drop drop
     # => [sender_id_suffix_type_version]
 
@@ -96,7 +98,7 @@ end
 #! Panics if:
 #! - the metadata encodes an unknown version.
 #! - the metadata has its reserved bit set.
-pub proc validate_metadata
+pub proc validate_metadata(metadata: NoteMetadata)
     # the version defines how the rest of the metadata is decoded, so assert it first
     dupw exec.metadata_into_version
     # => [version, METADATA]

--- a/crates/miden-protocol/asm/protocol_utils/src/types.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/types.masm
@@ -20,6 +20,9 @@ pub type NoteMetadata = word
 pub type NoteScriptRoot = word
 pub type TransactionScriptRoot = word
 
+#! Commitment to a block header.
+pub type BlockCommitment = word
+
 # Full asset: the asset ID (an AssetId) on top of the stack, the asset value (an AssetValue)
 # below it.
 pub type Asset = struct {
@@ -31,7 +34,11 @@ pub type Asset = struct {
 pub type Bool = i1
 pub type AssetAmount = felt
 pub type NoteTag = u32
-pub type NoteType = u8
+# Discriminants match the Rust NoteType representation.
+pub enum NoteType : u8 {
+    PRIVATE = 0,
+    PUBLIC = 1,
+}
 pub type BlockNumber = u32
 
 pub type DoubleWord = struct { lo: word, hi: word }
@@ -39,7 +46,12 @@ pub type DoubleWord = struct { lo: word, hi: word }
 # Asset class identifier and compact asset metadata fields.
 pub type AssetClass = struct { suffix: felt, prefix: felt }
 pub type AssetMetadata = u8
-pub type AssetComposition = u8
+# Discriminants match the Rust AssetComposition representation, including reserved custom logic.
+pub enum AssetComposition : u8 {
+    NONE = 0,
+    FUNGIBLE = 1,
+    CUSTOM = 2,
+}
 
 # Commitments to note data.
 pub type NoteAssetsCommitment = word

--- a/crates/miden-protocol/asm/protocol_utils/src/types.masm
+++ b/crates/miden-protocol/asm/protocol_utils/src/types.masm
@@ -1,5 +1,50 @@
 # TYPE ALIASES
 # =================================================================================================
+# Semantic aliases for values that protocol procedures move on the operand stack. Names mirror the
+# corresponding Rust types so signatures read as the Rust API does.
 
 # Two-felt identifier (suffix on top of the stack, prefix below).
 pub type AccountId = struct { suffix: felt, prefix: felt }
+
+# Two-felt identifier (suffix on top of the stack, prefix below).
+pub type StorageSlotId = struct { suffix: felt, prefix: felt }
+
+# Word-sized domain values that wrap a `Word` in Rust.
+pub type AssetId = word
+pub type NoteId = word
+pub type AssetValue = word
+pub type AccountProcedureRoot = word
+pub type StorageMapKey = word
+pub type NoteRecipient = word
+pub type NoteMetadata = word
+pub type NoteScriptRoot = word
+pub type TransactionScriptRoot = word
+
+# Full asset: the asset ID (an AssetId) on top of the stack, the asset value (an AssetValue)
+# below it.
+pub type Asset = struct {
+    id: AssetId,
+    value: AssetValue,
+}
+
+# Scalar domain values.
+pub type Bool = i1
+pub type AssetAmount = felt
+pub type NoteTag = u32
+pub type NoteType = u8
+pub type BlockNumber = u32
+
+pub type DoubleWord = struct { lo: word, hi: word }
+
+# Asset class identifier and compact asset metadata fields.
+pub type AssetClass = struct { suffix: felt, prefix: felt }
+pub type AssetMetadata = u8
+pub type AssetComposition = u8
+
+# Commitments to note data.
+pub type NoteAssetsCommitment = word
+pub type NoteStorageCommitment = word
+pub type NoteAttachmentCommitment = word
+pub type NoteAttachmentsCommitment = word
+pub type NoteArgs = word
+pub type NoteSerialNumber = word

--- a/crates/miden-standards/asm/components/access/authority/authority.masm
+++ b/crates/miden-standards/asm/components/access/authority/authority.masm
@@ -23,7 +23,7 @@ pub use {unfreeze} from miden::standards::access::authority
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_authority
+pub proc get_authority() -> u8
     push.AUTHORITY_SLOT[0..2] exec.active_account::get_item
     # => [authority, role_symbol, 0, 0, pad(16)]
 

--- a/crates/miden-standards/asm/components/auth/network_account/network_account.masm
+++ b/crates/miden-standards/asm/components/auth/network_account/network_account.masm
@@ -56,7 +56,7 @@ const ERR_NETWORK_ACCOUNT_SPONSORED_FEES_EXCEED_COLLECTED = "the fees moved into
 #! Outputs: []
 #!
 #! Invocation: exec
-proc assert_tx_has_effect
+proc assert_tx_has_effect()
     exec.tx::get_input_notes_commitment
     # => [INPUT_NOTES_COMMITMENT, pad(16)]
 

--- a/crates/miden-standards/asm/components/auth/no_auth/no_auth.masm
+++ b/crates/miden-standards/asm/components/auth/no_auth/no_auth.masm
@@ -32,7 +32,7 @@ const NO_AUTH_POST_FEE_CYCLES = 1024
 #!
 #! Invocation: call
 @auth_script
-pub proc auth_no_auth(auth_args: AuthArgs, padding: [felt; 12]) -> [felt; 16]
+pub proc auth_no_auth(auth_args: AuthArgs)
     dropw
     # => [pad(16)]
 

--- a/crates/miden-standards/asm/components/auth/no_auth/no_auth.masm
+++ b/crates/miden-standards/asm/components/auth/no_auth/no_auth.masm
@@ -1,3 +1,4 @@
+use {AuthArgs} from miden::standards::types
 use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::protocol::tx
@@ -31,7 +32,7 @@ const NO_AUTH_POST_FEE_CYCLES = 1024
 #!
 #! Invocation: call
 @auth_script
-pub proc auth_no_auth
+pub proc auth_no_auth(auth_args: AuthArgs, padding: [felt; 12]) -> [felt; 16]
     dropw
     # => [pad(16)]
 

--- a/crates/miden-standards/asm/standards/access/authority.masm
+++ b/crates/miden-standards/asm/standards/access/authority.masm
@@ -1,3 +1,4 @@
+use {Bool} from miden::protocol::types
 # miden::standards::access::authority
 #
 # Single source of truth for the account-wide authority. Components that gate state-mutating
@@ -57,7 +58,7 @@ const ERR_AUTHORITY_FROZEN = "authority is frozen"
 #!
 #! Invocation: call
 @account_procedure
-pub proc freeze
+pub proc freeze()
     exec.assert_sender_is_emergency_authority
     # => [pad(16)]
 
@@ -75,7 +76,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc unfreeze
+pub proc unfreeze()
     exec.assert_sender_is_emergency_authority
     # => [pad(16)]
 
@@ -116,7 +117,7 @@ end
 #! - the authority is an unknown value.
 #!
 #! Invocation: exec
-pub proc assert_authorized
+pub proc assert_authorized()
     push.AUTHORITY_SLOT[0..2] exec.active_account::get_item
     # => [authority, is_frozen, 0, 0]
 
@@ -177,7 +178,7 @@ end
 #! - the authority is AuthControlled or an unknown value.
 #!
 #! Invocation: exec
-proc assert_sender_is_emergency_authority
+proc assert_sender_is_emergency_authority()
     push.AUTHORITY_SLOT[0..2] exec.active_account::get_item
     # => [authority, is_frozen, 0, 0]
 
@@ -214,7 +215,7 @@ end
 #! - frozen_flag is the new emergency-switch state (0 = not frozen, 1 = frozen).
 #!
 #! Invocation: exec
-proc write_frozen_flag
+proc write_frozen_flag(frozen_flag: Bool)
     push.AUTHORITY_SLOT[0..2] exec.active_account::get_item
     # => [authority, old_is_frozen, 0, 0, frozen_flag]
 
@@ -246,7 +247,7 @@ end
 #! - no role is configured for the procedure and the sender does not hold ADMIN.
 #!
 #! Invocation: exec
-proc assert_authorized_rbac
+proc assert_authorized_rbac()
     # Resolve the calling procedure's root and look up its assigned role in the map.
     padw caller
     # => [CALLER_ROOT]

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -1,3 +1,5 @@
+use {OwnershipInfo} from miden::standards::types
+use {AccountId, Bool} from miden::protocol::types
 # miden::standards::access::ownable2step
 #
 # Provides two-step ownership management functionality for account components.
@@ -62,7 +64,7 @@ const ERR_SENDER_NOT_NOMINATED_OWNER = "note sender is not the nominated owner"
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_owner
+pub proc get_owner() -> AccountId
     exec.get_owner_internal
     # => [owner_suffix, owner_prefix, pad(16)]
 
@@ -81,7 +83,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_nominated_owner
+pub proc get_nominated_owner() -> AccountId
     exec.get_nominated_owner_internal
     # => [nominated_owner_suffix, nominated_owner_prefix, pad(16)]
 
@@ -110,7 +112,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc transfer_ownership
+pub proc transfer_ownership(new_owner: AccountId)
     exec.assert_sender_is_owner
     # => [new_owner_suffix, new_owner_prefix, pad(14)]
 
@@ -147,7 +149,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc accept_ownership
+pub proc accept_ownership()
     exec.load_ownership_info
     # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix, pad(16)]
 
@@ -196,7 +198,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc renounce_ownership
+pub proc renounce_ownership()
     exec.assert_sender_is_owner
     # => [pad(16)]
 
@@ -219,7 +221,7 @@ end
 #! - is_sender_owner is 1 if the note sender is the current owner, otherwise 0.
 #!
 #! Invocation: exec
-pub proc is_sender_owner
+pub proc is_sender_owner() -> Bool
     exec.active_note::get_sender
     # => [sender_suffix, sender_prefix]
 
@@ -236,7 +238,7 @@ end
 #! - the note sender is not the owner.
 #!
 #! Invocation: exec
-pub proc assert_sender_is_owner
+pub proc assert_sender_is_owner()
     exec.is_sender_owner
     # => [is_sender_owner]
 
@@ -256,7 +258,7 @@ end
 #! - owner_{suffix, prefix} are the suffix and prefix felts of the current owner account ID.
 #! - nominated_owner_{suffix, prefix} are the suffix and prefix felts of the nominated
 #!   owner account ID.
-proc load_ownership_info
+proc load_ownership_info() -> OwnershipInfo
     push.OWNER_CONFIG_SLOT[0..2] exec.active_account::get_item
     # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
 end
@@ -265,7 +267,7 @@ end
 #!
 #! Inputs:  [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
 #! Outputs: []
-proc save_ownership_info
+proc save_ownership_info(ownership: OwnershipInfo)
     push.OWNER_CONFIG_SLOT[0..2]
     # => [slot_suffix, slot_prefix, owner_suffix, owner_prefix,
     #     nominated_owner_suffix, nominated_owner_prefix]
@@ -284,7 +286,7 @@ end
 #!
 #! Where:
 #! - owner_{suffix, prefix} are the suffix and prefix felts of the owner account ID.
-proc get_owner_internal
+proc get_owner_internal() -> AccountId
     exec.load_ownership_info
     # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
 
@@ -303,7 +305,7 @@ end
 #! Where:
 #! - nominated_owner_{suffix, prefix} are the suffix and prefix felts of the nominated
 #!   owner account ID.
-proc get_nominated_owner_internal
+proc get_nominated_owner_internal() -> AccountId
     exec.load_ownership_info
     # => [owner_suffix, owner_prefix, nominated_owner_suffix, nominated_owner_prefix]
 
@@ -318,7 +320,7 @@ end
 #!
 #! Where:
 #! - is_owner is 1 if the account is the owner, 0 otherwise.
-proc is_owner_internal
+proc is_owner_internal(account_id: AccountId) -> Bool
     exec.get_owner_internal
     # => [owner_suffix, owner_prefix, account_id_suffix, account_id_prefix]
 
@@ -334,7 +336,7 @@ end
 #! Where:
 #! - account_id_{suffix, prefix} are the suffix and prefix felts of the account ID to check.
 #! - is_nominated_owner is 1 if the account is the nominated owner, 0 otherwise.
-proc is_nominated_owner_internal
+proc is_nominated_owner_internal(account_id: AccountId) -> Bool
     exec.get_nominated_owner_internal
     # => [nominated_owner_suffix, nominated_owner_prefix, account_id_suffix, account_id_prefix]
 

--- a/crates/miden-standards/asm/standards/access/ownable2step.masm
+++ b/crates/miden-standards/asm/standards/access/ownable2step.masm
@@ -1,4 +1,3 @@
-use {OwnershipInfo} from miden::standards::types
 use {AccountId, Bool} from miden::protocol::types
 # miden::standards::access::ownable2step
 #
@@ -33,6 +32,11 @@ use miden::protocol::account_id
 use miden::protocol::active_note
 use miden::protocol::native_account
 use {ZERO_WORD} from miden::standards::utils
+
+pub type OwnershipInfo = struct {
+    owner: AccountId,
+    nominated_owner: AccountId
+}
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/access/pausable/manager.masm
+++ b/crates/miden-standards/asm/standards/access/pausable/manager.masm
@@ -27,7 +27,7 @@ use miden::standards::access::pausable
 #!
 #! Invocation: call
 @account_procedure
-pub proc pause
+pub proc pause()
     exec.authority::assert_authorized
     # => [pad(16)]
 
@@ -45,7 +45,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc unpause
+pub proc unpause()
     exec.authority::assert_authorized
     # => [pad(16)]
 

--- a/crates/miden-standards/asm/standards/access/pausable/mod.masm
+++ b/crates/miden-standards/asm/standards/access/pausable/mod.masm
@@ -1,3 +1,4 @@
+use {Bool} from miden::protocol::types
 # miden::standards::access::pausable
 #
 # Pause primitive: storage slot + low-level helpers. The mutation helpers (`pause`, `unpause`)
@@ -46,7 +47,7 @@ const ERR_PAUSABLE_EXPECTED_PAUSE = "the contract is not paused"
 #!
 #! Invocation: call
 @account_procedure
-pub proc is_paused
+pub proc is_paused() -> Bool
     push.IS_PAUSED_SLOT[0..2]
     exec.active_account::get_item
     # => [is_paused, 0, 0, 0, pad(16)]
@@ -71,7 +72,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc pause
+pub proc pause()
     push.PAUSED_WORD
     # => [1, 0, 0, 0]
 
@@ -93,7 +94,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc unpause
+pub proc unpause()
     push.UNPAUSED_WORD
     # => [0, 0, 0, 0]
 
@@ -123,7 +124,7 @@ end
 #! - the slot is installed and the paused-state word is not the zero word.
 #!
 #! Invocation: exec
-pub proc assert_not_paused
+pub proc assert_not_paused()
     push.IS_PAUSED_SLOT[0..2]
     exec.active_account::has_storage_slot
     # => [has_slot]
@@ -156,7 +157,7 @@ end
 #! - the paused-state word is the zero word.
 #!
 #! Invocation: exec
-pub proc assert_paused
+pub proc assert_paused()
     push.IS_PAUSED_SLOT[0..2]
     exec.active_account::get_item
     # => [is_paused, 0, 0, 0]

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -1,3 +1,5 @@
+use {RoleConfig, RoleMemberCount, RoleSymbol} from miden::standards::types
+use {AccountId, Bool} from miden::protocol::types
 # miden::standards::access::rbac
 #
 # Role-based access control for account components.
@@ -88,7 +90,7 @@ const ERR_MEMBER_COUNT_OVERFLOW = "role member count overflowed u32"
 #!
 #! Invocation: call
 @account_procedure
-pub proc has_role
+pub proc has_role(role_symbol: RoleSymbol, account: AccountId) -> Bool
     exec.has_role_internal
     # => [has_role, pad(15)]
 end
@@ -108,7 +110,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_role_admin
+pub proc get_role_admin(role_symbol: RoleSymbol) -> RoleSymbol
     exec.get_role_admin_internal
     # => [admin_role_symbol, pad(15)]
 end
@@ -129,7 +131,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_role_member_count
+pub proc get_role_member_count(role_symbol: RoleSymbol) -> RoleMemberCount
     exec.get_role_member_count_internal
     # => [member_count, pad(15)]
 end
@@ -163,7 +165,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc set_role_admin
+pub proc set_role_admin(role_symbol: RoleSymbol, admin_role_symbol: RoleSymbol)
     dup exec.role_symbol::validate_encoding
     # => [role_symbol, new_admin_role_symbol, pad(14)]
 
@@ -203,7 +205,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc grant_role
+pub proc grant_role(role_symbol: RoleSymbol, account: AccountId)
     dup exec.role_symbol::validate_encoding
     # => [role_symbol, account_suffix, account_prefix, pad(13)]
 
@@ -243,7 +245,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc revoke_role
+pub proc revoke_role(role_symbol: RoleSymbol, account: AccountId)
     dup exec.role_symbol::validate_encoding
     # => [role_symbol, account_suffix, account_prefix, pad(13)]
 
@@ -271,7 +273,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc renounce_role
+pub proc renounce_role(role_symbol: RoleSymbol)
     dup exec.role_symbol::validate_encoding
     # => [role_symbol, pad(15)]
 
@@ -308,7 +310,7 @@ end
 #! - the note sender does not hold the given role.
 #!
 #! Invocation: exec
-pub proc assert_sender_has_role
+pub proc assert_sender_has_role(role_symbol: RoleSymbol)
     exec.is_sender_in_role
     # => [has_role]
 
@@ -325,7 +327,7 @@ end
 #! - the note sender does not hold the ADMIN role.
 #!
 #! Invocation: exec
-pub proc assert_sender_is_admin
+pub proc assert_sender_is_admin()
     push.ADMIN_ROLE exec.assert_sender_has_role
     # => []
 end
@@ -340,7 +342,7 @@ end
 #! Outputs: [member_count, admin_role_symbol]
 #!
 #! Invocation: exec
-proc get_role_config
+proc get_role_config(role_symbol: RoleSymbol) -> RoleConfig
     push.0.0.0
     # => [0, 0, 0, role_symbol]
 
@@ -360,7 +362,7 @@ end
 #! Outputs: [has_role]
 #!
 #! Invocation: exec
-proc has_role_internal
+proc has_role_internal(role_symbol: RoleSymbol, account: AccountId) -> Bool
     push.0
     # => [0, role_symbol, account_suffix, account_prefix]
 
@@ -380,7 +382,7 @@ end
 #! Outputs: [member_count]
 #!
 #! Invocation: exec
-proc get_role_member_count_internal
+proc get_role_member_count_internal(role_symbol: RoleSymbol) -> RoleMemberCount
     exec.get_role_config
     # => [member_count, admin_role_symbol]
 
@@ -394,7 +396,7 @@ end
 #! Outputs: [admin_role_symbol]
 #!
 #! Invocation: exec
-proc get_role_admin_internal
+proc get_role_admin_internal(role_symbol: RoleSymbol) -> RoleSymbol
     exec.get_role_config
     # => [member_count, admin_role_symbol]
 
@@ -408,7 +410,7 @@ end
 #! Outputs: [has_role]
 #!
 #! Invocation: exec
-proc is_sender_in_role
+proc is_sender_in_role(role_symbol: RoleSymbol) -> Bool
     exec.active_note::get_sender
     # => [sender_suffix, sender_prefix, role_symbol]
 
@@ -428,7 +430,7 @@ end
 #! Outputs: [effective_admin_role_symbol]
 #!
 #! Invocation: exec
-proc get_effective_role_admin
+proc get_effective_role_admin(role_symbol: RoleSymbol) -> RoleSymbol
     exec.get_role_admin_internal
     # => [admin_role_symbol]
 
@@ -455,7 +457,7 @@ end
 #!   memberless, the `ADMIN` role.
 #!
 #! Invocation: exec
-proc assert_sender_is_role_admin
+proc assert_sender_is_role_admin(role_symbol: RoleSymbol)
     exec.get_effective_role_admin
     # => [effective_admin_role_symbol]
 
@@ -483,7 +485,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc set_role_config
+proc set_role_config(role_symbol: RoleSymbol, config: RoleConfig)
     push.0.0
     # => [0, 0, role_symbol, member_count, admin_role_symbol]
 
@@ -524,7 +526,7 @@ end
 #!
 #! Invocation: exec
 @locals(2)
-proc set_membership_internal
+proc set_membership_internal(is_member: Bool, role_symbol: RoleSymbol, account: AccountId)
     # => [is_member, role_symbol, account_suffix, account_prefix]
 
     # Stash the membership flag and role_symbol; both are needed after the map write.

--- a/crates/miden-standards/asm/standards/access/rbac.masm
+++ b/crates/miden-standards/asm/standards/access/rbac.masm
@@ -1,4 +1,4 @@
-use {RoleConfig, RoleMemberCount, RoleSymbol} from miden::standards::types
+use {RoleSymbol} from miden::standards::access::role_symbol
 use {AccountId, Bool} from miden::protocol::types
 # miden::standards::access::rbac
 #
@@ -44,6 +44,13 @@ use miden::protocol::active_account
 use miden::protocol::active_note
 use miden::protocol::native_account
 use miden::standards::access::role_symbol
+
+# Membership counts are field elements; the role map does not impose a u32 bound.
+pub type RoleMemberCount = felt
+pub type RoleConfig = struct {
+    member_count: RoleMemberCount,
+    admin: RoleSymbol
+}
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/access/role_symbol.masm
+++ b/crates/miden-standards/asm/standards/access/role_symbol.masm
@@ -1,3 +1,4 @@
+use {RoleSymbol} from miden::standards::types
 # miden::standards::access::role_symbol
 #
 # Encoding of the role symbols used by role-based access control.
@@ -46,7 +47,7 @@ const ERR_INVALID_ROLE_SYMBOL = "role symbol is not a valid encoding"
 #! - role_symbol is not a valid role symbol encoding.
 #!
 #! Invocation: exec
-pub proc validate_encoding
+pub proc validate_encoding(role_symbol: RoleSymbol)
     dup eq.0 assertz.err=ERR_ROLE_SYMBOL_ZERO
     # => [role_symbol]
 
@@ -80,7 +81,7 @@ end
 #! - admin_role_symbol is non-zero and is not a valid role symbol encoding.
 #!
 #! Invocation: exec
-pub proc validate_admin_role_symbol
+pub proc validate_admin_role_symbol(admin_role_symbol: RoleSymbol)
     dup eq.0
     # => [is_unset, admin_role_symbol]
 
@@ -102,7 +103,7 @@ end
 #! Outputs: [num_chars]
 #!
 #! Invocation: exec
-proc get_num_chars
+proc get_num_chars(role_symbol: RoleSymbol) -> u8
     u32split
     # => [role_symbol_lo, role_symbol_hi]
 

--- a/crates/miden-standards/asm/standards/access/role_symbol.masm
+++ b/crates/miden-standards/asm/standards/access/role_symbol.masm
@@ -1,4 +1,3 @@
-use {RoleSymbol} from miden::standards::types
 # miden::standards::access::role_symbol
 #
 # Encoding of the role symbols used by role-based access control.
@@ -13,6 +12,8 @@ use {RoleSymbol} from miden::standards::types
 # Keep the constants below in sync with `RoleSymbol` on the Rust side.
 
 use miden::core::math::u64
+
+pub type RoleSymbol = felt
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/account_upgrade.masm
+++ b/crates/miden-standards/asm/standards/account_upgrade.masm
@@ -1,4 +1,3 @@
-use {CodeUpgradeCommitment, StorageUpgradeCommitment} from miden::standards::types
 # miden::standards::account_upgrade
 #
 # Account upgrade manager. Exposes `upgrade` as an `Invocation: call` procedure gated by the
@@ -9,6 +8,9 @@ use {CodeUpgradeCommitment, StorageUpgradeCommitment} from miden::standards::typ
 
 use miden::standards::access::authority
 use miden::protocol::native_account
+
+pub type CodeUpgradeCommitment = word
+pub type StorageUpgradeCommitment = word
 
 # PUBLIC INTERFACE
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/account_upgrade.masm
+++ b/crates/miden-standards/asm/standards/account_upgrade.masm
@@ -1,3 +1,4 @@
+use {CodeUpgradeCommitment, StorageUpgradeCommitment} from miden::standards::types
 # miden::standards::account_upgrade
 #
 # Account upgrade manager. Exposes `upgrade` as an `Invocation: call` procedure gated by the
@@ -32,7 +33,10 @@ use miden::protocol::native_account
 #!
 #! Invocation: call
 @account_procedure
-pub proc upgrade
+pub proc upgrade(
+    code_upgrade_commitment: CodeUpgradeCommitment,
+    storage_upgrade_commitment: StorageUpgradeCommitment
+)
     exec.authority::assert_authorized
     # => [CODE_UPGRADE_COMMITMENT, STORAGE_UPGRADE_COMMITMENT, pad(8)]
 

--- a/crates/miden-standards/asm/standards/assets/asset_amount.masm
+++ b/crates/miden-standards/asm/standards/assets/asset_amount.masm
@@ -1,3 +1,5 @@
+use {BigEndianUint256, EncodedUint256, Uint128, Uint256} from miden::standards::types
+use {AssetAmount} from miden::protocol::types
 use miden::core::math::u64
 use miden::core::word
 use miden::standards::utils
@@ -29,7 +31,7 @@ const MAX_SCALING_FACTOR=18
 #! - scale > 18 (overflow protection)
 #!
 #! Invocation: exec
-pub proc pow10
+pub proc pow10(scale: u8) -> felt
     u32assert.err=ERR_SCALE_AMOUNT_EXCEEDED_LIMIT
     # => [scale]
 
@@ -87,7 +89,7 @@ end
 #! - ETH: amount=1e10, target_scale=8 → 1e18
 #!
 #! Invocation: exec
-pub proc scale_asset_amount_to_u256
+pub proc scale_asset_amount_to_u256(amount: AssetAmount, target_scale: u8) -> Uint256
     swap
     # => [target_scale, amount]
 
@@ -114,7 +116,7 @@ end
 #! Reverse the limbs and change the byte endianness of the result.
 #!
 #! Invocation: exec
-pub proc reverse_limbs_and_change_byte_endianness
+pub proc reverse_limbs_and_change_byte_endianness(value: EncodedUint256) -> EncodedUint256
     # reverse the felts within each word
     # [a, b, c, d, e, f, g, h] -> [h, g, f, e, d, c, b, a]
     exec.word::reverse
@@ -150,7 +152,7 @@ end
 #!
 #! Panics if:
 #!   - y > x  (ERR_UNDERFLOW)
-proc u128_safe_sub
+proc u128_safe_sub(y: Uint128, x: Uint128) -> Uint128
     # Put x-word on top for easier access.
     swapw
     # => [x0, x1, x2, x3, y0, y1, y2, y3]
@@ -259,7 +261,7 @@ end
 #! - (z1, z0) >= 10^scale_exp (remainder too large)
 #!
 #! Invocation: exec
-pub proc verify_u128_to_asset_amount_conversion
+pub proc verify_u128_to_asset_amount_conversion(x: Uint128, scale_exp: u8, y: AssetAmount)
     # => [x0, x1, x2, x3, scale_exp, y]
 
     # =============================================================================================
@@ -382,8 +384,11 @@ end
 #! - (z1, z0) >= 10^scale_exp (remainder too large)
 #!
 #! Invocation: exec
-pub proc verify_u256_to_asset_amount_conversion
-
+pub proc verify_u256_to_asset_amount_conversion(
+    value: BigEndianUint256,
+    scale_exp: u8,
+    y: AssetAmount
+)
     # reverse limbs and byte endianness
     exec.reverse_limbs_and_change_byte_endianness
     # => [x0, x1, x2, x3, x4, x5, x6, x7, scale_exp, y]

--- a/crates/miden-standards/asm/standards/assets/fungible_asset.masm
+++ b/crates/miden-standards/asm/standards/assets/fungible_asset.masm
@@ -1,3 +1,4 @@
+use {AccountId, Asset, AssetAmount, AssetId, AssetValue} from miden::protocol::types
 use miden::protocol::active_account
 use miden::protocol::asset
 use miden::protocol::native_account
@@ -41,7 +42,7 @@ const ASSET_METADATA_FUNGIBLE = 0x11
 #! - ASSET_ID is the asset ID for the fungible asset.
 #!
 #! Invocation: exec
-pub proc create_id
+pub proc create_id(faucet_id: AccountId) -> AssetId
     # merge the fungible asset metadata into the lower 8 bits of the suffix
     add.ASSET_METADATA_FUNGIBLE
     # => [faucet_id_suffix_and_metadata, faucet_id_prefix]
@@ -61,7 +62,7 @@ end
 #! - ASSET_VALUE is the asset value word [amount, 0, 0, 0].
 #!
 #! Invocation: exec
-pub proc create_value
+pub proc create_value(amount: AssetAmount) -> AssetValue
     push.0.0.0 movup.3
     # => [ASSET_VALUE]
 end
@@ -84,7 +85,7 @@ end
 #! - the provided amount exceeds MAX_AMOUNT.
 #!
 #! Invocation: exec
-pub proc create
+pub proc create(faucet_id: AccountId, amount: AssetAmount) -> Asset
     # assert the amount is valid
     dup.2 lte.MAX_AMOUNT
     assert.err=ERR_FUNGIBLE_ASSET_AMOUNT_EXCEEDS_MAX_ALLOWED_AMOUNT
@@ -117,7 +118,7 @@ end
 #! - the current active account is not the native account of the transaction.
 #!
 #! Invocation: exec
-pub proc get_initial_native_account_balance
+pub proc get_initial_native_account_balance(asset_id: AssetId) -> AssetAmount
     # assert that the asset composition is fungible
     exec.asset::id_to_composition
     eq.COMPOSITION_FUNGIBLE
@@ -146,7 +147,7 @@ end
 #! - the asset composition encoded in ASSET_ID is not fungible.
 #!
 #! Invocation: exec
-pub proc get_active_account_balance
+pub proc get_active_account_balance(asset_id: AssetId) -> AssetAmount
     # assert that the asset composition is fungible
     exec.asset::id_to_composition
     eq.COMPOSITION_FUNGIBLE
@@ -173,7 +174,7 @@ end
 #! - amount is the amount of the fungible asset.
 #!
 #! Invocation: exec
-pub proc to_amount_unchecked
+pub proc to_amount_unchecked(asset: Asset) -> (AssetAmount, Asset)
     # => [ASSET_ID, [amount, 0, 0, 0]]
     dup.4
     # => [amount, ASSET_ID, ASSET_VALUE]
@@ -193,7 +194,7 @@ end
 #! - the asset amount exceeds maximum allowed amount.
 #!
 #! Invocation: exec
-pub proc value_into_amount
+pub proc value_into_amount(asset_value: AssetValue) -> AssetAmount
     # assert the amount does not exceed the maximum fungible asset amount
     dup lte.MAX_AMOUNT assert.err=ERR_FUNGIBLE_ASSET_AMOUNT_EXCEEDS_MAX_ALLOWED_AMOUNT
     # => [amount, e1, e2, e3]
@@ -224,7 +225,7 @@ end
 #! - the asset value is not well-formed (see value_into_amount).
 #!
 #! Invocation: exec
-pub proc validate
+pub proc validate(asset: Asset) -> Asset
     # assert the asset composition is fungible
     exec.asset::id_to_composition
     eq.COMPOSITION_FUNGIBLE

--- a/crates/miden-standards/asm/standards/assets/non_fungible_asset.masm
+++ b/crates/miden-standards/asm/standards/assets/non_fungible_asset.masm
@@ -2,6 +2,7 @@
 #!
 #! Provides procedures for creating non-fungible assets.
 
+use {AccountId, Asset, AssetClass, AssetValue} from miden::protocol::types
 use miden::protocol::asset
 use {COMPOSITION_NONE} from miden::protocol::asset
 
@@ -38,7 +39,7 @@ const ASSET_METADATA_NONE = 0x01
 #! - ASSET_VALUE is the value of the created non-fungible asset, which is identical to ASSET_VALUE.
 #!
 #! Invocation: exec
-pub proc create
+pub proc create(faucet_id: AccountId, asset_value: AssetValue) -> Asset
     # merge the non-fungible asset metadata into the lower 8 bits of the suffix
     add.ASSET_METADATA_NONE
     # => [faucet_id_suffix_and_metadata, faucet_id_prefix, ASSET_VALUE]
@@ -68,7 +69,7 @@ end
 #! - the asset class prefix of the asset ID does not match hash1 of the value.
 #!
 #! Invocation: exec
-pub proc validate
+pub proc validate(asset: Asset) -> Asset
     # assert the asset composition is non-fungible (None)
     exec.asset::id_to_composition
     eq.COMPOSITION_NONE
@@ -94,7 +95,7 @@ end
 #! - asset_class is the (suffix, prefix) pair of the non-fungible asset.
 #!
 #! Invocation: exec
-pub proc value_into_asset_class
+pub proc value_into_asset_class(asset_value: AssetValue) -> AssetClass
     # => [asset_class_suffix, asset_class_prefix, value_2, value_3]
     movup.3 drop movup.2 drop
     # => [asset_class_suffix, asset_class_prefix]

--- a/crates/miden-standards/asm/standards/attachments/network_account_target.masm
+++ b/crates/miden-standards/asm/standards/attachments/network_account_target.masm
@@ -2,6 +2,8 @@
 #!
 #! Provides a standardized way to work with network account targets.
 
+use {NetworkAccountTarget} from miden::standards::types
+use {AccountId, Bool} from miden::protocol::types
 use miden::protocol::account_id
 use miden::protocol::active_account
 use miden::protocol::active_note
@@ -33,7 +35,7 @@ const ERR_NETWORK_ACCOUNT_TARGET_INCORRECT_NUMBER_OF_WORDS = "network account ta
 #! Outputs: [is_network_account_target]
 #!
 #! Invocation: exec
-pub proc is_network_account_target
+pub proc is_network_account_target(attachment_scheme: u32) -> Bool
     eq.NETWORK_ACCOUNT_TARGET_ATTACHMENT_SCHEME
     # => [is_network_account_target]
 end
@@ -56,7 +58,7 @@ end
 #! - account_id_{suffix,prefix} are the suffix and prefix felts of an account ID.
 #!
 #! Invocation: exec
-pub proc into_target_id
+pub proc into_target_id(network_account_target_attachment: NetworkAccountTarget) -> AccountId
     # => [NETWORK_ACCOUNT_TARGET_ATTACHMENT]
     # => [account_id_suffix, account_id_prefix, exec_hint_tag, 0]
 
@@ -76,7 +78,7 @@ end
 #! - attachment_scheme is the attachment scheme (1) for use with `output_note::add_word_attachment`.
 #!
 #! Invocation: exec
-pub proc new
+pub proc new(account_id: AccountId, exec_hint_tag: felt) -> (u32, NetworkAccountTarget)
     # => [account_id_suffix, account_id_prefix, exec_hint_tag]
     push.0 movdn.3
     # => [NOTE_ATTACHMENT] = [account_id_suffix, account_id_prefix, exec_hint_tag, 0]
@@ -98,7 +100,7 @@ end
 #!
 #! Invocation: exec
 @locals(4)
-pub proc active_account_matches_target_account
+pub proc active_account_matches_target_account() -> Bool
     # find the network account target attachment, if any
     # if there are multiple, we consider the first one the canonical one
     push.NETWORK_ACCOUNT_TARGET_ATTACHMENT_SCHEME

--- a/crates/miden-standards/asm/standards/attachments/network_account_target.masm
+++ b/crates/miden-standards/asm/standards/attachments/network_account_target.masm
@@ -2,11 +2,16 @@
 #!
 #! Provides a standardized way to work with network account targets.
 
-use {NetworkAccountTarget} from miden::standards::types
 use {AccountId, Bool} from miden::protocol::types
 use miden::protocol::account_id
 use miden::protocol::active_account
 use miden::protocol::active_note
+
+pub type NetworkAccountTarget = struct {
+    account: AccountId,
+    execution_hint: felt,
+    padding: felt
+}
 
 # CONSTANTS
 # ================================================================================================

--- a/crates/miden-standards/asm/standards/auth/guardian.masm
+++ b/crates/miden-standards/asm/standards/auth/guardian.masm
@@ -92,7 +92,7 @@ pub proc update_guardian_public_key(new_guardian_scheme_id: felt, new_guardian_p
     # Store new scheme id as [scheme_id, 0, 0, 0] in the single-entry map.
     loc_load.0
     # => [scheme_id]
-    
+
     push.0.0.0 movup.3
     # => [NEW_GUARDIAN_SCHEME_ID_WORD]
 
@@ -147,7 +147,7 @@ end
 pub proc verify_signature(msg: word)
     procref.update_guardian_public_key
     # => [UPDATE_GUARDIAN_PUBLIC_KEY_ROOT, MSG]
-    
+
     exec.native_account::was_procedure_called
     # => [was_update_guardian_public_key_called, MSG]
 

--- a/crates/miden-standards/asm/standards/auth/mod.masm
+++ b/crates/miden-standards/asm/standards/auth/mod.masm
@@ -1,7 +1,7 @@
+use {BlockNumber} from miden::protocol::types
 use miden::protocol::native_account
 use miden::protocol::tx
 use miden::core::crypto::hashes::poseidon2
-use {BlockNumber} from miden::protocol::types
 
 pub mod guardian
 pub mod multisig

--- a/crates/miden-standards/asm/standards/auth/multisig.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig.masm
@@ -1,4 +1,4 @@
-use {Approver, SignatureThreshold, ThresholdConfig} from miden::standards::types
+use {Approver} from miden::standards::auth::signature
 use {AccountProcedureRoot, BlockNumber} from miden::protocol::types
 # The MASM code of the Multi-Signature Authentication Component.
 #
@@ -14,6 +14,18 @@ use {ConversionInfo} from miden::standards::fee
 use miden::core::mem
 use miden::core::word
 use {ONE_WORD} from miden::standards::utils
+
+# Standard multisig components support at most 64 approvers.
+pub type SignatureThreshold = u8
+pub type MultisigConfig = struct {
+    threshold: SignatureThreshold,
+    num_approvers: u8,
+    padding: [felt; 2]
+}
+pub type ThresholdConfig = struct {
+    threshold: SignatureThreshold,
+    num_approvers: u8
+}
 
 # Local Memory Addresses
 const IS_SIGNER_FOUND_LOC=0

--- a/crates/miden-standards/asm/standards/auth/multisig.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig.masm
@@ -1,3 +1,5 @@
+use {Approver, SignatureThreshold, ThresholdConfig} from miden::standards::types
+use {AccountProcedureRoot, BlockNumber} from miden::protocol::types
 # The MASM code of the Multi-Signature Authentication Component.
 #
 # See the `AuthMultisig` Rust type's documentation for more details.
@@ -6,7 +8,6 @@ use miden::protocol::active_account
 use {AUTH_UNAUTHORIZED_EVENT} from miden::protocol::auth
 use miden::protocol::native_account
 use miden::protocol::tx
-use {BlockNumber} from miden::protocol::types
 use miden::standards::auth
 use miden::standards::auth::signature
 use {ConversionInfo} from miden::standards::fee
@@ -293,7 +294,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_threshold_and_num_approvers
+pub proc get_threshold_and_num_approvers() -> ThresholdConfig
     exec.get_current_threshold_and_num_approvers
     # => [default_threshold, num_approvers, pad(16)]
 
@@ -324,7 +325,10 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc set_procedure_threshold
+pub proc set_procedure_threshold(
+    proc_threshold: SignatureThreshold,
+    proc_root: AccountProcedureRoot
+)
     exec.get_current_threshold_and_num_approvers
     # => [default_threshold, num_approvers, proc_threshold, PROC_ROOT]
 
@@ -378,7 +382,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_signer_at
+pub proc get_signer_at(index: u32) -> Approver
     # Bounds check: index must be < num_approvers
     dup exec.get_initial_threshold_and_num_approvers drop
     # => [num_approvers, index, index]
@@ -586,7 +590,7 @@ end
 #! - threshold > num_approvers.
 #!
 #! Invocation: exec
-pub proc assert_threshold_is_reachable
+pub proc assert_threshold_is_reachable(num_approvers: u8, threshold: SignatureThreshold)
     u32assert2.err=ERR_MALFORMED_MULTISIG_CONFIG
     u32gt assertz.err=ERR_MALFORMED_MULTISIG_CONFIG
 end
@@ -737,7 +741,7 @@ end
 #! Outputs: [default_threshold, num_approvers]
 #!
 #! Invocation: exec
-pub proc get_initial_threshold_and_num_approvers
+pub proc get_initial_threshold_and_num_approvers() -> (SignatureThreshold, u8)
     push.THRESHOLD_CONFIG_SLOT[0..2]
     exec.native_account::get_initial_item
     # => [default_threshold, num_approvers, 0, 0]
@@ -1189,7 +1193,7 @@ end
 #! Outputs: [default_threshold, num_approvers]
 #!
 #! Invocation: exec
-proc get_current_threshold_and_num_approvers
+proc get_current_threshold_and_num_approvers() -> (SignatureThreshold, u8)
     push.THRESHOLD_CONFIG_SLOT[0..2]
     exec.active_account::get_item
     # => [default_threshold, num_approvers, 0, 0]

--- a/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
@@ -1,7 +1,8 @@
+use {ProcedurePolicy, SignatureThreshold} from miden::standards::types
+use {AccountProcedureRoot, BlockNumber, Bool} from miden::protocol::types
 use miden::protocol::active_account
 use miden::protocol::native_account
 use {AUTH_UNAUTHORIZED_EVENT} from miden::protocol::auth
-use {BlockNumber} from miden::protocol::types
 use miden::standards::auth
 use miden::standards::auth::multisig
 use {APPROVER_PUBLIC_KEYS_SLOT} from miden::standards::auth::multisig
@@ -112,7 +113,7 @@ const INIT_NUM_OF_APPROVERS_LOC = 1
 #! Invocation: call
 @locals(3)
 @account_procedure
-pub proc set_procedure_policy
+pub proc set_procedure_policy(policy: ProcedurePolicy, proc_root: AccountProcedureRoot)
     loc_store.IMMEDIATE_THRESHOLD_LOC
     # => [delayed_threshold, note_restrictions, PROC_ROOT]
 
@@ -353,7 +354,7 @@ end
 #! - note_restrictions is the note restriction enum value in the 0..=NOTE_RESTRICTION_MAX range.
 #!
 #! Invocation: exec
-pub proc get_procedure_policy
+pub proc get_procedure_policy(proc_root: AccountProcedureRoot) -> (SignatureThreshold, SignatureThreshold, u8)
     push.PROCEDURE_POLICIES_SLOT[0..2]
     exec.native_account::get_initial_map_item
     # => [immediate_threshold, delayed_threshold, note_restrictions, 0]
@@ -372,7 +373,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc enforce_note_restrictions
+pub proc enforce_note_restrictions(note_restrictions: u8)
     dup u32and.NOTE_RESTRICTION_INPUT_NOTES_MASK eq.NOTE_RESTRICTION_INPUT_NOTES_MASK
     # => [has_input_note_restriction, note_restrictions]
 
@@ -502,7 +503,7 @@ end
 #! - note_restrictions is greater than NOTE_RESTRICTION_MAX.
 #!
 #! Invocation: exec
-proc assert_valid_note_restrictions
+proc assert_valid_note_restrictions(note_restrictions: u8)
     u32assert.err=ERR_INVALID_NOTE_RESTRICTIONS
     # => [note_restrictions]
 
@@ -522,7 +523,7 @@ end
 #! - num_approvers is the current number of signers configured in the threshold config.
 #!
 #! Invocation: exec
-proc get_current_num_approvers
+proc get_current_num_approvers() -> u8
     push.THRESHOLD_CONFIG_SLOT[0..2]
     exec.active_account::get_item
     # => [threshold, num_approvers, 0, 0]
@@ -546,7 +547,11 @@ end
 #! - num_approvers is the second felt of MULTISIG_CONFIG.
 #!
 #! Invocation: exec
-proc multisig_config_to_num_approvers
+proc multisig_config_to_num_approvers(
+    threshold: SignatureThreshold,
+    num_approvers: u8,
+    padding: [felt; 2],
+) -> (u8, SignatureThreshold, u8, [felt; 2])
     dup.1
     # => [num_approvers, MULTISIG_CONFIG]
 end
@@ -598,7 +603,12 @@ end
 #! - the procedure's policy exists but is configured for the opposite execution mode.
 #!
 #! Invocation: exec
-proc compute_proc_policy_contribution
+proc compute_proc_policy_contribution(
+    immediate: SignatureThreshold,
+    delayed: SignatureThreshold,
+    execution_mode: Bool,
+    default_threshold: SignatureThreshold
+) -> (SignatureThreshold, Bool)
     # selected = (execution_mode == DELAYED_EXECUTION_MODE) ? delayed : immediate
     dup dup.2
     # => [delayed, immediate, immediate, delayed, execution_mode, default_threshold]
@@ -703,7 +713,7 @@ end
 #! - DEFAULT_THRESHOLD_LOC: default_threshold
 @locals(2)
 proc compute_called_proc_policy(execution_mode: u32, default_threshold: u32)
-    loc_store.EXECUTION_MODE_LOC 
+    loc_store.EXECUTION_MODE_LOC
     loc_store.DEFAULT_THRESHOLD_LOC
     # => []
 
@@ -822,7 +832,7 @@ end
 #! - any stored immediate or delayed threshold exceeds num_approvers.
 #!
 #! Invocation: exec
-proc assert_proc_policies_lte_num_approvers
+proc assert_proc_policies_lte_num_approvers(num_approvers: u8)
     exec.active_account::get_num_procedures
     # => [num_procedures, num_approvers]
 

--- a/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
+++ b/crates/miden-standards/asm/standards/auth/multisig_smart/mod.masm
@@ -1,4 +1,4 @@
-use {ProcedurePolicy, SignatureThreshold} from miden::standards::types
+use {SignatureThreshold} from miden::standards::auth::multisig
 use {AccountProcedureRoot, BlockNumber, Bool} from miden::protocol::types
 use miden::protocol::active_account
 use miden::protocol::native_account
@@ -10,6 +10,12 @@ use {APPROVER_SCHEME_ID_SLOT} from miden::standards::auth::multisig
 use {THRESHOLD_CONFIG_SLOT} from miden::standards::auth::multisig
 use miden::standards::auth::signature
 use miden::standards::auth::tx_policy
+
+pub type ProcedurePolicy = struct {
+    immediate: SignatureThreshold,
+    delayed: SignatureThreshold,
+    note_restrictions: u8
+}
 
 # STORAGE SLOTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/auth/network_account.masm
+++ b/crates/miden-standards/asm/standards/auth/network_account.masm
@@ -1,3 +1,4 @@
+use {Bool, NoteScriptRoot, TransactionScriptRoot} from miden::protocol::types
 # Network-account configuration storage.
 #
 # Owns the standardized `AuthNetworkAccount` slots and provides:
@@ -12,7 +13,6 @@ use miden::protocol::native_account
 use miden::standards::access::authority
 use miden::standards::auth::note_script_allowlist
 use miden::standards::auth::tx_script_allowlist
-use {Bool, NoteScriptRoot, TransactionScriptRoot} from miden::protocol::types
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/auth/note_script_allowlist.masm
+++ b/crates/miden-standards/asm/standards/auth/note_script_allowlist.masm
@@ -1,3 +1,4 @@
+use {NoteScriptRoot, StorageSlotId} from miden::protocol::types
 # Reusable note-script allowlist primitive.
 #
 # Provides the operations used to restrict what notes an account can consume during a transaction:
@@ -14,7 +15,6 @@ use miden::protocol::native_account
 use miden::protocol::tx
 use miden::protocol::input_note
 use miden::core::word
-use {StorageSlotId, NoteScriptRoot} from miden::protocol::types
 use {ONE_WORD, ZERO_WORD} from miden::standards::utils
 
 # CONSTANTS

--- a/crates/miden-standards/asm/standards/auth/signature.masm
+++ b/crates/miden-standards/asm/standards/auth/signature.masm
@@ -1,3 +1,5 @@
+use {Approver, PublicKeyCommitment, SignatureMessage, SignatureScheme, SignatureSchemeWord} from miden::standards::types
+use {Bool, StorageMapKey, StorageSlotId} from miden::protocol::types
 use miden::core::crypto::dsa::falcon512_poseidon2
 use miden::core::crypto::hashes::poseidon2
 use miden::core::crypto::dsa::ecdsa_k256_keccak
@@ -62,7 +64,7 @@ const ERR_INVALID_SCHEME_ID_WORD = "invalid scheme ID word format expected three
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc authenticate_transaction
+pub proc authenticate_transaction(approver: Approver)
     # Increment the account's nonce.
     # ---------------------------------------------------------------------------------------------
     # This has to happen before computing the delta commitment, otherwise that procedure will abort
@@ -109,7 +111,11 @@ end
 #
 # Inputs:  [scheme_id, PK_COMM, MSG]
 # Outputs: []
-proc verify_signature_by_scheme
+proc verify_signature_by_scheme(
+    scheme_id: SignatureScheme,
+    pk_comm: PublicKeyCommitment,
+    msg: SignatureMessage
+)
     dup eq.ECDSA_K256_KECCAK_SCHEME_ID
     # => [is_one, scheme_id, PK_COMM, MESSAGE]
 
@@ -152,7 +158,7 @@ end
 #! - num_cycles is the estimated upper bound on authenticate_transaction's cycle count.
 #!
 #! Invocation: exec
-pub proc estimate_authentication_cycles
+pub proc estimate_authentication_cycles(scheme_id: SignatureScheme) -> u32
     eq.ECDSA_K256_KECCAK_SCHEME_ID
     # => [is_ecdsa]
 
@@ -195,7 +201,7 @@ end
 #! - num_cycles is the estimated upper bound on the authentication flow's cycle count.
 #!
 #! Invocation: exec
-pub proc estimate_multisig_authentication_cycles
+pub proc estimate_multisig_authentication_cycles(num_of_signers: u8) -> u32
     mul.FALCON_512_POSEIDON2_AUTH_CYCLES add.MULTISIG_AUTH_BASE_CYCLES
     # => [num_cycles]
 end
@@ -205,7 +211,7 @@ end
 #! Outputs: [is_supported]
 #!
 #! Invocation: exec
-pub proc is_supported_scheme
+pub proc is_supported_scheme(scheme_id: felt) -> Bool
     dup eq.ECDSA_K256_KECCAK_SCHEME_ID
     # => [is_1, scheme_id]
 
@@ -221,7 +227,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc assert_supported_scheme
+pub proc assert_supported_scheme(scheme_id: felt)
     exec.is_supported_scheme
     # => [is_supported]
 
@@ -235,7 +241,7 @@ end
 #! Outputs: [SCHEME_ID_WORD]
 #!
 #! Invocation: exec
-pub proc assert_supported_scheme_word
+pub proc assert_supported_scheme_word(scheme_id_word: word) -> SignatureSchemeWord
     dupw exec.assert_supported_scheme
     # => [0, 0, 0, SCHEME_ID_WORD]
 
@@ -264,7 +270,12 @@ end
 #!
 #! Invocation: exec
 @locals(5)
-pub proc verify_signatures
+pub proc verify_signatures(
+    approver_scheme_id_slot_id: StorageSlotId,
+    approver_pub_key_slot_id: StorageSlotId,
+    num_of_approvers: u8,
+    msg: SignatureMessage
+) -> (u8, SignatureMessage)
     loc_store.APPROVER_SCHEME_ID_SLOT_ID_SUFFIX_LOC
     loc_store.APPROVER_SCHEME_ID_SLOT_ID_PREFIX_LOC
     # => [approver_pub_key_slot_id_suffix, approver_pub_key_slot_id_prefix, num_of_approvers, MSG]
@@ -391,7 +402,7 @@ end
 #! Outputs: [APPROVER_MAP_KEY]
 #!
 #! Invocation: exec
-pub proc create_approver_map_key
+pub proc create_approver_map_key(key_index: u32) -> StorageMapKey
     push.0.0.0 movup.3
     # => [APPROVER_MAP_KEY]
 end

--- a/crates/miden-standards/asm/standards/auth/signature.masm
+++ b/crates/miden-standards/asm/standards/auth/signature.masm
@@ -1,4 +1,3 @@
-use {Approver, PublicKeyCommitment, SignatureMessage, SignatureScheme, SignatureSchemeWord} from miden::standards::types
 use {Bool, StorageMapKey, StorageSlotId} from miden::protocol::types
 use miden::core::crypto::dsa::falcon512_poseidon2
 use miden::core::crypto::hashes::poseidon2
@@ -6,6 +5,19 @@ use miden::core::crypto::dsa::ecdsa_k256_keccak
 use {AUTH_REQUEST_EVENT} from miden::protocol::auth
 use miden::protocol::native_account
 use miden::standards::auth
+
+# Schemes 1 (ECDSA) and 2 (Falcon) are currently supported.
+pub type SignatureScheme = u8
+pub type PublicKeyCommitment = word
+pub type SignatureMessage = word
+pub type Approver = struct {
+    public_key: PublicKeyCommitment,
+    scheme: SignatureScheme
+}
+pub type SignatureSchemeWord = struct {
+    scheme: SignatureScheme,
+    padding: [felt; 3]
+}
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/auth/tx_policy.masm
+++ b/crates/miden-standards/asm/standards/auth/tx_policy.masm
@@ -13,7 +13,7 @@ const ERR_AUTH_TRANSACTION_MUST_NOT_INCLUDE_OUTPUT_NOTES = "transaction must not
 #!
 #! Invocation: exec
 @locals(1) # non-auth called proc count
-pub proc assert_only_one_non_auth_procedure_called
+pub proc assert_only_one_non_auth_procedure_called()
     push.0
     loc_store.0
     # => []
@@ -62,7 +62,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc assert_no_input_notes
+pub proc assert_no_input_notes()
     exec.tx::get_num_input_notes
     # => [num_input_notes]
 
@@ -76,7 +76,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc assert_no_output_notes
+pub proc assert_no_output_notes()
     exec.tx::get_num_output_notes
     # => [num_output_notes]
 

--- a/crates/miden-standards/asm/standards/auth/tx_script_allowlist.masm
+++ b/crates/miden-standards/asm/standards/auth/tx_script_allowlist.masm
@@ -1,3 +1,4 @@
+use {StorageSlotId, TransactionScriptRoot} from miden::protocol::types
 # Reusable tx-script allowlist primitive.
 #
 # Provides the operations used to restrict which transaction scripts an account will execute:
@@ -13,7 +14,6 @@
 use miden::protocol::native_account
 use miden::protocol::tx
 use miden::core::word
-use {StorageSlotId, TransactionScriptRoot} from miden::protocol::types
 use {ONE_WORD, ZERO_WORD} from miden::standards::utils
 
 # CONSTANTS

--- a/crates/miden-standards/asm/standards/data_structures/array.masm
+++ b/crates/miden-standards/asm/standards/data_structures/array.masm
@@ -1,3 +1,4 @@
+use {StorageSlotId} from miden::protocol::types
 # The MASM code for the Array abstraction.
 #
 # It provides an abstraction layer over a storage map, treating it as an array,
@@ -24,7 +25,7 @@ use miden::protocol::native_account
 #! - VALUE is the word to store at the specified index.
 #!
 #! Invocation: exec
-pub proc set(slot_id_suffix: felt, slot_id_prefix: felt, index: felt, value: word) -> word
+pub proc set(slot_id: StorageSlotId, index: felt, value: word) -> word
     # Build KEY = [0, 0, 0, index]
     movup.2 push.0.0.0
     # => [0, 0, 0, index, slot_id_suffix, slot_id_prefix, VALUE]
@@ -47,7 +48,7 @@ end
 #! - VALUE is the word stored at the specified index (zero if not set).
 #!
 #! Invocation: exec
-pub proc get(slot_id_suffix: felt, slot_id_prefix: felt, index: felt) -> word
+pub proc get(slot_id: StorageSlotId, index: felt) -> word
     # Build KEY = [0, 0, 0, index]
     movup.2 push.0.0.0
     # => [0, 0, 0, index, slot_id_suffix, slot_id_prefix]

--- a/crates/miden-standards/asm/standards/data_structures/double_word_array.masm
+++ b/crates/miden-standards/asm/standards/data_structures/double_word_array.masm
@@ -1,3 +1,4 @@
+use {StorageSlotId} from miden::protocol::types
 # The MASM code for the Double-Word Array abstraction.
 #
 # It provides an abstraction layer over a storage map, treating it as an array
@@ -17,16 +18,7 @@ const SLOT_ID_PREFIX_LOC=0
 const SLOT_ID_SUFFIX_LOC=1
 const INDEX_LOC=2
 
-pub type DoubleWord = struct {
-    a: felt,
-    b: felt,
-    c: felt,
-    d: felt,
-    e: felt,
-    f: felt,
-    g: felt,
-    h: felt
-}
+pub use {DoubleWord} from miden::protocol::types
 
 # PROCEDURES
 # =================================================================================================
@@ -48,8 +40,7 @@ pub type DoubleWord = struct {
 #! Invocation: exec
 @locals(3)
 pub proc set(
-    slot_id_suffix: felt,
-    slot_id_prefix: felt,
+    slot_id: StorageSlotId,
     index: felt,
     value: DoubleWord
 ) -> DoubleWord
@@ -99,7 +90,7 @@ end
 #!
 #! Invocation: exec
 @locals(3)
-pub proc get(slot_id_suffix: felt, slot_id_prefix: felt, index: felt) -> DoubleWord
+pub proc get(slot_id: StorageSlotId, index: felt) -> DoubleWord
     # Save inputs to locals for reuse.
     loc_store.SLOT_ID_SUFFIX_LOC
     loc_store.SLOT_ID_PREFIX_LOC

--- a/crates/miden-standards/asm/standards/expiration.masm
+++ b/crates/miden-standards/asm/standards/expiration.masm
@@ -28,6 +28,6 @@ pub const DEFAULT_EXPIRATION_BLOCK_DELTA = 20
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc apply_default
+pub proc apply_default()
     push.DEFAULT_EXPIRATION_BLOCK_DELTA exec.tx::update_expiration_block_delta
 end

--- a/crates/miden-standards/asm/standards/faucets/fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/fungible.masm
@@ -1,3 +1,5 @@
+use {TokenConfig, TokenSymbol} from miden::standards::types
+use {Asset, AssetAmount, Bool, NoteRecipient, NoteTag, NoteType} from miden::protocol::types
 # miden::standards::faucets::fungible
 #
 # Fungible faucet logic: token config slot (supply, max_supply, decimals, symbol) and its
@@ -58,7 +60,7 @@ const ERR_FAUCET_BURN_AMOUNT_EXCEEDS_TOKEN_SUPPLY = "asset amount to burn exceed
 #!   (word[0] on top, little-endian).
 #!
 #! Invocation: exec
-proc get_token_config_internal
+proc get_token_config_internal() -> TokenConfig
     push.TOKEN_CONFIG_SLOT[0..2]
     exec.active_account::get_item
 end
@@ -69,7 +71,7 @@ end
 #! Outputs: [is_max_supply_mutable]
 #!
 #! Invocation: exec
-proc is_max_supply_mutable_internal
+proc is_max_supply_mutable_internal() -> Bool
     exec.faucets::get_mutability_config_word
     # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
     drop drop drop
@@ -87,7 +89,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_token_config
+pub proc get_token_config() -> TokenConfig
     exec.get_token_config_internal
     swapw dropw
     # => [token_supply, max_supply, decimals, token_symbol, pad(12)]
@@ -100,7 +102,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_max_supply
+pub proc get_max_supply() -> AssetAmount
     exec.get_token_config_internal
     # => [token_supply, max_supply, decimals, token_symbol, pad(16)]
     swap movdn.4 dropw
@@ -114,7 +116,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_decimals
+pub proc get_decimals() -> u8
     exec.get_token_config_internal
     # => [token_supply, max_supply, decimals, token_symbol, pad(16)]
     movup.2 movdn.4 dropw
@@ -128,7 +130,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_token_symbol
+pub proc get_token_symbol() -> TokenSymbol
     exec.get_token_config_internal
     # => [token_supply, max_supply, decimals, token_symbol, pad(16)]
     movup.3 movdn.4 dropw
@@ -142,7 +144,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_token_supply
+pub proc get_token_supply() -> AssetAmount
     exec.get_token_config_internal
     # => [token_supply, max_supply, decimals, token_symbol, pad(16)]
     movdn.4 dropw
@@ -156,7 +158,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc is_max_supply_mutable
+pub proc is_max_supply_mutable() -> Bool
     exec.is_max_supply_mutable_internal
     # => [is_max_supply_mutable, pad(16)]
     swap drop
@@ -181,7 +183,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc set_max_supply
+pub proc set_max_supply(new_max_supply: AssetAmount)
     # 1. Check max supply mutability
     exec.is_max_supply_mutable_internal
     # => [is_max_supply_mutable, new_max_supply, pad(15)]
@@ -258,7 +260,12 @@ end
 #! Invocation: call
 @locals(8)
 @account_procedure
-pub proc mint_and_send
+pub proc mint_and_send(
+    asset: Asset,
+    tag: NoteTag,
+    note_type: NoteType,
+    recipient: NoteRecipient
+) -> u16
     # save the MINT note's ASSET_ID in a local so it survives the mint policy and supply
     # checks; it is compared against the asset derived for the active faucet before minting
     loc_storew_le.MINT_ASSET_ID_LOCAL dropw
@@ -409,7 +416,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc receive_and_burn
+pub proc receive_and_burn(asset: Asset)
     # validate the asset to burn is well-formed before processing it
     # note that the asset's origin is validated by the kernel
     exec.fungible_asset::validate

--- a/crates/miden-standards/asm/standards/faucets/fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/fungible.masm
@@ -1,4 +1,4 @@
-use {TokenConfig, TokenSymbol} from miden::standards::types
+use {TokenSymbol} from miden::standards::faucets
 use {Asset, AssetAmount, Bool, NoteRecipient, NoteTag, NoteType} from miden::protocol::types
 # miden::standards::faucets::fungible
 #
@@ -19,6 +19,13 @@ use miden::standards::assets::fungible_asset
 use miden::standards::faucets::policies::policy_manager
 use miden::standards::faucets
 use miden::standards::access::pausable
+
+pub type TokenConfig = struct {
+    supply: AssetAmount,
+    max_supply: AssetAmount,
+    decimals: u8,
+    symbol: TokenSymbol
+}
 
 # =================================================================================================
 # CONSTANTS — slot names

--- a/crates/miden-standards/asm/standards/faucets/mod.masm
+++ b/crates/miden-standards/asm/standards/faucets/mod.masm
@@ -1,4 +1,4 @@
-use {Commitment, MetadataStringCommitment, MutabilityConfig, TokenName} from miden::standards::types
+use {Commitment} from miden::standards::types
 use {Bool} from miden::protocol::types
 # miden::standards::faucets
 #
@@ -14,6 +14,16 @@ use miden::protocol::active_account
 use miden::protocol::native_account
 use miden::standards::access::authority
 use miden::standards::access::pausable
+
+pub type TokenSymbol = felt
+pub type MutabilityConfig = struct {
+    description: Bool,
+    logo_uri: Bool,
+    external_link: Bool,
+    max_supply: Bool
+}
+pub type TokenName = struct { first: word, second: word }
+pub type MetadataStringCommitment = word
 
 pub mod fungible
 pub mod non_fungible

--- a/crates/miden-standards/asm/standards/faucets/mod.masm
+++ b/crates/miden-standards/asm/standards/faucets/mod.masm
@@ -1,3 +1,5 @@
+use {Commitment, MetadataStringCommitment, MutabilityConfig, TokenName} from miden::standards::types
+use {Bool} from miden::protocol::types
 # miden::standards::faucets
 #
 # Shared token metadata storage layout and accessors for faucet accounts. Holds the token name
@@ -65,7 +67,7 @@ const ERR_EXTERNAL_LINK_NOT_MUTABLE = "external link is not mutable"
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_name
+pub proc get_name() -> TokenName
     exec.get_name_chunk_1
     exec.get_name_chunk_0
     swapdw dropw dropw
@@ -79,7 +81,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_mutability_config
+pub proc get_mutability_config() -> MutabilityConfig
     exec.get_mutability_config_word
     # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable, pad(16)]
     swapw dropw
@@ -93,7 +95,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc is_description_mutable
+pub proc is_description_mutable() -> Bool
     exec.is_description_mutable_internal
     # => [is_description_mutable, pad(16)]
     swap drop
@@ -107,7 +109,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc is_logo_uri_mutable
+pub proc is_logo_uri_mutable() -> Bool
     exec.is_logo_uri_mutable_internal
     # => [is_logo_uri_mutable, pad(16)]
     swap drop
@@ -121,7 +123,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc is_external_link_mutable
+pub proc is_external_link_mutable() -> Bool
     exec.is_external_link_mutable_internal
     # => [is_external_link_mutable, pad(16)]
     swap drop
@@ -154,7 +156,7 @@ end
 #! Invocation: call
 @locals(28)
 @account_procedure
-pub proc set_description
+pub proc set_description(description_hash: MetadataStringCommitment)
     # Check mutability; verify owner.
     # => [DESCRIPTION_HASH, pad(12)]
 
@@ -231,7 +233,7 @@ end
 #! Invocation: call
 @locals(28)
 @account_procedure
-pub proc set_logo_uri
+pub proc set_logo_uri(logo_uri_hash: MetadataStringCommitment)
     # Check mutability; verify owner.
     # => [LOGO_URI_HASH, pad(12)]
 
@@ -307,7 +309,7 @@ end
 #! Invocation: call
 @locals(28)
 @account_procedure
-pub proc set_external_link
+pub proc set_external_link(external_link_hash: MetadataStringCommitment)
     # Check mutability; verify owner.
     # => [EXTERNAL_LINK_HASH, pad(12)]
 
@@ -370,7 +372,7 @@ end
 #!   (word[0] on top after get_item, little-endian).
 #!
 #! Invocation: exec
-pub proc get_mutability_config_word
+pub proc get_mutability_config_word() -> (Bool, Bool, Bool, Bool)
     push.MUTABILITY_CONFIG_SLOT[0..2]
     exec.active_account::get_item
 end
@@ -384,7 +386,7 @@ end
 #! Outputs: [NAME_CHUNK_0]
 #!
 #! Invocation: exec
-proc get_name_chunk_0
+proc get_name_chunk_0() -> word
     push.TOKEN_NAME_0_SLOT[0..2]
     exec.active_account::get_item
 end
@@ -395,7 +397,7 @@ end
 #! Outputs: [NAME_CHUNK_1]
 #!
 #! Invocation: exec
-proc get_name_chunk_1
+proc get_name_chunk_1() -> word
     push.TOKEN_NAME_1_SLOT[0..2]
     exec.active_account::get_item
 end
@@ -408,7 +410,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-proc pipe_to_memory
+proc pipe_to_memory(write_ptr: ptr<felt>, commitment: Commitment)
     push.7
     exec.mem::pipe_preimage_to_memory
     # => [write_ptr']
@@ -424,7 +426,7 @@ end
 #! Outputs: [is_description_mutable]
 #!
 #! Invocation: exec
-proc is_description_mutable_internal
+proc is_description_mutable_internal() -> Bool
     exec.get_mutability_config_word
     # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
     movdn.3 drop drop drop
@@ -437,7 +439,7 @@ end
 #! Outputs: [is_logo_uri_mutable]
 #!
 #! Invocation: exec
-proc is_logo_uri_mutable_internal
+proc is_logo_uri_mutable_internal() -> Bool
     exec.get_mutability_config_word
     # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
     drop movdn.2 drop drop
@@ -450,7 +452,7 @@ end
 #! Outputs: [is_external_link_mutable]
 #!
 #! Invocation: exec
-proc is_external_link_mutable_internal
+proc is_external_link_mutable_internal() -> Bool
     exec.get_mutability_config_word
     # => [is_description_mutable, is_logo_uri_mutable, is_external_link_mutable, is_max_supply_mutable]
     drop drop swap drop

--- a/crates/miden-standards/asm/standards/faucets/non_fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/non_fungible.masm
@@ -1,4 +1,4 @@
-use {TokenId, TokenStatus, TokenStatusValue, TokenSymbol} from miden::standards::types
+use {TokenSymbol} from miden::standards::faucets
 use {Asset, NoteRecipient, NoteTag, NoteType, StorageMapKey} from miden::protocol::types
 # miden::standards::faucets::non_fungible
 #
@@ -39,6 +39,13 @@ use miden::protocol::native_account
 use miden::protocol::output_note
 use miden::standards::assets::non_fungible_asset
 use miden::standards::faucets::policies::policy_manager
+
+pub type TokenId = struct { suffix: felt, prefix: felt }
+pub type TokenStatus = u8
+pub type TokenStatusValue = struct {
+    status: TokenStatus,
+    padding: [felt; 3]
+}
 
 # =================================================================================================
 # CONSTANTS — slot names

--- a/crates/miden-standards/asm/standards/faucets/non_fungible.masm
+++ b/crates/miden-standards/asm/standards/faucets/non_fungible.masm
@@ -1,3 +1,5 @@
+use {TokenId, TokenStatus, TokenStatusValue, TokenSymbol} from miden::standards::types
+use {Asset, NoteRecipient, NoteTag, NoteType, StorageMapKey} from miden::protocol::types
 # miden::standards::faucets::non_fungible
 #
 # Non-fungible (NFT) faucet logic: the token symbol slot and accessor, an asset-status registry
@@ -80,7 +82,7 @@ const ERR_MINT_NOTE_ASSET_NOT_FROM_THIS_FAUCET = "the asset stored in the MINT n
 #!   values that collide in their first two elements cannot produce two distinct status keys.
 #!
 #! Invocation: exec
-proc create_status_key
+proc create_status_key(token_id: TokenId) -> StorageMapKey
     push.0 push.0
     # => [0, 0, token_id_suffix, token_id_prefix]
 
@@ -97,7 +99,7 @@ end
 #! - STATUS_VALUE is `[status, 0, 0, 0]`.
 #!
 #! Invocation: exec
-proc build_status_value
+proc build_status_value(status: TokenStatus) -> TokenStatusValue
     push.0 push.0 push.0
     # => [0, 0, 0, status]
 
@@ -114,7 +116,7 @@ end
 #! - status is the first element of the registry value word; the other elements are always zero.
 #!
 #! Invocation: exec
-proc get_status_by_key
+proc get_status_by_key(status_key: StorageMapKey) -> TokenStatus
     push.ASSET_STATUS_SLOT[0..2]
     exec.active_account::get_map_item
     # => [status, 0, 0, 0]
@@ -134,7 +136,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_symbol
+pub proc get_symbol() -> TokenSymbol
     push.SYMBOL_SLOT[0..2] exec.active_account::get_item
     # => [symbol, 0, 0, 0, pad(16)]
 
@@ -157,7 +159,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_asset_status
+pub proc get_asset_status(token_id: TokenId) -> TokenStatus
     exec.create_status_key
     # => [STATUS_KEY, pad(14)]
 
@@ -204,7 +206,12 @@ end
 #! Invocation: call
 @locals(8)
 @account_procedure
-pub proc mint_and_send
+pub proc mint_and_send(
+    asset: Asset,
+    tag: NoteTag,
+    note_type: NoteType,
+    recipient: NoteRecipient
+) -> u16
     # save the MINT note's ASSET_ID
     loc_storew_le.MINT_ASSET_ID_LOCAL dropw
     # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(6)]
@@ -301,7 +308,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc receive_and_burn
+pub proc receive_and_burn(asset: Asset)
     # validate the asset to burn is well-formed before processing it
     # note that the asset's origin is validated by the kernel
     exec.non_fungible_asset::validate

--- a/crates/miden-standards/asm/standards/faucets/policies/burn/allow_all.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/burn/allow_all.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol::types
 # Generic burn policy procedures shared by policy manager flows.
 
 # POLICY PROCEDURES
@@ -10,7 +11,7 @@
 #!
 #! Invocation: call
 @account_procedure
-pub proc check_policy
+pub proc check_policy(asset: Asset)
     dropw dropw
     # => [pad(16)]
 end

--- a/crates/miden-standards/asm/standards/faucets/policies/burn/min_burn_amount.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/burn/min_burn_amount.masm
@@ -1,3 +1,4 @@
+use {Asset, AssetAmount} from miden::protocol::types
 # miden::standards::faucets::policies::burn::min_burn_amount
 #
 # `min_burn_amount` burn policy: rejects burns whose amount is below a configurable minimum.
@@ -40,7 +41,7 @@ const ERR_BURN_AMOUNT_BELOW_MIN_BURN_AMOUNT = "amount to be burned must meet or 
 #!
 #! Invocation: call
 @account_procedure
-pub proc check_policy
+pub proc check_policy(asset: Asset)
     dropw
     # => [ASSET_VALUE, pad(12)]
 
@@ -68,7 +69,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_min_burn_amount
+pub proc get_min_burn_amount() -> AssetAmount
     push.MIN_BURN_AMOUNT_SLOT[0..2] exec.active_account::get_item
     # => [min_burn_amount, 0, 0, 0, pad(16)]
 
@@ -88,7 +89,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc set_min_burn_amount
+pub proc set_min_burn_amount(new_min_burn_amount: AssetAmount)
     exec.authority::assert_authorized
     # => [new_min_burn_amount, pad(15)]
 

--- a/crates/miden-standards/asm/standards/faucets/policies/burn/owner_controlled/owner_only.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/burn/owner_controlled/owner_only.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol::types
 # miden::standards::faucets::policies::burn::owner_controlled::owner_only
 #
 # Owner-only burn policy: gates burning on the Ownable2Step owner via
@@ -22,7 +23,7 @@ use miden::standards::access::ownable2step
 #!
 #! Invocation: call
 @account_procedure
-pub proc check_policy
+pub proc check_policy(asset: Asset)
     exec.ownable2step::assert_sender_is_owner
     # => [ASSET_ID, ASSET_VALUE, pad(8)]
 

--- a/crates/miden-standards/asm/standards/faucets/policies/mint/allow_all.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/mint/allow_all.masm
@@ -1,3 +1,4 @@
+use {AssetValue, NoteRecipient, NoteTag, NoteType} from miden::protocol::types
 # Generic mint policy procedures shared by policy manager flows.
 
 # POLICY PROCEDURES
@@ -10,6 +11,11 @@
 #!
 #! Invocation: call
 @account_procedure
-pub proc check_policy
+pub proc check_policy(
+    asset_value: AssetValue,
+    tag: NoteTag,
+    note_type: NoteType,
+    recipient: NoteRecipient
+) -> (AssetValue, NoteTag, NoteType, NoteRecipient)
     push.0 drop
 end

--- a/crates/miden-standards/asm/standards/faucets/policies/mint/owner_controlled/owner_only.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/mint/owner_controlled/owner_only.masm
@@ -1,3 +1,4 @@
+use {AssetValue, NoteRecipient, NoteTag, NoteType} from miden::protocol::types
 # miden::standards::faucets::policies::mint::owner_controlled::owner_only
 #
 # Owner-only mint policy: gates minting on the Ownable2Step owner via
@@ -22,7 +23,12 @@ use miden::standards::access::ownable2step
 #!
 #! Invocation: call
 @account_procedure
-pub proc check_policy
+pub proc check_policy(
+    asset_value: AssetValue,
+    tag: NoteTag,
+    note_type: NoteType,
+    recipient: NoteRecipient
+) -> (AssetValue, NoteTag, NoteType, NoteRecipient)
     exec.ownable2step::assert_sender_is_owner
     # => [ASSET_VALUE, tag, note_type, RECIPIENT, pad(6)]
 end

--- a/crates/miden-standards/asm/standards/faucets/policies/policy_manager.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/policy_manager.masm
@@ -1,3 +1,4 @@
+use {AccountProcedureRoot, Asset, AssetValue, NoteRecipient, NoteTag, NoteType, StorageSlotId} from miden::protocol::types
 use miden::core::word
 use miden::protocol::active_account
 use miden::protocol::native_account
@@ -83,7 +84,7 @@ const ERR_RECEIVE_POLICY_ROOT_NOT_ALLOWED="receive policy root is not allowed"
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_mint_policy
+pub proc get_mint_policy() -> AccountProcedureRoot
     exec.get_mint_policy_root
     # => [MINT_POLICY_ROOT, pad(16)]
 
@@ -104,7 +105,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc set_mint_policy
+pub proc set_mint_policy(new_policy_root: AccountProcedureRoot)
     exec.authority::assert_authorized
     # => [NEW_POLICY_ROOT, pad(12)]
 
@@ -122,7 +123,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_burn_policy
+pub proc get_burn_policy() -> AccountProcedureRoot
     exec.get_burn_policy_root
     # => [BURN_POLICY_ROOT, pad(16)]
 
@@ -143,7 +144,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc set_burn_policy
+pub proc set_burn_policy(new_policy_root: AccountProcedureRoot)
     exec.authority::assert_authorized
     # => [NEW_POLICY_ROOT, pad(12)]
 
@@ -171,7 +172,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc invoke_send_policy
+pub proc invoke_send_policy(asset: Asset, note_idx: u16)
     push.ACTIVE_SEND_POLICY_PROC_ROOT_SLOT[0..2]
     # => [slot_id_suffix, slot_id_prefix, ASSET_ID, ASSET_VALUE, note_idx, pad(7)]
 
@@ -186,7 +187,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_send_policy
+pub proc get_send_policy() -> AccountProcedureRoot
     push.ACTIVE_SEND_POLICY_PROC_ROOT_SLOT[0..2] exec.active_account::get_item
     # => [SEND_POLICY_ROOT, pad(16)]
 
@@ -209,7 +210,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc set_send_policy
+pub proc set_send_policy(new_policy_root: AccountProcedureRoot)
     exec.authority::assert_authorized
     # => [NEW_POLICY_ROOT, pad(12)]
 
@@ -240,7 +241,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc invoke_receive_policy
+pub proc invoke_receive_policy(asset: Asset, custom_data: felt)
     push.ACTIVE_RECEIVE_POLICY_PROC_ROOT_SLOT[0..2]
     # => [slot_id_suffix, slot_id_prefix, ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
 
@@ -255,7 +256,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_receive_policy
+pub proc get_receive_policy() -> AccountProcedureRoot
     push.ACTIVE_RECEIVE_POLICY_PROC_ROOT_SLOT[0..2] exec.active_account::get_item
     # => [RECEIVE_POLICY_ROOT, pad(16)]
 
@@ -278,7 +279,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc set_receive_policy
+pub proc set_receive_policy(new_policy_root: AccountProcedureRoot)
     exec.authority::assert_authorized
     # => [NEW_POLICY_ROOT, pad(12)]
 
@@ -317,7 +318,12 @@ end
 #!
 #! Invocation: exec
 @locals(12)
-pub proc execute_mint_policy
+pub proc execute_mint_policy(
+    asset_value: AssetValue,
+    tag: NoteTag,
+    note_type: NoteType,
+    recipient: NoteRecipient
+) -> (AssetValue, NoteTag, NoteType, NoteRecipient)
     exec.pausable::assert_not_paused
     # => [ASSET_VALUE, tag, note_type, RECIPIENT]
 
@@ -389,7 +395,7 @@ end
 #!
 #! Invocation: exec
 @locals(4)
-pub proc execute_burn_policy
+pub proc execute_burn_policy(asset: Asset)
     exec.pausable::assert_not_paused
     # => [ASSET_ID, ASSET_VALUE]
 
@@ -427,7 +433,7 @@ end
 #! Outputs: [MINT_POLICY_ROOT]
 #!
 #! Invocation: exec
-proc get_mint_policy_root
+proc get_mint_policy_root() -> AccountProcedureRoot
     push.ACTIVE_MINT_POLICY_PROC_ROOT_SLOT[0..2] exec.active_account::get_item
     # => [MINT_POLICY_ROOT]
 end
@@ -443,7 +449,7 @@ end
 #! - policy root is not in the allowed mint policy roots map.
 #!
 #! Invocation: exec
-proc assert_allowed_mint_policy_root
+proc assert_allowed_mint_policy_root(mint_policy_root: AccountProcedureRoot) -> AccountProcedureRoot
     exec.word::testz
     assertz.err=ERR_MINT_POLICY_ROOT_IS_ZERO
     # => [MINT_POLICY_ROOT]
@@ -511,7 +517,7 @@ end
 #! Outputs: [BURN_POLICY_ROOT]
 #!
 #! Invocation: exec
-proc get_burn_policy_root
+proc get_burn_policy_root() -> AccountProcedureRoot
     push.ACTIVE_BURN_POLICY_PROC_ROOT_SLOT[0..2] exec.active_account::get_item
     # => [BURN_POLICY_ROOT]
 end
@@ -527,7 +533,7 @@ end
 #! - policy root is not in the allowed burn policy roots map.
 #!
 #! Invocation: exec
-proc assert_allowed_burn_policy_root
+proc assert_allowed_burn_policy_root(burn_policy_root: AccountProcedureRoot) -> AccountProcedureRoot
     exec.word::testz
     assertz.err=ERR_BURN_POLICY_ROOT_IS_ZERO
     # => [BURN_POLICY_ROOT]
@@ -557,7 +563,7 @@ end
 #! - policy root is not in the allowed send policy roots map.
 #!
 #! Invocation: exec
-proc assert_allowed_send_policy_root
+proc assert_allowed_send_policy_root(send_policy_root: AccountProcedureRoot) -> AccountProcedureRoot
     exec.word::testz
     assertz.err=ERR_SEND_POLICY_ROOT_IS_ZERO
     # => [SEND_POLICY_ROOT]
@@ -587,7 +593,7 @@ end
 #! - policy root is not in the allowed receive policy roots map.
 #!
 #! Invocation: exec
-proc assert_allowed_receive_policy_root
+proc assert_allowed_receive_policy_root(receive_policy_root: AccountProcedureRoot) -> AccountProcedureRoot
     exec.word::testz
     assertz.err=ERR_RECEIVE_POLICY_ROOT_IS_ZERO
     # => [RECEIVE_POLICY_ROOT]
@@ -630,7 +636,7 @@ end
 #!
 #! Invocation: exec
 @locals(4)
-proc invoke_transfer_policy
+proc invoke_transfer_policy(slot_id: StorageSlotId, asset: Asset, custom_data: felt)
     exec.active_account::get_item
     # => [POLICY_ROOT, ASSET_ID, ASSET_VALUE, custom_data]
 

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/allow_all.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/allow_all.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol::types
 # Generic transfer policy procedures shared by policy manager flows.
 
 # POLICY PROCEDURES
@@ -17,7 +18,7 @@
 #!
 #! Invocation: call
 @account_procedure
-pub proc check_policy
+pub proc check_policy(asset: Asset, custom_data: felt)
     dropw dropw drop
     # => [pad(16)]
 end

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/allowlist/manager.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/allowlist/manager.masm
@@ -1,3 +1,4 @@
+use {AccountId} from miden::protocol::types
 # miden::standards::faucets::policies::transfer::allowlist::manager
 #
 # Authority-gated allowlist admin: wraps the `Invocation: exec` helpers from
@@ -29,7 +30,7 @@ use miden::standards::faucets::policies::transfer::allowlist
 #!
 #! Invocation: call
 @account_procedure
-pub proc allow_account
+pub proc allow_account(account_id: AccountId)
     exec.authority::assert_authorized
     # => [account_id_suffix, account_id_prefix, pad(14)]
 
@@ -47,7 +48,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc disallow_account
+pub proc disallow_account(account_id: AccountId)
     exec.authority::assert_authorized
     # => [account_id_suffix, account_id_prefix, pad(14)]
 

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/allowlist/mod.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/allowlist/mod.masm
@@ -1,3 +1,4 @@
+use {AccountId, Bool, StorageMapKey} from miden::protocol::types
 # miden::standards::faucets::policies::transfer::allowlist
 #
 # Per-faucet allowlist primitive: storage slot plus low-level `Invocation: exec` helpers.
@@ -49,7 +50,7 @@ const ERR_ACCOUNT_IS_NOT_ALLOWED = "account is not in the allowlist"
 #! Outputs: [is_allowed]
 #!
 #! Invocation: exec
-pub proc is_allowed
+pub proc is_allowed(account_id: AccountId) -> Bool
     exec.build_allowed_accounts_map_key
     # => [KEY]
 
@@ -71,7 +72,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc allow_account
+pub proc allow_account(account_id: AccountId)
     exec.build_allowed_accounts_map_key
     # => [KEY]
 
@@ -95,7 +96,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc disallow_account
+pub proc disallow_account(account_id: AccountId)
     exec.build_allowed_accounts_map_key
     # => [KEY]
 
@@ -128,7 +129,7 @@ end
 #! - the stored entry for this account is the zero word.
 #!
 #! Invocation: exec
-pub proc assert_allowed
+pub proc assert_allowed(account_id: AccountId)
     exec.is_allowed
     # => [is_allowed]
 
@@ -148,7 +149,7 @@ end
 #! - KEY is [0, 0, account_id_suffix, account_id_prefix].
 #!
 #! Invocation: exec
-proc build_allowed_accounts_map_key
+proc build_allowed_accounts_map_key(account_id: AccountId) -> StorageMapKey
     push.0.0
     # => [0, 0, account_id_suffix, account_id_prefix]
     # => [KEY]

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/basic_allowlist.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/basic_allowlist.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol::types
 # miden::standards::faucets::policies::transfer::basic_allowlist
 #
 # Basic allowlist transfer policy: rejects transfers whose native account is not allowed on the
@@ -38,7 +39,7 @@ use miden::standards::expiration
 #!
 #! Invocation: call
 @account_procedure
-pub proc check_policy
+pub proc check_policy(asset: Asset, custom_data: felt)
     exec.expiration::apply_default
     # => [ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
 

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/basic_blocklist.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/basic_blocklist.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol::types
 # miden::standards::faucets::policies::transfer::basic_blocklist
 #
 # Basic blocklist transfer policy: rejects transfers whose native account is blocked on the
@@ -36,7 +37,7 @@ use miden::standards::expiration
 #!
 #! Invocation: call
 @account_procedure
-pub proc check_policy
+pub proc check_policy(asset: Asset, custom_data: felt)
     exec.expiration::apply_default
     # => [ASSET_ID, ASSET_VALUE, custom_data, pad(7)]
 

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/blocklist/manager.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/blocklist/manager.masm
@@ -1,3 +1,4 @@
+use {AccountId} from miden::protocol::types
 # miden::standards::faucets::policies::transfer::blocklist::manager
 #
 # Authority-gated blocklist admin: wraps the `Invocation: exec` helpers from
@@ -29,7 +30,7 @@ use miden::standards::faucets::policies::transfer::blocklist
 #!
 #! Invocation: call
 @account_procedure
-pub proc block_account
+pub proc block_account(account_id: AccountId)
     exec.authority::assert_authorized
     # => [account_id_suffix, account_id_prefix, pad(14)]
 
@@ -47,7 +48,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc unblock_account
+pub proc unblock_account(account_id: AccountId)
     exec.authority::assert_authorized
     # => [account_id_suffix, account_id_prefix, pad(14)]
 

--- a/crates/miden-standards/asm/standards/faucets/policies/transfer/blocklist/mod.masm
+++ b/crates/miden-standards/asm/standards/faucets/policies/transfer/blocklist/mod.masm
@@ -1,3 +1,4 @@
+use {AccountId, Bool, StorageMapKey} from miden::protocol::types
 # miden::standards::faucets::policies::transfer::blocklist
 #
 # Per-faucet blocklist primitive: storage slot plus low-level `Invocation: exec` helpers.
@@ -47,7 +48,7 @@ const ERR_ACCOUNT_IS_BLOCKED = "account is blocked"
 #! Outputs: [is_blocked]
 #!
 #! Invocation: exec
-pub proc is_blocked
+pub proc is_blocked(account_id: AccountId) -> Bool
     exec.build_blocked_accounts_map_key
     # => [KEY]
 
@@ -71,7 +72,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc block_account
+pub proc block_account(account_id: AccountId)
     exec.build_blocked_accounts_map_key
     # => [KEY]
 
@@ -95,7 +96,7 @@ end
 #! Outputs: []
 #!
 #! Invocation: exec
-pub proc unblock_account
+pub proc unblock_account(account_id: AccountId)
     exec.build_blocked_accounts_map_key
     # => [KEY]
 
@@ -127,7 +128,7 @@ end
 #! - the stored entry for this account is not the zero word.
 #!
 #! Invocation: exec
-pub proc assert_not_blocked
+pub proc assert_not_blocked(account_id: AccountId)
     exec.is_blocked
     # => [is_blocked]
 
@@ -150,7 +151,7 @@ end
 #! - KEY is [0, 0, account_id_suffix, account_id_prefix].
 #!
 #! Invocation: exec
-proc build_blocked_accounts_map_key
+proc build_blocked_accounts_map_key(account_id: AccountId) -> StorageMapKey
     push.0.0
     # => [0, 0, account_id_suffix, account_id_prefix]
     # => [KEY]

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol::types
 use miden::core::crypto::hashes::poseidon2
 use miden::core::math::u64
 use miden::core::math::u128

--- a/crates/miden-standards/asm/standards/fee/mod.masm
+++ b/crates/miden-standards/asm/standards/fee/mod.masm
@@ -1,4 +1,3 @@
-use {Asset} from miden::protocol::types
 use miden::core::crypto::hashes::poseidon2
 use miden::core::math::u64
 use miden::core::math::u128

--- a/crates/miden-standards/asm/standards/fees/fee_manager.masm
+++ b/crates/miden-standards/asm/standards/fees/fee_manager.masm
@@ -1,3 +1,4 @@
+use {AccountProcedureRoot, Asset, AssetId, NoteRecipient} from miden::protocol::types
 # miden::standards::fees::fee_manager
 #
 # Fee estimation reads the procedure root of the active fee policy and dispatches fee estimation
@@ -18,7 +19,6 @@ use miden::protocol::native_account
 use miden::standards::access::authority
 use miden::standards::expiration
 
-use {AccountProcedureRoot, Asset, AssetId, NoteRecipient} from miden::protocol::types
 use {ONE_WORD, ZERO_WORD} from miden::standards::utils
 
 # DEPENDENCY NOTE

--- a/crates/miden-standards/asm/standards/fees/mod.masm
+++ b/crates/miden-standards/asm/standards/fees/mod.masm
@@ -1,3 +1,4 @@
+use {Asset, AssetAmount, AssetId, Bool, NoteId} from miden::protocol::types
 # miden::standards::fees
 #
 # Fee collection and sponsorship-note creation for the fee manager account.
@@ -29,7 +30,6 @@ use {NUM_ASSETS as SPONSORSHIP_NUM_ASSETS, FEATURE_NOTE_ID_ITEM_OFFSET} from mid
 use {NETWORK_ACCOUNT_TARGET_ATTACHMENT_SCHEME, NETWORK_ACCOUNT_TARGET_ATTACHMENT_NUM_WORDS}
     from miden::standards::attachments::network_account_target
 
-use {Asset, AssetId, Bool} from miden::protocol::types
 
 pub mod fee_manager
 pub mod policies
@@ -355,7 +355,7 @@ end
 #! - num_elements is the number of elements to clear.
 #!
 #! Invocation: exec
-proc zeroize_elements
+proc zeroize_elements(num_elements: u32, start_ptr: ptr<felt>)
     # the number of elements is bounded by the kernel's input note limit, so it is a valid u32
     # rounds up to the next multiple of WORD_NUM_ELEMENTS by adding 3 and masking out the two least
     # significant bits
@@ -402,7 +402,7 @@ end
 #! - is_sponsorship is 1 if the note's script is the FEE_SPONSORSHIP script, 0 otherwise.
 #!
 #! Invocation: exec
-proc is_sponsorship_note
+proc is_sponsorship_note(note_idx: u16) -> Bool
     exec.input_note::get_script_root
     procref.fee_sponsorship::main
     # => [SPONSORSHIP_NOTE_SCRIPT_ROOT, NOTE_SCRIPT_ROOT]
@@ -422,7 +422,7 @@ end
 #!
 #! Invocation: exec
 @locals(8)
-proc get_sponsored_feature_note_id
+proc get_sponsored_feature_note_id(note_index: u16) -> NoteId
     # write the sponsorship note's storage items to memory
     locaddr.SPONSORSHIP_STORAGE_LOC swap exec.note::input_note_get_storage
     # => []
@@ -449,7 +449,7 @@ end
 #! - an input note's required fee exceeds the fee collected for it.
 #!
 #! Invocation: exec
-proc assert_input_note_fees_covered
+proc assert_input_note_fees_covered(num_input_notes: u32, required_fee_table_ptr: ptr<AssetAmount>)
     # walking entry pointers rather than note indices keeps the loop free of address arithmetic
     dup.1 add swap
     # => [entry_ptr, end_ptr]
@@ -487,7 +487,7 @@ end
 #! - required_fee_amount is the fee amount charged for the note, or 0 if the policy prices it to 0.
 #!
 #! Invocation: exec
-proc estimate_input_note_fee
+proc estimate_input_note_fee(note_index: u16) -> AssetAmount
     dup exec.input_note::get_recipient
     # => [RECIPIENT, note_index]
 
@@ -534,7 +534,7 @@ end
 #! - adding the asset to the vault overflows the fungible asset maximum.
 #!
 #! Invocation: exec
-proc move_sponsored_fee_to_vault
+proc move_sponsored_fee_to_vault(note_index: u16, fee_asset_id: AssetId) -> AssetAmount
     # move the sponsorship note's single asset into the vault
     exec.move_asset_to_vault
     # => [ASSET_ID, ASSET_VALUE, FEE_ASSET_ID]
@@ -564,7 +564,7 @@ end
 #!
 #! Invocation: exec
 @locals(8)
-proc move_asset_to_vault
+proc move_asset_to_vault(note_index: u16) -> Asset
     # remove all remaining assets from the note into the local buffer
     locaddr.0 exec.input_note::remove_all_assets
     # => [num_assets]

--- a/crates/miden-standards/asm/standards/fees/policies/basic_constant_fee.masm
+++ b/crates/miden-standards/asm/standards/fees/policies/basic_constant_fee.masm
@@ -1,3 +1,4 @@
+use {Asset, NoteRecipient, StorageMapKey} from miden::protocol::types
 # miden::standards::fees::policies::basic_constant_fee
 #
 # Basic constant fee policy: derives the fee from a fixed per-note-script fee schedule. It is a
@@ -19,7 +20,6 @@ use miden::protocol::active_account
 use miden::standards::fees::fee_manager
 use miden::standards::note
 
-use {Asset, NoteRecipient, StorageMapKey} from miden::protocol::types
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/fees/policies/constant_fee_manager.masm
+++ b/crates/miden-standards/asm/standards/fees/policies/constant_fee_manager.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol::types
 # miden::standards::fees::policies::constant_fee_manager
 #
 # Authority-gated admin for a constant-fee schedule: exposes `set_note_fee`, which updates a single
@@ -14,7 +15,6 @@ use miden::protocol::native_account
 use miden::standards::access::authority
 use miden::standards::fees::fee_manager
 
-use {Asset} from miden::protocol::types
 use miden::standards::assets::fungible_asset
 
 # CONSTANTS

--- a/crates/miden-standards/asm/standards/inspection/code_inspection.masm
+++ b/crates/miden-standards/asm/standards/inspection/code_inspection.masm
@@ -1,3 +1,5 @@
+use {CodeCommitment} from miden::standards::types
+use {AccountProcedureRoot, Bool} from miden::protocol::types
 # miden::standards::inspection::code_inspection
 #
 # Read-only introspection over the active account's own code. These procedures wrap the
@@ -21,7 +23,7 @@ use miden::protocol::active_account
 #!
 #! Invocation: call
 @account_procedure
-pub proc has_procedure
+pub proc has_procedure(proc_root: AccountProcedureRoot) -> Bool
     exec.active_account::has_procedure
 end
 
@@ -35,7 +37,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_code_commitment
+pub proc get_code_commitment() -> CodeCommitment
     exec.active_account::get_code_commitment
     # => [CODE_COMMITMENT, pad(16)]
 
@@ -54,7 +56,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_num_procedures
+pub proc get_num_procedures() -> u32
     exec.active_account::get_num_procedures
     # => [num_procedures, pad(16)]
 
@@ -77,7 +79,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_procedure_root
+pub proc get_procedure_root(index: u32) -> AccountProcedureRoot
     exec.active_account::get_procedure_root
     # => [PROC_ROOT, pad(15)]
 

--- a/crates/miden-standards/asm/standards/inspection/code_inspection.masm
+++ b/crates/miden-standards/asm/standards/inspection/code_inspection.masm
@@ -1,4 +1,3 @@
-use {CodeCommitment} from miden::standards::types
 use {AccountProcedureRoot, Bool} from miden::protocol::types
 # miden::standards::inspection::code_inspection
 #
@@ -9,6 +8,8 @@ use {AccountProcedureRoot, Bool} from miden::protocol::types
 # account can do without being granted access to the account's storage or vault.
 
 use miden::protocol::active_account
+
+pub type CodeCommitment = word
 
 #! Returns the binary flag indicating whether the procedure with the provided root is available on
 #! the active account.

--- a/crates/miden-standards/asm/standards/inspection/storage_schema.masm
+++ b/crates/miden-standards/asm/standards/inspection/storage_schema.masm
@@ -1,9 +1,10 @@
-use {StorageSchemaCommitment} from miden::standards::types
 # This module defines the storage schema functionality for accounts. It exposes the storage
 # slot at which an account stores a commitment to its storage schema, and provides a helper
 # procedure to load that commitment from the active account's storage.
 
 use miden::protocol::active_account
+
+pub type StorageSchemaCommitment = word
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/inspection/storage_schema.masm
+++ b/crates/miden-standards/asm/standards/inspection/storage_schema.masm
@@ -1,3 +1,4 @@
+use {StorageSchemaCommitment} from miden::standards::types
 # This module defines the storage schema functionality for accounts. It exposes the storage
 # slot at which an account stores a commitment to its storage schema, and provides a helper
 # procedure to load that commitment from the active account's storage.
@@ -20,7 +21,7 @@ const SCHEMA_COMMITMENT_SLOT = word("miden::standards::inspection::storage_schem
 #!
 #! Invocation: call
 @account_procedure
-pub proc get_schema_commitment
+pub proc get_schema_commitment() -> StorageSchemaCommitment
     push.SCHEMA_COMMITMENT_SLOT[0..2] exec.active_account::get_item
     # => [SCHEMA_COMMITMENT, pad(16)]
 

--- a/crates/miden-standards/asm/standards/interop/eth.masm
+++ b/crates/miden-standards/asm/standards/interop/eth.masm
@@ -1,11 +1,15 @@
+use {AccountId} from miden::protocol::types
 use miden::standards::utils
 use miden::protocol::account_id
 
 # TYPE ALIASES
 # =================================================================================================
 
-pub type EthereumAddress = struct { a: felt, b: felt, c: felt, d: felt, e: felt }
-pub type EthereumBytes32 = struct { a: felt, b: felt, c: felt, d: felt, e: felt, f: felt, g: felt, h: felt }
+# Two numeric u32 limbs in low-to-high order, with bytes reversed within each limb.
+pub type ByteSwappedU64 = struct { lo: u32, hi: u32 }
+
+pub type EthereumAddress = struct { a: u32, b: u32, c: u32, d: u32, e: u32 }
+pub type EthereumBytes32 = struct { a: u32, b: u32, c: u32, d: u32, e: u32, f: u32, g: u32, h: u32 }
 
 # ERRORS
 # =================================================================================================
@@ -48,7 +52,7 @@ const ERR_BYTES32_PADDING_NONZERO="leading 12 bytes must be zero for a bytes32-e
 #! - the decoded (suffix, prefix) is not a structurally valid AccountId.
 #!
 #! Invocation: exec
-pub proc to_account_id
+pub proc to_account_id(address: EthereumAddress) -> AccountId
     # limb0 must be 0 (most-significant limb, on top)
     assertz.err=ERR_MSB_NONZERO
     # => [limb1, limb2, limb3, limb4]
@@ -102,7 +106,7 @@ end
 #! - to_account_id fails to verify the embedded address.
 #!
 #! Invocation: exec
-pub proc bytes32_to_account_id
+pub proc bytes32_to_account_id(value: EthereumBytes32) -> AccountId
     # the three padding limbs (bytes 0..12) must be 0
     assertz.err=ERR_BYTES32_PADDING_NONZERO
     assertz.err=ERR_BYTES32_PADDING_NONZERO
@@ -126,7 +130,7 @@ end
 #! Outputs: [felt]
 #!
 #! Invocation: exec
-pub proc build_felt
+pub proc build_felt(value: ByteSwappedU64) -> felt
     # --- validate u32 limbs ---
     u32assert2.err=ERR_NOT_U32
     # => [lo_be, hi_be]

--- a/crates/miden-standards/asm/standards/mod.masm
+++ b/crates/miden-standards/asm/standards/mod.masm
@@ -13,5 +13,6 @@ pub mod interop
 pub mod note
 pub mod notes
 pub mod tx_scripts
+pub mod types
 pub mod utils
 pub mod wallets

--- a/crates/miden-standards/asm/standards/note/mod.masm
+++ b/crates/miden-standards/asm/standards/note/mod.masm
@@ -1,3 +1,4 @@
+use {NoteRecipient, NoteScriptRoot} from miden::protocol::types
 # miden::standards::note
 #
 # Collects note-related helper procedures that operate on input notes and are candidates for
@@ -9,7 +10,6 @@ use miden::protocol::active_note
 use miden::protocol::input_note
 use miden::protocol::output_note
 
-use {NoteRecipient, NoteScriptRoot} from miden::protocol::types
 
 pub mod execution_hint
 pub mod note_creator
@@ -42,7 +42,7 @@ const ERR_NOTE_RECIPIENT_PREIMAGE_MISMATCH = "recipient preimage from the advice
 #! - the advice-provided storage does not match the note's storage commitment.
 #!
 #! Invocation: exec
-pub proc input_note_get_storage
+pub proc input_note_get_storage(note_index: u16, dest_ptr: ptr<felt>)
     exec.input_note::get_storage_info
     # => [NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]
 

--- a/crates/miden-standards/asm/standards/note/note_creator.masm
+++ b/crates/miden-standards/asm/standards/note/note_creator.masm
@@ -1,3 +1,4 @@
+use {NoteRecipient, NoteTag, NoteType} from miden::protocol::types
 use miden::protocol::output_note
 
 # PUBLIC API
@@ -24,7 +25,7 @@ use miden::protocol::output_note
 #!
 #! Invocation: call
 @account_procedure
-pub proc create_note
+pub proc create_note(tag: NoteTag, note_type: NoteType, recipient: NoteRecipient) -> u16
     exec.output_note::create
     # => [note_idx, pad(15)]
 end

--- a/crates/miden-standards/asm/standards/note/note_tag.masm
+++ b/crates/miden-standards/asm/standards/note/note_tag.masm
@@ -1,3 +1,4 @@
+use {NoteTag} from miden::protocol::types
 use miden::core::math::u64
 
 # ERRORS
@@ -34,7 +35,7 @@ pub const DEFAULT_TAG = 0
 #! - note_tag is the created note tag.
 #!
 #! Invocation: exec
-pub proc create_account_target
+pub proc create_account_target(account_id_prefix: felt) -> NoteTag
     push.DEFAULT_ACCOUNT_TARGET_TAG_LENGTH
     exec.create_custom_account_target
     # => [note_tag]
@@ -60,7 +61,7 @@ end
 #! - the tag_len exceeds 32.
 #!
 #! Invocation: exec
-pub proc create_custom_account_target
+pub proc create_custom_account_target(tag_len: u8, account_id_prefix: felt) -> NoteTag
     u32assert.err=ERR_NOTE_TAG_MAX_ACCOUNT_TARGET_LENGTH_EXCEEDED
     # => [tag_len, account_id_prefix]
 

--- a/crates/miden-standards/asm/standards/notes/allowlist_config.masm
+++ b/crates/miden-standards/asm/standards/notes/allowlist_config.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
 use miden::standards::faucets::policies::transfer::allowlist::manager
@@ -68,7 +69,7 @@ const ERR_ALLOWLIST_CONFIG_NOTE_IS_NOT_PUBLIC = "allowlist config note must be p
 #! - the number of storage items does not match the selected action.
 #! - the caller is not authorized for the selected action per the installed `Authority` component.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -120,7 +121,7 @@ end
 #! - the caller is not authorized per the installed `Authority` component.
 #!
 #! Invocation: exec
-proc execute_allow_account
+proc execute_allow_account(num_storage_items: u32)
     eq.NUM_ITEMS_ALLOW_ACCOUNT
     assert.err=ERR_ALLOWLIST_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -149,7 +150,7 @@ end
 #! - the caller is not authorized per the installed `Authority` component.
 #!
 #! Invocation: exec
-proc execute_disallow_account
+proc execute_disallow_account(num_storage_items: u32)
     eq.NUM_ITEMS_DISALLOW_ACCOUNT
     assert.err=ERR_ALLOWLIST_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []

--- a/crates/miden-standards/asm/standards/notes/blocklist_config.masm
+++ b/crates/miden-standards/asm/standards/notes/blocklist_config.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
 use miden::standards::faucets::policies::transfer::blocklist::manager
@@ -68,7 +69,7 @@ const ERR_BLOCKLIST_CONFIG_NOTE_IS_NOT_PUBLIC = "blocklist config note must be p
 #! - the number of storage items does not match the selected action.
 #! - the caller is not authorized for the selected action per the installed `Authority` component.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -120,7 +121,7 @@ end
 #! - the caller is not authorized per the installed `Authority` component.
 #!
 #! Invocation: exec
-proc execute_block_account
+proc execute_block_account(num_storage_items: u32)
     eq.NUM_ITEMS_BLOCK_ACCOUNT
     assert.err=ERR_BLOCKLIST_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -149,7 +150,7 @@ end
 #! - the caller is not authorized per the installed `Authority` component.
 #!
 #! Invocation: exec
-proc execute_unblock_account
+proc execute_unblock_account(num_storage_items: u32)
     eq.NUM_ITEMS_UNBLOCK_ACCOUNT
     assert.err=ERR_BLOCKLIST_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []

--- a/crates/miden-standards/asm/standards/notes/burn.masm
+++ b/crates/miden-standards/asm/standards/notes/burn.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::standards::faucets::fungible as fungible
 use miden::standards::faucets::non_fungible as non_fungible
 use miden::standards::inspection::code_inspection
@@ -47,7 +48,7 @@ const ERR_BURN_ASSET_MISMATCH = "asset stored in the burn note must match the as
 #! - the note does not carry exactly one asset, or that asset differs from the stored asset.
 #! - any of the validations in the `receive_and_burn` procedure fail.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 

--- a/crates/miden-standards/asm/standards/notes/constant_fee_policy_config.masm
+++ b/crates/miden-standards/asm/standards/notes/constant_fee_policy_config.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
 use miden::standards::fees::policies::constant_fee_manager
@@ -62,7 +63,7 @@ const ERR_CONSTANT_FEE_POLICY_CONFIG_NOTE_IS_NOT_PUBLIC = "constant fee policy c
 #! - the caller is not authorized per the installed `Authority` component, or the fee asset ID does
 #!   not match (per `set_note_fee`).
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     # drop the note script args
     dropw
     # => [pad(16)]

--- a/crates/miden-standards/asm/standards/notes/faucet_metadata_config.masm
+++ b/crates/miden-standards/asm/standards/notes/faucet_metadata_config.masm
@@ -1,4 +1,4 @@
-use {MetadataStringCommitment} from miden::standards::types
+use {MetadataStringCommitment} from miden::standards::faucets
 use {NoteArgs} from miden::protocol::types
 use miden::core::crypto::hashes::poseidon2
 use miden::protocol::active_note

--- a/crates/miden-standards/asm/standards/notes/faucet_metadata_config.masm
+++ b/crates/miden-standards/asm/standards/notes/faucet_metadata_config.masm
@@ -1,3 +1,5 @@
+use {MetadataStringCommitment} from miden::standards::types
+use {NoteArgs} from miden::protocol::types
 use miden::core::crypto::hashes::poseidon2
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
@@ -90,7 +92,7 @@ const ERR_FAUCET_METADATA_CONFIG_NOTE_IS_NOT_PUBLIC = "faucet metadata config no
 #! - the selected field's mutability flag is not set, or the account is paused.
 #! - the caller is not authorized for the selected action per the installed `Authority` component.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -165,7 +167,7 @@ end
 #!   `fungible::set_max_supply`).
 #!
 #! Invocation: exec
-proc execute_set_max_supply
+proc execute_set_max_supply(num_storage_items: u32)
     eq.NUM_ITEMS_SET_MAX_SUPPLY
     assert.err=ERR_FAUCET_METADATA_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -204,7 +206,7 @@ end
 #! - num_storage_items is not NUM_ITEMS_SET_STRING.
 #!
 #! Invocation: exec
-proc prepare_string_call
+proc prepare_string_call(num_storage_items: u32) -> (MetadataStringCommitment, [felt; 12])
     eq.NUM_ITEMS_SET_STRING
     assert.err=ERR_FAUCET_METADATA_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -240,7 +242,7 @@ end
 #!   `faucets::set_description`).
 #!
 #! Invocation: exec
-proc execute_set_description
+proc execute_set_description(num_storage_items: u32)
     exec.prepare_string_call
     # => [DESCRIPTION_COMMITMENT, pad(12)]
 
@@ -263,7 +265,7 @@ end
 #!   `faucets::set_logo_uri`).
 #!
 #! Invocation: exec
-proc execute_set_logo_uri
+proc execute_set_logo_uri(num_storage_items: u32)
     exec.prepare_string_call
     # => [LOGO_URI_COMMITMENT, pad(12)]
 
@@ -286,7 +288,7 @@ end
 #!   `faucets::set_external_link`).
 #!
 #! Invocation: exec
-proc execute_set_external_link
+proc execute_set_external_link(num_storage_items: u32)
     exec.prepare_string_call
     # => [EXTERNAL_LINK_COMMITMENT, pad(12)]
 

--- a/crates/miden-standards/asm/standards/notes/faucet_policy_config.masm
+++ b/crates/miden-standards/asm/standards/notes/faucet_policy_config.masm
@@ -1,3 +1,4 @@
+use {AccountProcedureRoot, NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
 use miden::standards::faucets::policies::policy_manager
@@ -69,7 +70,7 @@ const ERR_FAUCET_POLICY_CONFIG_NOTE_IS_NOT_PUBLIC = "faucet policy config note m
 #! - the caller is not authorized per the installed `Authority` component, or the policy root is not
 #!   an allowed alternative (per the `TokenPolicyManager` procedures).
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -142,7 +143,7 @@ end
 #! - num_storage_items is not NUM_ITEMS_SET_POLICY.
 #!
 #! Invocation: exec
-proc load_policy_root_window
+proc load_policy_root_window(num_storage_items: u32) -> (AccountProcedureRoot, [felt; 12])
     eq.NUM_ITEMS_SET_POLICY
     assert.err=ERR_FAUCET_POLICY_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -164,7 +165,7 @@ end
 #!   allowed mint policy (per `policy_manager::set_mint_policy`).
 #!
 #! Invocation: exec
-proc execute_set_mint_policy
+proc execute_set_mint_policy(num_storage_items: u32)
     exec.load_policy_root_window
     # => [NEW_POLICY_ROOT, pad(12)]
 
@@ -186,7 +187,7 @@ end
 #!   allowed burn policy (per `policy_manager::set_burn_policy`).
 #!
 #! Invocation: exec
-proc execute_set_burn_policy
+proc execute_set_burn_policy(num_storage_items: u32)
     exec.load_policy_root_window
     # => [NEW_POLICY_ROOT, pad(12)]
 
@@ -208,7 +209,7 @@ end
 #!   allowed send policy (per `policy_manager::set_send_policy`).
 #!
 #! Invocation: exec
-proc execute_set_send_policy
+proc execute_set_send_policy(num_storage_items: u32)
     exec.load_policy_root_window
     # => [NEW_POLICY_ROOT, pad(12)]
 
@@ -230,7 +231,7 @@ end
 #!   allowed receive policy (per `policy_manager::set_receive_policy`).
 #!
 #! Invocation: exec
-proc execute_set_receive_policy
+proc execute_set_receive_policy(num_storage_items: u32)
     exec.load_policy_root_window
     # => [NEW_POLICY_ROOT, pad(12)]
 

--- a/crates/miden-standards/asm/standards/notes/fee_sponsorship.masm
+++ b/crates/miden-standards/asm/standards/notes/fee_sponsorship.masm
@@ -1,3 +1,4 @@
+use {AccountId, BlockNumber, NoteArgs, NoteId, NoteRecipient, NoteSerialNumber, NoteTag, NoteType} from miden::protocol::types
 use miden::protocol::account_id
 use miden::protocol::active_account
 use miden::protocol::active_note
@@ -7,7 +8,6 @@ use miden::protocol::tx
 
 use miden::standards::wallets::basic as basic_wallet
 
-use {AccountId, BlockNumber, NoteRecipient, NoteId, NoteTag, NoteType} from miden::protocol::types
 
 # CONSTANTS
 # =================================================================================================
@@ -67,7 +67,7 @@ const ERR_FEE_SPONSORSHIP_RECLAIM_ACCT_IS_NOT_RECLAIMER = "failed to reclaim fee
 #! - reclaim is disabled.
 #! - the reclaim block height has not been reached.
 #! - the active account is not the note's reclaimer.
-proc reclaim_note
+proc reclaim_note(reclaim_block_height: BlockNumber, reclaimer_id: AccountId)
     dup neq.0 assert.err=ERR_FEE_SPONSORSHIP_RECLAIM_DISABLED
     # => [reclaim_block_height, reclaimer_id_suffix, reclaimer_id_prefix]
 
@@ -134,7 +134,7 @@ end
 #! - the note is reclaimed and the reclaiming account does not expose the
 #!   miden::standards::wallets::basic::receive_asset procedure.
 @note_script
-pub proc main
+pub proc main(note_args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -211,7 +211,7 @@ pub proc prepare_note(
     reclaim_block_height: BlockNumber,
     tag: NoteTag,
     note_type: NoteType,
-    serial_num: word
+    serial_num: NoteSerialNumber
 ) -> (NoteTag, NoteType, NoteRecipient)
     # store the 7 storage items into locals in the layout the note script expects
     loc_storew_le.FEATURE_NOTE_ID_ITEM dropw

--- a/crates/miden-standards/asm/standards/notes/min_burn_amount_config.masm
+++ b/crates/miden-standards/asm/standards/notes/min_burn_amount_config.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
 use miden::standards::faucets::policies::burn::min_burn_amount
@@ -54,7 +55,7 @@ const ERR_MIN_BURN_AMOUNT_CONFIG_NOTE_IS_NOT_PUBLIC = "min burn amount config no
 #! - the number of storage items is not NUM_STORAGE_ITEMS.
 #! - the note sender is not authorized (per the `Authority` component).
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     # drop the note script args
     dropw
     # => [pad(16)]

--- a/crates/miden-standards/asm/standards/notes/mint/fungible.masm
+++ b/crates/miden-standards/asm/standards/notes/mint/fungible.masm
@@ -1,3 +1,4 @@
+use {Asset, NoteRecipient, NoteTag, NoteType} from miden::protocol::types
 use miden::protocol::active_note
 use miden::protocol::note
 use miden::standards::faucets::fungible as fungible
@@ -40,7 +41,7 @@ const ERR_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS = "fungible MINT scri
 #! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 #!
 #! Invocation: exec
-proc mint_public
+proc mint_public(num_storage_items: u32) -> (Asset, NoteTag, NoteType, NoteRecipient, [felt; 2])
     # pad the tail of the `mint_and_send` input window, keeping num_storage_items on top
     push.0.0 movup.2
     # => [num_storage_items, pad(2)]
@@ -84,7 +85,7 @@ end
 #! - the number of storage items is not exactly 13.
 #!
 #! Invocation: exec
-proc mint_private
+proc mint_private(num_storage_items: u32) -> (Asset, NoteTag, NoteType, NoteRecipient, [felt; 2])
     eq.FUNGIBLE_NUM_STORAGE_ITEMS_PRIVATE assert.err=ERR_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
 
@@ -122,7 +123,7 @@ end
 #! - the asset stored in the note does not belong to the consuming faucet.
 #!
 #! Invocation: exec
-pub proc mint
+pub proc mint()
     push.STORAGE_PTR exec.active_note::get_storage
     # => [num_storage_items]
 

--- a/crates/miden-standards/asm/standards/notes/mint/mod.masm
+++ b/crates/miden-standards/asm/standards/notes/mint/mod.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 # miden::standards::notes::mint
 #
 # The MINT note script, which mints against both fungible and non-fungible faucets. This module
@@ -41,7 +42,7 @@ const ERR_MINT_UNSUPPORTED_FAUCET = "the consuming account exposes neither a fun
 #! - the number of storage items does not match the detected faucet kind.
 #! - the asset stored in the note does not belong to the consuming faucet.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 

--- a/crates/miden-standards/asm/standards/notes/mint/non_fungible.masm
+++ b/crates/miden-standards/asm/standards/notes/mint/non_fungible.masm
@@ -1,3 +1,4 @@
+use {Asset, NoteRecipient, NoteTag, NoteType} from miden::protocol::types
 use miden::protocol::active_note
 use miden::protocol::asset
 use miden::protocol::note
@@ -41,7 +42,7 @@ const ERR_NON_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS = "non-fungible M
 #! Outputs: [ASSET_ID, ASSET_VALUE, tag, note_type, RECIPIENT, pad(2)]
 #!
 #! Invocation: exec
-proc mint_public
+proc mint_public(num_storage_items: u32) -> (Asset, NoteTag, NoteType, NoteRecipient, [felt; 2])
     # pad the tail of the `mint_and_send` input window, keeping num_storage_items on top
     push.0.0 movup.2
     # => [num_storage_items, pad(2)]
@@ -82,7 +83,7 @@ end
 #! - the number of storage items is not exactly 13.
 #!
 #! Invocation: exec
-proc mint_private
+proc mint_private(num_storage_items: u32) -> (Asset, NoteTag, NoteType, NoteRecipient, [felt; 2])
     eq.NFT_NUM_STORAGE_ITEMS_PRIVATE assert.err=ERR_NON_FUNGIBLE_MINT_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
 
@@ -117,7 +118,7 @@ end
 #! - the asset stored in the note does not belong to the consuming faucet.
 #!
 #! Invocation: exec
-pub proc mint
+pub proc mint()
     push.STORAGE_PTR exec.active_note::get_storage
     # => [num_storage_items]
 

--- a/crates/miden-standards/asm/standards/notes/network_account_config.masm
+++ b/crates/miden-standards/asm/standards/notes/network_account_config.masm
@@ -1,3 +1,5 @@
+use {Commitment} from miden::standards::types
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::attachments::network_account_target
 use miden::standards::auth::network_account
@@ -80,7 +82,7 @@ const ERR_NETWORK_ACCOUNT_CONFIG_NOTE_IS_NOT_PUBLIC = "network account config no
 #! - the caller is not authorized per the installed `Authority` component, as checked by the
 #!   `AuthNetworkAccount` procedures.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     # drop the note script args
     dropw
     # => [pad(16)]
@@ -177,7 +179,7 @@ end
 #! - num_storage_items is not equal to the expected number.
 #!
 #! Invocation: exec
-proc load_root
+proc load_root(num_storage_items: u32, padding: [felt; 16]) -> (Commitment, [felt; 12])
     eq.NUM_STORAGE_ITEMS
     assert.err=ERR_NETWORK_ACCOUNT_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => [pad(16)]
@@ -200,7 +202,7 @@ end
 #! - the caller is not authorized per the installed `Authority` component.
 #!
 #! Invocation: exec
-proc execute_add_allowed_note_script
+proc execute_add_allowed_note_script(num_storage_items: u32)
     exec.load_root
     # => [SCRIPT_ROOT, pad(12)]
 
@@ -222,7 +224,7 @@ end
 #!   `network_account::remove_allowed_note_script`.
 #!
 #! Invocation: exec
-proc execute_remove_allowed_note_script
+proc execute_remove_allowed_note_script(num_storage_items: u32)
     exec.load_root
     # => [SCRIPT_ROOT, pad(12)]
 
@@ -244,7 +246,7 @@ end
 #!   `network_account::add_allowed_tx_script`.
 #!
 #! Invocation: exec
-proc execute_add_allowed_tx_script
+proc execute_add_allowed_tx_script(num_storage_items: u32)
     exec.load_root
     # => [SCRIPT_ROOT, pad(12)]
 
@@ -266,7 +268,7 @@ end
 #!   `network_account::remove_allowed_tx_script`.
 #!
 #! Invocation: exec
-proc execute_remove_allowed_tx_script
+proc execute_remove_allowed_tx_script(num_storage_items: u32)
     exec.load_root
     # => [SCRIPT_ROOT, pad(12)]
 
@@ -288,7 +290,7 @@ end
 #!   `fee_manager::add_allowed_fee_policy`.
 #!
 #! Invocation: exec
-proc execute_add_allowed_fee_policy
+proc execute_add_allowed_fee_policy(num_storage_items: u32)
     exec.load_root
     # => [POLICY_ROOT, pad(12)]
 
@@ -311,7 +313,7 @@ end
 #!   `fee_manager::remove_allowed_fee_policy`.
 #!
 #! Invocation: exec
-proc execute_remove_allowed_fee_policy
+proc execute_remove_allowed_fee_policy(num_storage_items: u32)
     exec.load_root
     # => [POLICY_ROOT, pad(12)]
 

--- a/crates/miden-standards/asm/standards/notes/owner_config.masm
+++ b/crates/miden-standards/asm/standards/notes/owner_config.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::access::ownable2step
 use miden::standards::attachments::network_account_target
@@ -69,7 +70,7 @@ const ERR_OWNER_CONFIG_NOTE_IS_NOT_PUBLIC = "owner config note must be public"
 #! - the number of storage items does not match the selected action.
 #! - the note sender is not authorized for the selected action (per the `Ownable2Step` procedures).
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -132,7 +133,7 @@ end
 #! - the note sender is not the owner (per `ownable2step::transfer_ownership`).
 #!
 #! Invocation: exec
-proc execute_transfer_ownership
+proc execute_transfer_ownership(num_storage_items: u32)
     eq.NUM_ITEMS_TRANSFER_OWNERSHIP
     assert.err=ERR_OWNER_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -161,7 +162,7 @@ end
 #! - the note sender is not the nominated owner (per `ownable2step::accept_ownership`).
 #!
 #! Invocation: exec
-proc execute_accept_ownership
+proc execute_accept_ownership(num_storage_items: u32)
     eq.NUM_ITEMS_ACCEPT_OWNERSHIP
     assert.err=ERR_OWNER_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -188,7 +189,7 @@ end
 #! - the note sender is not the owner (per `ownable2step::renounce_ownership`).
 #!
 #! Invocation: exec
-proc execute_renounce_ownership
+proc execute_renounce_ownership(num_storage_items: u32)
     eq.NUM_ITEMS_RENOUNCE_OWNERSHIP
     assert.err=ERR_OWNER_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []

--- a/crates/miden-standards/asm/standards/notes/p2id.masm
+++ b/crates/miden-standards/asm/standards/notes/p2id.masm
@@ -1,3 +1,4 @@
+use {AccountId, NoteRecipient, NoteSerialNumber, NoteTag, NoteType} from miden::protocol::types
 use miden::protocol::active_account
 use miden::protocol::account_id
 use miden::protocol::active_note
@@ -43,7 +44,7 @@ const TARGET_ACCOUNT_ID_PREFIX_PTR = STORAGE_PTR + 1
 #! - Adding a fungible asset would result in amount overflow, i.e., the total amount would be
 #!   greater than 2^63.
 @note_script
-pub proc main
+pub proc main()
     # store the note storage to memory starting at address 0
     push.NUM_STORAGE_ITEMS push.STORAGE_PTR exec.active_note::get_bounded_storage
     # => [num_storage_items]
@@ -95,7 +96,12 @@ end
 #!
 #! Invocation: exec
 @locals(2)
-pub proc prepare_note
+pub proc prepare_note(
+    target_id: AccountId,
+    tag: NoteTag,
+    note_type: NoteType,
+    serial_num: NoteSerialNumber
+) -> (NoteTag, NoteType, NoteRecipient)
     # => [target_id_suffix, target_id_prefix, tag, note_type, SERIAL_NUM]
 
     loc_store.TARGET_ACCOUNT_ID_SUFFIX_PTR loc_store.TARGET_ACCOUNT_ID_PREFIX_PTR
@@ -144,7 +150,12 @@ end
 #! - note_idx is the index of the created note.
 #!
 #! Invocation: exec
-pub proc create_output_note
+pub proc create_output_note(
+    target_id: AccountId,
+    tag: NoteTag,
+    note_type: NoteType,
+    serial_num: NoteSerialNumber
+) -> u16
     exec.prepare_note
     # => [tag, note_type, RECIPIENT]
 

--- a/crates/miden-standards/asm/standards/notes/p2ide.masm
+++ b/crates/miden-standards/asm/standards/notes/p2ide.masm
@@ -1,3 +1,4 @@
+use {AccountId, BlockNumber} from miden::protocol::types
 use miden::protocol::active_account
 use miden::protocol::account_id
 use miden::protocol::active_note
@@ -46,7 +47,10 @@ const ERR_P2IDE_TIMELOCK_HEIGHT_NOT_REACHED="failed to consume P2IDE note becaus
 #!
 #! Inputs:  [current_block_height, timelock_block_height]
 #! Outputs: [current_block_height]
-proc assert_unlocked
+proc assert_unlocked(
+    current_block_height: BlockNumber,
+    timelock_block_height: BlockNumber
+) -> BlockNumber
     dup movdn.2
     # => [current_block_height, timelock_block_height, current_block_height]
 
@@ -73,7 +77,12 @@ end
 #! - the reclaim of the active note is disabled.
 #! - the reclaim block height is not reached yet.
 #! - the account attempting to reclaim the note is not the reclaimer account.
-proc reclaim_note
+proc reclaim_note(
+    account_id: AccountId,
+    current_block_height: BlockNumber,
+    reclaim_block_height: BlockNumber,
+    reclaimer_id: AccountId
+)
     # check that the reclaim of the active note is enabled
     movup.3 dup neq.0 assert.err=ERR_P2IDE_RECLAIM_DISABLED
     # => [reclaim_block_height, account_id_suffix, account_id_prefix, current_block_height, reclaimer_id_suffix, reclaimer_id_prefix]
@@ -127,7 +136,7 @@ end
 #! - Adding a fungible asset would result in an amount overflow, i.e., the total amount would be
 #!   greater than 2^63.
 @note_script
-pub proc main
+pub proc main()
     # store the note storage to memory starting at STORAGE_PTR
     push.NUM_STORAGE_ITEMS push.STORAGE_PTR exec.active_note::get_bounded_storage
     # => [num_storage_items]

--- a/crates/miden-standards/asm/standards/notes/pause_config.masm
+++ b/crates/miden-standards/asm/standards/notes/pause_config.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::access::pausable::manager
 use miden::standards::attachments::network_account_target
@@ -62,7 +63,7 @@ const ERR_PAUSE_CONFIG_NOTE_IS_NOT_PUBLIC = "pause config note must be public"
 #! - the number of storage items does not match the selected action.
 #! - the caller is not authorized for the selected action per the installed `Authority` component.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -114,7 +115,7 @@ end
 #! - the caller is not authorized per the installed `Authority` component.
 #!
 #! Invocation: exec
-proc execute_pause
+proc execute_pause(num_storage_items: u32)
     eq.NUM_ITEMS_PAUSE
     assert.err=ERR_PAUSE_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -141,7 +142,7 @@ end
 #! - the caller is not authorized per the installed `Authority` component.
 #!
 #! Invocation: exec
-proc execute_unpause
+proc execute_unpause(num_storage_items: u32)
     eq.NUM_ITEMS_UNPAUSE
     assert.err=ERR_PAUSE_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []

--- a/crates/miden-standards/asm/standards/notes/pswap.masm
+++ b/crates/miden-standards/asm/standards/notes/pswap.masm
@@ -1,3 +1,5 @@
+use {Uint64} from miden::standards::types
+use {AccountId, Asset, AssetAmount, Bool, NoteArgs, NoteSerialNumber, NoteTag, NoteType} from miden::protocol::types
 use miden::core::math::u64
 use miden::core::math::u128
 use miden::protocol::account_id
@@ -126,7 +128,7 @@ const ERR_PSWAP_DEPTH_OVERFLOW="PSWAP lineage depth exceeds u32"
 #! Outputs: [lo, hi]
 #!
 #! Panics if the value exceeds FUNGIBLE_ASSET_MAX_AMOUNT.
-proc assert_valid_asset_amount
+proc assert_valid_asset_amount(value: Uint64) -> Uint64
     dup.1 dup.1
     # => [lo, hi, lo, hi]
 
@@ -163,7 +165,11 @@ end
 @locals(2)
 # CALC_FILL_AMOUNT:      this leg's fill amount
 # CALC_FILL_REFERENCE: max(total_fill, min_requested_amount) — the fill that maps to the whole offered side
-proc calculate_output_amount
+proc calculate_output_amount(
+    offered: AssetAmount,
+    fill_reference: AssetAmount,
+    fill_amount: AssetAmount
+) -> AssetAmount
     movup.2 loc_store.CALC_FILL_AMOUNT
     # => [offered, fill_reference]
 
@@ -208,7 +214,7 @@ end
 #!
 #! Inputs:  [a, b]
 #! Outputs: [max(a, b)]
-proc max
+proc max(a: felt, b: felt) -> felt
     dup.1 dup.1 lt
     # => [b_lt_a, a, b]
     cdrop
@@ -219,7 +225,7 @@ end
 #!
 #! Inputs:  [a, b]
 #! Outputs: [min(a, b)]
-proc min
+proc min(a: felt, b: felt) -> felt
     dup dup.2 lt
     # => [a_lt_b, a, b]
     cdrop
@@ -246,7 +252,14 @@ end
 # P2ID_REQUESTED_FAUCET_PREFIX : faucet_prefix
 # P2ID_AMT_ACCOUNT_FILL      : amt_account_fill
 # P2ID_AMT_NOTE_FILL         : amt_note_fill
-proc create_p2id_note
+proc create_p2id_note(
+    creator: AccountId,
+    note_type: NoteType,
+    serial_num: NoteSerialNumber,
+    faucet: AccountId,
+    amt_account_fill: AssetAmount,
+    amt_note_fill: AssetAmount
+)
     # Derive P2ID serial: increment least significant element
     movup.3 add.1 movdn.3
     # => [creator_suffix, creator_prefix, note_type, P2ID_SERIAL_NUM,
@@ -295,7 +308,7 @@ proc create_p2id_note
     # Move account_fill_amount from consumer's vault to P2ID note (if > 0)
     loc_load.P2ID_AMT_ACCOUNT_FILL neq.0
     # => [has_account_fill]
-    
+
     if.true
         # create the asset
         loc_load.P2ID_AMT_ACCOUNT_FILL
@@ -362,7 +375,14 @@ end
 # REMAINDER_OFFERED_FAUCET_PREFIX : offered_faucet_prefix
 # REMAINDER_AMT_PAYOUT            : amt_payout
 # REMAINDER_AMT_OFFERED           : amt_offered
-proc create_remainder_note
+proc create_remainder_note(
+    offered_faucet: AccountId,
+    amt_payout: AssetAmount,
+    amt_offered: AssetAmount,
+    remaining_requested: AssetAmount,
+    note_type: NoteType,
+    tag: NoteTag
+)
     # Store offered asset info to locals (top element stored first)
     loc_store.REMAINDER_OFFERED_FAUCET_SUFFIX
     loc_store.REMAINDER_OFFERED_FAUCET_PREFIX
@@ -381,7 +401,7 @@ proc create_remainder_note
     # Derive remainder serial: increment most significant element
     exec.active_note::get_serial_number
     # => [s0, s1, s2, s3, SCRIPT_ROOT, note_type, tag]
-    
+
     movup.3 add.1 movdn.3
     # => [s0, s1, s2, s3+1, SCRIPT_ROOT, note_type, tag]
 
@@ -452,7 +472,7 @@ end
 #! Inputs: [creator_id_suffix, creator_id_prefix]
 #! Outputs: [is_creator]
 #!
-proc is_consumer_creator
+proc is_consumer_creator(creator_id: AccountId) -> Bool
     exec.active_account::get_id
     # => [acct_id_suffix, acct_id_prefix, creator_id_suffix, creator_id_prefix]
 
@@ -471,7 +491,7 @@ end
 #! - the remaining offered asset differs from the asset the note was created with.
 #!
 @locals(16)
-proc load_offered_asset
+proc load_offered_asset() -> Asset
     locaddr.OFFERED_REMAINING_ASSET_PTR exec.active_note::remove_all_assets
     # => [num_assets]
 
@@ -507,7 +527,7 @@ end
 #! Inputs: []
 #! Outputs: []
 #!
-proc handle_reclaim
+proc handle_reclaim()
     exec.load_offered_asset
     # => [ASSET_ID, ASSET_VALUE]
 
@@ -530,7 +550,7 @@ end
 #!
 #! Inputs:  []
 #! Outputs: [order_id]
-proc get_order_id
+proc get_order_id() -> felt
     exec.active_note::get_serial_number
     # => [s0, s1, s2, s3]
 
@@ -557,7 +577,7 @@ end
 #! - the parent depth is not a u32.
 #! - the incremented depth overflows a u32.
 @locals(4)
-proc get_current_depth
+proc get_current_depth() -> u32
     push.PSWAP_ATTACHMENT_SCHEME
     # => [PSWAP_ATTACHMENT_SCHEME]
 
@@ -629,7 +649,7 @@ end
 # EXEC_AMT_REQUESTED_ACCOUNT_FILL : amt_requested_account_fill
 # EXEC_AMT_REQUESTED_NOTE_FILL    : amt_requested_note_fill
 # EXEC_AMT_FILL_REFERENCE         : max(total_fill, min_requested_amount)
-proc execute_pswap
+proc execute_pswap(account_fill_amount: AssetAmount, note_fill_amount: AssetAmount)
     loc_store.EXEC_AMT_REQUESTED_ACCOUNT_FILL
     loc_store.EXEC_AMT_REQUESTED_NOTE_FILL
     # => []
@@ -856,7 +876,7 @@ end
 #! - the total fill (account_fill + note_fill) overflows u64 or exceeds the max asset amount.
 #! - the account does not expose `receive_asset` / `move_asset_to_note`.
 @note_script
-pub proc main
+pub proc main(note_args: NoteArgs)
     movdn.3 movdn.3 drop drop
     # => [account_fill_amount, note_fill_amount]
 

--- a/crates/miden-standards/asm/standards/notes/rbac_config.masm
+++ b/crates/miden-standards/asm/standards/notes/rbac_config.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::standards::access::rbac
 use miden::standards::attachments::network_account_target
@@ -75,7 +76,7 @@ const ERR_RBAC_CONFIG_NOTE_IS_NOT_PUBLIC = "rbac config note must be public"
 #! - the number of storage items does not match the selected action.
 #! - the note sender is not authorized for the selected action (per the `rbac` procedures).
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     dropw
     # => [pad(16)]
 
@@ -148,7 +149,7 @@ end
 #!   account ID is invalid (per `rbac::grant_role`).
 #!
 #! Invocation: exec
-proc execute_grant_role
+proc execute_grant_role(num_storage_items: u32)
     eq.NUM_ITEMS_GRANT_ROLE
     assert.err=ERR_RBAC_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -179,7 +180,7 @@ end
 #!   account does not hold the role (per `rbac::revoke_role`).
 #!
 #! Invocation: exec
-proc execute_revoke_role
+proc execute_revoke_role(num_storage_items: u32)
     eq.NUM_ITEMS_REVOKE_ROLE
     assert.err=ERR_RBAC_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -211,7 +212,7 @@ end
 #!   zero (per `rbac::set_role_admin`).
 #!
 #! Invocation: exec
-proc execute_set_role_admin
+proc execute_set_role_admin(num_storage_items: u32)
     eq.NUM_ITEMS_SET_ROLE_ADMIN
     assert.err=ERR_RBAC_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []
@@ -240,7 +241,7 @@ end
 #! - the role symbol is zero, or the note sender does not hold the role (per `rbac::renounce_role`).
 #!
 #! Invocation: exec
-proc execute_renounce_role
+proc execute_renounce_role(num_storage_items: u32)
     eq.NUM_ITEMS_RENOUNCE_ROLE
     assert.err=ERR_RBAC_CONFIG_UNEXPECTED_NUMBER_OF_STORAGE_ITEMS
     # => []

--- a/crates/miden-standards/asm/standards/notes/swap.masm
+++ b/crates/miden-standards/asm/standards/notes/swap.masm
@@ -1,3 +1,4 @@
+use {NoteArgs} from miden::protocol::types
 use miden::protocol::active_note
 use miden::protocol::asset
 use {NOTE_TYPE_PRIVATE} from miden::protocol::note
@@ -64,7 +65,7 @@ const ERR_SWAP_WRONG_NUMBER_OF_ASSETS="SWAP script requires exactly 1 note asset
 #! - adding a fungible asset would result in amount overflow, i.e., the total amount would be
 #!   greater than 2^63.
 @note_script
-pub proc main
+pub proc main(args: NoteArgs)
     # drop note args
     dropw
     # => []

--- a/crates/miden-standards/asm/standards/notes/tx_fee.masm
+++ b/crates/miden-standards/asm/standards/notes/tx_fee.masm
@@ -1,3 +1,4 @@
+use {NoteRecipient, NoteSerialNumber, NoteTag, NoteType} from miden::protocol::types
 use miden::protocol::active_note
 use miden::protocol::note
 use {NOTE_TYPE_PUBLIC} from miden::protocol::note
@@ -42,7 +43,7 @@ const TX_FEE_NOTE_TAG = 0xFEE
 #! - adding a fungible asset would result in amount overflow, i.e., the total amount would be
 #!   greater than 2^63.
 @note_script
-pub proc main
+pub proc main()
     # make sure the note carries no storage items
     push.NUM_STORAGE_ITEMS push.STORAGE_PTR exec.active_note::get_bounded_storage drop
     # => []
@@ -75,7 +76,7 @@ end
 #! - RECIPIENT is the computed recipient digest of the note (4 elements).
 #!
 #! Invocation: exec
-pub proc prepare_note
+pub proc prepare_note(serial_num: NoteSerialNumber) -> (NoteTag, NoteType, NoteRecipient)
     procref.main
     # => [SCRIPT_ROOT, SERIAL_NUM]
 
@@ -114,7 +115,7 @@ end
 #! - note_idx is the index of the created note.
 #!
 #! Invocation: exec
-pub proc create_output_note
+pub proc create_output_note(serial_num: NoteSerialNumber) -> u16
     exec.prepare_note
     # => [tag, note_type, RECIPIENT]
 

--- a/crates/miden-standards/asm/standards/tx_scripts/expiration.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/expiration.masm
@@ -1,3 +1,4 @@
+use {ExpirationArgs} from miden::standards::types
 use miden::protocol::tx
 
 #! Set the transaction's expiration delta.
@@ -10,7 +11,7 @@ use miden::protocol::tx
 #!
 #! Invocation: call
 @transaction_script
-pub proc main
+pub proc main(args: ExpirationArgs)
     exec.tx::update_expiration_block_delta
     # => [pad(16)]
 end

--- a/crates/miden-standards/asm/standards/tx_scripts/expiration.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/expiration.masm
@@ -1,5 +1,9 @@
-use {ExpirationArgs} from miden::standards::types
 use miden::protocol::tx
+
+pub type ExpirationArgs = struct {
+    delta: u16,
+    padding: [felt; 3]
+}
 
 #! Set the transaction's expiration delta.
 #!

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/common.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/common.masm
@@ -1,3 +1,4 @@
+use {AttachmentRecord, SendNotesPayloadCommitment} from miden::standards::types
 # Shared payload handling for the canonical `send_notes` transaction scripts.
 #
 # This module is private to `send_notes`: it is the shared implementation behind the
@@ -89,7 +90,10 @@ const ERR_SEND_NOTES_PAYLOAD_EMPTY = "send notes payload must not be empty"
 #! - the expiration delta is non-zero and not in the range 1..=0xFFFF.
 #!
 #! Invocation: exec
-pub proc write_payload_to_memory(payload_addr: u32, payload_commitment: word)
+pub proc write_payload_to_memory(
+    payload_addr: ptr<felt>,
+    payload_commitment: SendNotesPayloadCommitment
+)
     # push the payload from the advice map onto the advice stack, together with its length
     movdn.4 adv.push_mapvaln
     # OS => [PAYLOAD_COMMITMENT, payload_addr, pad(11)]
@@ -156,7 +160,11 @@ end
 #! - an attachment's elements are missing from the advice map.
 #!
 #! Invocation: exec
-pub proc add_attachments(note_idx: u32, attachments_ptr: u32, num_attachments: u32) -> u32
+pub proc add_attachments(
+    note_idx: u32,
+    attachments_ptr: ptr<AttachmentRecord>,
+    num_attachments: u32
+) -> ptr<AttachmentRecord>
     # the loop variables are kept on the stack
     movdn.2 swap
     # => [num_attachments, attachments_ptr, note_idx]

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/common.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/common.masm
@@ -1,4 +1,5 @@
-use {AttachmentRecord, SendNotesPayloadCommitment} from miden::standards::types
+use {SendNotesPayloadCommitment} from miden::standards::tx_scripts::send_notes
+use {NoteAttachmentCommitment} from miden::protocol::types
 # Shared payload handling for the canonical `send_notes` transaction scripts.
 #
 # This module is private to `send_notes`: it is the shared implementation behind the
@@ -23,6 +24,13 @@ use {AttachmentRecord, SendNotesPayloadCommitment} from miden::standards::types
 use miden::core::mem
 use miden::protocol::output_note
 use miden::protocol::tx
+
+# One send-notes attachment record: a padded scheme followed by its commitment.
+pub type AttachmentRecord = struct {
+    scheme: u32,
+    padding: [felt; 3],
+    commitment: NoteAttachmentCommitment
+}
 
 # CONSTANTS
 # =================================================================================================

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/fungible_faucet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/fungible_faucet.masm
@@ -1,3 +1,4 @@
+use {SendNotesPayloadCommitment} from miden::standards::types
 # The canonical `send_notes` transaction script for accounts exposing the fungible faucet
 # interface.
 #
@@ -49,7 +50,7 @@ const ERR_SEND_NOTES_FAUCET_NOTE_REQUIRES_ONE_ASSET = "faucet note must contain 
 #!
 #! Invocation: call
 @transaction_script
-pub proc main
+pub proc main(payload_commitment: SendNotesPayloadCommitment)
     push.PAYLOAD_ADDR
     # => [payload_addr, PAYLOAD_COMMITMENT, pad(11)]
 
@@ -87,7 +88,7 @@ end
 #!
 #! Invocation: exec
 @locals(2)
-proc process_notes
+proc process_notes()
     push.NOTES_START_ADDR loc_store.PROCESS_NOTES_READ_PTR_LOC
     # => [pad(16)]
 

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/fungible_faucet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/fungible_faucet.masm
@@ -1,4 +1,4 @@
-use {SendNotesPayloadCommitment} from miden::standards::types
+use {SendNotesPayloadCommitment} from miden::standards::tx_scripts::send_notes
 # The canonical `send_notes` transaction script for accounts exposing the fungible faucet
 # interface.
 #

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/mod.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/mod.masm
@@ -5,6 +5,8 @@
 # of output notes. The payload layout and the handling shared by all three live in the private
 # [`send_notes::common`] submodule.
 
+pub type SendNotesPayloadCommitment = word
+
 mod common
 pub mod fungible_faucet
 pub mod non_fungible_faucet

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/non_fungible_faucet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/non_fungible_faucet.masm
@@ -1,3 +1,4 @@
+use {SendNotesPayloadCommitment} from miden::standards::types
 # The canonical `send_notes` transaction script for accounts exposing the non-fungible faucet
 # interface.
 #
@@ -49,7 +50,7 @@ const ERR_SEND_NOTES_FAUCET_NOTE_REQUIRES_ONE_ASSET = "faucet note must contain 
 #!
 #! Invocation: call
 @transaction_script
-pub proc main
+pub proc main(payload_commitment: SendNotesPayloadCommitment)
     push.PAYLOAD_ADDR
     # => [payload_addr, PAYLOAD_COMMITMENT, pad(11)]
 
@@ -87,7 +88,7 @@ end
 #!
 #! Invocation: exec
 @locals(2)
-proc process_notes
+proc process_notes()
     push.NOTES_START_ADDR loc_store.PROCESS_NOTES_READ_PTR_LOC
     # => [pad(16)]
 

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/non_fungible_faucet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/non_fungible_faucet.masm
@@ -1,4 +1,4 @@
-use {SendNotesPayloadCommitment} from miden::standards::types
+use {SendNotesPayloadCommitment} from miden::standards::tx_scripts::send_notes
 # The canonical `send_notes` transaction script for accounts exposing the non-fungible faucet
 # interface.
 #

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/wallet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/wallet.masm
@@ -1,3 +1,4 @@
+use {SendNotesPayloadCommitment} from miden::standards::types
 # The canonical `send_notes` transaction script for accounts exposing the basic wallet
 # interface.
 #
@@ -45,7 +46,7 @@ const ERR_SEND_NOTES_NUM_ATTACHMENTS_INVALID = "send notes payload attachment co
 #!
 #! Invocation: call
 @transaction_script
-pub proc main
+pub proc main(payload_commitment: SendNotesPayloadCommitment)
     push.PAYLOAD_ADDR
     # => [payload_addr, PAYLOAD_COMMITMENT, pad(11)]
 
@@ -83,7 +84,7 @@ end
 #!
 #! Invocation: exec
 @locals(3)
-proc process_notes
+proc process_notes()
     push.NOTES_START_ADDR loc_store.PROCESS_NOTES_READ_PTR_LOC
     # => [pad(16)]
 

--- a/crates/miden-standards/asm/standards/tx_scripts/send_notes/wallet.masm
+++ b/crates/miden-standards/asm/standards/tx_scripts/send_notes/wallet.masm
@@ -1,4 +1,4 @@
-use {SendNotesPayloadCommitment} from miden::standards::types
+use {SendNotesPayloadCommitment} from miden::standards::tx_scripts::send_notes
 # The canonical `send_notes` transaction script for accounts exposing the basic wallet
 # interface.
 #

--- a/crates/miden-standards/asm/standards/types.masm
+++ b/crates/miden-standards/asm/standards/types.masm
@@ -1,0 +1,117 @@
+# Semantic stack values shared by the standard components and scripts.
+# Struct fields follow operand-stack order, starting at the top.
+
+use {AccountId, AssetAmount, Bool, NoteAttachmentCommitment} from ::miden::protocol::types
+
+pub type RoleSymbol = felt
+# Membership counts are field elements; the role map does not impose a u32 bound.
+pub type RoleMemberCount = felt
+pub type TokenSymbol = felt
+# Schemes 1 (ECDSA) and 2 (Falcon) are currently supported.
+pub type SignatureScheme = u8
+pub type PublicKeyCommitment = word
+pub type SignatureMessage = word
+pub type Commitment = word
+pub type TokenId = struct { suffix: felt, prefix: felt }
+# Standard multisig components support at most 64 approvers.
+pub type SignatureThreshold = u8
+pub type RoleConfig = struct {
+    member_count: RoleMemberCount,
+    admin: RoleSymbol
+}
+pub type OwnershipInfo = struct {
+    owner: AccountId,
+    nominated_owner: AccountId
+}
+pub type TokenConfig = struct {
+    supply: AssetAmount,
+    max_supply: AssetAmount,
+    decimals: u8,
+    symbol: TokenSymbol
+}
+pub type MutabilityConfig = struct {
+    description: Bool,
+    logo_uri: Bool,
+    external_link: Bool,
+    max_supply: Bool
+}
+pub type TokenName = struct { first: word, second: word }
+pub type MultisigConfig = struct {
+    threshold: SignatureThreshold,
+    num_approvers: u8,
+    padding: [felt; 2]
+}
+pub type ThresholdConfig = struct {
+    threshold: SignatureThreshold,
+    num_approvers: u8
+}
+pub type ProcedurePolicy = struct {
+    immediate: SignatureThreshold,
+    delayed: SignatureThreshold,
+    note_restrictions: u8
+}
+pub type NetworkAccountTarget = struct {
+    account: AccountId,
+    execution_hint: felt,
+    padding: felt
+}
+pub type TokenStatus = u8
+pub type Uint128 = struct { limb0: u32, limb1: u32, limb2: u32, limb3: u32 }
+pub type Uint256 = struct {
+    limb0: u32,
+    limb1: u32,
+    limb2: u32,
+    limb3: u32,
+    limb4: u32,
+    limb5: u32,
+    limb6: u32,
+    limb7: u32
+}
+pub type BigEndianUint256 = struct {
+    limb7: u32,
+    limb6: u32,
+    limb5: u32,
+    limb4: u32,
+    limb3: u32,
+    limb2: u32,
+    limb1: u32,
+    limb0: u32
+}
+pub type Uint64 = struct { lo: u32, hi: u32 }
+pub type ExpirationArgs = struct {
+    delta: u16,
+    padding: [felt; 3]
+}
+
+# Authentication arguments and encoded, padded storage records.
+pub type AuthArgs = word
+pub type Approver = struct {
+    public_key: PublicKeyCommitment,
+    scheme: SignatureScheme
+}
+pub type SignatureSchemeWord = struct {
+    scheme: SignatureScheme,
+    padding: [felt; 3]
+}
+pub type TokenStatusValue = struct {
+    status: TokenStatus,
+    padding: [felt; 3]
+}
+
+# Commitments name the advice-map preimages or account state they authenticate.
+pub type CodeCommitment = word
+pub type CodeUpgradeCommitment = word
+pub type StorageUpgradeCommitment = word
+pub type StorageSchemaCommitment = word
+pub type MetadataStringCommitment = word
+pub type SendNotesPayloadCommitment = word
+
+# One send-notes attachment record: a padded scheme followed by its commitment.
+pub type AttachmentRecord = struct {
+    scheme: u32,
+    padding: [felt; 3],
+    commitment: NoteAttachmentCommitment
+}
+
+# An integer encoding transformed without assuming its current limb or byte order.
+pub type EncodedUint256 = struct { limbs: [u32; 8] }

--- a/crates/miden-standards/asm/standards/types.masm
+++ b/crates/miden-standards/asm/standards/types.masm
@@ -1,61 +1,7 @@
 # Semantic stack values shared by the standard components and scripts.
 # Struct fields follow operand-stack order, starting at the top.
 
-use {AccountId, AssetAmount, Bool, NoteAttachmentCommitment} from ::miden::protocol::types
-
-pub type RoleSymbol = felt
-# Membership counts are field elements; the role map does not impose a u32 bound.
-pub type RoleMemberCount = felt
-pub type TokenSymbol = felt
-# Schemes 1 (ECDSA) and 2 (Falcon) are currently supported.
-pub type SignatureScheme = u8
-pub type PublicKeyCommitment = word
-pub type SignatureMessage = word
 pub type Commitment = word
-pub type TokenId = struct { suffix: felt, prefix: felt }
-# Standard multisig components support at most 64 approvers.
-pub type SignatureThreshold = u8
-pub type RoleConfig = struct {
-    member_count: RoleMemberCount,
-    admin: RoleSymbol
-}
-pub type OwnershipInfo = struct {
-    owner: AccountId,
-    nominated_owner: AccountId
-}
-pub type TokenConfig = struct {
-    supply: AssetAmount,
-    max_supply: AssetAmount,
-    decimals: u8,
-    symbol: TokenSymbol
-}
-pub type MutabilityConfig = struct {
-    description: Bool,
-    logo_uri: Bool,
-    external_link: Bool,
-    max_supply: Bool
-}
-pub type TokenName = struct { first: word, second: word }
-pub type MultisigConfig = struct {
-    threshold: SignatureThreshold,
-    num_approvers: u8,
-    padding: [felt; 2]
-}
-pub type ThresholdConfig = struct {
-    threshold: SignatureThreshold,
-    num_approvers: u8
-}
-pub type ProcedurePolicy = struct {
-    immediate: SignatureThreshold,
-    delayed: SignatureThreshold,
-    note_restrictions: u8
-}
-pub type NetworkAccountTarget = struct {
-    account: AccountId,
-    execution_hint: felt,
-    padding: felt
-}
-pub type TokenStatus = u8
 pub type Uint128 = struct { limb0: u32, limb1: u32, limb2: u32, limb3: u32 }
 pub type Uint256 = struct {
     limb0: u32,
@@ -78,40 +24,9 @@ pub type BigEndianUint256 = struct {
     limb0: u32
 }
 pub type Uint64 = struct { lo: u32, hi: u32 }
-pub type ExpirationArgs = struct {
-    delta: u16,
-    padding: [felt; 3]
-}
 
-# Authentication arguments and encoded, padded storage records.
+# Authentication arguments.
 pub type AuthArgs = word
-pub type Approver = struct {
-    public_key: PublicKeyCommitment,
-    scheme: SignatureScheme
-}
-pub type SignatureSchemeWord = struct {
-    scheme: SignatureScheme,
-    padding: [felt; 3]
-}
-pub type TokenStatusValue = struct {
-    status: TokenStatus,
-    padding: [felt; 3]
-}
-
-# Commitments name the advice-map preimages or account state they authenticate.
-pub type CodeCommitment = word
-pub type CodeUpgradeCommitment = word
-pub type StorageUpgradeCommitment = word
-pub type StorageSchemaCommitment = word
-pub type MetadataStringCommitment = word
-pub type SendNotesPayloadCommitment = word
-
-# One send-notes attachment record: a padded scheme followed by its commitment.
-pub type AttachmentRecord = struct {
-    scheme: u32,
-    padding: [felt; 3],
-    commitment: NoteAttachmentCommitment
-}
 
 # An integer encoding transformed without assuming its current limb or byte order.
 pub type EncodedUint256 = struct { limbs: [u32; 8] }

--- a/crates/miden-standards/asm/standards/utils.masm
+++ b/crates/miden-standards/asm/standards/utils.masm
@@ -1,11 +1,11 @@
+use {Uint64} from miden::standards::types
+use {DoubleWord} from miden::protocol::types
 # Shared utility constants and helper procedures reused across the standards modules:
 # common word constants, byte manipulation, and double word memory operations.
 #
 # Many modules keep a local, semantically-named word constant that is really just [1, 0, 0, 0] or
 # [0, 0, 0, 0]. They should alias these shared definitions so the raw literals live in one place.
 
-use {DoubleWord} from miden::protocol::types
-use {MemoryAddress} from miden::protocol::types
 
 # CONSTANTS
 # =================================================================================================
@@ -35,7 +35,7 @@ const ERR_MERGE_OVERFLOW="merged u32 limbs do not fit in a field element"
 #! Outputs: [swapped]
 #!
 #! Invocation: exec
-pub proc swap_u32_bytes
+pub proc swap_u32_bytes(value: u32) -> u32
     # part0 = (value & 0xFF) << 24
     dup u32and.0xFF u32shl.24
     # => [part0, value]
@@ -70,7 +70,7 @@ end
 #!   the combined value was reduced modulo the field prime).
 #!
 #! Invocation: exec
-pub proc merge_u32_limbs
+pub proc merge_u32_limbs(value: Uint64) -> felt
     # keep copies for the round-trip check
     dup.1 dup.1
     # => [lo, hi, lo, hi]
@@ -106,8 +106,8 @@ end
 #! Invocation: exec
 pub proc mem_store_double_word(
     double_word_to_store: DoubleWord,
-    mem_ptr: MemoryAddress
-) -> (DoubleWord, MemoryAddress)
+    mem_ptr: ptr<DoubleWord>
+) -> (DoubleWord, ptr<DoubleWord>)
     dup.8 mem_storew_le swapw
     # => [WORD_2, WORD_1, ptr]
 
@@ -123,7 +123,7 @@ end
 #! Invocation: exec
 pub proc mem_store_double_word_unaligned(
     double_word_to_store: DoubleWord,
-    mem_ptr: MemoryAddress
+    mem_ptr: ptr<DoubleWord>
 )
     # bring ptr to the top of the stack
     dup.8
@@ -151,7 +151,7 @@ end
 #! Outputs: [WORD_1, WORD_2]
 #!
 #! Invocation: exec
-pub proc mem_load_double_word(mem_ptr: MemoryAddress) -> DoubleWord
+pub proc mem_load_double_word(mem_ptr: ptr<DoubleWord>) -> DoubleWord
     padw dup.4 add.4 mem_loadw_le
     # => [WORD_2, ptr]
 
@@ -169,7 +169,7 @@ end
 #! Outputs: [WORD_1, WORD_2]
 #!
 #! Invocation: exec
-pub proc mem_load_double_word_unaligned(mem_ptr: MemoryAddress) -> DoubleWord
+pub proc mem_load_double_word_unaligned(mem_ptr: ptr<DoubleWord>) -> DoubleWord
     # Load WORD_2 first so it ends up underneath WORD_1 on the final stack.
     dup add.7 mem_load
     dup.1 add.6 mem_load

--- a/crates/miden-standards/asm/standards/wallets/basic.masm
+++ b/crates/miden-standards/asm/standards/wallets/basic.masm
@@ -1,3 +1,4 @@
+use {Asset} from miden::protocol::types
 use {ASSET_VALUE_MEMORY_OFFSET} from miden::protocol::asset
 use {ASSET_SIZE} from miden::protocol::asset
 use miden::protocol::native_account
@@ -25,7 +26,7 @@ pub use {create_note} from miden::standards::note::note_creator
 #!
 #! Invocation: call
 @account_procedure
-pub proc receive_asset
+pub proc receive_asset(asset: Asset)
     exec.native_account::add_asset
     # => [FINAL_ASSET_VALUE, pad(12)]
 
@@ -56,7 +57,7 @@ end
 #!
 #! Invocation: call
 @account_procedure
-pub proc move_asset_to_note
+pub proc move_asset_to_note(asset: Asset, note_idx: u16)
     dupw.1 dupw.1
     # => [ASSET_ID, ASSET_VALUE, ASSET_ID, ASSET_VALUE, note_idx, pad(7)]
 
@@ -85,7 +86,7 @@ end
 #!
 #! Invocation: exec
 @locals(128)
-pub proc move_note_assets_to_account
+pub proc move_note_assets_to_account()
     # write assets to local memory starting at offset 0
     # we have allocated ASSET_SIZE * MAX_ASSETS_PER_NOTE number of locals so all assets should fit
     # since the asset memory will be overwritten, we don't have to initialize the locals to zero


### PR DESCRIPTION
This PR contains the changes described below, intended to be released in 0.17.0 (so if this needs to be rebased to some other branch, let me know). It fixes two significant blockers for the compiler and assembler:

1. Without type signatures, the compiler cannot generate bindings to procedures defined by any of the Miden Assembly packages in this repo - the sole reason the compiler has to depend on the protocol crates today. Without binding generations, each release of the compiler is locked against a specific release of the protocol, even though compilation in general does not need to know anything about what version of the protocol is used.
2. The assembler cannot make type signatures required unless they are defined everywhere. The biggest source of untyped procedures is the Miden core library (fixed via a PR in the VM repo), and the protocol repo. There are other blockers before we can flip that switch, but this is the biggest one.

## Changes

* Add type signatures where missing through the Miden Assembly code in this repo
* Replace the `MemoryAddress` type alias with real pointer types, as `u32` conveyed zero useful information about the address space, alignment, or pointee where `MemoryAddress` was used.
* Define shared semantically-meaningful types and type aliases, ensuring that type signatures also convey useful semantic information about what is expected to be passed as arguments, and returned as results. This is particularly important for binding generation.
* Explicitly decorate procedures with `@callconv("component-model")` where appropriate (account procedures, note and transaction script entrypoints)
* Model FPI passthrough functions as variadic

**NOTE:** If any of the types or the signatures could be improved, please let me know - I took a stab at it, but I'm not as familiar with the MASM code here, and someone who is will likely be better positioned to know whether there are ways we can make the types better. Be aware that incorrect type signatures will result in undefined behavior, where the types are incorrect (wrong size or alignment, etc.). Adding these signatures _is_ a strict improvement over the situation today, but it is nevertheless imperative that we get them right. The compiler has analyses that can catch mistakes, and I plan to integrate some checks into the assembler as well in the future, but for now we don't have a lot of tools to catch mistakes here.