### PR TITLE
refactor(standards): complete the signature helper's type and trim the serial hash

### DIFF
--- a/crates/miden-standards/asm/components/auth/tx_fee_collector/tx_fee_collector.masm
+++ b/crates/miden-standards/asm/components/auth/tx_fee_collector/tx_fee_collector.masm
@@ -173,10 +173,10 @@ proc forward_note_assets
 
     # the serial number is unique per transaction, since no two valid transactions consume the
     # same notes
-    dupw exec.tx::get_input_notes_commitment
-    # => [INPUT_NOTES_COMMITMENT, AUTH_ARGS, AUTH_ARGS, num_input_notes]
+    exec.tx::get_input_notes_commitment
+    # => [INPUT_NOTES_COMMITMENT, AUTH_ARGS, num_input_notes]
 
-    swapw exec.poseidon2::merge
+    dupw.1 exec.poseidon2::merge
     # => [SERIAL_NUM, AUTH_ARGS, num_input_notes]
 
     swapw

--- a/crates/miden-standards/asm/standards/auth/signature.masm
+++ b/crates/miden-standards/asm/standards/auth/signature.masm
@@ -114,7 +114,7 @@ end
 #! - user_params are six arbitrary elements bound by the signature
 #!
 #! Invocation: exec
-pub proc authenticate_transaction_with_user_params(user_params: [felt; 6])
+pub proc authenticate_transaction_with_user_params(user_params: [felt; 6], approver: Approver)
     # Compute the message that is signed. The summary preimage is inserted into the advice map
     # for extraction by the host.
     # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
Addresses two of Philipp's post-merge comments on [#3844](https://github.com/0xMiden/protocol/pull/3844):

- `signature::authenticate_transaction_with_user_params` now declares the approver in its typed signature, `(user_params: [felt; 6], approver: Approver)`
- `AuthTxFeeCollector` drops a `swapw`.