### PR TITLE
chore: prepare v0.17.0-rc.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "miden-objects"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "assert_matches",
  "miden-protocol",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-build-utils"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "bon",
  "miden-agglayer",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 dependencies = [
  "miden-processor",
  "miden-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ homepage     = "https://miden.xyz"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/protocol"
 rust-version = "1.98.1"
-version      = "0.17.0-rc.1"
+version      = "0.17.0-rc.4"
 
 [profile.release]
 codegen-units = 1
@@ -38,14 +38,14 @@ lto           = true
 
 [workspace.dependencies]
 # Workspace crates
-miden-agglayer             = { default-features = false, path = "crates/miden-agglayer", version = "0.17.0-rc.1" }
-miden-block-prover         = { default-features = false, path = "crates/miden-block-prover", version = "0.17.0-rc.1" }
-miden-protocol             = { default-features = false, path = "crates/miden-protocol", version = "0.17.0-rc.1" }
-miden-protocol-build-utils = { default-features = false, path = "crates/miden-protocol-build-utils", version = "0.17.0-rc.1" }
-miden-standards            = { default-features = false, path = "crates/miden-standards", version = "0.17.0-rc.1" }
-miden-testing              = { default-features = false, path = "crates/miden-testing", version = "0.17.0-rc.1" }
-miden-tx                   = { default-features = false, path = "crates/miden-tx", version = "0.17.0-rc.1" }
-miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.17.0-rc.1" }
+miden-agglayer             = { default-features = false, path = "crates/miden-agglayer", version = "0.17.0-rc.4" }
+miden-block-prover         = { default-features = false, path = "crates/miden-block-prover", version = "0.17.0-rc.4" }
+miden-protocol             = { default-features = false, path = "crates/miden-protocol", version = "0.17.0-rc.4" }
+miden-protocol-build-utils = { default-features = false, path = "crates/miden-protocol-build-utils", version = "0.17.0-rc.4" }
+miden-standards            = { default-features = false, path = "crates/miden-standards", version = "0.17.0-rc.4" }
+miden-testing              = { default-features = false, path = "crates/miden-testing", version = "0.17.0-rc.4" }
+miden-tx                   = { default-features = false, path = "crates/miden-tx", version = "0.17.0-rc.4" }
+miden-tx-batch             = { default-features = false, path = "crates/miden-tx-batch", version = "0.17.0-rc.4" }
 
 # Miden dependencies
 miden-assembly         = { default-features = false, version = "0.32.0" }


### PR DESCRIPTION
Bump the workspace version and the workspace dependency versions from 0.17.0-rc.1 to 0.17.0-rc.4.

We should discuss in the sync whether this should target - and the released be cut from - `next`, or from the `v0.17` branch