### PR TITLE
fix(standards): detect standard components that share a procedure root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@
 - The PSWAP note script now bounds its lineage depth to a u32 and the `PswapNote` builder rejects a malformed `PswapAttachment` [#3777](https://github.com/0xMiden/protocol/pull/3777).
 - The standard config note scripts now reject a non-public note [#3779](https://github.com/0xMiden/protocol/pull/3779).
 - [BREAKING] `multisig_smart` now rejects delay-only procedure policies ([#3781](https://github.com/0xMiden/protocol/pull/3781)).
-- `AccountInterface` now matches standard components against the account's full interface, so a procedure root exported by two standard components (e.g. `has_procedure`, re-exported by both the fungible faucet and the code inspection component) no longer keeps the second component from being detected ([#3816](https://github.com/0xMiden/protocol/pull/3816)).
+- Fixed `AccountInterface` misreporting a standard component as custom when it shares a procedure root with another standard component, such as `has_procedure` on a fungible faucet installed alongside `CodeInspection` ([#3823](https://github.com/0xMiden/protocol/pull/3823)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - The PSWAP note script now bounds its lineage depth to a u32 and the `PswapNote` builder rejects a malformed `PswapAttachment` [#3777](https://github.com/0xMiden/protocol/pull/3777).
 - The standard config note scripts now reject a non-public note [#3779](https://github.com/0xMiden/protocol/pull/3779).
 - [BREAKING] `multisig_smart` now rejects delay-only procedure policies ([#3781](https://github.com/0xMiden/protocol/pull/3781)).
+- `AccountInterface` now matches standard components against the account's full interface, so a procedure root exported by two standard components (e.g. `has_procedure`, re-exported by both the fungible faucet and the code inspection component) no longer keeps the second component from being detected ([#3816](https://github.com/0xMiden/protocol/pull/3816)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/crates/miden-standards/src/account/components/mod.rs
+++ b/crates/miden-standards/src/account/components/mod.rs
@@ -40,6 +40,26 @@ pub enum StandardAccountComponent {
 }
 
 impl StandardAccountComponent {
+    /// All standard components, in the order in which they are matched against an account.
+    ///
+    /// `NoteCreator` must follow `BasicWallet`: its only procedure (`create_note`) is also
+    /// exported by the basic wallet, so the full wallet must claim it first to avoid misdetection.
+    const ALL: [Self; 13] = [
+        Self::BasicWallet,
+        Self::NoteCreator,
+        Self::FungibleFaucet,
+        Self::CodeInspection,
+        Self::Authority,
+        Self::RoleBasedAccessControl,
+        Self::Ownable2Step,
+        Self::AuthSingleSig,
+        Self::AuthGuardedMultisig,
+        Self::AuthMultisig,
+        Self::AuthMultisigSmart,
+        Self::AuthNoAuth,
+        Self::AuthNetworkAccount,
+    ];
+
     /// Returns the iterator over the [`AccountProcedureRoot`]s of all procedures exported from
     /// the component.
     pub fn procedure_roots(&self) -> impl Iterator<Item = AccountProcedureRoot> {
@@ -62,19 +82,33 @@ impl StandardAccountComponent {
         code.procedure_roots()
     }
 
-    /// Checks whether procedures from the current component are present in the procedures map
-    /// and if so it removes these procedures from this map and pushes the corresponding component
+    /// Checks whether procedures from the current component are present in `all_procedures` and if
+    /// so it claims these procedures from `unclaimed_set` and pushes the corresponding component
     /// interface to the component interface vector.
+    ///
+    /// Presence is checked against `all_procedures` rather than against `unclaimed_set`, so a
+    /// procedure root exported by two standard components (e.g. `has_procedure`, re-exported by
+    /// both the fungible faucet and the code inspection component) satisfies both instead of being
+    /// consumed by whichever component happens to be matched first. A component whose procedures
+    /// were all claimed already is skipped, which keeps a narrower component from being reported
+    /// alongside the broader one that contains it.
+    ///
+    /// TODO: replace with per-component detection once the `AccountComponentInterface` trait
+    /// (issue #2621) lands.
     fn extract_component(
         &self,
-        procedures_set: &mut BTreeSet<AccountProcedureRoot>,
+        all_procedures: &BTreeSet<AccountProcedureRoot>,
+        unclaimed_set: &mut BTreeSet<AccountProcedureRoot>,
         component_interface_vec: &mut Vec<AccountComponentInterface>,
     ) {
         // Determine if this component should be extracted based on procedure matching
-        if self.procedure_roots().all(|proc_root| procedures_set.contains(&proc_root)) {
-            // Remove the procedure root of any matching procedure.
+        let is_exported = self.procedure_roots().all(|root| all_procedures.contains(&root));
+        let is_unclaimed = self.procedure_roots().any(|root| unclaimed_set.contains(&root));
+
+        if is_exported && is_unclaimed {
+            // Claim the procedure root of any matching procedure.
             self.procedure_roots().for_each(|component_procedure| {
-                procedures_set.remove(&component_procedure);
+                unclaimed_set.remove(&component_procedure);
             });
 
             // Create the appropriate component interface
@@ -124,24 +158,20 @@ impl StandardAccountComponent {
 
     /// Gets all standard components which could be constructed from the provided procedures map
     /// and pushes them to the `component_interface_vec`.
+    ///
+    /// On return, `procedures_set` holds exactly the procedures that no standard component
+    /// claimed.
     pub fn extract_standard_components(
         procedures_set: &mut BTreeSet<AccountProcedureRoot>,
         component_interface_vec: &mut Vec<AccountComponentInterface>,
     ) {
-        Self::BasicWallet.extract_component(procedures_set, component_interface_vec);
-        // Must run after `BasicWallet`: `NoteCreator`'s only procedure (`create_note`) is a subset
-        // of the basic wallet's, so a full wallet must claim it first to avoid misdetection.
-        Self::NoteCreator.extract_component(procedures_set, component_interface_vec);
-        Self::FungibleFaucet.extract_component(procedures_set, component_interface_vec);
-        Self::CodeInspection.extract_component(procedures_set, component_interface_vec);
-        Self::Authority.extract_component(procedures_set, component_interface_vec);
-        Self::RoleBasedAccessControl.extract_component(procedures_set, component_interface_vec);
-        Self::Ownable2Step.extract_component(procedures_set, component_interface_vec);
-        Self::AuthSingleSig.extract_component(procedures_set, component_interface_vec);
-        Self::AuthGuardedMultisig.extract_component(procedures_set, component_interface_vec);
-        Self::AuthMultisig.extract_component(procedures_set, component_interface_vec);
-        Self::AuthMultisigSmart.extract_component(procedures_set, component_interface_vec);
-        Self::AuthNoAuth.extract_component(procedures_set, component_interface_vec);
-        Self::AuthNetworkAccount.extract_component(procedures_set, component_interface_vec);
+        // Match against a snapshot of the full interface so that a procedure root exported by two
+        // standard components can satisfy both, while `procedures_set` tracks what is still
+        // unclaimed.
+        let all_procedures = procedures_set.clone();
+
+        for component in Self::ALL {
+            component.extract_component(&all_procedures, procedures_set, component_interface_vec);
+        }
     }
 }

--- a/crates/miden-standards/src/account/interface/test.rs
+++ b/crates/miden-standards/src/account/interface/test.rs
@@ -1,8 +1,10 @@
+use alloc::vec::Vec;
+
 use assert_matches::assert_matches;
 use miden_protocol::Word;
-use miden_protocol::account::AccountBuilder;
 use miden_protocol::account::auth::{self, PublicKeyCommitment};
-use miden_protocol::asset::NonFungibleAsset;
+use miden_protocol::account::{AccountBuilder, AccountProcedureRoot, AccountType};
+use miden_protocol::asset::{AssetAmount, NonFungibleAsset, TokenSymbol};
 use miden_protocol::crypto::rand::RandomCoin;
 use miden_protocol::errors::NoteError;
 use miden_protocol::note::NoteType;
@@ -16,6 +18,8 @@ use crate::account::auth::{
     AuthSingleSig,
     NoAuth,
 };
+use crate::account::faucets::{FungibleFaucet, TokenName};
+use crate::account::inspection::CodeInspection;
 use crate::account::interface::{AccountComponentInterface, AccountInterface, AccountInterfaceExt};
 use crate::account::wallets::BasicWallet;
 use crate::note::SwapNote;
@@ -47,6 +51,72 @@ fn get_mock_falcon_auth_component() -> AuthSingleSig {
     let mock_word = Word::from([0, 1, 2, 3u32]);
     let mock_public_key = PublicKeyCommitment::from(mock_word);
     AuthSingleSig::new(Approver::new(mock_public_key, auth::AuthScheme::Falcon512Poseidon2))
+}
+
+fn get_mock_fungible_faucet_component() -> FungibleFaucet {
+    FungibleFaucet::builder()
+        .name(TokenName::new("Mock Token").unwrap())
+        .symbol(TokenSymbol::new("MOCK").unwrap())
+        .decimals(6)
+        .max_supply(AssetAmount::from(1_000_000u32))
+        .build()
+        .expect("mock fungible faucet should be valid")
+}
+
+/// Returns the procedure roots reported in the custom buckets of the provided interface.
+fn custom_procedures(interface: &AccountInterface) -> Vec<AccountProcedureRoot> {
+    interface
+        .components()
+        .iter()
+        .filter_map(|component| match component {
+            AccountComponentInterface::Custom(proc_roots) => Some(proc_roots.clone()),
+            _ => None,
+        })
+        .flatten()
+        .collect()
+}
+
+// STANDARD COMPONENT IDENTIFICATION TESTS
+// ================================================================================================
+
+/// A procedure root exported by two standard components must satisfy both: the fungible faucet
+/// and the code inspection component both export `has_procedure`.
+#[test]
+fn test_shared_procedure_root_does_not_hide_a_standard_component() -> anyhow::Result<()> {
+    let account = AccountBuilder::new([1; 32])
+        .account_type(AccountType::Public)
+        .with_component(NoAuth)
+        .with_component(get_mock_fungible_faucet_component())
+        .with_component(CodeInspection)
+        .build_existing()?;
+
+    let interface = AccountInterface::from_account(&account);
+
+    assert!(interface.components().contains(&AccountComponentInterface::FungibleFaucet));
+    assert!(interface.components().contains(&AccountComponentInterface::CodeInspection));
+    // Every procedure root is claimed by one of the two standard components.
+    assert!(custom_procedures(&interface).is_empty());
+
+    Ok(())
+}
+
+/// `NoteCreator`'s only procedure is also exported by `BasicWallet`, so a full wallet must not
+/// additionally be reported as a note creator.
+#[test]
+fn test_basic_wallet_is_not_reported_as_note_creator() -> anyhow::Result<()> {
+    let account = AccountBuilder::new([2; 32])
+        .account_type(AccountType::Public)
+        .with_component(NoAuth)
+        .with_component(BasicWallet)
+        .build_existing()?;
+
+    let interface = AccountInterface::from_account(&account);
+
+    assert!(interface.components().contains(&AccountComponentInterface::BasicWallet));
+    assert!(!interface.components().contains(&AccountComponentInterface::NoteCreator));
+    assert!(custom_procedures(&interface).is_empty());
+
+    Ok(())
 }
 
 // AUTH COMPONENT IDENTIFICATION TESTS


### PR DESCRIPTION
## Summary

- Match each standard component against the account's full interface, so a root exported by two standard components satisfies both.
- Skip a component whose procedure roots were all claimed already, keeping `NoteCreator` suppressed on an account that installs the full `BasicWallet`.
- Collapse the hand-written `extract_component` call sequence into a `StandardAccountComponent::ALL` constant.
- Add tests pinning that a fungible faucet and `CodeInspection` are both detected despite sharing `has_procedure`.

Closes [#3822](https://github.com/0xMiden/protocol/issues/3822).
