### PR TITLE
fix(standards): identify custom auth components in `AccountInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@
 - The PSWAP note script now bounds its lineage depth to a u32 and the `PswapNote` builder rejects a malformed `PswapAttachment` [#3777](https://github.com/0xMiden/protocol/pull/3777).
 - The standard config note scripts now reject a non-public note [#3779](https://github.com/0xMiden/protocol/pull/3779).
 - [BREAKING] `multisig_smart` now rejects delay-only procedure policies ([#3781](https://github.com/0xMiden/protocol/pull/3781)).
-- [BREAKING] Fixed `AccountInterface::from_account` and `from_code` panicking on accounts that authenticate through a custom auth component; `AccountComponentInterface` gained a `CustomAuth` variant carrying the account's authentication procedure ([#XXXX](https://github.com/0xMiden/protocol/pull/XXXX)).
+- [BREAKING] Fixed `AccountInterface::from_account` and `from_code` panicking on accounts that authenticate through a custom auth component ([#3825](https://github.com/0xMiden/protocol/pull/3825)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - The PSWAP note script now bounds its lineage depth to a u32 and the `PswapNote` builder rejects a malformed `PswapAttachment` [#3777](https://github.com/0xMiden/protocol/pull/3777).
 - The standard config note scripts now reject a non-public note [#3779](https://github.com/0xMiden/protocol/pull/3779).
 - [BREAKING] `multisig_smart` now rejects delay-only procedure policies ([#3781](https://github.com/0xMiden/protocol/pull/3781)).
+- [BREAKING] Fixed `AccountInterface::from_account` and `from_code` panicking on accounts that authenticate through a custom auth component; `AccountComponentInterface` gained a `CustomAuth` variant carrying the account's authentication procedure ([#XXXX](https://github.com/0xMiden/protocol/pull/XXXX)).
 
 ## v0.16.0 (2026-08-17)
 

--- a/crates/miden-standards/src/account/interface/component.rs
+++ b/crates/miden-standards/src/account/interface/component.rs
@@ -55,6 +55,8 @@ pub enum AccountComponentInterface {
     /// transactions that do not consume an input note, create an output note, or change the
     /// account before fee payment.
     AuthNetworkAccount,
+    /// A non-standard authentication component, holding the account's authentication procedure.
+    CustomAuth(AccountProcedureRoot),
     /// A non-standard, custom interface which exposes the contained procedures.
     ///
     /// Custom interface holds all procedures which are not part of some standard interface which is
@@ -85,6 +87,9 @@ impl AccountComponentInterface {
             AccountComponentInterface::AuthGuardedMultisig => "Guarded Multisig".to_string(),
             AccountComponentInterface::AuthNoAuth => "No Auth".to_string(),
             AccountComponentInterface::AuthNetworkAccount => "Network Account Auth".to_string(),
+            AccountComponentInterface::CustomAuth(proc_root) => {
+                format!("CustomAuth({})", &proc_root.mast_root().to_hex()[..9])
+            },
             AccountComponentInterface::Custom(proc_root_vec) => {
                 let result = proc_root_vec
                     .iter()
@@ -97,8 +102,6 @@ impl AccountComponentInterface {
     }
 
     /// Returns true if this component interface is an authentication component.
-    ///
-    /// TODO: currently this can identify only standard auth components
     pub fn is_auth_component(&self) -> bool {
         matches!(
             self,
@@ -108,6 +111,7 @@ impl AccountComponentInterface {
                 | AccountComponentInterface::AuthGuardedMultisig
                 | AccountComponentInterface::AuthNoAuth
                 | AccountComponentInterface::AuthNetworkAccount
+                | AccountComponentInterface::CustomAuth(_)
         )
     }
 }

--- a/crates/miden-standards/src/account/interface/component.rs
+++ b/crates/miden-standards/src/account/interface/component.rs
@@ -88,7 +88,7 @@ impl AccountComponentInterface {
             AccountComponentInterface::AuthNoAuth => "No Auth".to_string(),
             AccountComponentInterface::AuthNetworkAccount => "Network Account Auth".to_string(),
             AccountComponentInterface::CustomAuth(proc_root) => {
-                format!("CustomAuth({})", &proc_root.mast_root().to_hex()[..9])
+                format!("Custom Auth({})", &proc_root.mast_root().to_hex()[..9])
             },
             AccountComponentInterface::Custom(proc_root_vec) => {
                 let result = proc_root_vec

--- a/crates/miden-standards/src/account/interface/component.rs
+++ b/crates/miden-standards/src/account/interface/component.rs
@@ -88,14 +88,11 @@ impl AccountComponentInterface {
             AccountComponentInterface::AuthNoAuth => "No Auth".to_string(),
             AccountComponentInterface::AuthNetworkAccount => "Network Account Auth".to_string(),
             AccountComponentInterface::CustomAuth(proc_root) => {
-                format!("Custom Auth({})", &proc_root.mast_root().to_hex()[..9])
+                format!("Custom Auth({})", shortened_mast_root(proc_root))
             },
             AccountComponentInterface::Custom(proc_root_vec) => {
-                let result = proc_root_vec
-                    .iter()
-                    .map(|proc_root| proc_root.mast_root().to_hex()[..9].to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let result =
+                    proc_root_vec.iter().map(shortened_mast_root).collect::<Vec<_>>().join(", ");
                 format!("Custom([{result}])")
             },
         }
@@ -114,4 +111,13 @@ impl AccountComponentInterface {
                 | AccountComponentInterface::CustomAuth(_)
         )
     }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Returns a shortened hex representation of the procedure's MAST root: the `0x` prefix followed
+/// by the first seven hex digits, e.g. `0x6d93447`.
+fn shortened_mast_root(proc_root: &AccountProcedureRoot) -> String {
+    proc_root.mast_root().to_hex()[..9].to_string()
 }

--- a/crates/miden-standards/src/account/interface/extension.rs
+++ b/crates/miden-standards/src/account/interface/extension.rs
@@ -42,6 +42,7 @@ impl AccountComponentInterfaceExt for AccountComponentInterface {
     fn from_procedures(procedures: &[AccountProcedureRoot]) -> Vec<Self> {
         let mut component_interface_vec = Vec::new();
 
+        // `AccountCode` places the account's authentication procedure at index 0.
         let auth_procedure = procedures.first().copied();
 
         let mut procedures = BTreeSet::from_iter(procedures.iter().copied());
@@ -61,9 +62,9 @@ impl AccountComponentInterfaceExt for AccountComponentInterface {
 
         // If no standard auth interface claimed the authentication procedure, the account
         // authenticates through a custom component.
-        let standard_auth_detected =
-            component_interface_vec.iter().any(|component| component.is_auth_component());
-        if let Some(auth_procedure) = auth_procedure.filter(|_| !standard_auth_detected) {
+        if !component_interface_vec.iter().any(|component| component.is_auth_component())
+            && let Some(auth_procedure) = auth_procedure
+        {
             procedures.remove(&auth_procedure);
             component_interface_vec.push(AccountComponentInterface::CustomAuth(auth_procedure));
         }

--- a/crates/miden-standards/src/account/interface/extension.rs
+++ b/crates/miden-standards/src/account/interface/extension.rs
@@ -42,6 +42,8 @@ impl AccountComponentInterfaceExt for AccountComponentInterface {
     fn from_procedures(procedures: &[AccountProcedureRoot]) -> Vec<Self> {
         let mut component_interface_vec = Vec::new();
 
+        let auth_procedure = procedures.first().copied();
+
         let mut procedures = BTreeSet::from_iter(procedures.iter().copied());
 
         // Standard component interfaces
@@ -53,6 +55,18 @@ impl AccountComponentInterfaceExt for AccountComponentInterface {
             &mut procedures,
             &mut component_interface_vec,
         );
+
+        // Custom authentication component interface
+        // ----------------------------------------------------------------------------------------
+
+        // If no standard auth interface claimed the authentication procedure, the account
+        // authenticates through a custom component.
+        let standard_auth_detected =
+            component_interface_vec.iter().any(|component| component.is_auth_component());
+        if let Some(auth_procedure) = auth_procedure.filter(|_| !standard_auth_detected) {
+            procedures.remove(&auth_procedure);
+            component_interface_vec.push(AccountComponentInterface::CustomAuth(auth_procedure));
+        }
 
         // Custom component interfaces
         // ----------------------------------------------------------------------------------------

--- a/crates/miden-standards/src/account/interface/test.rs
+++ b/crates/miden-standards/src/account/interface/test.rs
@@ -19,6 +19,7 @@ use crate::account::auth::{
 use crate::account::interface::{AccountComponentInterface, AccountInterface, AccountInterfaceExt};
 use crate::account::wallets::BasicWallet;
 use crate::note::SwapNote;
+use crate::testing::account_component::IncrNonceAuthComponent;
 use crate::testing::account_interface::get_public_keys_from_account;
 
 /// Checks that building a SWAP note should fail if the requested asset is the same as the
@@ -84,6 +85,33 @@ fn test_account_interface_identifies_no_auth() {
         no_auth_account_interface.auth_component(),
         AccountComponentInterface::AuthNoAuth
     ));
+}
+
+#[test]
+fn test_account_interface_identifies_custom_auth() {
+    let mock_seed = Word::from([0, 1, 2, 3u32]).as_bytes();
+    let custom_auth_account = AccountBuilder::new(mock_seed)
+        .with_component(IncrNonceAuthComponent)
+        .with_component(BasicWallet)
+        .build_existing()
+        .expect("failed to create custom-auth account");
+
+    // `AccountCode` places the authentication procedure at index 0.
+    let auth_procedure = custom_auth_account.code().procedures()[0];
+
+    let custom_auth_account_interface = AccountInterface::from_account(&custom_auth_account);
+
+    assert_matches!(
+        custom_auth_account_interface.auth_component(),
+        AccountComponentInterface::CustomAuth(proc_root) if *proc_root == auth_procedure
+    );
+
+    // The authentication procedure must not also be reported as a plain custom procedure.
+    for component in custom_auth_account_interface.components() {
+        if let AccountComponentInterface::Custom(proc_roots) = component {
+            assert!(!proc_roots.contains(&auth_procedure));
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Report the authentication procedure as a new `AccountComponentInterface::CustomAuth` variant when no standard `Auth*` interface claims it, so `AccountInterface::from_account` and `from_code` no longer panic on accounts with a custom auth component.
- Cover `CustomAuth` in `is_auth_component` and `name`.
- Add a regression test building an account with a custom auth component.

Last item of [#3716](https://github.com/0xMiden/protocol/issues/3716), so the issue can be closed either.
