### PR TITLE
fix(standards): reject zero-amount assets in swap and pswap notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 
 ### Fixes
 
+- `SwapNote::new` and `PswapNoteBuilder::build` now reject a zero-amount asset on either side of the exchange. A zero requested asset produced a payback note carrying nothing, and a zero offered asset produced a note whose consumer pays and receives nothing ([#3840](https://github.com/0xMiden/protocol/pull/3840)).
 - [BREAKING] `NetworkAccountTarget` decoding no longer discards the target account ID when the execution hint slot holds an unrecognized encoding ([#3811](https://github.com/0xMiden/protocol/pull/3811)).
 - Fixed `AuthNetworkAccount` accepting empty fee-only transactions, which let callers drain the account's native fee-asset vault ([#3729](https://github.com/0xMiden/protocol/pull/3729)).
 - [BREAKING] AggLayer bridge token registration now rejects keys owned by another faucet, and token-key cleanup verifies ownership before clearing a mapping ([#3754](https://github.com/0xMiden/protocol/pull/3754)).

--- a/crates/miden-standards/src/note/pswap.rs
+++ b/crates/miden-standards/src/note/pswap.rs
@@ -321,8 +321,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns an error if the offered and requested assets have the same faucet ID, or if the
-    /// note carries a malformed [`PswapNote::PSWAP_ATTACHMENT_SCHEME`] attachment.
+    /// Returns an error if the offered and requested assets have the same faucet ID, if either of
+    /// them is zero, or if the note carries a malformed
+    /// [`PswapNote::PSWAP_ATTACHMENT_SCHEME`] attachment.
     pub fn build(self) -> Result<PswapNote, NoteError> {
         let note = self.build_internal();
 
@@ -330,6 +331,13 @@ where
             return Err(NoteError::other(
                 "offered and requested assets must have different faucets",
             ));
+        }
+
+        if note.offered_asset.amount() == AssetAmount::ZERO {
+            return Err(NoteError::other("offered asset must be non-zero"));
+        }
+        if note.storage.min_requested_asset().amount() == AssetAmount::ZERO {
+            return Err(NoteError::other("requested asset must be non-zero"));
         }
 
         if let Some(attachment) = note.attachment.as_ref()
@@ -989,6 +997,7 @@ impl NoteConsumptionCost for PswapNote {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use miden_protocol::account::{AccountId, AccountIdVersion, AccountType, AssetCallbackFlag};
     use miden_protocol::asset::FungibleAsset;
     use miden_protocol::crypto::rand::{FeltRng, RandomCoin};
@@ -1403,6 +1412,45 @@ mod tests {
         assert!(
             remainder.payback_note(consumer_id, &round_one_attachment).is_err(),
             "an attachment from the parent's own round is not a later round",
+        );
+    }
+
+    /// A PSWAP note holds the offered asset and its payback holds the requested one, so a zero
+    /// amount on either side leaves one of those two notes empty.
+    #[test]
+    fn pswap_note_builder_rejects_a_zero_asset() {
+        let mut rng = RandomCoin::new(Word::default());
+        let creator = dummy_creator_id();
+        let zero = FungibleAsset::new(dummy_faucet_id(3), 0).unwrap();
+        let some = FungibleAsset::new(dummy_faucet_id(4), 100).unwrap();
+
+        let mut build = |offered: FungibleAsset, requested: FungibleAsset| {
+            PswapNote::builder()
+                .sender(creator)
+                .storage(
+                    PswapNoteStorage::builder()
+                        .min_requested_asset(requested)
+                        .creator_account_id(creator)
+                        .build(),
+                )
+                .serial_number(rng.draw_word())
+                .note_type(NoteType::Public)
+                .offered_asset(offered)
+                .build()
+        };
+
+        let err = build(zero, some).expect_err("a zero offered asset must be rejected");
+        assert_matches!(
+            err,
+            NoteError::Other { error_msg, .. }
+                if error_msg == "offered asset must be non-zero".into()
+        );
+
+        let err = build(some, zero).expect_err("a zero requested asset must be rejected");
+        assert_matches!(
+            err,
+            NoteError::Other { error_msg, .. }
+                if error_msg == "requested asset must be non-zero".into()
         );
     }
 }

--- a/crates/miden-standards/src/note/swap.rs
+++ b/crates/miden-standards/src/note/swap.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use miden_protocol::account::AccountId;
 use miden_protocol::assembly::Path;
-use miden_protocol::asset::Asset;
+use miden_protocol::asset::{Asset, AssetAmount};
 use miden_protocol::crypto::rand::FeltRng;
 use miden_protocol::errors::NoteError;
 use miden_protocol::note::{
@@ -64,6 +64,12 @@ pub struct SwapNote {
     attachments: NoteAttachments,
 }
 
+/// Returns true when the asset is a fungible asset carrying no value. A non-fungible asset always
+/// carries value.
+fn is_zero_fungible(asset: &Asset) -> bool {
+    asset.is_fungible() && asset.unwrap_fungible().amount() == AssetAmount::ZERO
+}
+
 #[bon::bon]
 impl SwapNote {
     /// Builds a new [`SwapNote`].
@@ -75,6 +81,7 @@ impl SwapNote {
     ///
     /// Returns an error if:
     /// - The requested asset is the same as the offered asset.
+    /// - Either the offered or the requested asset is a zero-amount fungible asset.
     /// - The attachments exceed their protocol limit (see [`NoteAttachments::new`]).
     #[builder]
     pub fn new(
@@ -100,6 +107,13 @@ impl SwapNote {
     ) -> Result<Self, NoteError> {
         if requested_asset == offered_asset {
             return Err(NoteError::other("requested asset same as offered asset"));
+        }
+
+        if is_zero_fungible(&offered_asset) {
+            return Err(NoteError::other("offered asset must be non-zero"));
+        }
+        if is_zero_fungible(&requested_asset) {
+            return Err(NoteError::other("requested asset must be non-zero"));
         }
 
         let attachments = NoteAttachments::new(attachments)?;
@@ -812,6 +826,41 @@ mod tests {
             ((actual_tag.as_u32() & 0b00000000_01111111_00000000_00000000) >> 16) as u8,
             SwapNote::script_root().as_bytes()[1] >> 1,
             "swap script root byte 1 should match with the highest bit set to zero"
+        );
+    }
+
+    /// A SWAP note holds the offered asset and its payback holds the requested one, so a zero
+    /// amount on either side leaves one of those two notes empty.
+    #[test]
+    fn swap_note_builder_rejects_a_zero_asset() {
+        let zero = Asset::from(FungibleAsset::new(fungible_faucet(), 0).unwrap());
+
+        let err = SwapNote::builder()
+            .sender(dummy_target_id())
+            .offered_asset(zero)
+            .requested_asset(non_fungible_asset())
+            .note_type(NoteType::Public)
+            .generate_serial_number(&mut RandomCoin::new(Word::from([1, 2, 3, 4u32])))
+            .build()
+            .expect_err("a zero offered asset must be rejected");
+        assert_matches!(
+            err,
+            NoteError::Other { error_msg, .. }
+                if error_msg == "offered asset must be non-zero".into()
+        );
+
+        let err = SwapNote::builder()
+            .sender(dummy_target_id())
+            .offered_asset(non_fungible_asset())
+            .requested_asset(zero)
+            .note_type(NoteType::Public)
+            .generate_serial_number(&mut RandomCoin::new(Word::from([1, 2, 3, 4u32])))
+            .build()
+            .expect_err("a zero requested asset must be rejected");
+        assert_matches!(
+            err,
+            NoteError::Other { error_msg, .. }
+                if error_msg == "requested asset must be non-zero".into()
         );
     }
 }


### PR DESCRIPTION
Follow-up to [rust-sdk#2459](https://github.com/0xMiden/rust-sdk/pull/2459), where @igamigo noted these checks belong here as well.

### Problem

`SwapNote::new` rejects a self-swap, and `PswapNoteBuilder::build` rejects a same-faucet pair, but neither looks at the amounts:

```
SwapNote::new(offered = 0, requested = <non-fungible>)      -> Ok
SwapNote::new(offered = <non-fungible>, requested = 0)      -> Ok
PswapNote::builder()...(offered = 0, requested = 100)       -> Ok
PswapNote::builder()...(offered = 100, requested = 0)       -> Ok
```

Both sides carry value. The note holds the offered asset, and filling it emits a payback carrying the requested one, so a zero requested asset leaves the payback empty and a zero offered asset leaves a note whose consumer pays and receives nothing.

### Change

Reject a zero-amount asset on either side in both constructors, with `NoteError::other` alongside the existing checks.

For SWAP the assets are `Asset`, so the test goes through a small `is_zero_fungible` helper — a non-fungible asset always carries value. For PSWAP both sides are `FungibleAsset` and compare directly.

`PswapNoteStorage::min_fill_step` is left alone: it defaults to `AssetAmount::ZERO` on purpose, to disable the fill floor.

### Test plan

```
cargo test -p miden-standards --lib -- builder_rejects_a_zero_asset
```

`swap_note_builder_rejects_a_zero_asset` and `pswap_note_builder_rejects_a_zero_asset` cover both sides of each constructor. Both fail on `next` — the first `expect_err` gets an `Ok` note back.

All 275 `miden-standards` lib tests pass, and the workspace builds.
